### PR TITLE
fix: respect --provider and -m flags from command line

### DIFF
--- a/src-rust/crates/api/src/providers/openai_compat.rs
+++ b/src-rust/crates/api/src/providers/openai_compat.rs
@@ -125,6 +125,12 @@ impl OpenAiCompatProvider {
         self
     }
 
+    /// Override the base URL (e.g. from a user-supplied --api-base flag).
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = base_url.into();
+        self
+    }
+
     // -----------------------------------------------------------------------
     // Internal helpers
     // -----------------------------------------------------------------------

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -33,7 +33,7 @@ pub const ISSUES_EXPLAINER: &str = env!("ISSUES_EXPLAINER");
 use anyhow::Context;
 use claurst_core::{
     config::{Config, PermissionMode, Settings},
-    constants::{APP_VERSION, DEFAULT_MODEL},
+    constants::APP_VERSION,
     context::ContextBuilder,
     cost::CostTracker,
     permissions::{AutoPermissionHandler, InteractivePermissionHandler},
@@ -121,8 +121,8 @@ struct Cli {
     print: bool,
 
     /// Model to use
-    #[arg(short = 'm', long = "model", default_value = DEFAULT_MODEL)]
-    model: String,
+    #[arg(short = 'm', long = "model")]
+    model: Option<String>,
 
     /// Permission mode
     #[arg(long = "permission-mode", value_enum, default_value_t = CliPermissionMode::Default)]
@@ -454,7 +454,9 @@ async fn main() -> anyhow::Result<()> {
     if let Some(ref key) = cli.api_key {
         config.api_key = Some(key.clone());
     }
-    config.model = Some(cli.model.clone());
+    if let Some(ref m) = cli.model {
+        config.model = Some(m.clone());
+    }
     if let Some(mt) = cli.max_tokens {
         config.max_tokens = Some(mt);
     }
@@ -789,6 +791,8 @@ async fn main() -> anyhow::Result<()> {
         )
         .await
     } else {
+        let has_credentials = !api_key.is_empty()
+            || config.provider.as_deref().is_some_and(|p| p != "anthropic");
         run_interactive(
             config,
             settings,
@@ -799,7 +803,7 @@ async fn main() -> anyhow::Result<()> {
             cost_tracker,
             cli.resume,
             bridge_config,
-            !api_key.is_empty(),
+            has_credentials,
             model_registry,
         )
         .await

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -925,9 +925,39 @@ pub async fn run_query_loop(
 
             if provider_id_str != "anthropic" {
                 let pid = claurst_core::provider_id::ProviderId::new(&provider_id_str);
+
                 // Try registry first; if not found, build provider dynamically
                 // from auth_store (handles keys added at runtime via /connect).
-                let registry_provider = registry.get(&pid).cloned();
+                let mut registry_provider = registry.get(&pid).cloned();
+
+                // If the user supplied --api-base for a local provider (Ollama, LM Studio,
+                // llama.cpp), rebuild the provider with the override URL.  These providers
+                // are always pre-registered with a hardcoded default URL, so without this
+                // the --api-base flag would be silently ignored.
+                if let Some(override_base) = tool_ctx.config.provider_configs
+                    .get(&provider_id_str)
+                    .and_then(|pc| pc.api_base.as_deref())
+                {
+                    use claurst_api::providers::openai_compat_providers;
+                    let base_url = format!("{}/v1", override_base.trim_end_matches('/'));
+                    let overridden: Option<std::sync::Arc<dyn claurst_api::LlmProvider>> =
+                        match provider_id_str.as_str() {
+                            "ollama" => Some(std::sync::Arc::new(
+                                openai_compat_providers::ollama().with_base_url(base_url),
+                            )),
+                            "lmstudio" | "lm-studio" => Some(std::sync::Arc::new(
+                                openai_compat_providers::lm_studio().with_base_url(base_url),
+                            )),
+                            "llamacpp" | "llama-cpp" => Some(std::sync::Arc::new(
+                                openai_compat_providers::llama_cpp().with_base_url(base_url),
+                            )),
+                            _ => None,
+                        };
+                    if overridden.is_some() {
+                        registry_provider = overridden;
+                    }
+                }
+
                 let dynamic_provider: Option<std::sync::Arc<dyn claurst_api::LlmProvider>> = if registry_provider.is_none() {
                     let auth_store = claurst_core::AuthStore::load();
                     if let Some(key) = auth_store.api_key_for(&provider_id_str) {


### PR DESCRIPTION
## Summary

- `--model` / `-m` was declared with `default_value = DEFAULT_MODEL`, so clap always populated the field even when the flag wasn't passed. Changed to `Option<String>` so the model is only applied when explicitly specified.
- `has_credentials` (which controls the "No provider configured" warning in the TUI) was keyed only on the Anthropic API key. Local providers (Ollama, LM Studio, llama.cpp) don't need a key, so the warning was always shown when using them. Fixed to also treat any non-Anthropic provider selection as having credentials.
- `--api-base` was silently ignored for local providers because they are pre-registered at startup with hardcoded URLs. Added logic in the query loop to rebuild the provider with the user-supplied base URL when `provider_configs` contains an `api_base` override.