### PR TITLE
fix: make nix dependency Unix-only for Windows compilation

### DIFF
--- a/src-rust/crates/cli/Cargo.toml
+++ b/src-rust/crates/cli/Cargo.toml
@@ -34,11 +34,13 @@ url = { workspace = true }
 crossterm = { workspace = true }
 parking_lot = { workspace = true }
 dirs = { workspace = true }
-nix = { workspace = true }
 base64 = "0.22"
 sha2 = "0.10"
 open = "5"
 urlencoding = "2"
+
+[target.'cfg(unix)'.dependencies]
+nix = { workspace = true }
 
 [build-dependencies]
 chrono = { workspace = true }


### PR DESCRIPTION
## Summary
- Moves the `nix` crate dependency in `crates/cli/Cargo.toml` from unconditional `[dependencies]` to `[target.'cfg(unix)'.dependencies]`
- The code using `nix` in `main.rs:470-475` is already gated behind `#[cfg(unix)]`, but the dep itself was unconditional, which prevents `cargo build` on Windows since `nix` is a Unix-only crate
- `crates/tools/Cargo.toml` already had this correct — only `crates/cli` needed the fix

One-line change, no functional impact on Unix.

## Test plan
- [x] Full workspace `cargo build` succeeds on Windows 10 (previously failed)
- [x] `#[cfg(unix)]` root-detection block in main.rs unchanged
- [ ] Verify Linux/macOS CI still passes (no functional change on Unix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)