### PR TITLE
fix question mark always invoking help

### DIFF
--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -443,7 +443,7 @@ impl App {
                 self.show_help = !self.show_help;
                 self.help_overlay.toggle();
             }
-            KeyCode::Char('?') if key.modifiers.is_empty() && !self.is_streaming => {
+            KeyCode::Char('?') if key.modifiers.is_empty() && !self.is_streaming && self.input.is_empty() => {
                 self.show_help = !self.show_help;
                 self.help_overlay.toggle();
             }


### PR DESCRIPTION
Now "?" only opens help when the input is empty.
If you're typing a sentence, "?" is inserted as a normal character. F1 still toggles help unconditionally.