### PR TITLE
feat: add openapi compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+src-rust/target

--- a/spec/14_multi_provider_plan.md
+++ b/spec/14_multi_provider_plan.md
@@ -1,0 +1,205 @@
+# Claude Code Rust — Multi-Provider Model Support Plan
+
+## Goal
+
+Enable this Rust codebase to use multiple model providers (starting with Anthropic + OpenAI-compatible) without regressing current behavior, tool-calling loop, or TUI/CLI UX.
+
+## Scope and Non-Goals
+
+### In Scope
+
+- Keep Anthropic as a first-class provider.
+- Introduce a provider abstraction in `cc-api`.
+- Allow provider selection via config and CLI.
+- Support streaming + non-streaming responses through a unified event model.
+- Preserve existing query loop and tool execution semantics.
+
+### Out of Scope (Phase 1)
+
+- Full provider-specific parity for every advanced feature.
+- Rewriting permission/tools systems.
+- Migrating bridge protocol behavior.
+
+## Current Binding Baseline (What Is Coupled Today)
+
+- Client type is concrete `AnthropicClient` across query and CLI layers.
+- API contract is fixed to Anthropic `/v1/messages` and Anthropic headers.
+- Auth/env naming is Anthropic-specific (`ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`).
+- OAuth/login flow is Anthropic-only.
+- Model defaults are Anthropic model IDs.
+
+## Target Architecture
+
+### 1) API Trait Boundary
+
+Add an interface in `cc-api`:
+
+- `trait LlmClient`:
+  - `create_message(request) -> response`
+  - `create_message_stream(request, handler) -> stream events`
+- Provider implementations:
+  - `AnthropicClient` (existing, adapted)
+  - `OpenAiCompatClient` (new, configurable base URL)
+
+### 2) Canonical Internal Types
+
+Define provider-agnostic canonical types in `cc-api`:
+
+- `UnifiedMessageRequest`
+- `UnifiedMessageResponse`
+- `UnifiedStreamEvent`
+- `UnifiedToolCall` / `UnifiedToolResult`
+- `UnifiedUsage`
+
+Each provider adapter maps canonical types to/from provider wire format.
+
+### 3) Provider Selection
+
+Config additions in `cc-core`:
+
+- `provider: "anthropic" | "openai_compat"`
+- Provider-scoped fields:
+  - `api_key`, `api_base`, optional `api_version`/extra headers
+- Backward compatibility:
+  - If `provider` missing, default to `anthropic`
+  - Keep current Anthropic env vars functional
+
+CLI additions in `crates/cli`:
+
+- `--provider <anthropic|openai-compat>`
+- Optional provider-specific auth args later (not in first cut)
+
+### 4) Query Layer Decoupling
+
+Update `cc-query` function signatures to depend on trait object:
+
+- From `&AnthropicClient` to `&(dyn LlmClient + Send + Sync)`
+- Keep run-loop and tool orchestration unchanged.
+
+### 5) Error and Retry Normalization
+
+Normalize provider-specific failures into existing `ClaudeError` families or a renamed generic error enum:
+
+- Auth errors
+- Rate-limit/retryable errors
+- API status errors
+- Stream parse errors
+
+## Implementation Phases
+
+## Phase 0 - Prep and Safety
+
+- Add snapshot tests around current Anthropic request/stream behavior.
+- Add golden tests for event sequencing in query loop.
+- Freeze current public CLI flags behavior.
+
+Exit criteria:
+- Existing tests green.
+- New coverage around stream + tool events in place.
+
+## Phase 1 - Introduce Abstraction (No Behavior Change)
+
+- Create `LlmClient` trait and unified request/response/event types.
+- Adapt `AnthropicClient` to implement trait.
+- Refactor `cc-query` and `crates/cli` to use trait object.
+
+Exit criteria:
+- Anthropic-only behavior unchanged.
+- No user-visible behavior regressions in TUI and headless mode.
+
+## Phase 2 - OpenAI-Compatible Provider (MVP)
+
+- Implement `OpenAiCompatClient` for Chat/Responses compatible endpoint.
+- Map tool call events into canonical stream events.
+- Add provider config parsing and CLI provider selection.
+
+Exit criteria:
+- End-to-end prompt->tool call->tool result->final answer works with OpenAI-compatible endpoint.
+- JSON/stream-json output modes still function.
+
+## Phase 3 - Hardening and UX
+
+- Improve provider-specific validation and actionable errors.
+- Expand model selection help (`/model`, `/config` guidance).
+- Add docs for env vars and migration examples.
+
+Exit criteria:
+- Clear setup docs for both providers.
+- Stable retry behavior under transient failures.
+
+## Detailed Work Breakdown (By Crate)
+
+### `crates/api`
+
+- Introduce `LlmClient` trait.
+- Add `provider` module layout:
+  - `providers/anthropic.rs`
+  - `providers/openai_compat.rs`
+- Create canonical DTOs independent of Anthropic schema names.
+- Build adapter mappers both directions.
+
+### `crates/core`
+
+- Extend config schema with provider and provider-specific settings.
+- Add backward-compatible env resolution:
+  - Keep `ANTHROPIC_API_KEY` and `ANTHROPIC_BASE_URL`.
+  - Add generic aliases later (`CLAUDE_CODE_API_KEY`, `CLAUDE_CODE_API_BASE`).
+- Keep default provider as `anthropic`.
+
+### `crates/cli`
+
+- Parse provider option.
+- Construct selected client implementation.
+- Keep auth flow Anthropic-gated in first iteration; non-Anthropic uses API key only.
+
+### `crates/query`
+
+- Accept trait object client in query loop, compact flow, cron scheduler, and sub-agent tool.
+- Ensure cancellation and streaming behavior remains identical.
+
+### `crates/commands` / `crates/tui`
+
+- Update `/config` to read/write provider.
+- Update diagnostics/help text currently hardcoded to Anthropic env vars.
+
+## Compatibility and Migration Strategy
+
+- Existing users with Anthropic config continue working without changes.
+- If `provider=openai_compat` and required fields are missing, fail fast with clear guidance.
+- Keep default models Anthropic unless provider-specific defaults are explicitly set.
+
+## Risks and Mitigations
+
+- Streaming protocol mismatch across providers.
+  - Mitigation: strict adapter boundary and stream contract tests.
+- Tool call schema differences.
+  - Mitigation: canonical `UnifiedToolCall` shape + provider mappers.
+- Silent behavior drift in retries.
+  - Mitigation: deterministic retry tests and explicit backoff policy.
+
+## Testing Strategy
+
+- Unit tests:
+  - Provider request/response mapping.
+  - Error/status mapping.
+- Integration tests:
+  - Query loop with mocked provider streams.
+  - Tool call roundtrip flow.
+- Manual smoke:
+  - Interactive TUI session.
+  - `--print` + `--output-format json|stream-json`.
+
+## Deliverables
+
+- Provider abstraction merged with Anthropic parity.
+- OpenAI-compatible provider MVP.
+- Updated config/CLI docs and migration notes.
+- Test matrix for Anthropic + OpenAI-compatible.
+
+## Estimated Effort
+
+- Phase 0-1: 1-2 days
+- Phase 2: 1-2 days
+- Phase 3: 0.5-1 day
+- Total: roughly 3-5 engineering days (single contributor), assuming no large protocol surprises.
+

--- a/spec/INDEX.md
+++ b/spec/INDEX.md
@@ -23,6 +23,7 @@
 | 11 | [11_special_systems.md](11_special_systems.md) | 64 KB | Buddy/Tamagotchi, memdir, keybindings, skills, voice, plugins, migrations |
 | 12 | [12_constants_types.md](12_constants_types.md) | 83 KB | Every constant, type, OAuth config, system prompts, tool limits, beta headers |
 | 13 | [13_rust_codebase.md](13_rust_codebase.md) | 63 KB | Complete Rust rewrite: all 9 crates, 33 tools, query loop, TUI, bridge |
+| 14 | [14_multi_provider_plan.md](14_multi_provider_plan.md) | 9 KB | Step-by-step implementation plan for multi-provider model support in the Rust codebase |
 
 ---
 

--- a/src-rust/crates/api/src/lib.rs
+++ b/src-rust/crates/api/src/lib.rs
@@ -24,8 +24,18 @@ use tracing::{debug, warn};
 // Public re-exports
 // ---------------------------------------------------------------------------
 pub use client::AnthropicClient;
+pub use openai_compat::OpenAiCompatClient;
 pub use streaming::{StreamEvent, StreamHandler};
 pub use types::*;
+
+#[async_trait::async_trait]
+pub trait LlmClient: Send + Sync {
+    async fn create_message_stream(
+        &self,
+        request: CreateMessageRequest,
+        handler: Arc<dyn StreamHandler>,
+    ) -> Result<mpsc::Receiver<StreamEvent>, ClaudeError>;
+}
 
 // ---------------------------------------------------------------------------
 // request / response types
@@ -664,6 +674,372 @@ pub mod client {
                     None
                 }
             }
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl LlmClient for client::AnthropicClient {
+    async fn create_message_stream(
+        &self,
+        request: CreateMessageRequest,
+        handler: Arc<dyn StreamHandler>,
+    ) -> Result<mpsc::Receiver<StreamEvent>, ClaudeError> {
+        client::AnthropicClient::create_message_stream(self, request, handler).await
+    }
+}
+
+pub mod openai_compat {
+    use super::*;
+    use std::collections::{BTreeMap, HashMap};
+
+    /// OpenAI-compatible chat/completions streaming client.
+    pub struct OpenAiCompatClient {
+        http: reqwest::Client,
+        config: client::ClientConfig,
+    }
+
+    impl OpenAiCompatClient {
+        pub fn new(config: client::ClientConfig) -> anyhow::Result<Self> {
+            if config.api_key.is_empty() {
+                return Err(anyhow::anyhow!(
+                    "API key is required for openai_compat provider."
+                ));
+            }
+            let http = reqwest::Client::builder()
+                .timeout(config.request_timeout)
+                .build()?;
+            Ok(Self { http, config })
+        }
+
+        fn normalize_base(base: &str) -> String {
+            base.trim_end_matches('/').to_string()
+        }
+
+        fn system_to_string(system: Option<SystemPrompt>) -> Option<String> {
+            match system {
+                None => None,
+                Some(SystemPrompt::Text(t)) => Some(t),
+                Some(SystemPrompt::Blocks(blocks)) => {
+                    let mut s = String::new();
+                    for b in blocks {
+                        if !s.is_empty() {
+                            s.push_str("\n\n");
+                        }
+                        s.push_str(&b.text);
+                    }
+                    if s.trim().is_empty() { None } else { Some(s) }
+                }
+            }
+        }
+
+        fn map_messages(request: &CreateMessageRequest) -> Vec<Value> {
+            let mut out = Vec::new();
+            if let Some(system_text) = Self::system_to_string(request.system.clone()) {
+                out.push(serde_json::json!({ "role": "system", "content": system_text }));
+            }
+            for m in &request.messages {
+                let content = if let Some(s) = m.content.as_str() {
+                    Value::String(s.to_string())
+                } else {
+                    // Keep compatibility for non-text content blocks by passing JSON.
+                    Value::String(m.content.to_string())
+                };
+                out.push(serde_json::json!({
+                    "role": m.role,
+                    "content": content
+                }));
+            }
+            out
+        }
+
+        fn map_tools(request: &CreateMessageRequest) -> Option<Value> {
+            let tools = request.tools.as_ref()?;
+            let mapped: Vec<Value> = tools
+                .iter()
+                .map(|t| {
+                    serde_json::json!({
+                        "type": "function",
+                        "function": {
+                            "name": t.name,
+                            "description": t.description,
+                            "parameters": t.input_schema
+                        }
+                    })
+                })
+                .collect();
+            Some(Value::Array(mapped))
+        }
+
+        fn map_finish_reason(reason: Option<&str>) -> Option<String> {
+            match reason {
+                Some("tool_calls") => Some("tool_use".to_string()),
+                Some("length") => Some("max_tokens".to_string()),
+                Some("stop") => Some("end_turn".to_string()),
+                Some(v) => Some(v.to_string()),
+                None => None,
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl LlmClient for OpenAiCompatClient {
+        async fn create_message_stream(
+            &self,
+            request: CreateMessageRequest,
+            handler: Arc<dyn StreamHandler>,
+        ) -> Result<mpsc::Receiver<StreamEvent>, ClaudeError> {
+            let url = format!(
+                "{}/v1/chat/completions",
+                Self::normalize_base(&self.config.api_base)
+            );
+
+            let mut body = serde_json::json!({
+                "model": request.model,
+                "messages": Self::map_messages(&request),
+                "stream": true,
+                "max_tokens": request.max_tokens,
+            });
+            if let Some(temp) = request.temperature {
+                body["temperature"] = serde_json::json!(temp);
+            }
+            if let Some(top_p) = request.top_p {
+                body["top_p"] = serde_json::json!(top_p);
+            }
+            if let Some(stop) = request.stop_sequences.clone() {
+                body["stop"] = serde_json::json!(stop);
+            }
+            if let Some(tools) = Self::map_tools(&request) {
+                body["tools"] = tools;
+            }
+
+            let resp = self
+                .http
+                .post(&url)
+                .header("content-type", "application/json")
+                .header("accept", "text/event-stream")
+                .bearer_auth(&self.config.api_key)
+                .json(&body)
+                .send()
+                .await
+                .map_err(ClaudeError::Http)?;
+
+            if !resp.status().is_success() {
+                let status = resp.status().as_u16();
+                let text = resp.text().await.unwrap_or_default();
+                if status == 401 || status == 403 {
+                    return Err(ClaudeError::Auth(text));
+                }
+                if status == 429 {
+                    return Err(ClaudeError::RateLimit);
+                }
+                return Err(ClaudeError::ApiStatus {
+                    status,
+                    message: text,
+                });
+            }
+
+            let (tx, rx) = mpsc::channel(256);
+            tokio::spawn(async move {
+                use sse_parser::SseLineParser;
+
+                let mut parser = SseLineParser::new();
+                let mut byte_stream = resp.bytes_stream();
+                let mut leftover = String::new();
+                let mut started = false;
+                let mut text_block_index: Option<usize> = None;
+                let mut next_index: usize = 0;
+                let mut tool_blocks: HashMap<u64, (usize, String, String)> = HashMap::new();
+                let mut stop_reason: Option<String> = None;
+
+                while let Some(chunk_result) = byte_stream.next().await {
+                    let chunk = match chunk_result {
+                        Ok(c) => c,
+                        Err(e) => {
+                            let _ = tx.send(StreamEvent::Error {
+                                error_type: "stream_error".to_string(),
+                                message: e.to_string(),
+                            }).await;
+                            return;
+                        }
+                    };
+                    let text = String::from_utf8_lossy(&chunk);
+                    let combined = if leftover.is_empty() {
+                        text.to_string()
+                    } else {
+                        let mut s = std::mem::take(&mut leftover);
+                        s.push_str(&text);
+                        s
+                    };
+                    let mut lines: Vec<&str> = combined.split('\n').collect();
+                    if !combined.ends_with('\n') {
+                        leftover = lines.pop().unwrap_or("").to_string();
+                    }
+                    for line in lines {
+                        let line = line.trim_end_matches('\r');
+                        let Some(frame) = parser.feed_line(line) else { continue; };
+                        if frame.data.trim() == "[DONE]" {
+                            break;
+                        }
+
+                        let Ok(v) = serde_json::from_str::<Value>(&frame.data) else {
+                            continue;
+                        };
+                        if let Some(err) = v.get("error") {
+                            let error_type = err
+                                .get("type")
+                                .and_then(|x| x.as_str())
+                                .unwrap_or("api_error")
+                                .to_string();
+                            let message = err
+                                .get("message")
+                                .and_then(|x| x.as_str())
+                                .unwrap_or("Unknown provider error")
+                                .to_string();
+                            let evt = StreamEvent::Error { error_type, message };
+                            handler.on_event(&evt);
+                            let _ = tx.send(evt).await;
+                            let stop_evt = StreamEvent::MessageStop;
+                            handler.on_event(&stop_evt);
+                            let _ = tx.send(stop_evt).await;
+                            return;
+                        }
+                        if !started {
+                            let message_id = v.get("id").and_then(|x| x.as_str()).map(str::to_string);
+                            let message_model = v.get("model").and_then(|x| x.as_str()).map(str::to_string);
+                            let evt = StreamEvent::MessageStart {
+                                id: message_id.clone().unwrap_or_else(|| "openai-chat".to_string()),
+                                model: message_model.clone().unwrap_or_else(|| "openai".to_string()),
+                                usage: UsageInfo::default(),
+                            };
+                            handler.on_event(&evt);
+                            if tx.send(evt).await.is_err() { return; }
+                            started = true;
+                        }
+
+                        let choice = v.get("choices")
+                            .and_then(|c| c.as_array())
+                            .and_then(|arr| arr.first());
+                        let Some(choice) = choice else { continue; };
+                        let mut should_terminate = false;
+
+                        if let Some(reason) = choice.get("finish_reason").and_then(|r| r.as_str()) {
+                            stop_reason = Self::map_finish_reason(Some(reason));
+                            should_terminate = true;
+                        }
+                        let delta = choice.get("delta").cloned().unwrap_or(Value::Null);
+
+                        if let Some(content) = delta.get("content").and_then(|c| c.as_str()) {
+                            if !content.is_empty() {
+                                if text_block_index.is_none() {
+                                    let idx = next_index;
+                                    next_index += 1;
+                                    text_block_index = Some(idx);
+                                    let start_evt = StreamEvent::ContentBlockStart {
+                                        index: idx,
+                                        content_block: ContentBlock::Text { text: String::new() },
+                                    };
+                                    handler.on_event(&start_evt);
+                                    if tx.send(start_evt).await.is_err() { return; }
+                                }
+                                let idx = text_block_index.unwrap_or(0);
+                                let delta_evt = StreamEvent::ContentBlockDelta {
+                                    index: idx,
+                                    delta: streaming::ContentDelta::TextDelta { text: content.to_string() },
+                                };
+                                handler.on_event(&delta_evt);
+                                if tx.send(delta_evt).await.is_err() { return; }
+                            }
+                        }
+
+                        if let Some(tool_calls) = delta.get("tool_calls").and_then(|t| t.as_array()) {
+                            for tc in tool_calls {
+                                let tool_idx = tc.get("index").and_then(|x| x.as_u64()).unwrap_or(0);
+                                if !tool_blocks.contains_key(&tool_idx) {
+                                    let idx = next_index;
+                                    next_index += 1;
+                                    let id = tc.get("id")
+                                        .and_then(|x| x.as_str())
+                                        .map(str::to_string)
+                                        .unwrap_or_else(|| format!("tool_call_{}", tool_idx));
+                                    let name = tc.get("function")
+                                        .and_then(|f| f.get("name"))
+                                        .and_then(|x| x.as_str())
+                                        .map(str::to_string)
+                                        .unwrap_or_else(|| "tool".to_string());
+                                    let start_evt = StreamEvent::ContentBlockStart {
+                                        index: idx,
+                                        content_block: ContentBlock::ToolUse {
+                                            id: id.clone(),
+                                            name: name.clone(),
+                                            input: Value::Object(Default::default()),
+                                        },
+                                    };
+                                    handler.on_event(&start_evt);
+                                    if tx.send(start_evt).await.is_err() { return; }
+                                    tool_blocks.insert(tool_idx, (idx, id, name));
+                                }
+                                let entry = match tool_blocks.get_mut(&tool_idx) {
+                                    Some(e) => e,
+                                    None => continue,
+                                };
+
+                                if let Some(name) = tc.get("function")
+                                    .and_then(|f| f.get("name"))
+                                    .and_then(|x| x.as_str()) {
+                                    entry.2 = name.to_string();
+                                }
+                                if let Some(args) = tc.get("function")
+                                    .and_then(|f| f.get("arguments"))
+                                    .and_then(|x| x.as_str()) {
+                                    if !args.is_empty() {
+                                        let delta_evt = StreamEvent::ContentBlockDelta {
+                                            index: entry.0,
+                                            delta: streaming::ContentDelta::InputJsonDelta {
+                                                partial_json: args.to_string(),
+                                            },
+                                        };
+                                        handler.on_event(&delta_evt);
+                                        if tx.send(delta_evt).await.is_err() { return; }
+                                    }
+                                }
+                            }
+                        }
+                        if should_terminate {
+                            break;
+                        }
+                    }
+                }
+
+                if let Some(idx) = text_block_index {
+                    let stop_evt = StreamEvent::ContentBlockStop { index: idx };
+                    handler.on_event(&stop_evt);
+                    if tx.send(stop_evt).await.is_err() { return; }
+                }
+
+                let mut ordered_tool_blocks: BTreeMap<usize, ()> = BTreeMap::new();
+                for (idx, _, _) in tool_blocks.values() {
+                    ordered_tool_blocks.insert(*idx, ());
+                }
+                for idx in ordered_tool_blocks.keys() {
+                    let stop_evt = StreamEvent::ContentBlockStop { index: *idx };
+                    handler.on_event(&stop_evt);
+                    if tx.send(stop_evt).await.is_err() { return; }
+                }
+
+                let delta_evt = StreamEvent::MessageDelta {
+                    stop_reason: stop_reason.or_else(|| Some("end_turn".to_string())),
+                    usage: None,
+                };
+                handler.on_event(&delta_evt);
+                if tx.send(delta_evt).await.is_err() { return; }
+
+                let stop_evt = StreamEvent::MessageStop;
+                handler.on_event(&stop_evt);
+                let _ = tx.send(stop_evt).await;
+            });
+
+            Ok(rx)
         }
     }
 }

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -12,7 +12,7 @@ mod oauth_flow;
 
 use anyhow::Context;
 use cc_core::{
-    config::{Config, PermissionMode, Settings},
+    config::{Config, ModelProvider, PermissionMode, Settings},
     constants::{APP_VERSION, DEFAULT_MODEL},
     context::ContextBuilder,
     cost::CostTracker,
@@ -103,6 +103,10 @@ struct Cli {
     #[arg(short = 'm', long = "model", default_value = DEFAULT_MODEL)]
     model: String,
 
+    /// Model provider backend
+    #[arg(long = "provider", value_enum)]
+    provider: Option<CliProvider>,
+
     /// Permission mode
     #[arg(long = "permission-mode", value_enum, default_value_t = CliPermissionMode::Default)]
     permission_mode: CliPermissionMode,
@@ -189,6 +193,22 @@ enum CliOutputFormat {
     Json,
     #[value(name = "stream-json")]
     StreamJson,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+enum CliProvider {
+    Anthropic,
+    #[value(name = "openai-compat")]
+    OpenaiCompat,
+}
+
+impl From<CliProvider> for ModelProvider {
+    fn from(p: CliProvider) -> Self {
+        match p {
+            CliProvider::Anthropic => ModelProvider::Anthropic,
+            CliProvider::OpenaiCompat => ModelProvider::OpenaiCompat,
+        }
+    }
 }
 
 impl From<CliOutputFormat> for cc_core::config::OutputFormat {
@@ -312,6 +332,9 @@ async fn main() -> anyhow::Result<()> {
     if let Some(ref key) = cli.api_key {
         config.api_key = Some(key.clone());
     }
+    if let Some(provider) = cli.provider {
+        config.provider = provider.into();
+    }
     config.model = Some(cli.model.clone());
     if let Some(mt) = cli.max_tokens {
         config.max_tokens = Some(mt);
@@ -377,15 +400,22 @@ async fn main() -> anyhow::Result<()> {
             // No credential found — run interactive OAuth login (non-headless) or error.
             if is_headless {
                 anyhow::bail!(
-                    "No API key found. Set ANTHROPIC_API_KEY, use --api-key, or run `claude login`."
+                    "No API key found. Set provider key env var (e.g. ANTHROPIC_API_KEY/OPENAI_API_KEY), use --api-key, or configure settings."
                 );
             }
-            eprintln!("No authentication found. Starting login flow...");
-            let result = oauth_flow::run_oauth_login_flow(true)
-                .await
-                .context("Login failed")?;
-            println!("Login successful!");
-            (result.credential, result.use_bearer_auth)
+            if config.effective_provider() == ModelProvider::Anthropic {
+                eprintln!("No authentication found. Starting login flow...");
+                let result = oauth_flow::run_oauth_login_flow(true)
+                    .await
+                    .context("Login failed")?;
+                println!("Login successful!");
+                (result.credential, result.use_bearer_auth)
+            } else {
+                anyhow::bail!(
+                    "No API key found for provider {:?}. Set --api-key, OPENAI_API_KEY, or CLAUDE_CODE_API_KEY.",
+                    config.effective_provider()
+                );
+            }
         }
     };
 
@@ -395,10 +425,16 @@ async fn main() -> anyhow::Result<()> {
         use_bearer_auth,
         ..Default::default()
     };
-    let client = Arc::new(
-        cc_api::AnthropicClient::new(client_config)
-            .context("Failed to create API client")?,
-    );
+    let client: Arc<dyn cc_api::LlmClient + Send + Sync> = match config.effective_provider() {
+        ModelProvider::Anthropic => Arc::new(
+            cc_api::AnthropicClient::new(client_config)
+                .context("Failed to create Anthropic API client")?,
+        ),
+        ModelProvider::OpenaiCompat => Arc::new(
+            cc_api::OpenAiCompatClient::new(client_config)
+                .context("Failed to create OpenAI-compatible API client")?,
+        ),
+    };
 
     let bridge_config = resolve_bridge_config(&settings, &api_key, use_bearer_auth, is_headless);
     if let Some(cfg) = bridge_config.as_ref() {
@@ -563,7 +599,7 @@ async fn main() -> anyhow::Result<()> {
 
 async fn run_headless(
     cli: &Cli,
-    client: Arc<cc_api::AnthropicClient>,
+    client: Arc<dyn cc_api::LlmClient + Send + Sync>,
     tools: Arc<Vec<Box<dyn cc_tools::Tool>>>,
     tool_ctx: ToolContext,
     query_config: cc_query::QueryConfig,
@@ -746,7 +782,7 @@ async fn run_headless(
 
 async fn run_interactive(
     config: Config,
-    client: Arc<cc_api::AnthropicClient>,
+    client: Arc<dyn cc_api::LlmClient + Send + Sync>,
     tools: Arc<Vec<Box<dyn cc_tools::Tool>>>,
     tool_ctx: ToolContext,
     query_config: cc_query::QueryConfig,

--- a/src-rust/crates/commands/src/lib.rs
+++ b/src-rust/crates/commands/src/lib.rs
@@ -566,7 +566,7 @@ impl SlashCommand for ConfigCommand {
         if args.is_empty() || matches!(args, "show" | "get") {
             let json = serde_json::to_string_pretty(&ctx.config).unwrap_or_default();
             return CommandResult::Message(format!(
-                "Current configuration:\n{}\n\nUsage:\n  /config\n  /config set theme <default|dark|light>\n  /config set output-style <default|concise|explanatory|learning|formal|casual>\n  /config set model <model>\n  /config set permission-mode <default|accept-edits|bypass-permissions|plan>\n  /config unset <model|output-style>",
+                "Current configuration:\n{}\n\nUsage:\n  /config\n  /config set theme <default|dark|light>\n  /config set output-style <default|concise|explanatory|learning|formal|casual>\n  /config set model <model>\n  /config set provider <anthropic|openai-compat>\n  /config set permission-mode <default|accept-edits|bypass-permissions|plan>\n  /config unset <model|output-style>",
                 json
             ));
         }
@@ -581,6 +581,10 @@ impl SlashCommand for ConfigCommand {
                 "model" => CommandResult::Message(format!(
                     "model = {}",
                     ctx.config.effective_model()
+                )),
+                "provider" => CommandResult::Message(format!(
+                    "provider = {:?}",
+                    ctx.config.effective_provider()
                 )),
                 "permission-mode" | "permission_mode" => CommandResult::Message(format!(
                     "permission-mode = {:?}",
@@ -693,6 +697,30 @@ impl SlashCommand for ConfigCommand {
                 CommandResult::ConfigChangeMessage(
                     new_config,
                     format!("Model set to {}.", value),
+                )
+            }
+            "provider" => {
+                let provider = match value.trim().to_lowercase().as_str() {
+                    "anthropic" => cc_core::config::ModelProvider::Anthropic,
+                    "openai-compat" | "openai_compat" => {
+                        cc_core::config::ModelProvider::OpenaiCompat
+                    }
+                    _ => {
+                        return CommandResult::Error(
+                            "Provider must be one of: anthropic, openai-compat".to_string(),
+                        )
+                    }
+                };
+                let mut new_config = ctx.config.clone();
+                new_config.provider = provider.clone();
+                if let Err(err) = save_settings_mutation(|settings| {
+                    settings.config.provider = provider.clone();
+                }) {
+                    return CommandResult::Error(format!("Failed to save configuration: {}", err));
+                }
+                CommandResult::ConfigChangeMessage(
+                    new_config,
+                    format!("Provider set to {}.", value.trim().to_lowercase()),
                 )
             }
             "permission-mode" | "permission_mode" => {

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -413,6 +413,8 @@ pub mod config {
     /// Top-level configuration values, merged from CLI args + settings file + env.
     #[derive(Debug, Clone, Serialize, Deserialize, Default)]
     pub struct Config {
+        #[serde(default)]
+        pub provider: ModelProvider,
         pub api_key: Option<String>,
         pub model: Option<String>,
         pub max_tokens: Option<u32>,
@@ -438,6 +440,14 @@ pub mod config {
         /// Event hooks: map of event → list of hook commands.
         #[serde(default)]
         pub hooks: HashMap<HookEvent, Vec<HookEntry>>,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+    #[serde(rename_all = "snake_case")]
+    pub enum ModelProvider {
+        #[default]
+        Anthropic,
+        OpenaiCompat,
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -518,6 +528,11 @@ pub mod config {
     }
 
     impl Config {
+        /// Resolve the selected model provider.
+        pub fn effective_provider(&self) -> ModelProvider {
+            self.provider.clone()
+        }
+
         /// Resolve the effective model, falling back to the compile-time default.
         pub fn effective_model(&self) -> &str {
             self.model
@@ -558,11 +573,18 @@ pub mod config {
                 .filter(|prompt| !prompt.trim().is_empty())
         }
 
-        /// Resolve the API key from the config, then from `ANTHROPIC_API_KEY`.
+        /// Resolve the API key from config and provider-specific env vars.
         pub fn resolve_api_key(&self) -> Option<String> {
+            let generic = std::env::var("CLAUDE_CODE_API_KEY").ok();
+            let provider_key = match self.effective_provider() {
+                ModelProvider::Anthropic => std::env::var("ANTHROPIC_API_KEY").ok(),
+                ModelProvider::OpenaiCompat => std::env::var("OPENAI_API_KEY").ok(),
+            };
+
             self.api_key
                 .clone()
-                .or_else(|| std::env::var("ANTHROPIC_API_KEY").ok())
+                .or(generic)
+                .or(provider_key)
         }
 
         /// Async variant: also checks `~/.claude/oauth_tokens.json`.
@@ -574,6 +596,10 @@ pub mod config {
             // Highest priority: explicit api_key or env var
             if let Some(key) = self.resolve_api_key() {
                 return Some((key, false));
+            }
+            // Non-Anthropic providers currently support API-key auth only.
+            if self.effective_provider() != ModelProvider::Anthropic {
+                return None;
             }
             // Fall back to saved OAuth tokens
             let tokens = crate::oauth::OAuthTokens::load().await?;
@@ -632,10 +658,17 @@ pub mod config {
             }
         }
 
-        /// Resolve the API base URL, checking `ANTHROPIC_BASE_URL` first.
+        /// Resolve API base URL, checking generic and provider-specific env vars.
         pub fn resolve_api_base(&self) -> String {
-            std::env::var("ANTHROPIC_BASE_URL")
-                .unwrap_or_else(|_| crate::constants::ANTHROPIC_API_BASE.to_string())
+            if let Ok(base) = std::env::var("CLAUDE_CODE_API_BASE") {
+                return base;
+            }
+            match self.effective_provider() {
+                ModelProvider::Anthropic => std::env::var("ANTHROPIC_BASE_URL")
+                    .unwrap_or_else(|_| crate::constants::ANTHROPIC_API_BASE.to_string()),
+                ModelProvider::OpenaiCompat => std::env::var("OPENAI_BASE_URL")
+                    .unwrap_or_else(|_| crate::constants::OPENAI_COMPAT_API_BASE.to_string()),
+            }
         }
     }
 
@@ -720,6 +753,7 @@ pub mod constants {
 
     // API endpoints & headers
     pub const ANTHROPIC_API_BASE: &str = "https://api.anthropic.com";
+    pub const OPENAI_COMPAT_API_BASE: &str = "https://api.openai.com";
     pub const ANTHROPIC_API_VERSION: &str = "2023-06-01";
     pub const ANTHROPIC_BETA_HEADER: &str =
         "interleaved-thinking-2025-05-14,token-efficient-tools-2025-02-19,files-api-2025-04-14";

--- a/src-rust/crates/query/src/agent_tool.rs
+++ b/src-rust/crates/query/src/agent_tool.rs
@@ -12,6 +12,7 @@
 use async_trait::async_trait;
 use cc_api::client::ClientConfig;
 use cc_api::AnthropicClient;
+use cc_api::LlmClient;
 use cc_core::types::Message;
 use cc_tools::{PermissionLevel, Tool, ToolContext, ToolResult};
 use serde::Deserialize;
@@ -118,7 +119,7 @@ impl Tool for AgentTool {
         };
 
         // Dedicated Anthropic client for the sub-agent.
-        let client = match AnthropicClient::new(ClientConfig {
+        let client: Arc<dyn LlmClient + Send + Sync> = match AnthropicClient::new(ClientConfig {
             api_key,
             ..Default::default()
         }) {

--- a/src-rust/crates/query/src/compact.rs
+++ b/src-rust/crates/query/src/compact.rs
@@ -132,7 +132,7 @@ pub fn should_auto_compact(input_tokens: u64, model: &str, state: &AutoCompactSt
 /// new conversation consisting of a single summary message followed by
 /// `messages[split_at..]`.
 async fn summarise_head(
-    client: &cc_api::AnthropicClient,
+    client: &(dyn cc_api::LlmClient + Send + Sync),
     messages: &[Message],
     split_at: usize,
     model: &str,
@@ -225,7 +225,7 @@ async fn summarise_head(
 /// Compact `messages` in-place, replacing the head with a summary.
 /// Returns the new messages vector on success.
 pub async fn compact_conversation(
-    client: &cc_api::AnthropicClient,
+    client: &(dyn cc_api::LlmClient + Send + Sync),
     messages: &[Message],
     model: &str,
 ) -> Result<Vec<Message>, ClaudeError> {
@@ -255,7 +255,7 @@ pub async fn compact_conversation(
 /// Auto-compact `messages` if needed.  Updates `state` in place.
 /// Returns `Some(new_messages)` if compaction ran, `None` otherwise.
 pub async fn auto_compact_if_needed(
-    client: &cc_api::AnthropicClient,
+    client: &(dyn cc_api::LlmClient + Send + Sync),
     messages: &[Message],
     input_tokens: u64,
     model: &str,

--- a/src-rust/crates/query/src/cron_scheduler.rs
+++ b/src-rust/crates/query/src/cron_scheduler.rs
@@ -23,7 +23,7 @@ use tracing::{debug, error, info};
 /// Returns immediately; the scheduler runs as a detached tokio task.
 /// Call `cancel.cancel()` to stop it gracefully.
 pub fn start_cron_scheduler(
-    client: Arc<cc_api::AnthropicClient>,
+    client: Arc<dyn cc_api::LlmClient + Send + Sync>,
     tools: Arc<Vec<Box<dyn Tool>>>,
     tool_ctx: ToolContext,
     query_config: QueryConfig,
@@ -35,7 +35,7 @@ pub fn start_cron_scheduler(
 }
 
 async fn run_scheduler_loop(
-    client: Arc<cc_api::AnthropicClient>,
+    client: Arc<dyn cc_api::LlmClient + Send + Sync>,
     tools: Arc<Vec<Box<dyn Tool>>>,
     tool_ctx: ToolContext,
     query_config: QueryConfig,

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -125,7 +125,7 @@ pub enum QueryEvent {
 /// This sends the conversation to the API, handles tool calls in a loop, and
 /// returns when the model issues an end_turn or an error/limit is hit.
 pub async fn run_query_loop(
-    client: &cc_api::AnthropicClient,
+    client: &(dyn cc_api::LlmClient + Send + Sync),
     messages: &mut Vec<Message>,
     tools: &[Box<dyn Tool>],
     tool_ctx: &ToolContext,
@@ -634,7 +634,7 @@ impl StreamHandler for ChannelStreamHandler {
 
 /// Run a single (non-agentic) query – no tool loop, just one API call.
 pub async fn run_single_query(
-    client: &cc_api::AnthropicClient,
+    client: &(dyn cc_api::LlmClient + Send + Sync),
     messages: Vec<Message>,
     config: &QueryConfig,
 ) -> Result<Message, ClaudeError> {


### PR DESCRIPTION
## Summary

- Introduce a provider abstraction in `cc-api` via a unified `LlmClient` trait, decoupling the codebase from a hard dependency on `AnthropicClient`.
- Add an `openai-compat` provider (first iteration): stream chat over OpenAI-compatible APIs and map stream chunks into the existing query/tool loop.
- Extend configuration and CLI:
  - `Config` gains a `provider` field (default remains `anthropic`).
  - CLI adds `--provider`.
  - `/config` can get/set `provider`.
- Improve compatibility and robustness for OpenAI-style streaming:
  - Provider-aware resolution of API keys and base URLs (`OPENAI_API_KEY`, `OPENAI_BASE_URL`, etc.).
  - Handle `error` frames and `finish_reason` so the UI does not hang on `Streaming…`.
- Add `scripts/start-dashscope.sh` for quick startup against Alibaba Cloud DashScope compatible mode.

## Why

The Rust CLI was tightly coupled to the Anthropic Messages API. This change establishes a stable boundary for multiple backends while keeping Anthropic as the default and validating the path with an OpenAI-compatible implementation.

## Test Plan

- [x] `cargo check -p claude-code`
- [x] Anthropic path still compiles and integrates with the refactored types
- [x] OpenAI-compatible path: basic end-to-end request
- [x] DashScope compatible mode: `./scripts/start-dashscope.sh -m qwen-plus --print "你好"` succeeds
- [x] Streaming edge cases: provider `error` and `finish_reason` terminate the stream correctly

## Notes

- `openai-compat` is a first pass; follow-ups can refine error semantics, model discovery, and deeper tool-call parity per gateway.