### PR TITLE
fix: do not trigger help overlay when typing '?' in the prompt

### DIFF
--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -2860,7 +2860,7 @@ impl App {
                 self.show_help = !self.show_help;
                 self.help_overlay.toggle();
             }
-            KeyCode::Char('?') if key.modifiers.is_empty() && !self.is_streaming => {
+            KeyCode::Char('?') if key.modifiers.is_empty() && !self.is_streaming && self.prompt_input.text.is_empty() => {
                 self.show_help = !self.show_help;
                 self.help_overlay.toggle();
             }


### PR DESCRIPTION
## Summary

The `?` key handler lacked a guard for when the user was actively typing in the prompt input. Added a check for `self.prompt_input.text.is_empty()` so the help overlay only opens when the prompt is empty, not mid-input.