### PR TITLE
Fix ChatGPT Codex provider integration

### DIFF
--- a/src-rust/crates/api/src/providers/codex.rs
+++ b/src-rust/crates/api/src/providers/codex.rs
@@ -24,7 +24,7 @@ use claurst_core::codex_oauth::{
 use claurst_core::oauth_config::{get_codex_tokens, save_codex_tokens, CodexTokens};
 use claurst_core::provider_id::{ModelId, ProviderId};
 use claurst_core::types::UsageInfo;
-use futures::Stream;
+use futures::{Stream, StreamExt};
 use serde_json::{json, Value};
 use tracing::{debug, warn};
 
@@ -181,9 +181,7 @@ impl CodexProvider {
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 
-        let expires_in = json_val
-            .get("expires_in")
-            .and_then(|v| v.as_u64());
+        let expires_in = json_val.get("expires_in").and_then(|v| v.as_u64());
 
         let new_expires_at = expires_in.map(|secs| {
             SystemTime::now()
@@ -241,10 +239,23 @@ impl CodexProvider {
         self.tokens.lock().unwrap().account_id.clone()
     }
 
+    fn system_prompt_to_text(request: &ProviderRequest) -> String {
+        match request.system_prompt.as_ref() {
+            Some(crate::provider_types::SystemPrompt::Text(text)) => text.clone(),
+            Some(crate::provider_types::SystemPrompt::Blocks(blocks)) => blocks
+                .iter()
+                .map(|b| b.text.as_str())
+                .collect::<Vec<_>>()
+                .join("\n"),
+            None => String::new(),
+        }
+    }
+
     /// Build the Responses-API request body for Codex.
     fn build_responses_body(request: &ProviderRequest) -> Value {
         // Re-use the same message translation that the Copilot provider uses.
         let input = CopilotProvider::to_responses_input_pub(request);
+        let instructions = Self::system_prompt_to_text(request);
 
         let tools: Vec<Value> = request
             .tools
@@ -263,7 +274,7 @@ impl CodexProvider {
         let mut body = json!({
             "model": request.model,
             "input": input,
-            "max_output_tokens": request.max_tokens,
+            "instructions": instructions,
             "store": false,
         });
 
@@ -272,6 +283,72 @@ impl CodexProvider {
         }
 
         body
+    }
+
+    fn extract_stream_error_message(json_val: &Value) -> String {
+        json_val
+            .pointer("/error/message")
+            .and_then(|value| value.as_str())
+            .or_else(|| {
+                json_val
+                    .pointer("/response/error/message")
+                    .and_then(|value| value.as_str())
+            })
+            .or_else(|| {
+                json_val
+                    .pointer("/message")
+                    .and_then(|value| value.as_str())
+            })
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| json_val.to_string())
+    }
+
+    fn parse_stream_frame(
+        provider_id: &ProviderId,
+        event_name: &str,
+        data: &str,
+    ) -> Result<Option<ProviderResponse>, ProviderError> {
+        let trimmed = data.trim();
+        if trimmed.is_empty() || trimmed == "[DONE]" {
+            return Ok(None);
+        }
+
+        let json_val: Value =
+            serde_json::from_str(trimmed).map_err(|e| ProviderError::StreamError {
+                provider: provider_id.clone(),
+                message: format!("Failed to parse Codex stream JSON: {}", e),
+                partial_response: Some(trimmed.to_string()),
+            })?;
+
+        let effective_event = if event_name.is_empty() {
+            json_val
+                .get("type")
+                .and_then(|value| value.as_str())
+                .unwrap_or("")
+        } else {
+            event_name
+        };
+
+        match effective_event {
+            "response.completed" => {
+                let response_json = json_val.get("response").unwrap_or(&json_val);
+                let response =
+                    Self::parse_responses_response(provider_id, response_json).map_err(|e| {
+                        ProviderError::StreamError {
+                            provider: provider_id.clone(),
+                            message: format!("Failed to parse Codex completed event: {}", e),
+                            partial_response: Some(trimmed.to_string()),
+                        }
+                    })?;
+                Ok(Some(response))
+            }
+            "response.failed" | "response.error" | "error" => Err(ProviderError::StreamError {
+                provider: provider_id.clone(),
+                message: Self::extract_stream_error_message(&json_val),
+                partial_response: Some(trimmed.to_string()),
+            }),
+            _ => Ok(None),
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -324,7 +401,49 @@ impl CodexProvider {
             body: Some(text.clone()),
         })?;
 
-        self.parse_responses_response(&json_val)
+        Self::parse_responses_response(&self.id, &json_val)
+    }
+
+    async fn send_responses_streaming_request(
+        &self,
+        request: &ProviderRequest,
+    ) -> Result<reqwest::Response, ProviderError> {
+        let token = self.access_token().await?;
+        let account_id = self.account_id();
+
+        let mut body = Self::build_responses_body(request);
+        body["stream"] = json!(true);
+
+        let builder = self
+            .http_client
+            .post(CODEX_API_ENDPOINT)
+            .header("Content-Type", "application/json")
+            .header("Accept", "text/event-stream");
+        let builder = self.codex_headers(builder, &token, account_id.as_deref());
+
+        let resp = builder
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| ProviderError::Other {
+                provider: self.id.clone(),
+                message: format!("HTTP request failed: {}", e),
+                status: None,
+                body: None,
+            })?;
+
+        let status = resp.status().as_u16();
+        if !(200..300).contains(&(status as usize)) {
+            let text = resp.text().await.map_err(|e| ProviderError::Other {
+                provider: self.id.clone(),
+                message: format!("Failed to read response body: {}", e),
+                status: Some(status),
+                body: None,
+            })?;
+            return Err(parse_error_response(status, &text, &self.id));
+        }
+
+        Ok(resp)
     }
 
     // -----------------------------------------------------------------------
@@ -332,7 +451,7 @@ impl CodexProvider {
     // -----------------------------------------------------------------------
 
     fn parse_responses_response(
-        &self,
+        provider_id: &ProviderId,
         json_val: &Value,
     ) -> Result<ProviderResponse, ProviderError> {
         use claurst_core::types::ContentBlock;
@@ -352,7 +471,7 @@ impl CodexProvider {
             .get("output")
             .and_then(|v| v.as_array())
             .ok_or_else(|| ProviderError::Other {
-                provider: self.id.clone(),
+                provider: provider_id.clone(),
                 message: "No output in Codex Responses API response".to_string(),
                 status: None,
                 body: Some(json_val.to_string()),
@@ -368,9 +487,7 @@ impl CodexProvider {
                         for part in parts {
                             match part.get("type").and_then(|v| v.as_str()) {
                                 Some("output_text") | Some("text") => {
-                                    if let Some(text) =
-                                        part.get("text").and_then(|v| v.as_str())
-                                    {
+                                    if let Some(text) = part.get("text").and_then(|v| v.as_str()) {
                                         if !text.is_empty() {
                                             content.push(ContentBlock::Text {
                                                 text: text.to_string(),
@@ -453,7 +570,13 @@ impl CodexProvider {
             }
         };
 
-        Ok(ProviderResponse { id, content, stop_reason, usage, model })
+        Ok(ProviderResponse {
+            id,
+            content,
+            stop_reason,
+            usage,
+            model,
+        })
     }
 
     // -----------------------------------------------------------------------
@@ -461,7 +584,6 @@ impl CodexProvider {
     // -----------------------------------------------------------------------
 
     fn stream_synthetic_response(
-        &self,
         response: ProviderResponse,
     ) -> Pin<Box<dyn Stream<Item = Result<StreamEvent, ProviderError>> + Send>> {
         use claurst_core::types::ContentBlock;
@@ -558,8 +680,335 @@ impl LlmProvider for CodexProvider {
         request: ProviderRequest,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamEvent, ProviderError>> + Send>>, ProviderError>
     {
-        let response = self.send_responses_request(&request).await?;
-        Ok(self.stream_synthetic_response(response))
+        let resp = self.send_responses_streaming_request(&request).await?;
+        let provider_id = self.id.clone();
+
+        let s = stream! {
+            let mut byte_stream = resp.bytes_stream();
+            let mut leftover = String::new();
+            let mut current_event = String::new();
+            let mut current_data: Vec<String> = Vec::new();
+            let mut message_started = false;
+            let mut message_id = String::from("unknown");
+            let mut model_name = String::from(DEFAULT_CODEX_MODEL);
+            let mut saw_tool_call = false;
+            let mut open_blocks: std::collections::HashSet<usize> = std::collections::HashSet::new();
+
+            'outer: while let Some(chunk_result) = byte_stream.next().await {
+                let chunk = match chunk_result {
+                    Ok(chunk) => chunk,
+                    Err(e) => {
+                        yield Err(ProviderError::StreamError {
+                            provider: provider_id.clone(),
+                            message: format!("Stream read error: {}", e),
+                            partial_response: None,
+                        });
+                        return;
+                    }
+                };
+
+                let text = String::from_utf8_lossy(&chunk);
+                let combined = if leftover.is_empty() {
+                    text.to_string()
+                } else {
+                    let mut s = std::mem::take(&mut leftover);
+                    s.push_str(&text);
+                    s
+                };
+
+                let mut lines: Vec<&str> = combined.split('\n').collect();
+                if !combined.ends_with('\n') {
+                    leftover = lines.pop().unwrap_or("").to_string();
+                }
+
+                for raw_line in lines {
+                    let line = raw_line.trim_end_matches('\r');
+
+                    if line.is_empty() {
+                        if current_data.is_empty() {
+                            current_event.clear();
+                            continue;
+                        }
+
+                        let data = current_data.join("\n");
+                        current_data.clear();
+                        let trimmed = data.trim();
+                        if trimmed.is_empty() || trimmed == "[DONE]" {
+                            current_event.clear();
+                            continue;
+                        }
+
+                        let json_val: Value = match serde_json::from_str(trimmed) {
+                            Ok(value) => value,
+                            Err(e) => {
+                                yield Err(ProviderError::StreamError {
+                                    provider: provider_id.clone(),
+                                    message: format!("Failed to parse Codex stream JSON: {}", e),
+                                    partial_response: Some(trimmed.to_string()),
+                                });
+                                return;
+                            }
+                        };
+
+                        let event_name = if current_event.is_empty() {
+                            json_val
+                                .get("type")
+                                .and_then(|value| value.as_str())
+                                .unwrap_or("")
+                                .to_string()
+                        } else {
+                            current_event.clone()
+                        };
+
+                        match event_name.as_str() {
+                            "response.created" | "response.in_progress" => {
+                                if let Some(response) = json_val.get("response") {
+                                    if let Some(id) = response.get("id").and_then(|value| value.as_str()) {
+                                        message_id = id.to_string();
+                                    }
+                                    if let Some(model) = response.get("model").and_then(|value| value.as_str()) {
+                                        model_name = model.to_string();
+                                    }
+                                    if !message_started {
+                                        yield Ok(StreamEvent::MessageStart {
+                                            id: message_id.clone(),
+                                            model: model_name.clone(),
+                                            usage: UsageInfo::default(),
+                                        });
+                                        message_started = true;
+                                    }
+                                }
+                            }
+                            "response.output_item.added" => {
+                                let output_index = json_val
+                                    .get("output_index")
+                                    .and_then(|value| value.as_u64())
+                                    .unwrap_or(0) as usize;
+                                if let Some(item) = json_val.get("item") {
+                                    match item.get("type").and_then(|value| value.as_str()) {
+                                        Some("message") => {
+                                            if let Some(id) = item.get("id").and_then(|value| value.as_str()) {
+                                                message_id = id.to_string();
+                                            }
+                                            if !message_started {
+                                                yield Ok(StreamEvent::MessageStart {
+                                                    id: message_id.clone(),
+                                                    model: model_name.clone(),
+                                                    usage: UsageInfo::default(),
+                                                });
+                                                message_started = true;
+                                            }
+                                        }
+                                        Some("function_call") => {
+                                            saw_tool_call = true;
+                                            let call_id = item
+                                                .get("call_id")
+                                                .or_else(|| item.get("id"))
+                                                .and_then(|value| value.as_str())
+                                                .unwrap_or("")
+                                                .to_string();
+                                            let name = item
+                                                .get("name")
+                                                .and_then(|value| value.as_str())
+                                                .unwrap_or("")
+                                                .to_string();
+                                            if open_blocks.insert(output_index) {
+                                                yield Ok(StreamEvent::ContentBlockStart {
+                                                    index: output_index,
+                                                    content_block: claurst_core::types::ContentBlock::ToolUse {
+                                                        id: call_id,
+                                                        name,
+                                                        input: json!({}),
+                                                    },
+                                                });
+                                            }
+                                        }
+                                        _ => {}
+                                    }
+                                }
+                            }
+                            "response.content_part.added" => {
+                                let output_index = json_val
+                                    .get("output_index")
+                                    .and_then(|value| value.as_u64())
+                                    .unwrap_or(0) as usize;
+                                if let Some(part) = json_val.get("part") {
+                                    if matches!(part.get("type").and_then(|value| value.as_str()), Some("output_text") | Some("text")) {
+                                        if !message_started {
+                                            yield Ok(StreamEvent::MessageStart {
+                                                id: message_id.clone(),
+                                                model: model_name.clone(),
+                                                usage: UsageInfo::default(),
+                                            });
+                                            message_started = true;
+                                        }
+                                        if open_blocks.insert(output_index) {
+                                            yield Ok(StreamEvent::ContentBlockStart {
+                                                index: output_index,
+                                                content_block: claurst_core::types::ContentBlock::Text {
+                                                    text: String::new(),
+                                                },
+                                            });
+                                        }
+                                    }
+                                }
+                            }
+                            "response.output_text.delta" => {
+                                let output_index = json_val
+                                    .get("output_index")
+                                    .and_then(|value| value.as_u64())
+                                    .unwrap_or(0) as usize;
+                                let delta = json_val
+                                    .get("delta")
+                                    .and_then(|value| value.as_str())
+                                    .unwrap_or("");
+                                if !message_started {
+                                    yield Ok(StreamEvent::MessageStart {
+                                        id: message_id.clone(),
+                                        model: model_name.clone(),
+                                        usage: UsageInfo::default(),
+                                    });
+                                    message_started = true;
+                                }
+                                if open_blocks.insert(output_index) {
+                                    yield Ok(StreamEvent::ContentBlockStart {
+                                        index: output_index,
+                                        content_block: claurst_core::types::ContentBlock::Text {
+                                            text: String::new(),
+                                        },
+                                    });
+                                }
+                                if !delta.is_empty() {
+                                    yield Ok(StreamEvent::TextDelta {
+                                        index: output_index,
+                                        text: delta.to_string(),
+                                    });
+                                }
+                            }
+                            "response.function_call_arguments.delta" => {
+                                let output_index = json_val
+                                    .get("output_index")
+                                    .and_then(|value| value.as_u64())
+                                    .unwrap_or(0) as usize;
+                                let delta = json_val
+                                    .get("delta")
+                                    .and_then(|value| value.as_str())
+                                    .unwrap_or("");
+                                if !delta.is_empty() {
+                                    yield Ok(StreamEvent::InputJsonDelta {
+                                        index: output_index,
+                                        partial_json: delta.to_string(),
+                                    });
+                                }
+                            }
+                            "response.output_item.done" => {
+                                let output_index = json_val
+                                    .get("output_index")
+                                    .and_then(|value| value.as_u64())
+                                    .unwrap_or(0) as usize;
+                                if open_blocks.remove(&output_index) {
+                                    yield Ok(StreamEvent::ContentBlockStop { index: output_index });
+                                }
+                            }
+                            "response.completed" => {
+                                if let Some(response) = json_val.get("response") {
+                                    if let Some(id) = response.get("id").and_then(|value| value.as_str()) {
+                                        message_id = id.to_string();
+                                    }
+                                    if let Some(model) = response.get("model").and_then(|value| value.as_str()) {
+                                        model_name = model.to_string();
+                                    }
+
+                                    if !message_started {
+                                        yield Ok(StreamEvent::MessageStart {
+                                            id: message_id.clone(),
+                                            model: model_name.clone(),
+                                            usage: UsageInfo::default(),
+                                        });
+                                        message_started = true;
+                                    }
+
+                                    let mut remaining: Vec<usize> = open_blocks.drain().collect();
+                                    remaining.sort_unstable();
+                                    for index in remaining {
+                                        yield Ok(StreamEvent::ContentBlockStop { index });
+                                    }
+
+                                    let usage_json = response.get("usage");
+                                    let usage = UsageInfo {
+                                        input_tokens: usage_json
+                                            .and_then(|value| value.get("input_tokens"))
+                                            .and_then(|value| value.as_u64())
+                                            .unwrap_or(0),
+                                        output_tokens: usage_json
+                                            .and_then(|value| value.get("output_tokens"))
+                                            .and_then(|value| value.as_u64())
+                                            .unwrap_or(0),
+                                        cache_creation_input_tokens: 0,
+                                        cache_read_input_tokens: usage_json
+                                            .and_then(|value| value.get("input_tokens_details"))
+                                            .and_then(|value| value.get("cached_tokens"))
+                                            .and_then(|value| value.as_u64())
+                                            .unwrap_or(0),
+                                    };
+
+                                    let stop_reason = if saw_tool_call {
+                                        StopReason::ToolUse
+                                    } else {
+                                        match response
+                                            .get("incomplete_details")
+                                            .and_then(|value| value.get("reason"))
+                                            .and_then(|value| value.as_str())
+                                        {
+                                            Some("max_output_tokens") => StopReason::MaxTokens,
+                                            Some("content_filter") => StopReason::ContentFiltered,
+                                            Some(other) if !other.is_empty() => StopReason::Other(other.to_string()),
+                                            _ => StopReason::EndTurn,
+                                        }
+                                    };
+
+                                    yield Ok(StreamEvent::MessageDelta {
+                                        stop_reason: Some(stop_reason),
+                                        usage: Some(usage),
+                                    });
+                                    yield Ok(StreamEvent::MessageStop);
+                                    return;
+                                }
+                            }
+                            "response.failed" | "response.error" | "error" => {
+                                yield Err(ProviderError::StreamError {
+                                    provider: provider_id.clone(),
+                                    message: Self::extract_stream_error_message(&json_val),
+                                    partial_response: Some(trimmed.to_string()),
+                                });
+                                return;
+                            }
+                            _ => {}
+                        }
+
+                        current_event.clear();
+                        continue;
+                    }
+
+                    if let Some(rest) = line.strip_prefix("event:") {
+                        current_event = rest.trim().to_string();
+                        continue;
+                    }
+
+                    if let Some(rest) = line.strip_prefix("data:") {
+                        current_data.push(rest.trim_start().to_string());
+                    }
+                }
+            }
+
+            yield Err(ProviderError::StreamError {
+                provider: provider_id,
+                message: "Codex stream ended before response.completed".to_string(),
+                partial_response: None,
+            });
+        };
+
+        Ok(Box::pin(s))
     }
 
     async fn list_models(&self) -> Result<Vec<ModelInfo>, ProviderError> {

--- a/src-rust/crates/api/src/registry.rs
+++ b/src-rust/crates/api/src/registry.rs
@@ -34,7 +34,7 @@ fn provider_from_key(provider_id: &str, key: String) -> Option<Arc<dyn LlmProvid
         "openai" => Some(Arc::new(OpenAiProvider::new(key))),
         "google" => Some(Arc::new(GoogleProvider::new(key))),
         "github-copilot" => Some(Arc::new(CopilotProvider::new(key))),
-        "codex" => {
+        "codex" | "openai-codex" => {
             // The Codex provider is OAuth-based; the `key` field is not used.
             // Load from the stored token file instead.
             CodexProvider::from_stored().map(|p| Arc::new(p) as Arc<dyn LlmProvider>)
@@ -84,6 +84,9 @@ pub fn runtime_provider_for(provider_id: &str) -> Option<Arc<dyn LlmProvider>> {
         "lmstudio" | "lm-studio" => return Some(Arc::new(p::lm_studio())),
         // "llama-server" is the binary name for the modern llama.cpp server.
         "llamacpp" | "llama-cpp" | "llama-server" => return Some(Arc::new(p::llama_cpp())),
+        "codex" | "openai-codex" => {
+            return CodexProvider::from_stored().map(|p| Arc::new(p) as Arc<dyn LlmProvider>);
+        }
         _ => {}
     }
 

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -2613,7 +2613,7 @@ async fn run_interactive(
                         )).await;
                     });
                 }
-                "openai-codex" => {
+                "codex" | "openai-codex" => {
                     let tx2 = device_auth_tx.clone();
                     // Keep the dialog in WaitingForCode until GotBrowserUrl arrives.
                     // (set_browser_url() transitions it to BrowserAuth with the URL.)

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -8,8 +8,8 @@
 //    - Headless (--print / -p) mode: single query, output to stdout
 //    - Interactive REPL mode: full TUI with ratatui
 
-mod oauth_flow;
 mod codex_oauth_flow;
+mod oauth_flow;
 
 // ---------------------------------------------------------------------------
 // Build-time metadata (embedded via build.rs)
@@ -31,6 +31,9 @@ pub const FEEDBACK_CHANNEL: &str = env!("FEEDBACK_CHANNEL");
 pub const ISSUES_EXPLAINER: &str = env!("ISSUES_EXPLAINER");
 
 use anyhow::Context;
+use async_trait::async_trait;
+use clap::{ArgAction, Parser, ValueEnum};
+use claurst_core::types::ToolDefinition;
 use claurst_core::{
     config::{Config, PermissionMode, Settings},
     constants::APP_VERSION,
@@ -38,10 +41,7 @@ use claurst_core::{
     cost::CostTracker,
     permissions::{AutoPermissionHandler, InteractivePermissionHandler},
 };
-use async_trait::async_trait;
-use claurst_core::types::ToolDefinition;
 use claurst_tools::{PermissionLevel, Tool, ToolContext, ToolResult};
-use clap::{ArgAction, Parser, ValueEnum};
 use parking_lot::Mutex as ParkingMutex;
 use std::{path::PathBuf, sync::Arc};
 use tracing::{debug, info, warn};
@@ -361,7 +361,8 @@ async fn main() -> anyhow::Result<()> {
         let mut entries = registry.list_all();
         // Sort by provider then model id for stable output.
         entries.sort_by(|a, b| {
-            (&*a.info.provider_id).cmp(&*b.info.provider_id)
+            (&*a.info.provider_id)
+                .cmp(&*b.info.provider_id)
                 .then_with(|| (&*a.info.id).cmp(&*b.info.id))
         });
         for entry in entries {
@@ -383,7 +384,8 @@ async fn main() -> anyhow::Result<()> {
     if let Some(cmd_name) = raw_args.get(1).map(|s| s.as_str()) {
         // Only intercept if it looks like a subcommand (no leading `-` or `/`)
         if !cmd_name.starts_with('-') && !cmd_name.starts_with('/') {
-            if let Some(named_cmd) = claurst_commands::named_commands::find_named_command(cmd_name) {
+            if let Some(named_cmd) = claurst_commands::named_commands::find_named_command(cmd_name)
+            {
                 // Build a minimal CommandContext (named commands are pre-session)
                 let settings = Settings::load().await.unwrap_or_default();
                 let config = settings.effective_config();
@@ -427,8 +429,7 @@ async fn main() -> anyhow::Result<()> {
     let log_level = if cli.verbose { "debug" } else { "warn" };
     tracing_subscriber::fmt()
         .with_env_filter(
-            EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| EnvFilter::new(log_level)),
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(log_level)),
         )
         .with_target(false)
         .without_time()
@@ -487,7 +488,10 @@ async fn main() -> anyhow::Result<()> {
     }
     if let Some(base) = &cli.api_base {
         // Store in the provider's config entry
-        let provider_id = config.provider.clone().unwrap_or_else(|| "anthropic".to_string());
+        let provider_id = config
+            .provider
+            .clone()
+            .unwrap_or_else(|| "anthropic".to_string());
         config
             .provider_configs
             .entry(provider_id)
@@ -497,8 +501,7 @@ async fn main() -> anyhow::Result<()> {
 
     // --dump-system-prompt fast path
     if cli.dump_system_prompt {
-        let ctx = ContextBuilder::new(cwd.clone())
-            .disable_claude_mds(config.disable_claude_mds);
+        let ctx = ContextBuilder::new(cwd.clone()).disable_claude_mds(config.disable_claude_mds);
         let sys = ctx.build_system_context().await;
         let user = ctx.build_user_context().await;
         println!("{}\n\n{}", sys, user);
@@ -506,8 +509,8 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // Build context
-    let ctx_builder = ContextBuilder::new(cwd.clone())
-        .disable_claude_mds(config.disable_claude_mds);
+    let ctx_builder =
+        ContextBuilder::new(cwd.clone()).disable_claude_mds(config.disable_claude_mds);
     let system_ctx = ctx_builder.build_system_context().await;
     let user_ctx = ctx_builder.build_user_context().await;
 
@@ -537,8 +540,7 @@ async fn main() -> anyhow::Result<()> {
     // explicitly the intended provider and no key exists at all.
     let other_provider_configured = {
         let active_provider = config.provider.as_deref().unwrap_or("anthropic");
-        let has_non_anthropic_env =
-            std::env::var("OPENAI_API_KEY").is_ok()
+        let has_non_anthropic_env = std::env::var("OPENAI_API_KEY").is_ok()
             || std::env::var("GOOGLE_API_KEY").is_ok()
             || std::env::var("GOOGLE_GENERATIVE_AI_API_KEY").is_ok()
             || std::env::var("GROQ_API_KEY").is_ok()
@@ -564,7 +566,9 @@ async fn main() -> anyhow::Result<()> {
 
     let (api_key, use_bearer_auth) = match config.resolve_auth_async().await {
         Some(auth) => auth,
-        None if other_provider_configured && config.provider.as_deref().unwrap_or("anthropic") != "anthropic" => {
+        None if other_provider_configured
+            && config.provider.as_deref().unwrap_or("anthropic") != "anthropic" =>
+        {
             // Non-Anthropic provider selected — no Anthropic key needed.
             (String::new(), false)
         }
@@ -690,11 +694,8 @@ async fn main() -> anyhow::Result<()> {
 
         // Register plugin MCP servers into the in-memory config so they are
         // picked up by any subsequent MCP manager construction.
-        let existing_names: std::collections::HashSet<String> = config
-            .mcp_servers
-            .iter()
-            .map(|s| s.name.clone())
-            .collect();
+        let existing_names: std::collections::HashSet<String> =
+            config.mcp_servers.iter().map(|s| s.name.clone()).collect();
         for mcp_server in plugin_registry.all_mcp_servers() {
             if !existing_names.contains(&mcp_server.name) {
                 config.mcp_servers.push(mcp_server);
@@ -708,7 +709,8 @@ async fn main() -> anyhow::Result<()> {
     let model_registry = load_cached_model_registry();
 
     // Build query config
-    let mut query_config = claurst_query::QueryConfig::from_config_with_registry(&config, &model_registry);
+    let mut query_config =
+        claurst_query::QueryConfig::from_config_with_registry(&config, &model_registry);
     query_config.model_registry = Some(model_registry.clone());
     query_config.max_turns = cli.max_turns;
     query_config.system_prompt = Some(system_prompt);
@@ -721,7 +723,10 @@ async fn main() -> anyhow::Result<()> {
         if let Some(level) = claurst_core::effort::EffortLevel::from_str(level_str) {
             query_config.effort_level = Some(level);
         } else {
-            eprintln!("Warning: unknown effort level '{}' — expected low/medium/high/max", level_str);
+            eprintln!(
+                "Warning: unknown effort level '{}' — expected low/medium/high/max",
+                level_str
+            );
         }
     }
     if let Some(usd) = cli.max_budget_usd {
@@ -749,7 +754,10 @@ async fn main() -> anyhow::Result<()> {
             }
             filter_tools_for_agent(tools, &access)
         } else {
-            eprintln!("Warning: unknown agent '{}'. Run /agent to see available agents.", agent_name);
+            eprintln!(
+                "Warning: unknown agent '{}'. Run /agent to see available agents.",
+                agent_name
+            );
             tools
         }
     } else {
@@ -769,18 +777,10 @@ async fn main() -> anyhow::Result<()> {
 
     // --print mode (headless)
     let result = if is_headless {
-        run_headless(
-            &cli,
-            client,
-            tools,
-            tool_ctx,
-            query_config,
-            cost_tracker,
-        )
-        .await
+        run_headless(&cli, client, tools, tool_ctx, query_config, cost_tracker).await
     } else {
-        let has_credentials = !api_key.is_empty()
-            || config.provider.as_deref().is_some_and(|p| p != "anthropic");
+        let has_credentials =
+            !api_key.is_empty() || config.provider.as_deref().is_some_and(|p| p != "anthropic");
         run_interactive(
             config,
             settings,
@@ -801,14 +801,15 @@ async fn main() -> anyhow::Result<()> {
     result
 }
 
-async fn connect_mcp_manager_arc(
-    config: &Config,
-) -> Option<Arc<claurst_mcp::McpManager>> {
+async fn connect_mcp_manager_arc(config: &Config) -> Option<Arc<claurst_mcp::McpManager>> {
     if config.mcp_servers.is_empty() {
         return None;
     }
 
-    info!(count = config.mcp_servers.len(), "Connecting to MCP servers");
+    info!(
+        count = config.mcp_servers.len(),
+        "Connecting to MCP servers"
+    );
     let mcp_manager = claurst_mcp::McpManager::connect_all(&config.mcp_servers).await;
     Some(Arc::new(mcp_manager))
 }
@@ -950,9 +951,8 @@ async fn refresh_provider_runtime_state(
         claurst_api::AnthropicClient::new(client_config.clone())
             .context("Failed to rebuild Anthropic client")?,
     );
-    let provider_registry = Arc::new(
-        claurst_api::ProviderRegistry::from_environment_with_auth_store(client_config),
-    );
+    let provider_registry =
+        Arc::new(claurst_api::ProviderRegistry::from_environment_with_auth_store(client_config));
     let model_registry = load_cached_model_registry();
 
     spawn_models_cache_refresh();
@@ -964,6 +964,14 @@ async fn refresh_provider_runtime_state(
         model_registry,
         auth_store: claurst_core::AuthStore::default(),
     })
+}
+
+fn normalize_provider_from_model(config: &mut Config) {
+    if let Some(model) = config.model.as_deref() {
+        if let Some((provider, _)) = model.split_once('/') {
+            config.provider = Some(provider.to_string());
+        }
+    }
 }
 
 /// Filter the tool list based on the agent's access level.
@@ -1025,72 +1033,78 @@ async fn run_headless(
     // --input-format stream-json: stdin is newline-delimited JSON, each line is
     //   {"role":"user"|"assistant","content":"..."} (mirrors TS --input-format stream-json).
     // --input-format text (default): read prompt from positional arg or entire stdin as text.
-    let mut messages: Vec<claurst_core::types::Message> = if cli.input_format == CliInputFormat::StreamJson {
-        use tokio::io::{self, AsyncBufReadExt, BufReader};
-        let stdin = io::stdin();
-        let mut reader = BufReader::new(stdin);
-        let mut line = String::new();
-        let mut parsed: Vec<claurst_core::types::Message> = Vec::new();
-        loop {
-            line.clear();
-            let n = reader.read_line(&mut line).await?;
-            if n == 0 {
-                break;
-            }
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-            match serde_json::from_str::<serde_json::Value>(trimmed) {
-                Ok(v) => {
-                    let role = v.get("role").and_then(|r| r.as_str()).unwrap_or("user");
-                    let content = v
-                        .get("content")
-                        .and_then(|c| c.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    if role == "assistant" {
-                        parsed.push(claurst_core::types::Message::assistant(content));
-                    } else {
-                        parsed.push(claurst_core::types::Message::user(content));
+    let mut messages: Vec<claurst_core::types::Message> =
+        if cli.input_format == CliInputFormat::StreamJson {
+            use tokio::io::{self, AsyncBufReadExt, BufReader};
+            let stdin = io::stdin();
+            let mut reader = BufReader::new(stdin);
+            let mut line = String::new();
+            let mut parsed: Vec<claurst_core::types::Message> = Vec::new();
+            loop {
+                line.clear();
+                let n = reader.read_line(&mut line).await?;
+                if n == 0 {
+                    break;
+                }
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                match serde_json::from_str::<serde_json::Value>(trimmed) {
+                    Ok(v) => {
+                        let role = v.get("role").and_then(|r| r.as_str()).unwrap_or("user");
+                        let content = v
+                            .get("content")
+                            .and_then(|c| c.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        if role == "assistant" {
+                            parsed.push(claurst_core::types::Message::assistant(content));
+                        } else {
+                            parsed.push(claurst_core::types::Message::user(content));
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "Warning: skipping malformed JSON line: {} ({:?})",
+                            trimmed, e
+                        );
                     }
                 }
-                Err(e) => {
-                    eprintln!("Warning: skipping malformed JSON line: {} ({:?})", trimmed, e);
+            }
+            if parsed.is_empty() {
+                // Also check positional arg as fallback
+                if let Some(ref p) = cli.prompt {
+                    parsed.push(claurst_core::types::Message::user(p.clone()));
                 }
             }
-        }
-        if parsed.is_empty() {
-            // Also check positional arg as fallback
-            if let Some(ref p) = cli.prompt {
-                parsed.push(claurst_core::types::Message::user(p.clone()));
-            }
-        }
-        parsed
-    } else {
-        // Plain text mode
-        let prompt = if let Some(ref p) = cli.prompt {
-            p.clone()
+            parsed
         } else {
-            use tokio::io::{self, AsyncReadExt};
-            let mut stdin = io::stdin();
-            let mut buf = String::new();
-            stdin.read_to_string(&mut buf).await?;
-            buf.trim().to_string()
+            // Plain text mode
+            let prompt = if let Some(ref p) = cli.prompt {
+                p.clone()
+            } else {
+                use tokio::io::{self, AsyncReadExt};
+                let mut stdin = io::stdin();
+                let mut buf = String::new();
+                stdin.read_to_string(&mut buf).await?;
+                buf.trim().to_string()
+            };
+
+            if prompt.is_empty() {
+                eprintln!("Error: No prompt provided. Use --print <prompt> or pipe text to stdin.");
+                std::process::exit(1);
+            }
+
+            vec![claurst_core::types::Message::user(prompt)]
         };
-
-        if prompt.is_empty() {
-            eprintln!("Error: No prompt provided. Use --print <prompt> or pipe text to stdin.");
-            std::process::exit(1);
-        }
-
-        vec![claurst_core::types::Message::user(prompt)]
-    };
 
     // --prefill: inject a partial assistant turn before the query so the model
     // continues from that text (mirrors TS --prefill flag).
     if let Some(ref prefill_text) = cli.prefill {
-        messages.push(claurst_core::types::Message::assistant(prefill_text.clone()));
+        messages.push(claurst_core::types::Message::assistant(
+            prefill_text.clone(),
+        ));
     }
 
     if messages.is_empty() {
@@ -1098,7 +1112,10 @@ async fn run_headless(
         std::process::exit(1);
     }
 
-    let is_json_output = matches!(cli.output_format, CliOutputFormat::Json | CliOutputFormat::StreamJson);
+    let is_json_output = matches!(
+        cli.output_format,
+        CliOutputFormat::Json | CliOutputFormat::StreamJson
+    );
     let is_stream_json = matches!(cli.output_format, CliOutputFormat::StreamJson);
 
     let (event_tx, mut event_rx) = mpsc::unbounded_channel::<QueryEvent>();
@@ -1174,35 +1191,33 @@ async fn run_headless(
 
     // Final output
     match cli.output_format {
-        CliOutputFormat::Json => {
-            match outcome {
-                QueryOutcome::EndTurn { message, usage } => {
-                    let result_text = if full_text.is_empty() {
-                        message.get_all_text()
-                    } else {
-                        full_text
-                    };
-                    let out = serde_json::json!({
-                        "type": "result",
-                        "result": result_text,
-                        "usage": {
-                            "input_tokens": usage.input_tokens,
-                            "output_tokens": usage.output_tokens,
-                            "cache_creation_input_tokens": usage.cache_creation_input_tokens,
-                            "cache_read_input_tokens": usage.cache_read_input_tokens,
-                        },
-                        "cost_usd": cost_tracker.total_cost_usd(),
-                    });
-                    println!("{}", out);
-                }
-                QueryOutcome::Error(e) => {
-                    let out = serde_json::json!({ "type": "error", "error": e.to_string() });
-                    eprintln!("{}", out);
-                    std::process::exit(1);
-                }
-                _ => {}
+        CliOutputFormat::Json => match outcome {
+            QueryOutcome::EndTurn { message, usage } => {
+                let result_text = if full_text.is_empty() {
+                    message.get_all_text()
+                } else {
+                    full_text
+                };
+                let out = serde_json::json!({
+                    "type": "result",
+                    "result": result_text,
+                    "usage": {
+                        "input_tokens": usage.input_tokens,
+                        "output_tokens": usage.output_tokens,
+                        "cache_creation_input_tokens": usage.cache_creation_input_tokens,
+                        "cache_read_input_tokens": usage.cache_read_input_tokens,
+                    },
+                    "cost_usd": cost_tracker.total_cost_usd(),
+                });
+                println!("{}", out);
             }
-        }
+            QueryOutcome::Error(e) => {
+                let out = serde_json::json!({ "type": "error", "error": e.to_string() });
+                eprintln!("{}", out);
+                std::process::exit(1);
+            }
+            _ => {}
+        },
         CliOutputFormat::StreamJson => {
             // Already streamed above; emit final result event
             match outcome {
@@ -1241,7 +1256,10 @@ async fn run_headless(
                     eprintln!("Error: {}", e);
                     std::process::exit(1);
                 }
-                QueryOutcome::BudgetExceeded { cost_usd, limit_usd } => {
+                QueryOutcome::BudgetExceeded {
+                    cost_usd,
+                    limit_usd,
+                } => {
                     eprintln!(
                         "Budget limit ${:.4} reached (spent ${:.4}). Stopping.",
                         limit_usd, cost_usd
@@ -1273,13 +1291,12 @@ async fn run_interactive(
     has_credentials: bool,
     model_registry: Arc<claurst_api::ModelRegistry>,
 ) -> anyhow::Result<()> {
-    use claurst_commands::{execute_command, CommandContext, CommandResult};
     use claurst_bridge::{BridgeOutbound, TuiBridgeEvent};
+    use claurst_commands::{execute_command, CommandContext, CommandResult};
     use claurst_query::{QueryEvent, QueryOutcome};
     use claurst_tui::{
-        bridge_state::BridgeConnectionState, notifications::NotificationKind,
-        render::render_app, restore_terminal, setup_terminal, App,
-        device_auth_dialog::DeviceAuthEvent,
+        bridge_state::BridgeConnectionState, device_auth_dialog::DeviceAuthEvent,
+        notifications::NotificationKind, render::render_app, restore_terminal, setup_terminal, App,
     };
     use crossterm::event::{self, Event, KeyCode};
     use std::time::Duration;
@@ -1304,20 +1321,18 @@ async fn run_interactive(
             }
             Err(e) => {
                 eprintln!("Warning: could not load session {}: {}", id, e);
-                let mut session =
-                    claurst_core::history::ConversationSession::new(
-                        claurst_api::effective_model_for_config(&config, &model_registry),
-                    );
+                let mut session = claurst_core::history::ConversationSession::new(
+                    claurst_api::effective_model_for_config(&config, &model_registry),
+                );
                 session.id = tool_ctx.session_id.clone();
                 session.working_dir = Some(tool_ctx.working_dir.display().to_string());
                 session
             }
         }
     } else {
-        let mut session =
-            claurst_core::history::ConversationSession::new(
-                claurst_api::effective_model_for_config(&config, &model_registry),
-            );
+        let mut session = claurst_core::history::ConversationSession::new(
+            claurst_api::effective_model_for_config(&config, &model_registry),
+        );
         session.id = tool_ctx.session_id.clone();
         session.working_dir = Some(tool_ctx.working_dir.display().to_string());
         session
@@ -1337,10 +1352,10 @@ async fn run_interactive(
     if let Some(level) = base_query_config.effort_level {
         use claurst_tui::EffortLevel as TuiEL;
         app.effort_level = match level {
-            claurst_core::effort::EffortLevel::Low    => TuiEL::Low,
+            claurst_core::effort::EffortLevel::Low => TuiEL::Low,
             claurst_core::effort::EffortLevel::Medium => TuiEL::Normal,
-            claurst_core::effort::EffortLevel::High   => TuiEL::High,
-            claurst_core::effort::EffortLevel::Max    => TuiEL::Max,
+            claurst_core::effort::EffortLevel::High => TuiEL::High,
+            claurst_core::effort::EffortLevel::Max => TuiEL::Max,
         };
     }
     app.provider_registry = base_query_config.provider_registry.clone();
@@ -1392,7 +1407,8 @@ async fn run_interactive(
         if !settings.has_completed_onboarding {
             app.onboarding_dialog.show();
         } else {
-            app.status_message = Some("No provider configured. Run /connect to set one up.".to_string());
+            app.status_message =
+                Some("No provider configured. Run /connect to set one up.".to_string());
         }
     } else if !settings.has_completed_onboarding {
         // User has credentials but hasn't formally completed onboarding — mark it done
@@ -1466,9 +1482,7 @@ async fn run_interactive(
 
     // Preserve the bridge token before consuming bridge_config so we can reconstruct
     // a BridgeSessionInfo once the bridge worker reports it has connected.
-    let bridge_token: Option<String> = bridge_config
-        .as_ref()
-        .and_then(|c| c.session_token.clone());
+    let bridge_token: Option<String> = bridge_config.as_ref().and_then(|c| c.session_token.clone());
 
     let mut bridge_runtime: Option<BridgeRuntime> = if let Some(cfg) = bridge_config {
         let bridge_cancel = CancellationToken::new();
@@ -1480,7 +1494,9 @@ async fn run_interactive(
 
         let cancel_clone = bridge_cancel.clone();
         tokio::spawn(async move {
-            if let Err(e) = claurst_bridge::run_bridge_loop(cfg, tui_tx, outbound_rx, cancel_clone).await {
+            if let Err(e) =
+                claurst_bridge::run_bridge_loop(cfg, tui_tx, outbound_rx, cancel_clone).await
+            {
                 warn!("Bridge loop exited with error: {}", e);
             }
         });
@@ -1571,10 +1587,13 @@ async fn run_interactive(
 
                     // Ctrl+C: copy selected text if there's a selection, otherwise cancel/quit
                     if key.code == KeyCode::Char('c')
-                        && key.modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
+                        && key
+                            .modifiers
+                            .contains(crossterm::event::KeyModifiers::CONTROL)
                     {
                         // Check if there's an active text selection — copy instead of cancel/quit
-                        let has_selection = app.selection_anchor.is_some() && !app.selection_text.borrow().is_empty();
+                        let has_selection = app.selection_anchor.is_some()
+                            && !app.selection_text.borrow().is_empty();
                         if has_selection {
                             // Let the app handle the copy via its normal key handler
                             app.handle_key_event(key);
@@ -1596,7 +1615,9 @@ async fn run_interactive(
 
                     // Ctrl+D on empty input => quit
                     if key.code == KeyCode::Char('d')
-                        && key.modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
+                        && key
+                            .modifiers
+                            .contains(crossterm::event::KeyModifiers::CONTROL)
                         && app.prompt_input.is_empty()
                     {
                         break 'main;
@@ -1668,8 +1689,15 @@ async fn run_interactive(
                             let skip_tui_for_args = !cmd_args.is_empty()
                                 && matches!(
                                     cmd_name.as_str(),
-                                    "model" | "theme" | "resume" | "session"
-                                        | "vim" | "vi" | "voice" | "fast" | "speed"
+                                    "model"
+                                        | "theme"
+                                        | "resume"
+                                        | "session"
+                                        | "vim"
+                                        | "vi"
+                                        | "voice"
+                                        | "fast"
+                                        | "speed"
                                 );
                             let handled_by_tui = if skip_tui_for_args {
                                 false
@@ -1681,14 +1709,18 @@ async fn run_interactive(
                             // (no-args /effort → cycle Low→Med→High→Max→Low).
                             if handled_by_tui && cmd_name == "effort" && cmd_args.is_empty() {
                                 current_effort = Some(match app.effort_level {
-                                    claurst_tui::EffortLevel::Low =>
-                                        claurst_core::effort::EffortLevel::Low,
-                                    claurst_tui::EffortLevel::Normal =>
-                                        claurst_core::effort::EffortLevel::Medium,
-                                    claurst_tui::EffortLevel::High =>
-                                        claurst_core::effort::EffortLevel::High,
-                                    claurst_tui::EffortLevel::Max =>
-                                        claurst_core::effort::EffortLevel::Max,
+                                    claurst_tui::EffortLevel::Low => {
+                                        claurst_core::effort::EffortLevel::Low
+                                    }
+                                    claurst_tui::EffortLevel::Normal => {
+                                        claurst_core::effort::EffortLevel::Medium
+                                    }
+                                    claurst_tui::EffortLevel::High => {
+                                        claurst_core::effort::EffortLevel::High
+                                    }
+                                    claurst_tui::EffortLevel::Max => {
+                                        claurst_core::effort::EffortLevel::Max
+                                    }
                                 });
                             }
 
@@ -1716,12 +1748,10 @@ async fn run_interactive(
                                     app.replace_messages(Vec::new());
                                     session.messages.clear();
                                     session.updated_at = chrono::Utc::now();
-                                    app.status_message =
-                                        Some("Conversation cleared.".to_string());
+                                    app.status_message = Some("Conversation cleared.".to_string());
                                 }
                                 Some(CommandResult::SetMessages(new_msgs)) => {
-                                    let removed =
-                                        messages.len().saturating_sub(new_msgs.len());
+                                    let removed = messages.len().saturating_sub(new_msgs.len());
                                     messages = new_msgs.clone();
                                     app.replace_messages(new_msgs);
                                     session.messages = messages.clone();
@@ -1760,44 +1790,34 @@ async fn run_interactive(
                                     tool_ctx.file_history = Arc::new(ParkingMutex::new(
                                         claurst_core::file_history::FileHistory::new(),
                                     ));
-                                    tool_ctx.current_turn = Arc::new(
-                                        std::sync::atomic::AtomicUsize::new(0),
-                                    );
+                                    tool_ctx.current_turn =
+                                        Arc::new(std::sync::atomic::AtomicUsize::new(0));
                                     cmd_ctx.session_id = session.id.clone();
                                     cmd_ctx.session_title = session.title.clone();
                                     if let Some(saved_dir) = session.working_dir.as_ref() {
-                                        let saved_path =
-                                            std::path::PathBuf::from(saved_dir);
+                                        let saved_path = std::path::PathBuf::from(saved_dir);
                                         if saved_path.exists() {
                                             tool_ctx.working_dir = saved_path.clone();
                                             cmd_ctx.working_dir = saved_path;
                                         }
                                     }
-                                    app.config.project_dir =
-                                        Some(tool_ctx.working_dir.clone());
+                                    app.config.project_dir = Some(tool_ctx.working_dir.clone());
                                     app.attach_turn_diff_state(
                                         tool_ctx.file_history.clone(),
                                         tool_ctx.current_turn.clone(),
                                     );
-                                    claurst_tui::update_terminal_title(
-                                        session.title.as_deref(),
-                                    );
-                                    app.status_message = Some(format!(
-                                        "Resumed session {}.",
-                                        &session.id[..8]
-                                    ));
+                                    claurst_tui::update_terminal_title(session.title.as_deref());
+                                    app.status_message =
+                                        Some(format!("Resumed session {}.", &session.id[..8]));
                                 }
                                 Some(CommandResult::RenameSession(title)) => {
                                     session.title = Some(title.clone());
                                     session.updated_at = chrono::Utc::now();
                                     cmd_ctx.session_title = session.title.clone();
-                                    let _ =
-                                        claurst_core::history::save_session(&session).await;
+                                    let _ = claurst_core::history::save_session(&session).await;
                                     claurst_tui::update_terminal_title(Some(&title));
-                                    app.status_message = Some(format!(
-                                        "Session renamed to \"{}\".",
-                                        title
-                                    ));
+                                    app.status_message =
+                                        Some(format!("Session renamed to \"{}\".", title));
                                 }
                                 Some(CommandResult::RefreshProviderState) => {
                                     if app.is_streaming || current_query.is_some() {
@@ -1806,7 +1826,8 @@ async fn run_interactive(
                                                 .to_string(),
                                         );
                                     } else {
-                                        match refresh_provider_runtime_state(&cmd_ctx.config).await {
+                                        match refresh_provider_runtime_state(&cmd_ctx.config).await
+                                        {
                                             Ok(refreshed) => {
                                                 cmd_ctx.config = refreshed.config.clone();
                                                 tool_ctx.config = refreshed.config.clone();
@@ -1837,10 +1858,8 @@ async fn run_interactive(
                                                 );
                                             }
                                             Err(err) => {
-                                                app.status_message = Some(format!(
-                                                    "Error: {}",
-                                                    err
-                                                ));
+                                                app.status_message =
+                                                    Some(format!("Error: {}", err));
                                             }
                                         }
                                     }
@@ -1855,44 +1874,56 @@ async fn run_interactive(
                                     // overlay for this command (e.g. /stats opens dialog
                                     // AND would push a text message — drop the text).
                                     if !handled_by_tui {
-                                        app.push_message(
-                                            claurst_core::types::Message::assistant(msg),
-                                        );
+                                        app.push_message(claurst_core::types::Message::assistant(
+                                            msg,
+                                        ));
                                     }
                                 }
                                 Some(CommandResult::ConfigChange(new_cfg)) => {
-                                    cmd_ctx.config = new_cfg.clone();
-                                    tool_ctx.config = new_cfg.clone();
-                                    app.config = new_cfg.clone();
-                                    // Sync model name shown in the TUI header.
-                                    if let Some(ref model) = new_cfg.model {
-                                        app.model_name = model.clone();
+                                    let mut applied_cfg = new_cfg;
+                                    normalize_provider_from_model(&mut applied_cfg);
+                                    cmd_ctx.config = applied_cfg.clone();
+                                    tool_ctx.config = applied_cfg.clone();
+                                    app.config = applied_cfg.clone();
+                                    // Sync model/provider shown in the TUI header.
+                                    if let Some(ref model) = applied_cfg.model {
+                                        app.set_model(model.clone());
                                     }
                                     // Sync fast_mode visual indicator.
-                                    app.fast_mode = new_cfg.model
+                                    app.fast_mode = applied_cfg
+                                        .model
                                         .as_deref()
                                         .map(|m| m.contains("haiku"))
                                         .unwrap_or(false);
                                     // Sync plan_mode visual indicator.
                                     app.plan_mode = matches!(
-                                        new_cfg.permission_mode,
+                                        applied_cfg.permission_mode,
                                         claurst_core::config::PermissionMode::Plan
                                     );
-                                    app.status_message =
-                                        Some("Configuration updated.".to_string());
+                                    session.model = claurst_api::effective_model_for_config(
+                                        &cmd_ctx.config,
+                                        &model_registry,
+                                    );
+                                    app.status_message = Some("Configuration updated.".to_string());
                                 }
                                 Some(CommandResult::ConfigChangeMessage(new_cfg, msg)) => {
-                                    cmd_ctx.config = new_cfg.clone();
-                                    tool_ctx.config = new_cfg.clone();
-                                    // Sync model name + fast_mode visual indicator.
-                                    if let Some(ref model) = new_cfg.model {
-                                        app.model_name = model.clone();
+                                    let mut applied_cfg = new_cfg;
+                                    normalize_provider_from_model(&mut applied_cfg);
+                                    cmd_ctx.config = applied_cfg.clone();
+                                    tool_ctx.config = applied_cfg.clone();
+                                    // Sync model/provider + fast_mode visual indicator.
+                                    if let Some(ref model) = applied_cfg.model {
+                                        app.set_model(model.clone());
                                         app.fast_mode = model.contains("haiku");
                                     } else {
                                         // model reset to None means fast mode off.
                                         app.fast_mode = false;
                                     }
-                                    app.config = new_cfg;
+                                    app.config = applied_cfg.clone();
+                                    session.model = claurst_api::effective_model_for_config(
+                                        &cmd_ctx.config,
+                                        &model_registry,
+                                    );
                                     app.status_message = Some(msg);
                                 }
                                 Some(CommandResult::UserMessage(msg)) => {
@@ -1901,11 +1932,7 @@ async fn run_interactive(
                                 }
                                 Some(CommandResult::StartOAuthFlow(with_claude_ai)) => {
                                     claurst_tui::restore_terminal(&mut terminal).ok();
-                                    match oauth_flow::run_oauth_login_flow(
-                                        with_claude_ai,
-                                    )
-                                    .await
-                                    {
+                                    match oauth_flow::run_oauth_login_flow(with_claude_ai).await {
                                         Ok(_) => {
                                             app.status_message =
                                                 Some("Login successful!".to_string());
@@ -1931,23 +1958,24 @@ async fn run_interactive(
 
                             // Sync effort visual + API level when CLI handled
                             // /effort with explicit args (/effort high).
-                            if handled_by_cli
-                                && cmd_name == "effort"
-                                && !cmd_args.is_empty()
-                            {
+                            if handled_by_cli && cmd_name == "effort" && !cmd_args.is_empty() {
                                 if let Some(level) =
                                     claurst_core::effort::EffortLevel::from_str(&cmd_args)
                                 {
                                     current_effort = Some(level);
                                     app.effort_level = match level {
-                                        claurst_core::effort::EffortLevel::Low =>
-                                            claurst_tui::EffortLevel::Low,
-                                        claurst_core::effort::EffortLevel::Medium =>
-                                            claurst_tui::EffortLevel::Normal,
-                                        claurst_core::effort::EffortLevel::High =>
-                                            claurst_tui::EffortLevel::High,
-                                        claurst_core::effort::EffortLevel::Max =>
-                                            claurst_tui::EffortLevel::Max,
+                                        claurst_core::effort::EffortLevel::Low => {
+                                            claurst_tui::EffortLevel::Low
+                                        }
+                                        claurst_core::effort::EffortLevel::Medium => {
+                                            claurst_tui::EffortLevel::Normal
+                                        }
+                                        claurst_core::effort::EffortLevel::High => {
+                                            claurst_tui::EffortLevel::High
+                                        }
+                                        claurst_core::effort::EffortLevel::Max => {
+                                            claurst_tui::EffortLevel::Max
+                                        }
                                     };
                                     app.status_message = Some(format!(
                                         "Effort: {} {}",
@@ -1967,10 +1995,8 @@ async fn run_interactive(
                             }
 
                             if !handled_by_cli && !handled_by_tui {
-                                app.status_message = Some(format!(
-                                    "Unknown command: /{}",
-                                    cmd_name
-                                ));
+                                app.status_message =
+                                    Some(format!("Unknown command: /{}", cmd_name));
                             }
 
                             // If a UserMessage was queued (e.g. /compact), submit it.
@@ -2010,18 +2036,21 @@ async fn run_interactive(
                             let mut blocks: Vec<claurst_core::types::ContentBlock> = pending_imgs
                                 .iter()
                                 .filter_map(|img| {
-                                    claurst_tui::image_paste::encode_image_base64(&img.path)
-                                        .map(|b64| claurst_core::types::ContentBlock::Image {
+                                    claurst_tui::image_paste::encode_image_base64(&img.path).map(
+                                        |b64| claurst_core::types::ContentBlock::Image {
                                             source: claurst_core::types::ImageSource {
                                                 source_type: "base64".to_string(),
                                                 media_type: Some("image/png".to_string()),
                                                 data: Some(b64),
                                                 url: None,
                                             },
-                                        })
+                                        },
+                                    )
                                 })
                                 .collect();
-                            blocks.push(claurst_core::types::ContentBlock::Text { text: input.clone() });
+                            blocks.push(claurst_core::types::ContentBlock::Text {
+                                text: input.clone(),
+                            });
                             claurst_core::types::Message::user_blocks(blocks)
                         };
                         messages.push(user_msg.clone());
@@ -2053,7 +2082,10 @@ async fn run_interactive(
                         let tools_arc_clone = tools_arc.clone();
                         let ctx_clone = tool_ctx.clone();
                         let mut qcfg = base_query_config.clone();
-                        qcfg.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
+                        qcfg.model = claurst_api::effective_model_for_config(
+                            &cmd_ctx.config,
+                            &model_registry,
+                        );
                         qcfg.max_tokens = cmd_ctx.config.effective_max_tokens();
                         qcfg.append_system_prompt = cmd_ctx.config.append_system_prompt.clone();
                         qcfg.system_prompt = base_query_config.system_prompt.clone();
@@ -2147,26 +2179,31 @@ async fn run_interactive(
                         delta: text.clone(),
                         message_id: format!("msg-{}", index),
                     }),
-                    QueryEvent::ToolStart { tool_name, tool_id, input_json } => {
-                        Some(BridgeOutbound::ToolStart {
-                            id: tool_id.clone(),
-                            name: tool_name.clone(),
-                            input_preview: Some(input_json.clone()),
-                        })
-                    }
-                    QueryEvent::ToolEnd { tool_id, result, is_error, .. } => {
-                        Some(BridgeOutbound::ToolEnd {
-                            id: tool_id.clone(),
-                            output: result.clone(),
-                            is_error: *is_error,
-                        })
-                    }
-                    QueryEvent::TurnComplete { stop_reason, turn, .. } => {
-                        Some(BridgeOutbound::TurnComplete {
-                            message_id: format!("turn-{}", turn),
-                            stop_reason: stop_reason.clone(),
-                        })
-                    }
+                    QueryEvent::ToolStart {
+                        tool_name,
+                        tool_id,
+                        input_json,
+                    } => Some(BridgeOutbound::ToolStart {
+                        id: tool_id.clone(),
+                        name: tool_name.clone(),
+                        input_preview: Some(input_json.clone()),
+                    }),
+                    QueryEvent::ToolEnd {
+                        tool_id,
+                        result,
+                        is_error,
+                        ..
+                    } => Some(BridgeOutbound::ToolEnd {
+                        id: tool_id.clone(),
+                        output: result.clone(),
+                        is_error: *is_error,
+                    }),
+                    QueryEvent::TurnComplete {
+                        stop_reason, turn, ..
+                    } => Some(BridgeOutbound::TurnComplete {
+                        message_id: format!("turn-{}", turn),
+                        stop_reason: stop_reason.clone(),
+                    }),
                     QueryEvent::Error(msg) => Some(BridgeOutbound::Error {
                         message: msg.clone(),
                     }),
@@ -2183,27 +2220,41 @@ async fn run_interactive(
                     QueryEvent::Stream(claurst_api::AnthropicStreamEvent::ContentBlockDelta {
                         delta: claurst_api::streaming::ContentDelta::TextDelta { text },
                         ..
-                    }) => Some(serde_json::json!({
-                        "type": "text_chunk",
-                        "text": text,
-                    }).to_string()),
-                    QueryEvent::ToolStart { tool_name, tool_id, input_json } => {
-                        Some(serde_json::json!({
+                    }) => Some(
+                        serde_json::json!({
+                            "type": "text_chunk",
+                            "text": text,
+                        })
+                        .to_string(),
+                    ),
+                    QueryEvent::ToolStart {
+                        tool_name,
+                        tool_id,
+                        input_json,
+                    } => Some(
+                        serde_json::json!({
                             "type": "tool_start",
                             "tool_name": tool_name,
                             "tool_id": tool_id,
                             "input": input_json,
-                        }).to_string())
-                    }
-                    QueryEvent::ToolEnd { tool_name, tool_id, result, is_error } => {
-                        Some(serde_json::json!({
+                        })
+                        .to_string(),
+                    ),
+                    QueryEvent::ToolEnd {
+                        tool_name,
+                        tool_id,
+                        result,
+                        is_error,
+                    } => Some(
+                        serde_json::json!({
                             "type": "tool_end",
                             "tool_name": tool_name,
                             "tool_id": tool_id,
                             "result": result,
                             "is_error": is_error,
-                        }).to_string())
-                    }
+                        })
+                        .to_string(),
+                    ),
                     _ => None,
                 };
                 if let Some(payload) = relay_payload {
@@ -2220,7 +2271,8 @@ async fn run_interactive(
             && current_query.is_none()
             && !app.auto_compact_running
         {
-            let used_pct = (app.context_used_tokens as f64 / app.context_window_size as f64 * 100.0) as u64;
+            let used_pct =
+                (app.context_used_tokens as f64 / app.context_window_size as f64 * 100.0) as u64;
             if used_pct >= 99 {
                 app.auto_compact_running = true;
                 let msg_count = messages.len();
@@ -2246,7 +2298,8 @@ async fn run_interactive(
                 let tools_arc_clone = tools_arc.clone();
                 let ctx_clone = tool_ctx.clone();
                 let mut qcfg = base_query_config.clone();
-                qcfg.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
+                qcfg.model =
+                    claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
                 qcfg.max_tokens = cmd_ctx.config.effective_max_tokens();
                 let tracker = cost_tracker.clone();
                 let tx = event_tx.clone();
@@ -2279,7 +2332,10 @@ async fn run_interactive(
         if let Some(runtime) = bridge_runtime.as_mut() {
             loop {
                 match runtime.tui_rx.try_recv() {
-                    Ok(TuiBridgeEvent::Connected { session_url, session_id: conn_sid }) => {
+                    Ok(TuiBridgeEvent::Connected {
+                        session_url,
+                        session_id: conn_sid,
+                    }) => {
                         let short = if session_url.len() > 60 {
                             format!("{}…", &session_url[..60])
                         } else {
@@ -2319,11 +2375,9 @@ async fn run_interactive(
                                 tokio::spawn(async move {
                                     let mut rx = rx;
                                     while let Some(payload) = rx.recv().await {
-                                        let _ = claurst_bridge::post_bridge_event(
-                                            &info_relay,
-                                            payload,
-                                        )
-                                        .await;
+                                        let _ =
+                                            claurst_bridge::post_bridge_event(&info_relay, payload)
+                                                .await;
                                     }
                                 });
                             }
@@ -2357,10 +2411,7 @@ async fn run_interactive(
                                         }
                                         _ => {}
                                     }
-                                    tokio::time::sleep(
-                                        std::time::Duration::from_secs(2),
-                                    )
-                                    .await;
+                                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
                                 }
                             });
                         }
@@ -2400,7 +2451,10 @@ async fn run_interactive(
                         let tools_arc_clone = tools_arc.clone();
                         let ctx_clone = tool_ctx.clone();
                         let mut qcfg = base_query_config.clone();
-                        qcfg.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
+                        qcfg.model = claurst_api::effective_model_for_config(
+                            &cmd_ctx.config,
+                            &model_registry,
+                        );
                         qcfg.max_tokens = cmd_ctx.config.effective_max_tokens();
                         let tracker = cost_tracker.clone();
                         let tx = event_tx.clone();
@@ -2430,18 +2484,21 @@ async fn run_interactive(
                                 ct.cancel();
                             }
                             app.is_streaming = false;
-                            app.status_message =
-                                Some("Cancelled by remote control.".to_string());
+                            app.status_message = Some("Cancelled by remote control.".to_string());
                         }
                     }
-                    Ok(TuiBridgeEvent::PermissionResponse { tool_use_id, response }) => {
+                    Ok(TuiBridgeEvent::PermissionResponse {
+                        tool_use_id,
+                        response,
+                    }) => {
                         // Resolve a pending permission dialog if IDs match.
                         if let Some(ref pr) = app.permission_request {
                             if pr.tool_use_id == tool_use_id {
                                 use claurst_bridge::PermissionResponseKind;
                                 let _allow = matches!(
                                     response,
-                                    PermissionResponseKind::Allow | PermissionResponseKind::AllowSession
+                                    PermissionResponseKind::Allow
+                                        | PermissionResponseKind::AllowSession
                                 );
                                 app.permission_request = None;
                             }
@@ -2508,7 +2565,8 @@ async fn run_interactive(
                 let tools_arc_clone = tools_arc.clone();
                 let ctx_clone = tool_ctx.clone();
                 let mut qcfg = base_query_config.clone();
-                qcfg.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
+                qcfg.model =
+                    claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
                 qcfg.max_tokens = cmd_ctx.config.effective_max_tokens();
                 let tracker = cost_tracker.clone();
                 let tx = event_tx.clone();
@@ -2571,14 +2629,18 @@ async fn run_interactive(
                             COPILOT_CLIENT_ID,
                             "read:user",
                             "https://github.com/login/device/code",
-                        ).await {
+                        )
+                        .await
+                        {
                             Ok(resp) => {
-                                let _ = tx2.send(DeviceAuthEvent::GotCode {
-                                    user_code: resp.user_code,
-                                    verification_uri: resp.verification_uri,
-                                    device_code: resp.device_code.clone(),
-                                    interval: resp.interval,
-                                }).await;
+                                let _ = tx2
+                                    .send(DeviceAuthEvent::GotCode {
+                                        user_code: resp.user_code,
+                                        verification_uri: resp.verification_uri,
+                                        device_code: resp.device_code.clone(),
+                                        interval: resp.interval,
+                                    })
+                                    .await;
                                 // Step 2: Poll for access token
                                 match claurst_core::device_code::poll_for_token(
                                     COPILOT_CLIENT_ID,
@@ -2586,9 +2648,12 @@ async fn run_interactive(
                                     "https://github.com/login/oauth/access_token",
                                     resp.interval,
                                     300,
-                                ).await {
+                                )
+                                .await
+                                {
                                     Ok(token) => {
-                                        let _ = tx2.send(DeviceAuthEvent::TokenReceived(token)).await;
+                                        let _ =
+                                            tx2.send(DeviceAuthEvent::TokenReceived(token)).await;
                                     }
                                     Err(e) => {
                                         let _ = tx2.send(DeviceAuthEvent::Error(e)).await;
@@ -2607,10 +2672,13 @@ async fn run_interactive(
                     // Claurst does not have its own registered OAuth app with Anthropic.
                     // Users should use an API key from console.anthropic.com instead.
                     tokio::spawn(async move {
-                        let _ = tx2.send(DeviceAuthEvent::Error(
-                            "Anthropic OAuth requires a registered application.\n\
-                             Use an API key instead: console.anthropic.com/settings/keys".to_string()
-                        )).await;
+                        let _ = tx2
+                            .send(DeviceAuthEvent::Error(
+                                "Anthropic OAuth requires a registered application.\n\
+                             Use an API key instead: console.anthropic.com/settings/keys"
+                                    .to_string(),
+                            ))
+                            .await;
                     });
                 }
                 "codex" | "openai-codex" => {
@@ -2620,14 +2688,17 @@ async fn run_interactive(
                     tokio::spawn(async move {
                         match crate::codex_oauth_flow::run_oauth_flow(tx2.clone()).await {
                             Ok(tokens) => {
-                                let _ = tx2.send(DeviceAuthEvent::TokenReceived(
-                                    tokens.access_token,
-                                )).await;
+                                let _ = tx2
+                                    .send(DeviceAuthEvent::TokenReceived(tokens.access_token))
+                                    .await;
                             }
                             Err(e) => {
-                                let _ = tx2.send(DeviceAuthEvent::Error(
-                                    format!("Codex OAuth failed: {}", e),
-                                )).await;
+                                let _ = tx2
+                                    .send(DeviceAuthEvent::Error(format!(
+                                        "Codex OAuth failed: {}",
+                                        e
+                                    )))
+                                    .await;
                             }
                         }
                     });
@@ -2655,8 +2726,12 @@ async fn run_interactive(
                     // Auto-open the verification URL in the browser
                     let _ = open::that(&verification_uri);
 
-                    app.device_auth_dialog
-                        .set_code(user_code, verification_uri, device_code, interval);
+                    app.device_auth_dialog.set_code(
+                        user_code,
+                        verification_uri,
+                        device_code,
+                        interval,
+                    );
 
                     app.notifications.push(
                         claurst_tui::NotificationKind::Info,
@@ -2699,7 +2774,8 @@ async fn run_interactive(
                 messages = msgs_arc.lock().await.clone();
                 session.messages = messages.clone();
                 session.updated_at = chrono::Utc::now();
-                session.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
+                session.model =
+                    claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
                 session.working_dir = Some(tool_ctx.working_dir.display().to_string());
                 app.is_streaming = false;
                 app.status_message = None;
@@ -2725,8 +2801,16 @@ async fn run_interactive(
                         for msg in &session.messages {
                             let content_str = match &msg.content {
                                 claurst_core::types::MessageContent::Text(t) => t.clone(),
-                                claurst_core::types::MessageContent::Blocks(blocks) => blocks.iter()
-                                    .filter_map(|b| if let claurst_core::types::ContentBlock::Text { text } = b { Some(text.as_str()) } else { None })
+                                claurst_core::types::MessageContent::Blocks(blocks) => blocks
+                                    .iter()
+                                    .filter_map(|b| {
+                                        if let claurst_core::types::ContentBlock::Text { text } = b
+                                        {
+                                            Some(text.as_str())
+                                        } else {
+                                            None
+                                        }
+                                    })
                                     .collect::<Vec<_>>()
                                     .join(" "),
                             };
@@ -2735,7 +2819,8 @@ async fn run_interactive(
                                 claurst_core::types::Role::Assistant => "assistant",
                             };
                             let msg_id = msg.uuid.as_deref().unwrap_or("unknown");
-                            let _ = store.save_message(&session.id, msg_id, role, &content_str, None);
+                            let _ =
+                                store.save_message(&session.id, msg_id, role, &content_str, None);
                         }
                     }
                 }
@@ -2829,7 +2914,9 @@ async fn handle_auth_command(args: &[String]) -> anyhow::Result<()> {
             eprintln!("Unknown auth subcommand: '{}'", unknown);
             eprintln!();
             eprintln!("Usage: claude auth <subcommand>");
-            eprintln!("  login [--console]   Authenticate (claude.ai by default; --console for API key)");
+            eprintln!(
+                "  login [--console]   Authenticate (claude.ai by default; --console for API key)"
+            );
             eprintln!("  logout              Remove stored credentials");
             eprintln!("  status [--json]     Show authentication status");
             std::process::exit(1);
@@ -2850,7 +2937,9 @@ async fn handle_auth_command(args: &[String]) -> anyhow::Result<()> {
 /// Print current auth status, then exit with code 0 (logged in) or 1 (not logged in).
 async fn auth_status(json_output: bool) {
     // Gather auth state
-    let env_api_key = std::env::var("ANTHROPIC_API_KEY").ok().filter(|k| !k.is_empty());
+    let env_api_key = std::env::var("ANTHROPIC_API_KEY")
+        .ok()
+        .filter(|k| !k.is_empty());
     let settings = Settings::load().await.unwrap_or_default();
     let settings_api_key = settings.config.api_key.clone().filter(|k| !k.is_empty());
     let oauth_tokens = claurst_core::oauth::OAuthTokens::load().await;
@@ -2907,7 +2996,11 @@ async fn auth_status(json_output: bool) {
     // Determine auth method (mirrors TypeScript authStatus())
     let (auth_method, logged_in) = if let Some(ref tokens) = oauth_tokens {
         let uses_bearer = tokens.uses_bearer_auth();
-        let method = if uses_bearer { "claude.ai" } else { "oauth_token" };
+        let method = if uses_bearer {
+            "claude.ai"
+        } else {
+            "oauth_token"
+        };
         (method.to_string(), true)
     } else if env_api_key.is_some() {
         ("api_key".to_string(), true)
@@ -3042,4 +3135,3 @@ fn json_null_or_string(opt: &Option<String>) -> serde_json::Value {
         None => serde_json::Value::Null,
     }
 }
-

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -779,7 +779,11 @@ async fn main() -> anyhow::Result<()> {
         )
         .await
     } else {
+        let auth_store = claurst_core::AuthStore::load();
+        let has_saved_credentials = !auth_store.credentials.is_empty()
+            || claurst_core::oauth_config::get_codex_tokens().is_some();
         let has_credentials = !api_key.is_empty()
+            || has_saved_credentials
             || config.provider.as_deref().is_some_and(|p| p != "anthropic");
         run_interactive(
             config,

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -8,8 +8,8 @@
 //    - Headless (--print / -p) mode: single query, output to stdout
 //    - Interactive REPL mode: full TUI with ratatui
 
-mod codex_oauth_flow;
 mod oauth_flow;
+mod codex_oauth_flow;
 
 // ---------------------------------------------------------------------------
 // Build-time metadata (embedded via build.rs)
@@ -31,9 +31,6 @@ pub const FEEDBACK_CHANNEL: &str = env!("FEEDBACK_CHANNEL");
 pub const ISSUES_EXPLAINER: &str = env!("ISSUES_EXPLAINER");
 
 use anyhow::Context;
-use async_trait::async_trait;
-use clap::{ArgAction, Parser, ValueEnum};
-use claurst_core::types::ToolDefinition;
 use claurst_core::{
     config::{Config, PermissionMode, Settings},
     constants::APP_VERSION,
@@ -41,7 +38,10 @@ use claurst_core::{
     cost::CostTracker,
     permissions::{AutoPermissionHandler, InteractivePermissionHandler},
 };
+use async_trait::async_trait;
+use claurst_core::types::ToolDefinition;
 use claurst_tools::{PermissionLevel, Tool, ToolContext, ToolResult};
+use clap::{ArgAction, Parser, ValueEnum};
 use parking_lot::Mutex as ParkingMutex;
 use std::{path::PathBuf, sync::Arc};
 use tracing::{debug, info, warn};
@@ -361,8 +361,7 @@ async fn main() -> anyhow::Result<()> {
         let mut entries = registry.list_all();
         // Sort by provider then model id for stable output.
         entries.sort_by(|a, b| {
-            (&*a.info.provider_id)
-                .cmp(&*b.info.provider_id)
+            (&*a.info.provider_id).cmp(&*b.info.provider_id)
                 .then_with(|| (&*a.info.id).cmp(&*b.info.id))
         });
         for entry in entries {
@@ -384,8 +383,7 @@ async fn main() -> anyhow::Result<()> {
     if let Some(cmd_name) = raw_args.get(1).map(|s| s.as_str()) {
         // Only intercept if it looks like a subcommand (no leading `-` or `/`)
         if !cmd_name.starts_with('-') && !cmd_name.starts_with('/') {
-            if let Some(named_cmd) = claurst_commands::named_commands::find_named_command(cmd_name)
-            {
+            if let Some(named_cmd) = claurst_commands::named_commands::find_named_command(cmd_name) {
                 // Build a minimal CommandContext (named commands are pre-session)
                 let settings = Settings::load().await.unwrap_or_default();
                 let config = settings.effective_config();
@@ -429,7 +427,8 @@ async fn main() -> anyhow::Result<()> {
     let log_level = if cli.verbose { "debug" } else { "warn" };
     tracing_subscriber::fmt()
         .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(log_level)),
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::new(log_level)),
         )
         .with_target(false)
         .without_time()
@@ -488,10 +487,7 @@ async fn main() -> anyhow::Result<()> {
     }
     if let Some(base) = &cli.api_base {
         // Store in the provider's config entry
-        let provider_id = config
-            .provider
-            .clone()
-            .unwrap_or_else(|| "anthropic".to_string());
+        let provider_id = config.provider.clone().unwrap_or_else(|| "anthropic".to_string());
         config
             .provider_configs
             .entry(provider_id)
@@ -501,7 +497,8 @@ async fn main() -> anyhow::Result<()> {
 
     // --dump-system-prompt fast path
     if cli.dump_system_prompt {
-        let ctx = ContextBuilder::new(cwd.clone()).disable_claude_mds(config.disable_claude_mds);
+        let ctx = ContextBuilder::new(cwd.clone())
+            .disable_claude_mds(config.disable_claude_mds);
         let sys = ctx.build_system_context().await;
         let user = ctx.build_user_context().await;
         println!("{}\n\n{}", sys, user);
@@ -509,8 +506,8 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // Build context
-    let ctx_builder =
-        ContextBuilder::new(cwd.clone()).disable_claude_mds(config.disable_claude_mds);
+    let ctx_builder = ContextBuilder::new(cwd.clone())
+        .disable_claude_mds(config.disable_claude_mds);
     let system_ctx = ctx_builder.build_system_context().await;
     let user_ctx = ctx_builder.build_user_context().await;
 
@@ -540,7 +537,8 @@ async fn main() -> anyhow::Result<()> {
     // explicitly the intended provider and no key exists at all.
     let other_provider_configured = {
         let active_provider = config.provider.as_deref().unwrap_or("anthropic");
-        let has_non_anthropic_env = std::env::var("OPENAI_API_KEY").is_ok()
+        let has_non_anthropic_env =
+            std::env::var("OPENAI_API_KEY").is_ok()
             || std::env::var("GOOGLE_API_KEY").is_ok()
             || std::env::var("GOOGLE_GENERATIVE_AI_API_KEY").is_ok()
             || std::env::var("GROQ_API_KEY").is_ok()
@@ -566,9 +564,7 @@ async fn main() -> anyhow::Result<()> {
 
     let (api_key, use_bearer_auth) = match config.resolve_auth_async().await {
         Some(auth) => auth,
-        None if other_provider_configured
-            && config.provider.as_deref().unwrap_or("anthropic") != "anthropic" =>
-        {
+        None if other_provider_configured && config.provider.as_deref().unwrap_or("anthropic") != "anthropic" => {
             // Non-Anthropic provider selected — no Anthropic key needed.
             (String::new(), false)
         }
@@ -694,8 +690,11 @@ async fn main() -> anyhow::Result<()> {
 
         // Register plugin MCP servers into the in-memory config so they are
         // picked up by any subsequent MCP manager construction.
-        let existing_names: std::collections::HashSet<String> =
-            config.mcp_servers.iter().map(|s| s.name.clone()).collect();
+        let existing_names: std::collections::HashSet<String> = config
+            .mcp_servers
+            .iter()
+            .map(|s| s.name.clone())
+            .collect();
         for mcp_server in plugin_registry.all_mcp_servers() {
             if !existing_names.contains(&mcp_server.name) {
                 config.mcp_servers.push(mcp_server);
@@ -709,8 +708,7 @@ async fn main() -> anyhow::Result<()> {
     let model_registry = load_cached_model_registry();
 
     // Build query config
-    let mut query_config =
-        claurst_query::QueryConfig::from_config_with_registry(&config, &model_registry);
+    let mut query_config = claurst_query::QueryConfig::from_config_with_registry(&config, &model_registry);
     query_config.model_registry = Some(model_registry.clone());
     query_config.max_turns = cli.max_turns;
     query_config.system_prompt = Some(system_prompt);
@@ -723,10 +721,7 @@ async fn main() -> anyhow::Result<()> {
         if let Some(level) = claurst_core::effort::EffortLevel::from_str(level_str) {
             query_config.effort_level = Some(level);
         } else {
-            eprintln!(
-                "Warning: unknown effort level '{}' — expected low/medium/high/max",
-                level_str
-            );
+            eprintln!("Warning: unknown effort level '{}' — expected low/medium/high/max", level_str);
         }
     }
     if let Some(usd) = cli.max_budget_usd {
@@ -754,10 +749,7 @@ async fn main() -> anyhow::Result<()> {
             }
             filter_tools_for_agent(tools, &access)
         } else {
-            eprintln!(
-                "Warning: unknown agent '{}'. Run /agent to see available agents.",
-                agent_name
-            );
+            eprintln!("Warning: unknown agent '{}'. Run /agent to see available agents.", agent_name);
             tools
         }
     } else {
@@ -777,10 +769,18 @@ async fn main() -> anyhow::Result<()> {
 
     // --print mode (headless)
     let result = if is_headless {
-        run_headless(&cli, client, tools, tool_ctx, query_config, cost_tracker).await
+        run_headless(
+            &cli,
+            client,
+            tools,
+            tool_ctx,
+            query_config,
+            cost_tracker,
+        )
+        .await
     } else {
-        let has_credentials =
-            !api_key.is_empty() || config.provider.as_deref().is_some_and(|p| p != "anthropic");
+        let has_credentials = !api_key.is_empty()
+            || config.provider.as_deref().is_some_and(|p| p != "anthropic");
         run_interactive(
             config,
             settings,
@@ -801,15 +801,14 @@ async fn main() -> anyhow::Result<()> {
     result
 }
 
-async fn connect_mcp_manager_arc(config: &Config) -> Option<Arc<claurst_mcp::McpManager>> {
+async fn connect_mcp_manager_arc(
+    config: &Config,
+) -> Option<Arc<claurst_mcp::McpManager>> {
     if config.mcp_servers.is_empty() {
         return None;
     }
 
-    info!(
-        count = config.mcp_servers.len(),
-        "Connecting to MCP servers"
-    );
+    info!(count = config.mcp_servers.len(), "Connecting to MCP servers");
     let mcp_manager = claurst_mcp::McpManager::connect_all(&config.mcp_servers).await;
     Some(Arc::new(mcp_manager))
 }
@@ -951,8 +950,9 @@ async fn refresh_provider_runtime_state(
         claurst_api::AnthropicClient::new(client_config.clone())
             .context("Failed to rebuild Anthropic client")?,
     );
-    let provider_registry =
-        Arc::new(claurst_api::ProviderRegistry::from_environment_with_auth_store(client_config));
+    let provider_registry = Arc::new(
+        claurst_api::ProviderRegistry::from_environment_with_auth_store(client_config),
+    );
     let model_registry = load_cached_model_registry();
 
     spawn_models_cache_refresh();
@@ -1033,78 +1033,72 @@ async fn run_headless(
     // --input-format stream-json: stdin is newline-delimited JSON, each line is
     //   {"role":"user"|"assistant","content":"..."} (mirrors TS --input-format stream-json).
     // --input-format text (default): read prompt from positional arg or entire stdin as text.
-    let mut messages: Vec<claurst_core::types::Message> =
-        if cli.input_format == CliInputFormat::StreamJson {
-            use tokio::io::{self, AsyncBufReadExt, BufReader};
-            let stdin = io::stdin();
-            let mut reader = BufReader::new(stdin);
-            let mut line = String::new();
-            let mut parsed: Vec<claurst_core::types::Message> = Vec::new();
-            loop {
-                line.clear();
-                let n = reader.read_line(&mut line).await?;
-                if n == 0 {
-                    break;
-                }
-                let trimmed = line.trim();
-                if trimmed.is_empty() {
-                    continue;
-                }
-                match serde_json::from_str::<serde_json::Value>(trimmed) {
-                    Ok(v) => {
-                        let role = v.get("role").and_then(|r| r.as_str()).unwrap_or("user");
-                        let content = v
-                            .get("content")
-                            .and_then(|c| c.as_str())
-                            .unwrap_or("")
-                            .to_string();
-                        if role == "assistant" {
-                            parsed.push(claurst_core::types::Message::assistant(content));
-                        } else {
-                            parsed.push(claurst_core::types::Message::user(content));
-                        }
-                    }
-                    Err(e) => {
-                        eprintln!(
-                            "Warning: skipping malformed JSON line: {} ({:?})",
-                            trimmed, e
-                        );
+    let mut messages: Vec<claurst_core::types::Message> = if cli.input_format == CliInputFormat::StreamJson {
+        use tokio::io::{self, AsyncBufReadExt, BufReader};
+        let stdin = io::stdin();
+        let mut reader = BufReader::new(stdin);
+        let mut line = String::new();
+        let mut parsed: Vec<claurst_core::types::Message> = Vec::new();
+        loop {
+            line.clear();
+            let n = reader.read_line(&mut line).await?;
+            if n == 0 {
+                break;
+            }
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<serde_json::Value>(trimmed) {
+                Ok(v) => {
+                    let role = v.get("role").and_then(|r| r.as_str()).unwrap_or("user");
+                    let content = v
+                        .get("content")
+                        .and_then(|c| c.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    if role == "assistant" {
+                        parsed.push(claurst_core::types::Message::assistant(content));
+                    } else {
+                        parsed.push(claurst_core::types::Message::user(content));
                     }
                 }
-            }
-            if parsed.is_empty() {
-                // Also check positional arg as fallback
-                if let Some(ref p) = cli.prompt {
-                    parsed.push(claurst_core::types::Message::user(p.clone()));
+                Err(e) => {
+                    eprintln!("Warning: skipping malformed JSON line: {} ({:?})", trimmed, e);
                 }
             }
-            parsed
+        }
+        if parsed.is_empty() {
+            // Also check positional arg as fallback
+            if let Some(ref p) = cli.prompt {
+                parsed.push(claurst_core::types::Message::user(p.clone()));
+            }
+        }
+        parsed
+    } else {
+        // Plain text mode
+        let prompt = if let Some(ref p) = cli.prompt {
+            p.clone()
         } else {
-            // Plain text mode
-            let prompt = if let Some(ref p) = cli.prompt {
-                p.clone()
-            } else {
-                use tokio::io::{self, AsyncReadExt};
-                let mut stdin = io::stdin();
-                let mut buf = String::new();
-                stdin.read_to_string(&mut buf).await?;
-                buf.trim().to_string()
-            };
-
-            if prompt.is_empty() {
-                eprintln!("Error: No prompt provided. Use --print <prompt> or pipe text to stdin.");
-                std::process::exit(1);
-            }
-
-            vec![claurst_core::types::Message::user(prompt)]
+            use tokio::io::{self, AsyncReadExt};
+            let mut stdin = io::stdin();
+            let mut buf = String::new();
+            stdin.read_to_string(&mut buf).await?;
+            buf.trim().to_string()
         };
+
+        if prompt.is_empty() {
+            eprintln!("Error: No prompt provided. Use --print <prompt> or pipe text to stdin.");
+            std::process::exit(1);
+        }
+
+        vec![claurst_core::types::Message::user(prompt)]
+    };
 
     // --prefill: inject a partial assistant turn before the query so the model
     // continues from that text (mirrors TS --prefill flag).
     if let Some(ref prefill_text) = cli.prefill {
-        messages.push(claurst_core::types::Message::assistant(
-            prefill_text.clone(),
-        ));
+        messages.push(claurst_core::types::Message::assistant(prefill_text.clone()));
     }
 
     if messages.is_empty() {
@@ -1112,10 +1106,7 @@ async fn run_headless(
         std::process::exit(1);
     }
 
-    let is_json_output = matches!(
-        cli.output_format,
-        CliOutputFormat::Json | CliOutputFormat::StreamJson
-    );
+    let is_json_output = matches!(cli.output_format, CliOutputFormat::Json | CliOutputFormat::StreamJson);
     let is_stream_json = matches!(cli.output_format, CliOutputFormat::StreamJson);
 
     let (event_tx, mut event_rx) = mpsc::unbounded_channel::<QueryEvent>();
@@ -1191,33 +1182,35 @@ async fn run_headless(
 
     // Final output
     match cli.output_format {
-        CliOutputFormat::Json => match outcome {
-            QueryOutcome::EndTurn { message, usage } => {
-                let result_text = if full_text.is_empty() {
-                    message.get_all_text()
-                } else {
-                    full_text
-                };
-                let out = serde_json::json!({
-                    "type": "result",
-                    "result": result_text,
-                    "usage": {
-                        "input_tokens": usage.input_tokens,
-                        "output_tokens": usage.output_tokens,
-                        "cache_creation_input_tokens": usage.cache_creation_input_tokens,
-                        "cache_read_input_tokens": usage.cache_read_input_tokens,
-                    },
-                    "cost_usd": cost_tracker.total_cost_usd(),
-                });
-                println!("{}", out);
+        CliOutputFormat::Json => {
+            match outcome {
+                QueryOutcome::EndTurn { message, usage } => {
+                    let result_text = if full_text.is_empty() {
+                        message.get_all_text()
+                    } else {
+                        full_text
+                    };
+                    let out = serde_json::json!({
+                        "type": "result",
+                        "result": result_text,
+                        "usage": {
+                            "input_tokens": usage.input_tokens,
+                            "output_tokens": usage.output_tokens,
+                            "cache_creation_input_tokens": usage.cache_creation_input_tokens,
+                            "cache_read_input_tokens": usage.cache_read_input_tokens,
+                        },
+                        "cost_usd": cost_tracker.total_cost_usd(),
+                    });
+                    println!("{}", out);
+                }
+                QueryOutcome::Error(e) => {
+                    let out = serde_json::json!({ "type": "error", "error": e.to_string() });
+                    eprintln!("{}", out);
+                    std::process::exit(1);
+                }
+                _ => {}
             }
-            QueryOutcome::Error(e) => {
-                let out = serde_json::json!({ "type": "error", "error": e.to_string() });
-                eprintln!("{}", out);
-                std::process::exit(1);
-            }
-            _ => {}
-        },
+        }
         CliOutputFormat::StreamJson => {
             // Already streamed above; emit final result event
             match outcome {
@@ -1256,10 +1249,7 @@ async fn run_headless(
                     eprintln!("Error: {}", e);
                     std::process::exit(1);
                 }
-                QueryOutcome::BudgetExceeded {
-                    cost_usd,
-                    limit_usd,
-                } => {
+                QueryOutcome::BudgetExceeded { cost_usd, limit_usd } => {
                     eprintln!(
                         "Budget limit ${:.4} reached (spent ${:.4}). Stopping.",
                         limit_usd, cost_usd
@@ -1291,12 +1281,13 @@ async fn run_interactive(
     has_credentials: bool,
     model_registry: Arc<claurst_api::ModelRegistry>,
 ) -> anyhow::Result<()> {
-    use claurst_bridge::{BridgeOutbound, TuiBridgeEvent};
     use claurst_commands::{execute_command, CommandContext, CommandResult};
+    use claurst_bridge::{BridgeOutbound, TuiBridgeEvent};
     use claurst_query::{QueryEvent, QueryOutcome};
     use claurst_tui::{
-        bridge_state::BridgeConnectionState, device_auth_dialog::DeviceAuthEvent,
-        notifications::NotificationKind, render::render_app, restore_terminal, setup_terminal, App,
+        bridge_state::BridgeConnectionState, notifications::NotificationKind,
+        render::render_app, restore_terminal, setup_terminal, App,
+        device_auth_dialog::DeviceAuthEvent,
     };
     use crossterm::event::{self, Event, KeyCode};
     use std::time::Duration;
@@ -1321,18 +1312,20 @@ async fn run_interactive(
             }
             Err(e) => {
                 eprintln!("Warning: could not load session {}: {}", id, e);
-                let mut session = claurst_core::history::ConversationSession::new(
-                    claurst_api::effective_model_for_config(&config, &model_registry),
-                );
+                let mut session =
+                    claurst_core::history::ConversationSession::new(
+                        claurst_api::effective_model_for_config(&config, &model_registry),
+                    );
                 session.id = tool_ctx.session_id.clone();
                 session.working_dir = Some(tool_ctx.working_dir.display().to_string());
                 session
             }
         }
     } else {
-        let mut session = claurst_core::history::ConversationSession::new(
-            claurst_api::effective_model_for_config(&config, &model_registry),
-        );
+        let mut session =
+            claurst_core::history::ConversationSession::new(
+                claurst_api::effective_model_for_config(&config, &model_registry),
+            );
         session.id = tool_ctx.session_id.clone();
         session.working_dir = Some(tool_ctx.working_dir.display().to_string());
         session
@@ -1352,10 +1345,10 @@ async fn run_interactive(
     if let Some(level) = base_query_config.effort_level {
         use claurst_tui::EffortLevel as TuiEL;
         app.effort_level = match level {
-            claurst_core::effort::EffortLevel::Low => TuiEL::Low,
+            claurst_core::effort::EffortLevel::Low    => TuiEL::Low,
             claurst_core::effort::EffortLevel::Medium => TuiEL::Normal,
-            claurst_core::effort::EffortLevel::High => TuiEL::High,
-            claurst_core::effort::EffortLevel::Max => TuiEL::Max,
+            claurst_core::effort::EffortLevel::High   => TuiEL::High,
+            claurst_core::effort::EffortLevel::Max    => TuiEL::Max,
         };
     }
     app.provider_registry = base_query_config.provider_registry.clone();
@@ -1407,8 +1400,7 @@ async fn run_interactive(
         if !settings.has_completed_onboarding {
             app.onboarding_dialog.show();
         } else {
-            app.status_message =
-                Some("No provider configured. Run /connect to set one up.".to_string());
+            app.status_message = Some("No provider configured. Run /connect to set one up.".to_string());
         }
     } else if !settings.has_completed_onboarding {
         // User has credentials but hasn't formally completed onboarding — mark it done
@@ -1482,7 +1474,9 @@ async fn run_interactive(
 
     // Preserve the bridge token before consuming bridge_config so we can reconstruct
     // a BridgeSessionInfo once the bridge worker reports it has connected.
-    let bridge_token: Option<String> = bridge_config.as_ref().and_then(|c| c.session_token.clone());
+    let bridge_token: Option<String> = bridge_config
+        .as_ref()
+        .and_then(|c| c.session_token.clone());
 
     let mut bridge_runtime: Option<BridgeRuntime> = if let Some(cfg) = bridge_config {
         let bridge_cancel = CancellationToken::new();
@@ -1494,9 +1488,7 @@ async fn run_interactive(
 
         let cancel_clone = bridge_cancel.clone();
         tokio::spawn(async move {
-            if let Err(e) =
-                claurst_bridge::run_bridge_loop(cfg, tui_tx, outbound_rx, cancel_clone).await
-            {
+            if let Err(e) = claurst_bridge::run_bridge_loop(cfg, tui_tx, outbound_rx, cancel_clone).await {
                 warn!("Bridge loop exited with error: {}", e);
             }
         });
@@ -1587,13 +1579,10 @@ async fn run_interactive(
 
                     // Ctrl+C: copy selected text if there's a selection, otherwise cancel/quit
                     if key.code == KeyCode::Char('c')
-                        && key
-                            .modifiers
-                            .contains(crossterm::event::KeyModifiers::CONTROL)
+                        && key.modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
                     {
                         // Check if there's an active text selection — copy instead of cancel/quit
-                        let has_selection = app.selection_anchor.is_some()
-                            && !app.selection_text.borrow().is_empty();
+                        let has_selection = app.selection_anchor.is_some() && !app.selection_text.borrow().is_empty();
                         if has_selection {
                             // Let the app handle the copy via its normal key handler
                             app.handle_key_event(key);
@@ -1615,9 +1604,7 @@ async fn run_interactive(
 
                     // Ctrl+D on empty input => quit
                     if key.code == KeyCode::Char('d')
-                        && key
-                            .modifiers
-                            .contains(crossterm::event::KeyModifiers::CONTROL)
+                        && key.modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
                         && app.prompt_input.is_empty()
                     {
                         break 'main;
@@ -1689,15 +1676,8 @@ async fn run_interactive(
                             let skip_tui_for_args = !cmd_args.is_empty()
                                 && matches!(
                                     cmd_name.as_str(),
-                                    "model"
-                                        | "theme"
-                                        | "resume"
-                                        | "session"
-                                        | "vim"
-                                        | "vi"
-                                        | "voice"
-                                        | "fast"
-                                        | "speed"
+                                    "model" | "theme" | "resume" | "session"
+                                        | "vim" | "vi" | "voice" | "fast" | "speed"
                                 );
                             let handled_by_tui = if skip_tui_for_args {
                                 false
@@ -1709,18 +1689,14 @@ async fn run_interactive(
                             // (no-args /effort → cycle Low→Med→High→Max→Low).
                             if handled_by_tui && cmd_name == "effort" && cmd_args.is_empty() {
                                 current_effort = Some(match app.effort_level {
-                                    claurst_tui::EffortLevel::Low => {
-                                        claurst_core::effort::EffortLevel::Low
-                                    }
-                                    claurst_tui::EffortLevel::Normal => {
-                                        claurst_core::effort::EffortLevel::Medium
-                                    }
-                                    claurst_tui::EffortLevel::High => {
-                                        claurst_core::effort::EffortLevel::High
-                                    }
-                                    claurst_tui::EffortLevel::Max => {
-                                        claurst_core::effort::EffortLevel::Max
-                                    }
+                                    claurst_tui::EffortLevel::Low =>
+                                        claurst_core::effort::EffortLevel::Low,
+                                    claurst_tui::EffortLevel::Normal =>
+                                        claurst_core::effort::EffortLevel::Medium,
+                                    claurst_tui::EffortLevel::High =>
+                                        claurst_core::effort::EffortLevel::High,
+                                    claurst_tui::EffortLevel::Max =>
+                                        claurst_core::effort::EffortLevel::Max,
                                 });
                             }
 
@@ -1748,10 +1724,12 @@ async fn run_interactive(
                                     app.replace_messages(Vec::new());
                                     session.messages.clear();
                                     session.updated_at = chrono::Utc::now();
-                                    app.status_message = Some("Conversation cleared.".to_string());
+                                    app.status_message =
+                                        Some("Conversation cleared.".to_string());
                                 }
                                 Some(CommandResult::SetMessages(new_msgs)) => {
-                                    let removed = messages.len().saturating_sub(new_msgs.len());
+                                    let removed =
+                                        messages.len().saturating_sub(new_msgs.len());
                                     messages = new_msgs.clone();
                                     app.replace_messages(new_msgs);
                                     session.messages = messages.clone();
@@ -1790,34 +1768,44 @@ async fn run_interactive(
                                     tool_ctx.file_history = Arc::new(ParkingMutex::new(
                                         claurst_core::file_history::FileHistory::new(),
                                     ));
-                                    tool_ctx.current_turn =
-                                        Arc::new(std::sync::atomic::AtomicUsize::new(0));
+                                    tool_ctx.current_turn = Arc::new(
+                                        std::sync::atomic::AtomicUsize::new(0),
+                                    );
                                     cmd_ctx.session_id = session.id.clone();
                                     cmd_ctx.session_title = session.title.clone();
                                     if let Some(saved_dir) = session.working_dir.as_ref() {
-                                        let saved_path = std::path::PathBuf::from(saved_dir);
+                                        let saved_path =
+                                            std::path::PathBuf::from(saved_dir);
                                         if saved_path.exists() {
                                             tool_ctx.working_dir = saved_path.clone();
                                             cmd_ctx.working_dir = saved_path;
                                         }
                                     }
-                                    app.config.project_dir = Some(tool_ctx.working_dir.clone());
+                                    app.config.project_dir =
+                                        Some(tool_ctx.working_dir.clone());
                                     app.attach_turn_diff_state(
                                         tool_ctx.file_history.clone(),
                                         tool_ctx.current_turn.clone(),
                                     );
-                                    claurst_tui::update_terminal_title(session.title.as_deref());
-                                    app.status_message =
-                                        Some(format!("Resumed session {}.", &session.id[..8]));
+                                    claurst_tui::update_terminal_title(
+                                        session.title.as_deref(),
+                                    );
+                                    app.status_message = Some(format!(
+                                        "Resumed session {}.",
+                                        &session.id[..8]
+                                    ));
                                 }
                                 Some(CommandResult::RenameSession(title)) => {
                                     session.title = Some(title.clone());
                                     session.updated_at = chrono::Utc::now();
                                     cmd_ctx.session_title = session.title.clone();
-                                    let _ = claurst_core::history::save_session(&session).await;
+                                    let _ =
+                                        claurst_core::history::save_session(&session).await;
                                     claurst_tui::update_terminal_title(Some(&title));
-                                    app.status_message =
-                                        Some(format!("Session renamed to \"{}\".", title));
+                                    app.status_message = Some(format!(
+                                        "Session renamed to \"{}\".",
+                                        title
+                                    ));
                                 }
                                 Some(CommandResult::RefreshProviderState) => {
                                     if app.is_streaming || current_query.is_some() {
@@ -1826,8 +1814,7 @@ async fn run_interactive(
                                                 .to_string(),
                                         );
                                     } else {
-                                        match refresh_provider_runtime_state(&cmd_ctx.config).await
-                                        {
+                                        match refresh_provider_runtime_state(&cmd_ctx.config).await {
                                             Ok(refreshed) => {
                                                 cmd_ctx.config = refreshed.config.clone();
                                                 tool_ctx.config = refreshed.config.clone();
@@ -1858,8 +1845,10 @@ async fn run_interactive(
                                                 );
                                             }
                                             Err(err) => {
-                                                app.status_message =
-                                                    Some(format!("Error: {}", err));
+                                                app.status_message = Some(format!(
+                                                    "Error: {}",
+                                                    err
+                                                ));
                                             }
                                         }
                                     }
@@ -1874,9 +1863,9 @@ async fn run_interactive(
                                     // overlay for this command (e.g. /stats opens dialog
                                     // AND would push a text message — drop the text).
                                     if !handled_by_tui {
-                                        app.push_message(claurst_core::types::Message::assistant(
-                                            msg,
-                                        ));
+                                        app.push_message(
+                                            claurst_core::types::Message::assistant(msg),
+                                        );
                                     }
                                 }
                                 Some(CommandResult::ConfigChange(new_cfg)) => {
@@ -1890,8 +1879,7 @@ async fn run_interactive(
                                         app.set_model(model.clone());
                                     }
                                     // Sync fast_mode visual indicator.
-                                    app.fast_mode = applied_cfg
-                                        .model
+                                    app.fast_mode = applied_cfg.model
                                         .as_deref()
                                         .map(|m| m.contains("haiku"))
                                         .unwrap_or(false);
@@ -1904,7 +1892,8 @@ async fn run_interactive(
                                         &cmd_ctx.config,
                                         &model_registry,
                                     );
-                                    app.status_message = Some("Configuration updated.".to_string());
+                                    app.status_message =
+                                        Some("Configuration updated.".to_string());
                                 }
                                 Some(CommandResult::ConfigChangeMessage(new_cfg, msg)) => {
                                     let mut applied_cfg = new_cfg;
@@ -1932,7 +1921,11 @@ async fn run_interactive(
                                 }
                                 Some(CommandResult::StartOAuthFlow(with_claude_ai)) => {
                                     claurst_tui::restore_terminal(&mut terminal).ok();
-                                    match oauth_flow::run_oauth_login_flow(with_claude_ai).await {
+                                    match oauth_flow::run_oauth_login_flow(
+                                        with_claude_ai,
+                                    )
+                                    .await
+                                    {
                                         Ok(_) => {
                                             app.status_message =
                                                 Some("Login successful!".to_string());
@@ -1958,24 +1951,23 @@ async fn run_interactive(
 
                             // Sync effort visual + API level when CLI handled
                             // /effort with explicit args (/effort high).
-                            if handled_by_cli && cmd_name == "effort" && !cmd_args.is_empty() {
+                            if handled_by_cli
+                                && cmd_name == "effort"
+                                && !cmd_args.is_empty()
+                            {
                                 if let Some(level) =
                                     claurst_core::effort::EffortLevel::from_str(&cmd_args)
                                 {
                                     current_effort = Some(level);
                                     app.effort_level = match level {
-                                        claurst_core::effort::EffortLevel::Low => {
-                                            claurst_tui::EffortLevel::Low
-                                        }
-                                        claurst_core::effort::EffortLevel::Medium => {
-                                            claurst_tui::EffortLevel::Normal
-                                        }
-                                        claurst_core::effort::EffortLevel::High => {
-                                            claurst_tui::EffortLevel::High
-                                        }
-                                        claurst_core::effort::EffortLevel::Max => {
-                                            claurst_tui::EffortLevel::Max
-                                        }
+                                        claurst_core::effort::EffortLevel::Low =>
+                                            claurst_tui::EffortLevel::Low,
+                                        claurst_core::effort::EffortLevel::Medium =>
+                                            claurst_tui::EffortLevel::Normal,
+                                        claurst_core::effort::EffortLevel::High =>
+                                            claurst_tui::EffortLevel::High,
+                                        claurst_core::effort::EffortLevel::Max =>
+                                            claurst_tui::EffortLevel::Max,
                                     };
                                     app.status_message = Some(format!(
                                         "Effort: {} {}",
@@ -1995,8 +1987,10 @@ async fn run_interactive(
                             }
 
                             if !handled_by_cli && !handled_by_tui {
-                                app.status_message =
-                                    Some(format!("Unknown command: /{}", cmd_name));
+                                app.status_message = Some(format!(
+                                    "Unknown command: /{}",
+                                    cmd_name
+                                ));
                             }
 
                             // If a UserMessage was queued (e.g. /compact), submit it.
@@ -2036,21 +2030,18 @@ async fn run_interactive(
                             let mut blocks: Vec<claurst_core::types::ContentBlock> = pending_imgs
                                 .iter()
                                 .filter_map(|img| {
-                                    claurst_tui::image_paste::encode_image_base64(&img.path).map(
-                                        |b64| claurst_core::types::ContentBlock::Image {
+                                    claurst_tui::image_paste::encode_image_base64(&img.path)
+                                        .map(|b64| claurst_core::types::ContentBlock::Image {
                                             source: claurst_core::types::ImageSource {
                                                 source_type: "base64".to_string(),
                                                 media_type: Some("image/png".to_string()),
                                                 data: Some(b64),
                                                 url: None,
                                             },
-                                        },
-                                    )
+                                        })
                                 })
                                 .collect();
-                            blocks.push(claurst_core::types::ContentBlock::Text {
-                                text: input.clone(),
-                            });
+                            blocks.push(claurst_core::types::ContentBlock::Text { text: input.clone() });
                             claurst_core::types::Message::user_blocks(blocks)
                         };
                         messages.push(user_msg.clone());
@@ -2082,10 +2073,7 @@ async fn run_interactive(
                         let tools_arc_clone = tools_arc.clone();
                         let ctx_clone = tool_ctx.clone();
                         let mut qcfg = base_query_config.clone();
-                        qcfg.model = claurst_api::effective_model_for_config(
-                            &cmd_ctx.config,
-                            &model_registry,
-                        );
+                        qcfg.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
                         qcfg.max_tokens = cmd_ctx.config.effective_max_tokens();
                         qcfg.append_system_prompt = cmd_ctx.config.append_system_prompt.clone();
                         qcfg.system_prompt = base_query_config.system_prompt.clone();
@@ -2179,31 +2167,26 @@ async fn run_interactive(
                         delta: text.clone(),
                         message_id: format!("msg-{}", index),
                     }),
-                    QueryEvent::ToolStart {
-                        tool_name,
-                        tool_id,
-                        input_json,
-                    } => Some(BridgeOutbound::ToolStart {
-                        id: tool_id.clone(),
-                        name: tool_name.clone(),
-                        input_preview: Some(input_json.clone()),
-                    }),
-                    QueryEvent::ToolEnd {
-                        tool_id,
-                        result,
-                        is_error,
-                        ..
-                    } => Some(BridgeOutbound::ToolEnd {
-                        id: tool_id.clone(),
-                        output: result.clone(),
-                        is_error: *is_error,
-                    }),
-                    QueryEvent::TurnComplete {
-                        stop_reason, turn, ..
-                    } => Some(BridgeOutbound::TurnComplete {
-                        message_id: format!("turn-{}", turn),
-                        stop_reason: stop_reason.clone(),
-                    }),
+                    QueryEvent::ToolStart { tool_name, tool_id, input_json } => {
+                        Some(BridgeOutbound::ToolStart {
+                            id: tool_id.clone(),
+                            name: tool_name.clone(),
+                            input_preview: Some(input_json.clone()),
+                        })
+                    }
+                    QueryEvent::ToolEnd { tool_id, result, is_error, .. } => {
+                        Some(BridgeOutbound::ToolEnd {
+                            id: tool_id.clone(),
+                            output: result.clone(),
+                            is_error: *is_error,
+                        })
+                    }
+                    QueryEvent::TurnComplete { stop_reason, turn, .. } => {
+                        Some(BridgeOutbound::TurnComplete {
+                            message_id: format!("turn-{}", turn),
+                            stop_reason: stop_reason.clone(),
+                        })
+                    }
                     QueryEvent::Error(msg) => Some(BridgeOutbound::Error {
                         message: msg.clone(),
                     }),
@@ -2220,41 +2203,27 @@ async fn run_interactive(
                     QueryEvent::Stream(claurst_api::AnthropicStreamEvent::ContentBlockDelta {
                         delta: claurst_api::streaming::ContentDelta::TextDelta { text },
                         ..
-                    }) => Some(
-                        serde_json::json!({
-                            "type": "text_chunk",
-                            "text": text,
-                        })
-                        .to_string(),
-                    ),
-                    QueryEvent::ToolStart {
-                        tool_name,
-                        tool_id,
-                        input_json,
-                    } => Some(
-                        serde_json::json!({
+                    }) => Some(serde_json::json!({
+                        "type": "text_chunk",
+                        "text": text,
+                    }).to_string()),
+                    QueryEvent::ToolStart { tool_name, tool_id, input_json } => {
+                        Some(serde_json::json!({
                             "type": "tool_start",
                             "tool_name": tool_name,
                             "tool_id": tool_id,
                             "input": input_json,
-                        })
-                        .to_string(),
-                    ),
-                    QueryEvent::ToolEnd {
-                        tool_name,
-                        tool_id,
-                        result,
-                        is_error,
-                    } => Some(
-                        serde_json::json!({
+                        }).to_string())
+                    }
+                    QueryEvent::ToolEnd { tool_name, tool_id, result, is_error } => {
+                        Some(serde_json::json!({
                             "type": "tool_end",
                             "tool_name": tool_name,
                             "tool_id": tool_id,
                             "result": result,
                             "is_error": is_error,
-                        })
-                        .to_string(),
-                    ),
+                        }).to_string())
+                    }
                     _ => None,
                 };
                 if let Some(payload) = relay_payload {
@@ -2271,8 +2240,7 @@ async fn run_interactive(
             && current_query.is_none()
             && !app.auto_compact_running
         {
-            let used_pct =
-                (app.context_used_tokens as f64 / app.context_window_size as f64 * 100.0) as u64;
+            let used_pct = (app.context_used_tokens as f64 / app.context_window_size as f64 * 100.0) as u64;
             if used_pct >= 99 {
                 app.auto_compact_running = true;
                 let msg_count = messages.len();
@@ -2298,8 +2266,7 @@ async fn run_interactive(
                 let tools_arc_clone = tools_arc.clone();
                 let ctx_clone = tool_ctx.clone();
                 let mut qcfg = base_query_config.clone();
-                qcfg.model =
-                    claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
+                qcfg.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
                 qcfg.max_tokens = cmd_ctx.config.effective_max_tokens();
                 let tracker = cost_tracker.clone();
                 let tx = event_tx.clone();
@@ -2332,10 +2299,7 @@ async fn run_interactive(
         if let Some(runtime) = bridge_runtime.as_mut() {
             loop {
                 match runtime.tui_rx.try_recv() {
-                    Ok(TuiBridgeEvent::Connected {
-                        session_url,
-                        session_id: conn_sid,
-                    }) => {
+                    Ok(TuiBridgeEvent::Connected { session_url, session_id: conn_sid }) => {
                         let short = if session_url.len() > 60 {
                             format!("{}…", &session_url[..60])
                         } else {
@@ -2375,9 +2339,11 @@ async fn run_interactive(
                                 tokio::spawn(async move {
                                     let mut rx = rx;
                                     while let Some(payload) = rx.recv().await {
-                                        let _ =
-                                            claurst_bridge::post_bridge_event(&info_relay, payload)
-                                                .await;
+                                        let _ = claurst_bridge::post_bridge_event(
+                                            &info_relay,
+                                            payload,
+                                        )
+                                        .await;
                                     }
                                 });
                             }
@@ -2411,7 +2377,10 @@ async fn run_interactive(
                                         }
                                         _ => {}
                                     }
-                                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                                    tokio::time::sleep(
+                                        std::time::Duration::from_secs(2),
+                                    )
+                                    .await;
                                 }
                             });
                         }
@@ -2451,10 +2420,7 @@ async fn run_interactive(
                         let tools_arc_clone = tools_arc.clone();
                         let ctx_clone = tool_ctx.clone();
                         let mut qcfg = base_query_config.clone();
-                        qcfg.model = claurst_api::effective_model_for_config(
-                            &cmd_ctx.config,
-                            &model_registry,
-                        );
+                        qcfg.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
                         qcfg.max_tokens = cmd_ctx.config.effective_max_tokens();
                         let tracker = cost_tracker.clone();
                         let tx = event_tx.clone();
@@ -2484,21 +2450,18 @@ async fn run_interactive(
                                 ct.cancel();
                             }
                             app.is_streaming = false;
-                            app.status_message = Some("Cancelled by remote control.".to_string());
+                            app.status_message =
+                                Some("Cancelled by remote control.".to_string());
                         }
                     }
-                    Ok(TuiBridgeEvent::PermissionResponse {
-                        tool_use_id,
-                        response,
-                    }) => {
+                    Ok(TuiBridgeEvent::PermissionResponse { tool_use_id, response }) => {
                         // Resolve a pending permission dialog if IDs match.
                         if let Some(ref pr) = app.permission_request {
                             if pr.tool_use_id == tool_use_id {
                                 use claurst_bridge::PermissionResponseKind;
                                 let _allow = matches!(
                                     response,
-                                    PermissionResponseKind::Allow
-                                        | PermissionResponseKind::AllowSession
+                                    PermissionResponseKind::Allow | PermissionResponseKind::AllowSession
                                 );
                                 app.permission_request = None;
                             }
@@ -2565,8 +2528,7 @@ async fn run_interactive(
                 let tools_arc_clone = tools_arc.clone();
                 let ctx_clone = tool_ctx.clone();
                 let mut qcfg = base_query_config.clone();
-                qcfg.model =
-                    claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
+                qcfg.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
                 qcfg.max_tokens = cmd_ctx.config.effective_max_tokens();
                 let tracker = cost_tracker.clone();
                 let tx = event_tx.clone();
@@ -2629,18 +2591,14 @@ async fn run_interactive(
                             COPILOT_CLIENT_ID,
                             "read:user",
                             "https://github.com/login/device/code",
-                        )
-                        .await
-                        {
+                        ).await {
                             Ok(resp) => {
-                                let _ = tx2
-                                    .send(DeviceAuthEvent::GotCode {
-                                        user_code: resp.user_code,
-                                        verification_uri: resp.verification_uri,
-                                        device_code: resp.device_code.clone(),
-                                        interval: resp.interval,
-                                    })
-                                    .await;
+                                let _ = tx2.send(DeviceAuthEvent::GotCode {
+                                    user_code: resp.user_code,
+                                    verification_uri: resp.verification_uri,
+                                    device_code: resp.device_code.clone(),
+                                    interval: resp.interval,
+                                }).await;
                                 // Step 2: Poll for access token
                                 match claurst_core::device_code::poll_for_token(
                                     COPILOT_CLIENT_ID,
@@ -2648,12 +2606,9 @@ async fn run_interactive(
                                     "https://github.com/login/oauth/access_token",
                                     resp.interval,
                                     300,
-                                )
-                                .await
-                                {
+                                ).await {
                                     Ok(token) => {
-                                        let _ =
-                                            tx2.send(DeviceAuthEvent::TokenReceived(token)).await;
+                                        let _ = tx2.send(DeviceAuthEvent::TokenReceived(token)).await;
                                     }
                                     Err(e) => {
                                         let _ = tx2.send(DeviceAuthEvent::Error(e)).await;
@@ -2672,13 +2627,10 @@ async fn run_interactive(
                     // Claurst does not have its own registered OAuth app with Anthropic.
                     // Users should use an API key from console.anthropic.com instead.
                     tokio::spawn(async move {
-                        let _ = tx2
-                            .send(DeviceAuthEvent::Error(
-                                "Anthropic OAuth requires a registered application.\n\
-                             Use an API key instead: console.anthropic.com/settings/keys"
-                                    .to_string(),
-                            ))
-                            .await;
+                        let _ = tx2.send(DeviceAuthEvent::Error(
+                            "Anthropic OAuth requires a registered application.\n\
+                             Use an API key instead: console.anthropic.com/settings/keys".to_string()
+                        )).await;
                     });
                 }
                 "codex" | "openai-codex" => {
@@ -2688,17 +2640,14 @@ async fn run_interactive(
                     tokio::spawn(async move {
                         match crate::codex_oauth_flow::run_oauth_flow(tx2.clone()).await {
                             Ok(tokens) => {
-                                let _ = tx2
-                                    .send(DeviceAuthEvent::TokenReceived(tokens.access_token))
-                                    .await;
+                                let _ = tx2.send(DeviceAuthEvent::TokenReceived(
+                                    tokens.access_token,
+                                )).await;
                             }
                             Err(e) => {
-                                let _ = tx2
-                                    .send(DeviceAuthEvent::Error(format!(
-                                        "Codex OAuth failed: {}",
-                                        e
-                                    )))
-                                    .await;
+                                let _ = tx2.send(DeviceAuthEvent::Error(
+                                    format!("Codex OAuth failed: {}", e),
+                                )).await;
                             }
                         }
                     });
@@ -2726,12 +2675,8 @@ async fn run_interactive(
                     // Auto-open the verification URL in the browser
                     let _ = open::that(&verification_uri);
 
-                    app.device_auth_dialog.set_code(
-                        user_code,
-                        verification_uri,
-                        device_code,
-                        interval,
-                    );
+                    app.device_auth_dialog
+                        .set_code(user_code, verification_uri, device_code, interval);
 
                     app.notifications.push(
                         claurst_tui::NotificationKind::Info,
@@ -2774,8 +2719,7 @@ async fn run_interactive(
                 messages = msgs_arc.lock().await.clone();
                 session.messages = messages.clone();
                 session.updated_at = chrono::Utc::now();
-                session.model =
-                    claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
+                session.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
                 session.working_dir = Some(tool_ctx.working_dir.display().to_string());
                 app.is_streaming = false;
                 app.status_message = None;
@@ -2801,16 +2745,8 @@ async fn run_interactive(
                         for msg in &session.messages {
                             let content_str = match &msg.content {
                                 claurst_core::types::MessageContent::Text(t) => t.clone(),
-                                claurst_core::types::MessageContent::Blocks(blocks) => blocks
-                                    .iter()
-                                    .filter_map(|b| {
-                                        if let claurst_core::types::ContentBlock::Text { text } = b
-                                        {
-                                            Some(text.as_str())
-                                        } else {
-                                            None
-                                        }
-                                    })
+                                claurst_core::types::MessageContent::Blocks(blocks) => blocks.iter()
+                                    .filter_map(|b| if let claurst_core::types::ContentBlock::Text { text } = b { Some(text.as_str()) } else { None })
                                     .collect::<Vec<_>>()
                                     .join(" "),
                             };
@@ -2819,8 +2755,7 @@ async fn run_interactive(
                                 claurst_core::types::Role::Assistant => "assistant",
                             };
                             let msg_id = msg.uuid.as_deref().unwrap_or("unknown");
-                            let _ =
-                                store.save_message(&session.id, msg_id, role, &content_str, None);
+                            let _ = store.save_message(&session.id, msg_id, role, &content_str, None);
                         }
                     }
                 }
@@ -2914,9 +2849,7 @@ async fn handle_auth_command(args: &[String]) -> anyhow::Result<()> {
             eprintln!("Unknown auth subcommand: '{}'", unknown);
             eprintln!();
             eprintln!("Usage: claude auth <subcommand>");
-            eprintln!(
-                "  login [--console]   Authenticate (claude.ai by default; --console for API key)"
-            );
+            eprintln!("  login [--console]   Authenticate (claude.ai by default; --console for API key)");
             eprintln!("  logout              Remove stored credentials");
             eprintln!("  status [--json]     Show authentication status");
             std::process::exit(1);
@@ -2937,9 +2870,7 @@ async fn handle_auth_command(args: &[String]) -> anyhow::Result<()> {
 /// Print current auth status, then exit with code 0 (logged in) or 1 (not logged in).
 async fn auth_status(json_output: bool) {
     // Gather auth state
-    let env_api_key = std::env::var("ANTHROPIC_API_KEY")
-        .ok()
-        .filter(|k| !k.is_empty());
+    let env_api_key = std::env::var("ANTHROPIC_API_KEY").ok().filter(|k| !k.is_empty());
     let settings = Settings::load().await.unwrap_or_default();
     let settings_api_key = settings.config.api_key.clone().filter(|k| !k.is_empty());
     let oauth_tokens = claurst_core::oauth::OAuthTokens::load().await;
@@ -2996,11 +2927,7 @@ async fn auth_status(json_output: bool) {
     // Determine auth method (mirrors TypeScript authStatus())
     let (auth_method, logged_in) = if let Some(ref tokens) = oauth_tokens {
         let uses_bearer = tokens.uses_bearer_auth();
-        let method = if uses_bearer {
-            "claude.ai"
-        } else {
-            "oauth_token"
-        };
+        let method = if uses_bearer { "claude.ai" } else { "oauth_token" };
         (method.to_string(), true)
     } else if env_api_key.is_some() {
         ("api_key".to_string(), true)
@@ -3135,3 +3062,4 @@ fn json_null_or_string(opt: &Option<String>) -> serde_json::Value {
         None => serde_json::Value::Null,
     }
 }
+

--- a/src-rust/crates/commands/src/lib.rs
+++ b/src-rust/crates/commands/src/lib.rs
@@ -9,9 +9,9 @@ use claurst_core::config::{Config, Settings, Theme};
 use claurst_core::cost::CostTracker;
 use claurst_core::types::Message;
 use std::collections::BTreeMap;
-use std::sync::Arc;
 #[allow(unused_imports)]
 use std::path::PathBuf;
+use std::sync::Arc;
 
 // ---------------------------------------------------------------------------
 // Core trait
@@ -304,10 +304,7 @@ fn generate_keybindings_template() -> anyhow::Result<String> {
             .collect(),
     };
 
-    Ok(format!(
-        "{}\n",
-        serde_json::to_string_pretty(&template)?
-    ))
+    Ok(format!("{}\n", serde_json::to_string_pretty(&template)?))
 }
 
 fn parse_theme(name: &str) -> Option<Theme> {
@@ -389,31 +386,37 @@ fn command_category(name: &str) -> &'static str {
         "clear" | "compact" | "rewind" | "summary" | "export" | "rename" | "branch" | "fork" => {
             "Conversation"
         }
-        "model" | "config" | "theme" | "color" | "vim" | "fast" | "effort"
-        | "voice" | "statusline" | "output-style" | "keybindings"
-        | "privacy-settings" | "rate-limit-options" | "sandbox-toggle" => "Settings",
+        "model" | "config" | "theme" | "color" | "vim" | "fast" | "effort" | "voice"
+        | "statusline" | "output-style" | "keybindings" | "privacy-settings"
+        | "rate-limit-options" | "sandbox-toggle" => "Settings",
         "cost" | "stats" | "usage" | "extra-usage" | "context" | "ctx-viz" => "Usage & Cost",
         "status" | "doctor" | "terminal-setup" | "version" | "update" | "upgrade"
         | "release-notes" => "System",
         "login" | "logout" | "refresh" | "permissions" => "Auth & Permissions",
-        "memory" | "files" | "diff" | "init" | "commit" | "review"
-        | "security-review" => "Project",
+        "memory" | "files" | "diff" | "init" | "commit" | "review" | "security-review" => "Project",
         "mcp" | "hooks" | "ide" | "chrome" => "Integrations",
-        "session" | "resume" | "remote-control" | "remote-env"
-        | "share" | "teleport" => "Sessions & Remote",
+        "session" | "resume" | "remote-control" | "remote-env" | "share" | "teleport" => {
+            "Sessions & Remote"
+        }
         "help" | "exit" | "feedback" | "bug" => "General",
         "think-back" | "thinkback-play" | "thinking" | "plan" | "tasks" => "AI & Thinking",
-        "copy" | "skills" | "agents" | "plugin" | "reload-plugins"
-        | "stickers" | "passes" | "desktop" | "mobile" | "btw" => "Tools & Extras",
+        "copy" | "skills" | "agents" | "plugin" | "reload-plugins" | "stickers" | "passes"
+        | "desktop" | "mobile" | "btw" => "Tools & Extras",
         _ => "Other",
     }
 }
 
 #[async_trait]
 impl SlashCommand for HelpCommand {
-    fn name(&self) -> &str { "help" }
-    fn aliases(&self) -> Vec<&str> { vec!["h", "?"] }
-    fn description(&self) -> &str { "Show available commands and usage information" }
+    fn name(&self) -> &str {
+        "help"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["h", "?"]
+    }
+    fn description(&self) -> &str {
+        "Show available commands and usage information"
+    }
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         if !args.is_empty() {
@@ -425,7 +428,11 @@ impl SlashCommand for HelpCommand {
                 } else {
                     format!(
                         "\nAliases: {}",
-                        aliases.iter().map(|a| format!("/{}", a)).collect::<Vec<_>>().join(", ")
+                        aliases
+                            .iter()
+                            .map(|a| format!("/{}", a))
+                            .collect::<Vec<_>>()
+                            .join(", ")
                     )
                 };
                 return CommandResult::Message(format!(
@@ -470,13 +477,18 @@ impl SlashCommand for HelpCommand {
             } else {
                 format!(
                     " ({})",
-                    aliases.iter().map(|a| format!("/{}", a)).collect::<Vec<_>>().join(", ")
+                    aliases
+                        .iter()
+                        .map(|a| format!("/{}", a))
+                        .collect::<Vec<_>>()
+                        .join(", ")
                 )
             };
-            by_cat
-                .entry(cat)
-                .or_default()
-                .push(format!("  /{:<20} {}", format!("{}{}", cmd.name(), alias_str), cmd.description()));
+            by_cat.entry(cat).or_default().push(format!(
+                "  /{:<20} {}",
+                format!("{}{}", cmd.name(), alias_str),
+                cmd.description()
+            ));
         }
 
         let mut output = String::from("Claurst — Slash Commands\n");
@@ -500,9 +512,15 @@ impl SlashCommand for HelpCommand {
 
 #[async_trait]
 impl SlashCommand for ClearCommand {
-    fn name(&self) -> &str { "clear" }
-    fn aliases(&self) -> Vec<&str> { vec!["c", "reset", "new"] }
-    fn description(&self) -> &str { "Clear the conversation history" }
+    fn name(&self) -> &str {
+        "clear"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["c", "reset", "new"]
+    }
+    fn description(&self) -> &str {
+        "Clear the conversation history"
+    }
 
     async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
         CommandResult::ClearConversation
@@ -513,8 +531,12 @@ impl SlashCommand for ClearCommand {
 
 #[async_trait]
 impl SlashCommand for CompactCommand {
-    fn name(&self) -> &str { "compact" }
-    fn description(&self) -> &str { "Compact the conversation to reduce token usage" }
+    fn name(&self) -> &str {
+        "compact"
+    }
+    fn description(&self) -> &str {
+        "Compact the conversation to reduce token usage"
+    }
 
     async fn execute(&self, args: &str, ctx: &mut CommandContext) -> CommandResult {
         let msg_count = ctx.messages.len();
@@ -538,8 +560,12 @@ impl SlashCommand for CompactCommand {
 
 #[async_trait]
 impl SlashCommand for CostCommand {
-    fn name(&self) -> &str { "cost" }
-    fn description(&self) -> &str { "Show token usage and cost for this session" }
+    fn name(&self) -> &str {
+        "cost"
+    }
+    fn description(&self) -> &str {
+        "Show token usage and cost for this session"
+    }
     fn help(&self) -> &str {
         "Usage: /cost\n\n\
          Shows per-category token counts and the estimated cost for this session.\n\
@@ -561,10 +587,10 @@ impl SlashCommand for CostCommand {
         let cost = tracker.total_cost_usd();
 
         // Per-category cost breakdown.
-        let input_cost    = (input as f64 * pricing.input_per_mtk) / 1_000_000.0;
-        let output_cost   = (output as f64 * pricing.output_per_mtk) / 1_000_000.0;
-        let cc_cost       = (cache_create as f64 * pricing.cache_creation_per_mtk) / 1_000_000.0;
-        let cr_cost       = (cache_read as f64 * pricing.cache_read_per_mtk) / 1_000_000.0;
+        let input_cost = (input as f64 * pricing.input_per_mtk) / 1_000_000.0;
+        let output_cost = (output as f64 * pricing.output_per_mtk) / 1_000_000.0;
+        let cc_cost = (cache_create as f64 * pricing.cache_creation_per_mtk) / 1_000_000.0;
+        let cr_cost = (cache_read as f64 * pricing.cache_read_per_mtk) / 1_000_000.0;
 
         // Pricing info line.
         let pricing_line = format!(
@@ -578,10 +604,12 @@ impl SlashCommand for CostCommand {
         // Cache savings note: how much input cost was avoided by using cache-read
         // instead of re-sending those tokens as normal input.
         let savings = if cache_read > 0 {
-            let saved =
-                (cache_read as f64 * (pricing.input_per_mtk - pricing.cache_read_per_mtk))
-                    / 1_000_000.0;
-            format!("\n  Cache savings:  ${:.4}  ({} tokens served from cache)", saved, cache_read)
+            let saved = (cache_read as f64 * (pricing.input_per_mtk - pricing.cache_read_per_mtk))
+                / 1_000_000.0;
+            format!(
+                "\n  Cache savings:  ${:.4}  ({} tokens served from cache)",
+                saved, cache_read
+            )
         } else {
             String::new()
         };
@@ -619,9 +647,15 @@ impl SlashCommand for CostCommand {
 
 #[async_trait]
 impl SlashCommand for ExitCommand {
-    fn name(&self) -> &str { "exit" }
-    fn aliases(&self) -> Vec<&str> { vec!["quit", "q"] }
-    fn description(&self) -> &str { "Exit Claurst" }
+    fn name(&self) -> &str {
+        "exit"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["quit", "q"]
+    }
+    fn description(&self) -> &str {
+        "Exit Claurst"
+    }
 
     async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
         CommandResult::Exit
@@ -632,8 +666,12 @@ impl SlashCommand for ExitCommand {
 
 #[async_trait]
 impl SlashCommand for ModelCommand {
-    fn name(&self) -> &str { "model" }
-    fn description(&self) -> &str { "Show or change the current model" }
+    fn name(&self) -> &str {
+        "model"
+    }
+    fn description(&self) -> &str {
+        "Show or change the current model"
+    }
     fn help(&self) -> &str {
         "Usage: /model [<model-id>]\n\n\
          Without arguments, shows the current model.\n\n\
@@ -650,10 +688,7 @@ impl SlashCommand for ModelCommand {
     async fn execute(&self, args: &str, ctx: &mut CommandContext) -> CommandResult {
         let args = args.trim();
         if args.is_empty() {
-            CommandResult::Message(format!(
-                "Current model: {}",
-                ctx.config.effective_model()
-            ))
+            CommandResult::Message(format!("Current model: {}", ctx.config.effective_model()))
         } else {
             // Accept both "provider/model" and bare model names.
             // The config stores the full string (including provider prefix when present)
@@ -669,7 +704,10 @@ impl SlashCommand for ModelCommand {
                 format!("Switched to {}", model_str)
             };
             let mut new_config = ctx.config.clone();
-            new_config.model = Some(model_str);
+            new_config.model = Some(model_str.clone());
+            if let Some((provider, _)) = model_str.split_once('/') {
+                new_config.provider = Some(provider.to_string());
+            }
             CommandResult::ConfigChangeMessage(new_config, confirmation)
         }
     }
@@ -679,9 +717,15 @@ impl SlashCommand for ModelCommand {
 
 #[async_trait]
 impl SlashCommand for ConfigCommand {
-    fn name(&self) -> &str { "config" }
-    fn aliases(&self) -> Vec<&str> { vec!["settings"] }
-    fn description(&self) -> &str { "Show or modify configuration settings" }
+    fn name(&self) -> &str {
+        "config"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["settings"]
+    }
+    fn description(&self) -> &str {
+        "Show or modify configuration settings"
+    }
 
     async fn execute(&self, args: &str, ctx: &mut CommandContext) -> CommandResult {
         let args = args.trim();
@@ -700,10 +744,9 @@ impl SlashCommand for ConfigCommand {
                     "output-style = {}",
                     current_output_style_name(&ctx.config)
                 )),
-                "model" => CommandResult::Message(format!(
-                    "model = {}",
-                    ctx.config.effective_model()
-                )),
+                "model" => {
+                    CommandResult::Message(format!("model = {}", ctx.config.effective_model()))
+                }
                 "permission-mode" | "permission_mode" => CommandResult::Message(format!(
                     "permission-mode = {:?}",
                     ctx.config.permission_mode
@@ -717,7 +760,8 @@ impl SlashCommand for ConfigCommand {
                 "model" => {
                     let mut new_config = ctx.config.clone();
                     new_config.model = None;
-                    if let Err(err) = save_settings_mutation(|settings| settings.config.model = None)
+                    if let Err(err) =
+                        save_settings_mutation(|settings| settings.config.model = None)
                     {
                         return CommandResult::Error(format!(
                             "Failed to save configuration: {}",
@@ -788,8 +832,7 @@ impl SlashCommand for ConfigCommand {
                 }
 
                 let mut new_config = ctx.config.clone();
-                new_config.output_style =
-                    (normalized != "default").then(|| normalized.clone());
+                new_config.output_style = (normalized != "default").then(|| normalized.clone());
                 if let Err(err) = save_settings_mutation(|settings| {
                     settings.config.output_style =
                         (normalized != "default").then(|| normalized.clone());
@@ -807,15 +850,22 @@ impl SlashCommand for ConfigCommand {
             "model" => {
                 let mut new_config = ctx.config.clone();
                 new_config.model = Some(value.to_string());
+                let inferred_provider = value
+                    .split_once('/')
+                    .map(|(provider, _)| provider.to_string());
+                if let Some(ref provider) = inferred_provider {
+                    new_config.provider = Some(provider.clone());
+                }
                 if let Err(err) = save_settings_mutation(|settings| {
                     settings.config.model = Some(value.to_string());
+                    if let Some(ref provider) = inferred_provider {
+                        settings.provider = Some(provider.clone());
+                        settings.config.provider = Some(provider.clone());
+                    }
                 }) {
                     return CommandResult::Error(format!("Failed to save configuration: {}", err));
                 }
-                CommandResult::ConfigChangeMessage(
-                    new_config,
-                    format!("Model set to {}.", value),
-                )
+                CommandResult::ConfigChangeMessage(new_config, format!("Model set to {}.", value))
             }
             "permission-mode" | "permission_mode" => {
                 let mode = match value.trim().to_lowercase().as_str() {
@@ -856,8 +906,12 @@ impl SlashCommand for ConfigCommand {
 
 #[async_trait]
 impl SlashCommand for ColorCommand {
-    fn name(&self) -> &str { "color" }
-    fn description(&self) -> &str { "Set or show the prompt bar color for this session" }
+    fn name(&self) -> &str {
+        "color"
+    }
+    fn description(&self) -> &str {
+        "Set or show the prompt bar color for this session"
+    }
     fn help(&self) -> &str {
         "Usage: /color [<name|#RRGGBB|default>]\n\n\
          Sets the accent color for the prompt bar in this session.\n\
@@ -884,10 +938,11 @@ impl SlashCommand for ColorCommand {
             None
         } else {
             let known_colors = [
-                "red", "green", "blue", "yellow", "cyan", "magenta",
-                "white", "orange", "purple", "pink", "gray", "grey",
+                "red", "green", "blue", "yellow", "cyan", "magenta", "white", "orange", "purple",
+                "pink", "gray", "grey",
             ];
-            let is_hex = color.starts_with('#') && (color.len() == 4 || color.len() == 7)
+            let is_hex = color.starts_with('#')
+                && (color.len() == 4 || color.len() == 7)
                 && color[1..].chars().all(|c| c.is_ascii_hexdigit());
             if !is_hex && !known_colors.contains(&color.to_lowercase().as_str()) {
                 return CommandResult::Error(format!(
@@ -913,8 +968,12 @@ impl SlashCommand for ColorCommand {
 
 #[async_trait]
 impl SlashCommand for ThemeCommand {
-    fn name(&self) -> &str { "theme" }
-    fn description(&self) -> &str { "Show or change the current theme" }
+    fn name(&self) -> &str {
+        "theme"
+    }
+    fn description(&self) -> &str {
+        "Show or change the current theme"
+    }
     fn help(&self) -> &str {
         "Usage: /theme [default|dark|light]\n\
          Without arguments, shows the active theme. With an argument, updates the theme for this and future sessions."
@@ -930,15 +989,12 @@ impl SlashCommand for ThemeCommand {
         }
 
         let Some(theme) = parse_theme(args) else {
-            return CommandResult::Error(
-                "Theme must be one of: default, dark, light".to_string(),
-            );
+            return CommandResult::Error("Theme must be one of: default, dark, light".to_string());
         };
 
         let mut new_config = ctx.config.clone();
         new_config.theme = theme.clone();
-        if let Err(err) = save_settings_mutation(|settings| settings.config.theme = theme.clone())
-        {
+        if let Err(err) = save_settings_mutation(|settings| settings.config.theme = theme.clone()) {
             return CommandResult::Error(format!("Failed to save theme: {}", err));
         }
 
@@ -953,8 +1009,12 @@ impl SlashCommand for ThemeCommand {
 
 #[async_trait]
 impl SlashCommand for OutputStyleCommand {
-    fn name(&self) -> &str { "output-style" }
-    fn description(&self) -> &str { "Show or switch the current output style" }
+    fn name(&self) -> &str {
+        "output-style"
+    }
+    fn description(&self) -> &str {
+        "Show or switch the current output style"
+    }
     fn help(&self) -> &str {
         "Usage: /output-style [style-name]\n\n\
          With no argument: list available styles and show the current one.\n\
@@ -992,8 +1052,7 @@ impl SlashCommand for OutputStyleCommand {
         let mut new_config = ctx.config.clone();
         new_config.output_style = (normalized != "default").then(|| normalized.clone());
         if let Err(err) = save_settings_mutation(|settings| {
-            settings.config.output_style =
-                (normalized != "default").then(|| normalized.clone());
+            settings.config.output_style = (normalized != "default").then(|| normalized.clone());
         }) {
             return CommandResult::Error(format!("Failed to save configuration: {}", err));
         }
@@ -1012,8 +1071,12 @@ impl SlashCommand for OutputStyleCommand {
 
 #[async_trait]
 impl SlashCommand for KeybindingsCommand {
-    fn name(&self) -> &str { "keybindings" }
-    fn description(&self) -> &str { "Create or open ~/.claurst/keybindings.json" }
+    fn name(&self) -> &str {
+        "keybindings"
+    }
+    fn description(&self) -> &str {
+        "Create or open ~/.claurst/keybindings.json"
+    }
 
     async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let config_dir = Settings::config_dir();
@@ -1078,8 +1141,12 @@ impl SlashCommand for KeybindingsCommand {
 
 #[async_trait]
 impl SlashCommand for PrivacySettingsCommand {
-    fn name(&self) -> &str { "privacy-settings" }
-    fn description(&self) -> &str { "Open Claurst privacy settings" }
+    fn name(&self) -> &str {
+        "privacy-settings"
+    }
+    fn description(&self) -> &str {
+        "Open Claurst privacy settings"
+    }
 
     async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let url = "https://claude.ai/settings/data-privacy-controls";
@@ -1095,15 +1162,18 @@ impl SlashCommand for PrivacySettingsCommand {
 
 #[async_trait]
 impl SlashCommand for VersionCommand {
-    fn name(&self) -> &str { "version" }
-    fn aliases(&self) -> Vec<&str> { vec!["v"] }
-    fn description(&self) -> &str { "Show version information" }
+    fn name(&self) -> &str {
+        "version"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["v"]
+    }
+    fn description(&self) -> &str {
+        "Show version information"
+    }
 
     async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
-        CommandResult::Message(format!(
-            "Claurst v{}",
-            claurst_core::constants::APP_VERSION
-        ))
+        CommandResult::Message(format!("Claurst v{}", claurst_core::constants::APP_VERSION))
     }
 }
 
@@ -1111,9 +1181,15 @@ impl SlashCommand for VersionCommand {
 
 #[async_trait]
 impl SlashCommand for ResumeCommand {
-    fn name(&self) -> &str { "resume" }
-    fn aliases(&self) -> Vec<&str> { vec!["r", "continue"] }
-    fn description(&self) -> &str { "Resume a previous conversation" }
+    fn name(&self) -> &str {
+        "resume"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["r", "continue"]
+    }
+    fn description(&self) -> &str {
+        "Resume a previous conversation"
+    }
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         if args.is_empty() {
@@ -1123,10 +1199,7 @@ impl SlashCommand for ResumeCommand {
             }
             let mut output = String::from("Recent sessions:\n\n");
             for (i, session) in sessions.iter().take(10).enumerate() {
-                let title = session
-                    .title
-                    .as_deref()
-                    .unwrap_or("(untitled)");
+                let title = session.title.as_deref().unwrap_or("(untitled)");
                 let id_short = &session.id[..session.id.len().min(8)];
                 output.push_str(&format!(
                     "  {}. {} - {} ({} messages)\n",
@@ -1141,11 +1214,9 @@ impl SlashCommand for ResumeCommand {
         } else {
             match claurst_core::history::load_session(args.trim()).await {
                 Ok(session) => CommandResult::ResumeSession(session),
-                Err(e) => CommandResult::Error(format!(
-                    "Failed to load session {}: {}",
-                    args.trim(),
-                    e
-                )),
+                Err(e) => {
+                    CommandResult::Error(format!("Failed to load session {}: {}", args.trim(), e))
+                }
             }
         }
     }
@@ -1155,8 +1226,12 @@ impl SlashCommand for ResumeCommand {
 
 #[async_trait]
 impl SlashCommand for StatusCommand {
-    fn name(&self) -> &str { "status" }
-    fn description(&self) -> &str { "Show comprehensive system and session status" }
+    fn name(&self) -> &str {
+        "status"
+    }
+    fn description(&self) -> &str {
+        "Show comprehensive system and session status"
+    }
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         // Auth status
@@ -1242,8 +1317,12 @@ impl SlashCommand for StatusCommand {
 
 #[async_trait]
 impl SlashCommand for DiffCommand {
-    fn name(&self) -> &str { "diff" }
-    fn description(&self) -> &str { "Show git diff of changes in the working directory" }
+    fn name(&self) -> &str {
+        "diff"
+    }
+    fn description(&self) -> &str {
+        "Show git diff of changes in the working directory"
+    }
     fn help(&self) -> &str {
         "Usage: /diff [--stat|--staged|<ref>]\n\n\
          Shows git diff output for the current working directory.\n\n\
@@ -1314,8 +1393,12 @@ impl SlashCommand for DiffCommand {
 
 #[async_trait]
 impl SlashCommand for MemoryCommand {
-    fn name(&self) -> &str { "memory" }
-    fn description(&self) -> &str { "View, edit, or clear AGENTS.md memory files" }
+    fn name(&self) -> &str {
+        "memory"
+    }
+    fn description(&self) -> &str {
+        "View, edit, or clear AGENTS.md memory files"
+    }
     fn help(&self) -> &str {
         "Usage: /memory [edit|clear] [global]\n\n\
          Shows the content of AGENTS.md files that provide project context to Claurst.\n\
@@ -1351,7 +1434,10 @@ impl SlashCommand for MemoryCommand {
 
         // ---- /memory edit [global|project] ------------------------------------
         if cmd == "edit" || cmd.starts_with("edit ") {
-            let target_hint = cmd.strip_prefix("edit").map(|s| s.trim()).unwrap_or("project");
+            let target_hint = cmd
+                .strip_prefix("edit")
+                .map(|s| s.trim())
+                .unwrap_or("project");
             let target = match target_hint {
                 "global" => {
                     // Ensure global dir exists
@@ -1392,11 +1478,10 @@ impl SlashCommand for MemoryCommand {
             } else if let Ok(ed) = std::env::var("EDITOR") {
                 format!("Using $EDITOR=\"{}\".", ed)
             } else {
-                "To use a different editor, set the $EDITOR or $VISUAL environment variable.".to_string()
+                "To use a different editor, set the $EDITOR or $VISUAL environment variable."
+                    .to_string()
             };
-            let spawn_result = std::process::Command::new(&editor)
-                .arg(&target)
-                .status();
+            let spawn_result = std::process::Command::new(&editor).arg(&target).status();
             return match spawn_result {
                 Ok(_) => CommandResult::Message(format!(
                     "Opened {} in your editor.\n{}",
@@ -1405,14 +1490,20 @@ impl SlashCommand for MemoryCommand {
                 )),
                 Err(e) => CommandResult::Message(format!(
                     "Could not launch '{}': {}. Edit {} manually.\n{}",
-                    editor, e, target.display(), editor_hint
+                    editor,
+                    e,
+                    target.display(),
+                    editor_hint
                 )),
             };
         }
 
         // ---- /memory clear [global|project] -----------------------------------
         if cmd == "clear" || cmd.starts_with("clear ") {
-            let target_hint = cmd.strip_prefix("clear").map(|s| s.trim()).unwrap_or("project");
+            let target_hint = cmd
+                .strip_prefix("clear")
+                .map(|s| s.trim())
+                .unwrap_or("project");
             let (label, target) = match target_hint {
                 "global" => ("global (~/.claurst/AGENTS.md)", global_path.clone()),
                 _ => {
@@ -1436,9 +1527,9 @@ impl SlashCommand for MemoryCommand {
                     label,
                     target.display()
                 )),
-                Err(e) => CommandResult::Error(format!(
-                    "Failed to clear {}: {}", target.display(), e
-                )),
+                Err(e) => {
+                    CommandResult::Error(format!("Failed to clear {}: {}", target.display(), e))
+                }
             };
         }
 
@@ -1462,7 +1553,11 @@ impl SlashCommand for MemoryCommand {
                             lines = lines,
                             chars = chars,
                             content = if content.len() > 2000 {
-                                format!("{}…\n(truncated — file is {} chars)", &content[..2000], chars)
+                                format!(
+                                    "{}…\n(truncated — file is {} chars)",
+                                    &content[..2000],
+                                    chars
+                                )
                             } else {
                                 content.clone()
                             }
@@ -1470,7 +1565,9 @@ impl SlashCommand for MemoryCommand {
                     }
                     Err(e) => output.push_str(&format!(
                         "\n[{label}] — Error reading {}: {}\n",
-                        path.display(), e, label = label
+                        path.display(),
+                        e,
+                        label = label
                     )),
                 }
             }
@@ -1480,7 +1577,7 @@ impl SlashCommand for MemoryCommand {
             output.push_str(
                 "\nNo AGENTS.md files found.\n\
                  Use /init to create one in the current project.\n\
-                 Use /memory edit to create and open a memory file."
+                 Use /memory edit to create and open a memory file.",
             );
         } else {
             output.push_str(
@@ -1488,7 +1585,7 @@ impl SlashCommand for MemoryCommand {
                  /memory edit          — edit project AGENTS.md\n\
                  /memory edit global   — edit global ~/.claurst/AGENTS.md\n\
                  /memory clear         — clear project AGENTS.md\n\
-                 /memory clear global  — clear global AGENTS.md"
+                 /memory clear global  — clear global AGENTS.md",
             );
         }
 
@@ -1500,10 +1597,18 @@ impl SlashCommand for MemoryCommand {
 
 #[async_trait]
 impl SlashCommand for BugCommand {
-    fn name(&self) -> &str { "feedback" }
-    fn aliases(&self) -> Vec<&str> { vec!["bug"] }
-    fn description(&self) -> &str { "Submit feedback about Claurst" }
-    fn help(&self) -> &str { "Usage: /feedback [report]" }
+    fn name(&self) -> &str {
+        "feedback"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["bug"]
+    }
+    fn description(&self) -> &str {
+        "Submit feedback about Claurst"
+    }
+    fn help(&self) -> &str {
+        "Usage: /feedback [report]"
+    }
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let report = args.trim();
@@ -1525,8 +1630,12 @@ impl SlashCommand for BugCommand {
 
 #[async_trait]
 impl SlashCommand for UsageCommand {
-    fn name(&self) -> &str { "usage" }
-    fn description(&self) -> &str { "Show API usage, quotas, and rate limit status" }
+    fn name(&self) -> &str {
+        "usage"
+    }
+    fn description(&self) -> &str {
+        "Show API usage, quotas, and rate limit status"
+    }
     fn help(&self) -> &str {
         "Usage: /usage\n\n\
          Shows current session API usage and account quota information.\n\
@@ -1587,9 +1696,15 @@ impl SlashCommand for UsageCommand {
 
 #[async_trait]
 impl SlashCommand for PluginCommand {
-    fn name(&self) -> &str { "plugin" }
-    fn aliases(&self) -> Vec<&str> { vec!["plugins"] }
-    fn description(&self) -> &str { "Manage plugins" }
+    fn name(&self) -> &str {
+        "plugin"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["plugins"]
+    }
+    fn description(&self) -> &str {
+        "Manage plugins"
+    }
     fn help(&self) -> &str {
         "Usage: /plugin [list|info <name>|enable <name>|disable <name>|install <path>|reload]\n\
          Manage Claurst plugins.\n\n\
@@ -1608,9 +1723,7 @@ impl SlashCommand for PluginCommand {
 
         // Helper: prefer the already-loaded global registry, falling back to a
         // fresh disk scan so the command still works without the global being set.
-        async fn get_registry(
-            project_dir: &std::path::Path,
-        ) -> claurst_plugins::PluginRegistry {
+        async fn get_registry(project_dir: &std::path::Path) -> claurst_plugins::PluginRegistry {
             if let Some(global) = claurst_plugins::global_plugin_registry() {
                 let mut reg = claurst_plugins::PluginRegistry::new();
                 for p in global.all() {
@@ -1691,9 +1804,7 @@ impl SlashCommand for PluginCommand {
                 )
             }
             claurst_plugins::PluginSubCommand::Install(path) => {
-                let result = claurst_plugins::install_plugin_from_path(
-                    std::path::Path::new(&path),
-                );
+                let result = claurst_plugins::install_plugin_from_path(std::path::Path::new(&path));
                 match result {
                     Ok(name) => CommandResult::Message(format!(
                         "Plugin '{}' installed successfully. Run `/plugin reload` to activate it.",
@@ -1708,9 +1819,8 @@ impl SlashCommand for PluginCommand {
                     claurst_plugins::reload_plugins(&old_registry, &project_dir, &[]).await;
                 CommandResult::Message(claurst_plugins::format_reload_summary(&new_registry, &diff))
             }
-            claurst_plugins::PluginSubCommand::Help => {
-                CommandResult::Message(
-                    "Plugin commands:\n\
+            claurst_plugins::PluginSubCommand::Help => CommandResult::Message(
+                "Plugin commands:\n\
                      /plugin              — list all installed plugins\n\
                      /plugin list         — list all installed plugins\n\
                      /plugin info <name>  — show plugin details\n\
@@ -1718,9 +1828,8 @@ impl SlashCommand for PluginCommand {
                      /plugin disable <name>  — disable a plugin\n\
                      /plugin install <path>  — install plugin from local path\n\
                      /plugin reload       — reload plugins from disk"
-                        .to_string(),
-                )
-            }
+                    .to_string(),
+            ),
         }
     }
 }
@@ -1729,8 +1838,12 @@ impl SlashCommand for PluginCommand {
 
 #[async_trait]
 impl SlashCommand for ReloadPluginsCommand {
-    fn name(&self) -> &str { "reload-plugins" }
-    fn description(&self) -> &str { "Reload all plugins without restarting" }
+    fn name(&self) -> &str {
+        "reload-plugins"
+    }
+    fn description(&self) -> &str {
+        "Reload all plugins without restarting"
+    }
     fn help(&self) -> &str {
         "Usage: /reload-plugins\n\
          Reloads all plugins and shows what changed."
@@ -1805,14 +1918,15 @@ impl SlashCommand for PluginSlashCommandAdapter {
                 } else {
                     format!("{} {}", command, args)
                 };
-                let cmd_result = std::process::Command::new(if cfg!(windows) { "cmd" } else { "sh" })
-                    .args(if cfg!(windows) {
-                        vec!["/C", &full_cmd]
-                    } else {
-                        vec!["-c", &full_cmd]
-                    })
-                    .env("CLAUDE_PLUGIN_ROOT", plugin_root)
-                    .output();
+                let cmd_result =
+                    std::process::Command::new(if cfg!(windows) { "cmd" } else { "sh" })
+                        .args(if cfg!(windows) {
+                            vec!["/C", &full_cmd]
+                        } else {
+                            vec!["-c", &full_cmd]
+                        })
+                        .env("CLAUDE_PLUGIN_ROOT", plugin_root)
+                        .output();
                 match cmd_result {
                     Ok(out) => {
                         let stdout = String::from_utf8_lossy(&out.stdout);
@@ -1834,8 +1948,12 @@ impl SlashCommand for PluginSlashCommandAdapter {
 
 #[async_trait]
 impl SlashCommand for DoctorCommand {
-    fn name(&self) -> &str { "doctor" }
-    fn description(&self) -> &str { "Check system health and diagnose issues" }
+    fn name(&self) -> &str {
+        "doctor"
+    }
+    fn description(&self) -> &str {
+        "Check system health and diagnose issues"
+    }
     fn help(&self) -> &str {
         "Usage: /doctor\n\
          Runs a comprehensive system diagnostics check:\n\
@@ -1906,7 +2024,10 @@ impl SlashCommand for DoctorCommand {
             }
         }
         // Show which model is active
-        lines.push(format!("  • Active model: {}", ctx.config.effective_model()));
+        lines.push(format!(
+            "  • Active model: {}",
+            ctx.config.effective_model()
+        ));
         lines.push(String::new());
 
         // ── Git ─────────────────────────────────────────────────────────────
@@ -1938,7 +2059,9 @@ impl SlashCommand for DoctorCommand {
                     .to_string();
                 lines.push(format!("  ✓ ripgrep: {first}"));
             }
-            _ => lines.push("  ⚠ ripgrep (rg) not found — Grep tool will fall back to built-in".to_string()),
+            _ => lines.push(
+                "  ⚠ ripgrep (rg) not found — Grep tool will fall back to built-in".to_string(),
+            ),
         }
         lines.push(String::new());
 
@@ -2015,10 +2138,10 @@ impl SlashCommand for DoctorCommand {
                         .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
                     {
                         Some(_) => lines.push(
-                            "  ⚠ settings.json is JSON but has unexpected structure".to_string()
+                            "  ⚠ settings.json is JSON but has unexpected structure".to_string(),
                         ),
                         None => lines.push(
-                            "  ✗ settings.json is invalid JSON — run /config to repair".to_string()
+                            "  ✗ settings.json is invalid JSON — run /config to repair".to_string(),
                         ),
                     }
                 }
@@ -2032,7 +2155,9 @@ impl SlashCommand for DoctorCommand {
         if claude_md.exists() {
             lines.push("  ✓ AGENTS.md present in working directory".to_string());
         } else {
-            lines.push("  • No AGENTS.md in working directory (run /init to create one)".to_string());
+            lines.push(
+                "  • No AGENTS.md in working directory (run /init to create one)".to_string(),
+            );
         }
         lines.push(String::new());
 
@@ -2047,13 +2172,19 @@ impl SlashCommand for DoctorCommand {
             for srv in ctx.config.mcp_servers.iter().take(12) {
                 let status_str = match statuses.get(&srv.name) {
                     Some(claurst_mcp::McpServerStatus::Connected { tool_count }) => {
-                        format!("  ✓ {} — connected ({} tool{})",
-                            srv.name, tool_count, if *tool_count == 1 { "" } else { "s" })
+                        format!(
+                            "  ✓ {} — connected ({} tool{})",
+                            srv.name,
+                            tool_count,
+                            if *tool_count == 1 { "" } else { "s" }
+                        )
                     }
                     Some(claurst_mcp::McpServerStatus::Connecting) => {
                         format!("  ⚠ {} — connecting…", srv.name)
                     }
-                    Some(claurst_mcp::McpServerStatus::Disconnected { last_error: Some(e) }) => {
+                    Some(claurst_mcp::McpServerStatus::Disconnected {
+                        last_error: Some(e),
+                    }) => {
                         format!("  ✗ {} — failed: {}", srv.name, e)
                     }
                     Some(claurst_mcp::McpServerStatus::Disconnected { last_error: None }) => {
@@ -2071,7 +2202,9 @@ impl SlashCommand for DoctorCommand {
             }
         } else {
             // No live manager — just show configured names
-            lines.push(format!("  ✓ {mcp_count} MCP server(s) configured (not yet connected):"));
+            lines.push(format!(
+                "  ✓ {mcp_count} MCP server(s) configured (not yet connected):"
+            ));
             for srv in ctx.config.mcp_servers.iter().take(8) {
                 lines.push(format!("    - {}", srv.name));
             }
@@ -2087,8 +2220,10 @@ impl SlashCommand for DoctorCommand {
         if hook_count == 0 {
             lines.push("  • No hooks configured".to_string());
         } else {
-            lines.push(format!("  ✓ {hook_count} hook(s) configured across {} event(s)",
-                ctx.config.hooks.len()));
+            lines.push(format!(
+                "  ✓ {hook_count} hook(s) configured across {} event(s)",
+                ctx.config.hooks.len()
+            ));
         }
         lines.push(String::new());
 
@@ -2102,15 +2237,21 @@ impl SlashCommand for DoctorCommand {
         let allowed_count = ctx.config.allowed_tools.len();
         let denied_count = ctx.config.disallowed_tools.len();
         // Tools not in allowed or denied lists require user confirmation
-        let explicit_tools: std::collections::HashSet<&str> = ctx.config.allowed_tools.iter()
+        let explicit_tools: std::collections::HashSet<&str> = ctx
+            .config
+            .allowed_tools
+            .iter()
             .chain(ctx.config.disallowed_tools.iter())
             .map(|s| s.as_str())
             .collect();
-        let confirm_count = all_tool_names.iter()
+        let confirm_count = all_tool_names
+            .iter()
             .filter(|n| !explicit_tools.contains(n.as_str()))
             .count();
         let mode_label = match ctx.config.permission_mode {
-            claurst_core::PermissionMode::BypassPermissions => "bypass-permissions (no confirmation required)",
+            claurst_core::PermissionMode::BypassPermissions => {
+                "bypass-permissions (no confirmation required)"
+            }
             claurst_core::PermissionMode::AcceptEdits => "accept-edits (file edits auto-approved)",
             claurst_core::PermissionMode::Plan => "plan (read-only, no writes)",
             claurst_core::PermissionMode::Default => "default (confirm destructive actions)",
@@ -2118,17 +2259,24 @@ impl SlashCommand for DoctorCommand {
         lines.push(format!("  • Mode: {mode_label}"));
         lines.push(format!("  • Total built-in tools: {total_tools}"));
         if allowed_count > 0 {
-            lines.push(format!("  ✓ Always allowed: {} tool(s) — {}",
+            lines.push(format!(
+                "  ✓ Always allowed: {} tool(s) — {}",
                 allowed_count,
-                ctx.config.allowed_tools.join(", ")));
+                ctx.config.allowed_tools.join(", ")
+            ));
         }
         if denied_count > 0 {
-            lines.push(format!("  ✗ Always denied: {} tool(s) — {}",
+            lines.push(format!(
+                "  ✗ Always denied: {} tool(s) — {}",
                 denied_count,
-                ctx.config.disallowed_tools.join(", ")));
+                ctx.config.disallowed_tools.join(", ")
+            ));
         }
         if ctx.config.permission_mode == claurst_core::PermissionMode::Default {
-            lines.push(format!("  ⚠ Require confirmation: {} tool(s)", confirm_count));
+            lines.push(format!(
+                "  ⚠ Require confirmation: {} tool(s)",
+                confirm_count
+            ));
         }
         lines.push(String::new());
 
@@ -2151,8 +2299,12 @@ impl SlashCommand for DoctorCommand {
 
 #[async_trait]
 impl SlashCommand for LoginCommand {
-    fn name(&self) -> &str { "login" }
-    fn description(&self) -> &str { "Authenticate with Anthropic (OAuth PKCE flow)" }
+    fn name(&self) -> &str {
+        "login"
+    }
+    fn description(&self) -> &str {
+        "Authenticate with Anthropic (OAuth PKCE flow)"
+    }
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         // `--console` flag → Console/API-key auth; default → Claude.ai subscription auth
@@ -2165,8 +2317,12 @@ impl SlashCommand for LoginCommand {
 
 #[async_trait]
 impl SlashCommand for LogoutCommand {
-    fn name(&self) -> &str { "logout" }
-    fn description(&self) -> &str { "Clear stored OAuth tokens and API key" }
+    fn name(&self) -> &str {
+        "logout"
+    }
+    fn description(&self) -> &str {
+        "Clear stored OAuth tokens and API key"
+    }
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         // Clear OAuth tokens file
@@ -2174,7 +2330,9 @@ impl SlashCommand for LogoutCommand {
             return CommandResult::Error(format!("Failed to clear OAuth tokens: {}", e));
         }
         // Also clear any API key stored in settings
-        let mut settings = claurst_core::config::Settings::load().await.unwrap_or_default();
+        let mut settings = claurst_core::config::Settings::load()
+            .await
+            .unwrap_or_default();
         settings.config.api_key = None;
         if let Err(e) = settings.save().await {
             return CommandResult::Error(format!("Failed to update settings: {}", e));
@@ -2188,8 +2346,12 @@ impl SlashCommand for LogoutCommand {
 
 #[async_trait]
 impl SlashCommand for RefreshCommand {
-    fn name(&self) -> &str { "refresh" }
-    fn description(&self) -> &str { "Clear saved provider auth and model caches" }
+    fn name(&self) -> &str {
+        "refresh"
+    }
+    fn description(&self) -> &str {
+        "Clear saved provider auth and model caches"
+    }
     fn help(&self) -> &str {
         "Usage: /refresh\n\n\
          Clears saved provider credentials, provider/model selection, and model caches, then rebuilds the live runtime state.\n\
@@ -2221,8 +2383,12 @@ fn parse_speech_level(args: &str) -> String {
 
 #[async_trait]
 impl SlashCommand for CavemanCommand {
-    fn name(&self) -> &str { "caveman" }
-    fn description(&self) -> &str { "Caveman speech mode — why use many token when few token do trick" }
+    fn name(&self) -> &str {
+        "caveman"
+    }
+    fn description(&self) -> &str {
+        "Caveman speech mode — why use many token when few token do trick"
+    }
     fn help(&self) -> &str {
         "Usage: /caveman [lite|full|ultra]\n\n\
          Activates caveman speech mode that cuts ~75% of output tokens.\n\
@@ -2233,14 +2399,21 @@ impl SlashCommand for CavemanCommand {
     }
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let level = parse_speech_level(args);
-        CommandResult::SpeechMode { mode: Some("caveman".to_string()), level }
+        CommandResult::SpeechMode {
+            mode: Some("caveman".to_string()),
+            level,
+        }
     }
 }
 
 #[async_trait]
 impl SlashCommand for RockyCommand {
-    fn name(&self) -> &str { "rocky" }
-    fn description(&self) -> &str { "Rocky speech mode — Eridian alien engineer from Project Hail Mary. Save big token. Good good good." }
+    fn name(&self) -> &str {
+        "rocky"
+    }
+    fn description(&self) -> &str {
+        "Rocky speech mode — Eridian alien engineer from Project Hail Mary. Save big token. Good good good."
+    }
     fn help(&self) -> &str {
         "Usage: /rocky [lite|full|ultra]\n\n\
          Speak like Rocky from Project Hail Mary. Saves big token. Amaze amaze amaze.\n\
@@ -2251,19 +2424,29 @@ impl SlashCommand for RockyCommand {
     }
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let level = parse_speech_level(args);
-        CommandResult::SpeechMode { mode: Some("rocky".to_string()), level }
+        CommandResult::SpeechMode {
+            mode: Some("rocky".to_string()),
+            level,
+        }
     }
 }
 
 #[async_trait]
 impl SlashCommand for NormalCommand {
-    fn name(&self) -> &str { "normal" }
-    fn description(&self) -> &str { "Deactivate speech mode (caveman/rocky)" }
+    fn name(&self) -> &str {
+        "normal"
+    }
+    fn description(&self) -> &str {
+        "Deactivate speech mode (caveman/rocky)"
+    }
     fn help(&self) -> &str {
         "Usage: /normal\n\nDeactivate any active speech mode and return to normal output."
     }
     async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
-        CommandResult::SpeechMode { mode: None, level: "full".to_string() }
+        CommandResult::SpeechMode {
+            mode: None,
+            level: "full".to_string(),
+        }
     }
 }
 
@@ -2271,8 +2454,12 @@ impl SlashCommand for NormalCommand {
 
 #[async_trait]
 impl SlashCommand for InitCommand {
-    fn name(&self) -> &str { "init" }
-    fn description(&self) -> &str { "Initialize a new project with AGENTS.md" }
+    fn name(&self) -> &str {
+        "init"
+    }
+    fn description(&self) -> &str {
+        "Initialize a new project with AGENTS.md"
+    }
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         let path = ctx.working_dir.join("AGENTS.md");
@@ -2291,10 +2478,7 @@ impl SlashCommand for InitCommand {
             - List important files and their purposes\n";
 
         match tokio::fs::write(&path, default_content).await {
-            Ok(()) => CommandResult::Message(format!(
-                "Created AGENTS.md at {}",
-                path.display()
-            )),
+            Ok(()) => CommandResult::Message(format!("Created AGENTS.md at {}", path.display())),
             Err(e) => CommandResult::Error(format!("Failed to create AGENTS.md: {}", e)),
         }
     }
@@ -2304,8 +2488,12 @@ impl SlashCommand for InitCommand {
 
 #[async_trait]
 impl SlashCommand for ReviewCommand {
-    fn name(&self) -> &str { "review" }
-    fn description(&self) -> &str { "Review code changes via LLM and optionally post to GitHub PR" }
+    fn name(&self) -> &str {
+        "review"
+    }
+    fn description(&self) -> &str {
+        "Review code changes via LLM and optionally post to GitHub PR"
+    }
     fn help(&self) -> &str {
         "Usage: /review [base-ref]\n\n\
          Runs `git diff <base>...HEAD` (or `git diff --cached` when no base is given),\n\
@@ -2349,10 +2537,7 @@ impl SlashCommand for ReviewCommand {
                 }
                 Ok(o) => {
                     let stderr = String::from_utf8_lossy(&o.stderr);
-                    return CommandResult::Error(format!(
-                        "git diff failed: {}",
-                        stderr.trim()
-                    ));
+                    return CommandResult::Error(format!("git diff failed: {}", stderr.trim()));
                 }
                 Err(e) => return CommandResult::Error(format!("Failed to run git: {}", e)),
             }
@@ -2470,9 +2655,7 @@ impl SlashCommand for ReviewCommand {
                 let (msg, _usage, _stop) = acc.finish();
                 let text = msg.get_all_text();
                 if text.is_empty() {
-                    return CommandResult::Error(
-                        "LLM returned an empty review.".to_string(),
-                    );
+                    return CommandResult::Error("LLM returned an empty review.".to_string());
                 }
                 text
             }
@@ -2524,14 +2707,11 @@ impl SlashCommand for ReviewCommand {
                         Ok(resp) => {
                             let status = resp.status().as_u16();
                             let body = resp.text().await.unwrap_or_default();
-                            github_post_result = Some(format!(
-                                "\nGitHub API returned {}: {}",
-                                status, body
-                            ));
+                            github_post_result =
+                                Some(format!("\nGitHub API returned {}: {}", status, body));
                         }
                         Err(e) => {
-                            github_post_result =
-                                Some(format!("\nFailed to post to GitHub: {}", e));
+                            github_post_result = Some(format!("\nFailed to post to GitHub: {}", e));
                         }
                     }
                 } else {
@@ -2643,8 +2823,12 @@ fn parse_github_remote_url(url: &str) -> Option<(String, String)> {
 
 #[async_trait]
 impl SlashCommand for HooksCommand {
-    fn name(&self) -> &str { "hooks" }
-    fn description(&self) -> &str { "Show configured event hooks" }
+    fn name(&self) -> &str {
+        "hooks"
+    }
+    fn description(&self) -> &str {
+        "Show configured event hooks"
+    }
     fn help(&self) -> &str {
         "Usage: /hooks\n\
          Show hooks configured in settings.json under 'hooks'.\n\
@@ -2683,8 +2867,12 @@ impl SlashCommand for HooksCommand {
 
 #[async_trait]
 impl SlashCommand for McpCommand {
-    fn name(&self) -> &str { "mcp" }
-    fn description(&self) -> &str { "Show MCP server status and manage connections" }
+    fn name(&self) -> &str {
+        "mcp"
+    }
+    fn description(&self) -> &str {
+        "Show MCP server status and manage connections"
+    }
     fn help(&self) -> &str {
         "Usage: /mcp [list|status|auth <server>|connect <server>|logs <server>|resources|prompts|get-prompt ...]\n\n\
          Manages Model Context Protocol (MCP) servers.\n\
@@ -2814,7 +3002,7 @@ impl SlashCommand for McpCommand {
                 output.push_str(
                     "\nNote: MCP manager is not active in this session.\n\
                      Restart Claurst to connect to MCP servers.\n\
-                     Use /mcp connect <server> to retry a single server."
+                     Use /mcp connect <server> to retry a single server.",
                 );
             }
             return CommandResult::Message(output);
@@ -2854,7 +3042,7 @@ impl SlashCommand for McpCommand {
         }
         output.push_str(
             "\nSubcommands: status | auth <server> | connect <server> | logs <server>\n\
-             Also: resources | prompts | get-prompt <server> <prompt> [key=val ...]"
+             Also: resources | prompts | get-prompt <server> <prompt> [key=val ...]",
         );
         CommandResult::Message(output)
     }
@@ -2869,15 +3057,29 @@ impl McpCommand {
     ///
     /// For stdio servers: shows env-var auth instructions.
     async fn handle_auth(server_name: &str, ctx: &CommandContext) -> CommandResult {
-        let srv = match ctx.config.mcp_servers.iter().find(|s| s.name == server_name) {
+        let srv = match ctx
+            .config
+            .mcp_servers
+            .iter()
+            .find(|s| s.name == server_name)
+        {
             Some(s) => s,
             None => {
-                let configured: Vec<&str> = ctx.config.mcp_servers.iter().map(|s| s.name.as_str()).collect();
+                let configured: Vec<&str> = ctx
+                    .config
+                    .mcp_servers
+                    .iter()
+                    .map(|s| s.name.as_str())
+                    .collect();
                 return CommandResult::Error(format!(
                     "No MCP server named '{}' is configured.\n\
                      Configured servers: {}",
                     server_name,
-                    if configured.is_empty() { "(none)".to_string() } else { configured.join(", ") }
+                    if configured.is_empty() {
+                        "(none)".to_string()
+                    } else {
+                        configured.join(", ")
+                    }
                 ));
             }
         };
@@ -2981,22 +3183,31 @@ impl McpCommand {
     fn handle_tools(server_filter: Option<&str>, ctx: &CommandContext) -> CommandResult {
         let manager = match ctx.mcp_manager.as_ref() {
             Some(m) => m,
-            None => return CommandResult::Message(
-                "MCP manager is not active. No tool information available.\n\
-                 Restart Claurst to connect to MCP servers.".to_string()
-            ),
+            None => {
+                return CommandResult::Message(
+                    "MCP manager is not active. No tool information available.\n\
+                 Restart Claurst to connect to MCP servers."
+                        .to_string(),
+                )
+            }
         };
 
         let all_tools = manager.all_tool_definitions();
         let tools: Vec<_> = if let Some(filter) = server_filter {
-            all_tools.iter().filter(|(srv, _)| srv.as_str() == filter).collect()
+            all_tools
+                .iter()
+                .filter(|(srv, _)| srv.as_str() == filter)
+                .collect()
         } else {
             all_tools.iter().collect()
         };
 
         if tools.is_empty() {
             return CommandResult::Message(if let Some(filter) = server_filter {
-                format!("No tools available from server '{}' (not connected or has no tools).", filter)
+                format!(
+                    "No tools available from server '{}' (not connected or has no tools).",
+                    filter
+                )
             } else {
                 "No tools available from any connected MCP server.".to_string()
             });
@@ -3015,9 +3226,16 @@ impl McpCommand {
                 last_server = server.as_str();
             }
             // Strip the "servername_" prefix for display
-            let bare = tool.name.strip_prefix(&format!("{}_", server)).unwrap_or(&tool.name);
+            let bare = tool
+                .name
+                .strip_prefix(&format!("{}_", server))
+                .unwrap_or(&tool.name);
             let preview: String = tool.description.chars().take(80).collect();
-            let ellipsis = if tool.description.len() > 80 { "…" } else { "" };
+            let ellipsis = if tool.description.len() > 80 {
+                "…"
+            } else {
+                ""
+            };
             out.push_str(&format!("  {}\n    {}{}\n", bare, preview, ellipsis));
         }
         CommandResult::Message(out)
@@ -3027,12 +3245,21 @@ impl McpCommand {
     async fn handle_connect(server_name: &str, ctx: &CommandContext) -> CommandResult {
         // Validate that the server is configured.
         if !ctx.config.mcp_servers.iter().any(|s| s.name == server_name) {
-            let names: Vec<&str> = ctx.config.mcp_servers.iter().map(|s| s.name.as_str()).collect();
+            let names: Vec<&str> = ctx
+                .config
+                .mcp_servers
+                .iter()
+                .map(|s| s.name.as_str())
+                .collect();
             return CommandResult::Error(format!(
                 "No MCP server named '{}' is configured.\n\
                  Configured servers: {}",
                 server_name,
-                if names.is_empty() { "(none)".to_string() } else { names.join(", ") }
+                if names.is_empty() {
+                    "(none)".to_string()
+                } else {
+                    names.join(", ")
+                }
             ));
         }
 
@@ -3052,21 +3279,17 @@ impl McpCommand {
                 let current = manager.server_status(server_name);
                 use claurst_mcp::McpServerStatus;
                 match current {
-                    McpServerStatus::Connected { tool_count } => {
-                        CommandResult::Message(format!(
-                            "MCP server '{}' is already connected ({} tool{} available).",
-                            server_name,
-                            tool_count,
-                            if tool_count == 1 { "" } else { "s" }
-                        ))
-                    }
-                    McpServerStatus::Connecting => {
-                        CommandResult::Message(format!(
-                            "MCP server '{}' is already in the process of connecting.\n\
+                    McpServerStatus::Connected { tool_count } => CommandResult::Message(format!(
+                        "MCP server '{}' is already connected ({} tool{} available).",
+                        server_name,
+                        tool_count,
+                        if tool_count == 1 { "" } else { "s" }
+                    )),
+                    McpServerStatus::Connecting => CommandResult::Message(format!(
+                        "MCP server '{}' is already in the process of connecting.\n\
                              Check back in a moment.",
-                            server_name
-                        ))
-                    }
+                        server_name
+                    )),
                     McpServerStatus::Disconnected { .. } | McpServerStatus::Failed { .. } => {
                         // The McpManager doesn't expose a reconnect method — it's built at
                         // startup.  Inform the user and suggest a restart.
@@ -3093,16 +3316,28 @@ impl McpCommand {
     fn handle_logs(server_name: &str, ctx: &CommandContext) -> CommandResult {
         // Validate server name.
         if !ctx.config.mcp_servers.iter().any(|s| s.name == server_name) {
-            let names: Vec<&str> = ctx.config.mcp_servers.iter().map(|s| s.name.as_str()).collect();
+            let names: Vec<&str> = ctx
+                .config
+                .mcp_servers
+                .iter()
+                .map(|s| s.name.as_str())
+                .collect();
             return CommandResult::Error(format!(
                 "No MCP server named '{}' is configured.\n\
                  Configured servers: {}",
                 server_name,
-                if names.is_empty() { "(none)".to_string() } else { names.join(", ") }
+                if names.is_empty() {
+                    "(none)".to_string()
+                } else {
+                    names.join(", ")
+                }
             ));
         }
 
-        let mut lines = vec![format!("MCP Server Logs — '{}'\n──────────────────────", server_name)];
+        let mut lines = vec![format!(
+            "MCP Server Logs — '{}'\n──────────────────────",
+            server_name
+        )];
 
         if let Some(manager) = &ctx.mcp_manager {
             use claurst_mcp::McpServerStatus;
@@ -3110,30 +3345,52 @@ impl McpCommand {
             lines.push(format!("Current status:  {}", status.display()));
 
             match &status {
-                McpServerStatus::Disconnected { last_error: Some(e) } => {
+                McpServerStatus::Disconnected {
+                    last_error: Some(e),
+                } => {
                     lines.push(format!("\nLast connection error:\n  {}", e));
                     lines.push(String::new());
                     lines.push("Troubleshooting:".to_string());
-                    lines.push(format!("  /mcp auth {}    — check authentication", server_name));
-                    lines.push(format!("  /mcp connect {} — attempt reconnect", server_name));
+                    lines.push(format!(
+                        "  /mcp auth {}    — check authentication",
+                        server_name
+                    ));
+                    lines.push(format!(
+                        "  /mcp connect {} — attempt reconnect",
+                        server_name
+                    ));
                 }
                 McpServerStatus::Failed { error, retry_at } => {
                     lines.push(format!("\nConnection failure:\n  {}", error));
-                    let retry_secs = retry_at.saturating_duration_since(std::time::Instant::now()).as_secs();
+                    let retry_secs = retry_at
+                        .saturating_duration_since(std::time::Instant::now())
+                        .as_secs();
                     if retry_secs > 0 {
                         lines.push(format!("  Automatic retry in {}s", retry_secs));
                     }
                     let _ = retry_at; // used above
                 }
                 McpServerStatus::Connected { tool_count } => {
-                    lines.push(format!("\nServer is healthy — {} tool{} available.", tool_count, if *tool_count == 1 { "" } else { "s" }));
+                    lines.push(format!(
+                        "\nServer is healthy — {} tool{} available.",
+                        tool_count,
+                        if *tool_count == 1 { "" } else { "s" }
+                    ));
                     // Show catalog info if available.
                     if let Some(catalog) = manager.server_catalog(server_name) {
                         if !catalog.resources.is_empty() {
-                            lines.push(format!("Resources ({}): {}", catalog.resource_count, catalog.resources.join(", ")));
+                            lines.push(format!(
+                                "Resources ({}): {}",
+                                catalog.resource_count,
+                                catalog.resources.join(", ")
+                            ));
                         }
                         if !catalog.prompts.is_empty() {
-                            lines.push(format!("Prompts ({}): {}", catalog.prompt_count, catalog.prompts.join(", ")));
+                            lines.push(format!(
+                                "Prompts ({}): {}",
+                                catalog.prompt_count,
+                                catalog.prompts.join(", ")
+                            ));
                         }
                     }
                 }
@@ -3160,9 +3417,12 @@ impl McpCommand {
 
         // Hint about log files.
         lines.push(String::new());
-        lines.push("Note: Detailed stdio output from MCP server processes is not\n\
+        lines.push(
+            "Note: Detailed stdio output from MCP server processes is not\n\
                     captured by the manager. Run the server command directly in a\n\
-                    terminal to see its full output.".to_string());
+                    terminal to see its full output."
+                .to_string(),
+        );
 
         CommandResult::Message(lines.join("\n"))
     }
@@ -3180,7 +3440,8 @@ impl McpCommand {
                 let resources = manager.list_all_resources(filter).await;
                 if resources.is_empty() {
                     return Some(CommandResult::Message(
-                        "No resources available (servers may not support resources/list).".to_string()
+                        "No resources available (servers may not support resources/list)."
+                            .to_string(),
                     ));
                 }
                 let mut out = format!("MCP Resources ({})\n──────────────────\n", resources.len());
@@ -3202,21 +3463,36 @@ impl McpCommand {
                 let prompts = manager.list_all_prompts(filter).await;
                 if prompts.is_empty() {
                     return Some(CommandResult::Message(
-                        "No prompt templates available (servers may not support prompts/list).".to_string()
+                        "No prompt templates available (servers may not support prompts/list)."
+                            .to_string(),
                     ));
                 }
-                let mut out = format!("MCP Prompt Templates ({})\n─────────────────────────\n", prompts.len());
+                let mut out = format!(
+                    "MCP Prompt Templates ({})\n─────────────────────────\n",
+                    prompts.len()
+                );
                 for p in &prompts {
                     let server = p.get("server").and_then(|v| v.as_str()).unwrap_or("?");
                     let name = p.get("name").and_then(|v| v.as_str()).unwrap_or("?");
                     let desc = p.get("description").and_then(|v| v.as_str()).unwrap_or("");
-                    let args: Vec<String> = p.get("arguments")
+                    let args: Vec<String> = p
+                        .get("arguments")
                         .and_then(|a| a.as_array())
-                        .map(|arr| arr.iter()
-                            .filter_map(|a| a.get("name").and_then(|n| n.as_str()).map(|s| s.to_string()))
-                            .collect())
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|a| {
+                                    a.get("name")
+                                        .and_then(|n| n.as_str())
+                                        .map(|s| s.to_string())
+                                })
+                                .collect()
+                        })
                         .unwrap_or_default();
-                    let args_display = if args.is_empty() { String::new() } else { format!(" ({})", args.join(", ")) };
+                    let args_display = if args.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" ({})", args.join(", "))
+                    };
                     if desc.is_empty() {
                         out.push_str(&format!("  [{server}] {name}{args_display}\n"));
                     } else {
@@ -3230,13 +3506,22 @@ impl McpCommand {
                 // /mcp get-prompt <server> <prompt-name> [key=val key2=val2 ...]
                 let server = match parts.get(1) {
                     Some(s) => *s,
-                    None => return Some(CommandResult::Error("Usage: /mcp get-prompt <server> <prompt> [key=value ...]".to_string())),
+                    None => {
+                        return Some(CommandResult::Error(
+                            "Usage: /mcp get-prompt <server> <prompt> [key=value ...]".to_string(),
+                        ))
+                    }
                 };
                 let prompt_name = match parts.get(2) {
                     Some(p) => *p,
-                    None => return Some(CommandResult::Error("Usage: /mcp get-prompt <server> <prompt> [key=value ...]".to_string())),
+                    None => {
+                        return Some(CommandResult::Error(
+                            "Usage: /mcp get-prompt <server> <prompt> [key=value ...]".to_string(),
+                        ))
+                    }
                 };
-                let mut args: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+                let mut args: std::collections::HashMap<String, String> =
+                    std::collections::HashMap::new();
                 if let Some(kv_str) = parts.get(3) {
                     for kv in kv_str.split_whitespace() {
                         if let Some((k, v)) = kv.split_once('=') {
@@ -3251,7 +3536,9 @@ impl McpCommand {
                         for msg in &result.messages {
                             let text = match &msg.content {
                                 claurst_mcp::PromptMessageContent::Text { text } => text.clone(),
-                                claurst_mcp::PromptMessageContent::Image { .. } => "[image]".to_string(),
+                                claurst_mcp::PromptMessageContent::Image { .. } => {
+                                    "[image]".to_string()
+                                }
                                 claurst_mcp::PromptMessageContent::Resource { resource } => {
                                     resource.to_string()
                                 }
@@ -3260,7 +3547,10 @@ impl McpCommand {
                         }
                         Some(CommandResult::UserMessage(injected.trim().to_string()))
                     }
-                    Err(e) => Some(CommandResult::Error(format!("Failed to get prompt '{}' from '{}': {}", prompt_name, server, e))),
+                    Err(e) => Some(CommandResult::Error(format!(
+                        "Failed to get prompt '{}' from '{}': {}",
+                        prompt_name, server, e
+                    ))),
                 }
             }
             _ => None,
@@ -3272,8 +3562,12 @@ impl McpCommand {
 
 #[async_trait]
 impl SlashCommand for PermissionsCommand {
-    fn name(&self) -> &str { "permissions" }
-    fn description(&self) -> &str { "View or change tool permission settings" }
+    fn name(&self) -> &str {
+        "permissions"
+    }
+    fn description(&self) -> &str {
+        "View or change tool permission settings"
+    }
     fn help(&self) -> &str {
         "Usage: /permissions [set <mode>|allow <tool>|deny <tool>|reset]\n\n\
          Modes: default, accept-edits, bypass-permissions, plan\n\n\
@@ -3308,9 +3602,7 @@ impl SlashCommand for PermissionsCommand {
                  Use /permissions set <mode> to change the permission mode.\n\
                  Use /permissions allow|deny <tool> to override individual tools.\n\
                  Use /permissions reset to clear all overrides.",
-                ctx.config.permission_mode,
-                allowed_display,
-                denied_display,
+                ctx.config.permission_mode, allowed_display, denied_display,
             ));
         }
 
@@ -3322,16 +3614,24 @@ impl SlashCommand for PermissionsCommand {
             "set" => {
                 let mode = match arg.to_lowercase().as_str() {
                     "default" => claurst_core::config::PermissionMode::Default,
-                    "accept-edits" | "accept_edits" => claurst_core::config::PermissionMode::AcceptEdits,
-                    "bypass-permissions" | "bypass_permissions" => claurst_core::config::PermissionMode::BypassPermissions,
+                    "accept-edits" | "accept_edits" => {
+                        claurst_core::config::PermissionMode::AcceptEdits
+                    }
+                    "bypass-permissions" | "bypass_permissions" => {
+                        claurst_core::config::PermissionMode::BypassPermissions
+                    }
                     "plan" => claurst_core::config::PermissionMode::Plan,
-                    _ => return CommandResult::Error(
-                        "Mode must be: default, accept-edits, bypass-permissions, or plan".to_string()
-                    ),
+                    _ => {
+                        return CommandResult::Error(
+                            "Mode must be: default, accept-edits, bypass-permissions, or plan"
+                                .to_string(),
+                        )
+                    }
                 };
                 let mut new_config = ctx.config.clone();
                 new_config.permission_mode = mode.clone();
-                if let Err(e) = save_settings_mutation(|s| s.config.permission_mode = mode.clone()) {
+                if let Err(e) = save_settings_mutation(|s| s.config.permission_mode = mode.clone())
+                {
                     return CommandResult::Error(format!("Failed to save: {}", e));
                 }
                 CommandResult::ConfigChangeMessage(
@@ -3408,8 +3708,12 @@ impl SlashCommand for PermissionsCommand {
 
 #[async_trait]
 impl SlashCommand for PlanCommand {
-    fn name(&self) -> &str { "plan" }
-    fn description(&self) -> &str { "Enter plan mode – model outputs a plan for approval before acting" }
+    fn name(&self) -> &str {
+        "plan"
+    }
+    fn description(&self) -> &str {
+        "Enter plan mode – model outputs a plan for approval before acting"
+    }
     fn help(&self) -> &str {
         "Usage: /plan [description]\n\n\
          Switches to plan mode where the model will create a detailed plan before executing.\n\
@@ -3420,7 +3724,7 @@ impl SlashCommand for PlanCommand {
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         if args.trim() == "exit" {
             return CommandResult::UserMessage(
-                "[Exiting plan mode. Resuming normal execution.]".to_string()
+                "[Exiting plan mode. Resuming normal execution.]".to_string(),
             );
         }
         let task_desc = if args.is_empty() {
@@ -3441,13 +3745,20 @@ impl SlashCommand for PlanCommand {
 
 #[async_trait]
 impl SlashCommand for TasksCommand {
-    fn name(&self) -> &str { "tasks" }
-    fn aliases(&self) -> Vec<&str> { vec!["bashes"] }
-    fn description(&self) -> &str { "List and manage background tasks" }
+    fn name(&self) -> &str {
+        "tasks"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["bashes"]
+    }
+    fn description(&self) -> &str {
+        "List and manage background tasks"
+    }
 
     async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
         CommandResult::UserMessage(
-            "Please list all current tasks using the TaskList tool and show their status.".to_string()
+            "Please list all current tasks using the TaskList tool and show their status."
+                .to_string(),
         )
     }
 }
@@ -3456,9 +3767,15 @@ impl SlashCommand for TasksCommand {
 
 #[async_trait]
 impl SlashCommand for SessionCommand {
-    fn name(&self) -> &str { "session" }
-    fn aliases(&self) -> Vec<&str> { vec!["remote"] }
-    fn description(&self) -> &str { "Show or manage conversation sessions" }
+    fn name(&self) -> &str {
+        "session"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["remote"]
+    }
+    fn description(&self) -> &str {
+        "Show or manage conversation sessions"
+    }
 
     async fn execute(&self, args: &str, ctx: &mut CommandContext) -> CommandResult {
         match args.trim() {
@@ -3522,7 +3839,11 @@ impl SlashCommand for SessionCommand {
                         for sess in sessions.iter().take(5) {
                             let updated = sess.updated_at.format("%Y-%m-%d %H:%M").to_string();
                             let id_short = &sess.id[..sess.id.len().min(8)];
-                            let marker = if sess.id == ctx.session_id { " ◀ current" } else { "" };
+                            let marker = if sess.id == ctx.session_id {
+                                " ◀ current"
+                            } else {
+                                ""
+                            };
                             output.push_str(&format!(
                                 "  {} | {} | {} messages | {}{}\n",
                                 id_short,
@@ -3532,13 +3853,18 @@ impl SlashCommand for SessionCommand {
                                 marker,
                             ));
                         }
-                        output.push_str("\nUse /session list for all sessions, /resume <id> to switch.");
+                        output.push_str(
+                            "\nUse /session list for all sessions, /resume <id> to switch.",
+                        );
                     }
 
                     CommandResult::Message(output)
                 }
             }
-            _ => CommandResult::Error(format!("Unknown subcommand: {}\n\nUsage: /session [list]", args)),
+            _ => CommandResult::Error(format!(
+                "Unknown subcommand: {}\n\nUsage: /session [list]",
+                args
+            )),
         }
     }
 }
@@ -3547,8 +3873,12 @@ impl SlashCommand for SessionCommand {
 
 #[async_trait]
 impl SlashCommand for ForkCommand {
-    fn name(&self) -> &str { "fork" }
-    fn description(&self) -> &str { "Fork the current session into a new branch" }
+    fn name(&self) -> &str {
+        "fork"
+    }
+    fn description(&self) -> &str {
+        "Fork the current session into a new branch"
+    }
     fn help(&self) -> &str {
         "Usage: /fork [message_index]\n\n\
          Fork the current session at the specified message index (or at the\n\
@@ -3575,9 +3905,7 @@ impl SlashCommand for ForkCommand {
             "Fork of {}",
             ctx.session_title.as_deref().unwrap_or("session")
         ));
-        new_session.working_dir = Some(
-            ctx.working_dir.to_string_lossy().to_string(),
-        );
+        new_session.working_dir = Some(ctx.working_dir.to_string_lossy().to_string());
 
         let new_id = new_session.id.clone();
         match claurst_core::history::save_session(&new_session).await {
@@ -3594,9 +3922,15 @@ impl SlashCommand for ForkCommand {
 
 #[async_trait]
 impl SlashCommand for ThinkingCommand {
-    fn name(&self) -> &str { "thinking" }
-    fn description(&self) -> &str { "Toggle extended thinking mode" }
-    fn aliases(&self) -> Vec<&str> { vec!["think"] }
+    fn name(&self) -> &str {
+        "thinking"
+    }
+    fn description(&self) -> &str {
+        "Toggle extended thinking mode"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["think"]
+    }
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         // Extended thinking is configured through the model; just inform the user
@@ -3604,7 +3938,8 @@ impl SlashCommand for ThinkingCommand {
         if model.contains("claude-3-5") || model.contains("claude-3.5") {
             CommandResult::Message(
                 "Extended thinking is not available for Claude 3.5 models.\n\
-                 Use claude-opus-4-6 or claude-sonnet-4-6 for extended thinking.".to_string()
+                 Use claude-opus-4-6 or claude-sonnet-4-6 for extended thinking."
+                    .to_string(),
             )
         } else {
             CommandResult::Message(format!(
@@ -3683,7 +4018,12 @@ fn export_message_to_markdown(
                 'search: for next_msg in all_messages.iter().skip(msg_idx + 1) {
                     if let MessageContent::Blocks(next_blocks) = &next_msg.content {
                         for nb in next_blocks {
-                            if let ContentBlock::ToolResult { tool_use_id, content, is_error } = nb {
+                            if let ContentBlock::ToolResult {
+                                tool_use_id,
+                                content,
+                                is_error,
+                            } = nb
+                            {
                                 if tool_use_id.as_str() == *tool_id {
                                     let text = match content {
                                         ToolResultContent::Text(t) => t.clone(),
@@ -3699,17 +4039,27 @@ fn export_message_to_markdown(
                                             .collect::<Vec<_>>()
                                             .join(""),
                                     };
-                                    let label = if is_error.unwrap_or(false) { "Error" } else { "Output" };
-                                    found_output = Some(format!("**{}:** `{}`\n",
+                                    let label = if is_error.unwrap_or(false) {
+                                        "Error"
+                                    } else {
+                                        "Output"
+                                    };
+                                    found_output = Some(format!(
+                                        "**{}:** `{}`\n",
                                         label,
-                                        text.lines().next().unwrap_or(&text).trim()));
+                                        text.lines().next().unwrap_or(&text).trim()
+                                    ));
                                     break 'search;
                                 }
                             }
                         }
                     }
                 }
-                out.push_str(found_output.as_deref().unwrap_or("**Output:** *(pending)*\n"));
+                out.push_str(
+                    found_output
+                        .as_deref()
+                        .unwrap_or("**Output:** *(pending)*\n"),
+                );
             }
         }
     }
@@ -3723,7 +4073,10 @@ fn build_markdown_export(ctx: &CommandContext) -> String {
     out.push_str("# Conversation Export\n\n");
     out.push_str(&format!("- **Session ID:** {}\n", ctx.session_id));
     out.push_str(&format!("- **Model:** {}\n", ctx.config.effective_model()));
-    out.push_str(&format!("- **Exported:** {}\n", chrono::Utc::now().to_rfc3339()));
+    out.push_str(&format!(
+        "- **Exported:** {}\n",
+        chrono::Utc::now().to_rfc3339()
+    ));
     if let Some(ref title) = ctx.session_title {
         out.push_str(&format!("- **Title:** {}\n", title));
     }
@@ -3758,8 +4111,12 @@ fn build_json_export(ctx: &CommandContext) -> serde_json::Value {
 
 #[async_trait]
 impl SlashCommand for ExportCommand {
-    fn name(&self) -> &str { "export" }
-    fn description(&self) -> &str { "Export conversation to markdown or JSON" }
+    fn name(&self) -> &str {
+        "export"
+    }
+    fn description(&self) -> &str {
+        "Export conversation to markdown or JSON"
+    }
     fn help(&self) -> &str {
         "Usage: /export [--format markdown|json] [--output <file>]\n\n\
          Export the current conversation.\n\n\
@@ -3791,7 +4148,7 @@ impl SlashCommand for ExportCommand {
                         i += 2;
                     } else {
                         return CommandResult::Error(
-                            "--format requires a value: markdown or json".to_string()
+                            "--format requires a value: markdown or json".to_string(),
                         );
                     }
                 }
@@ -3800,9 +4157,7 @@ impl SlashCommand for ExportCommand {
                         output_path = Some(tokens[i + 1].to_string());
                         i += 2;
                     } else {
-                        return CommandResult::Error(
-                            "--output requires a file path".to_string()
-                        );
+                        return CommandResult::Error("--output requires a file path".to_string());
                     }
                 }
                 other if !other.starts_with('-') => {
@@ -3824,7 +4179,8 @@ impl SlashCommand for ExportCommand {
             Some("json") => "json",
             Some(other) => {
                 return CommandResult::Error(format!(
-                    "Unknown format '{}'. Use 'markdown' or 'json'.", other
+                    "Unknown format '{}'. Use 'markdown' or 'json'.",
+                    other
                 ));
             }
             None => {
@@ -3861,7 +4217,11 @@ impl SlashCommand for ExportCommand {
                     format!(
                         "{}.{}",
                         filename,
-                        if resolved_format == "markdown" { "md" } else { "json" }
+                        if resolved_format == "markdown" {
+                            "md"
+                        } else {
+                            "json"
+                        }
                     )
                 } else {
                     filename.to_string()
@@ -3880,9 +4240,9 @@ impl SlashCommand for ExportCommand {
                         ctx.messages.len(),
                         resolved_format,
                     )),
-                    Err(e) => CommandResult::Error(format!(
-                        "Failed to write {}: {}", path.display(), e
-                    )),
+                    Err(e) => {
+                        CommandResult::Error(format!("Failed to write {}: {}", path.display(), e))
+                    }
                 }
             }
             None => {
@@ -3897,9 +4257,15 @@ impl SlashCommand for ExportCommand {
 
 #[async_trait]
 impl SlashCommand for SkillsCommand {
-    fn name(&self) -> &str { "skills" }
-    fn aliases(&self) -> Vec<&str> { vec!["skill"] }
-    fn description(&self) -> &str { "List available skills in .claurst/commands/" }
+    fn name(&self) -> &str {
+        "skills"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["skill"]
+    }
+    fn description(&self) -> &str {
+        "List available skills in .claurst/commands/"
+    }
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         let mut found: Vec<String> = Vec::new();
@@ -3957,15 +4323,13 @@ impl SlashCommand for SkillsCommand {
         }
 
         // Include discovered skills from .claurst/skills/ and configured paths/URLs.
-        let discovered = claurst_core::discover_skills(
-            &ctx.working_dir,
-            &ctx.config.skills,
-        );
+        let discovered = claurst_core::discover_skills(&ctx.working_dir, &ctx.config.skills);
 
         let mut output = if found.is_empty() && discovered.is_empty() {
             return CommandResult::Message(
                 "No skills found.\nCreate .md files in .claurst/commands/ to define skills.\n\
-                 Example: .claurst/commands/review.md".to_string(),
+                 Example: .claurst/commands/review.md"
+                    .to_string(),
             );
         } else if found.is_empty() {
             String::new()
@@ -3974,7 +4338,11 @@ impl SlashCommand for SkillsCommand {
             format!(
                 "Available skills ({}):\n{}",
                 found.len(),
-                found.iter().map(|s| format!("  /{}", s)).collect::<Vec<_>>().join("\n")
+                found
+                    .iter()
+                    .map(|s| format!("  /{}", s))
+                    .collect::<Vec<_>>()
+                    .join("\n")
             )
         };
 
@@ -4005,8 +4373,12 @@ impl SlashCommand for SkillsCommand {
 
 #[async_trait]
 impl SlashCommand for RewindCommand {
-    fn name(&self) -> &str { "rewind" }
-    fn description(&self) -> &str { "Interactively select a message to rewind to" }
+    fn name(&self) -> &str {
+        "rewind"
+    }
+    fn description(&self) -> &str {
+        "Interactively select a message to rewind to"
+    }
     fn help(&self) -> &str {
         "Usage: /rewind\n\
          Opens an interactive overlay to select the message to rewind to.\n\
@@ -4015,7 +4387,9 @@ impl SlashCommand for RewindCommand {
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         if ctx.messages.is_empty() {
-            return CommandResult::Message("Nothing to rewind — conversation is empty.".to_string());
+            return CommandResult::Message(
+                "Nothing to rewind — conversation is empty.".to_string(),
+            );
         }
         CommandResult::OpenRewindOverlay
     }
@@ -4025,8 +4399,12 @@ impl SlashCommand for RewindCommand {
 
 #[async_trait]
 impl SlashCommand for StatsCommand {
-    fn name(&self) -> &str { "stats" }
-    fn description(&self) -> &str { "Show token usage and cost statistics" }
+    fn name(&self) -> &str {
+        "stats"
+    }
+    fn description(&self) -> &str {
+        "Show token usage and cost statistics"
+    }
     fn help(&self) -> &str {
         "Usage: /stats\n\n\
          Shows detailed token usage and cost breakdown for the current session,\n\
@@ -4044,15 +4422,21 @@ impl SlashCommand for StatsCommand {
         let model = ctx.config.effective_model();
 
         // Count user/assistant turns separately.
-        let user_turns = ctx.messages.iter()
+        let user_turns = ctx
+            .messages
+            .iter()
             .filter(|m| m.role == claurst_core::types::Role::User)
             .count();
-        let assistant_turns = ctx.messages.iter()
+        let assistant_turns = ctx
+            .messages
+            .iter()
             .filter(|m| m.role == claurst_core::types::Role::Assistant)
             .count();
 
         // Count tool-use invocations.
-        let tool_calls: usize = ctx.messages.iter()
+        let tool_calls: usize = ctx
+            .messages
+            .iter()
             .map(|m| m.get_tool_use_blocks().len())
             .sum();
 
@@ -4103,14 +4487,19 @@ impl SlashCommand for StatsCommand {
 
 #[async_trait]
 impl SlashCommand for FilesCommand {
-    fn name(&self) -> &str { "files" }
-    fn description(&self) -> &str { "List files referenced in the current conversation" }
+    fn name(&self) -> &str {
+        "files"
+    }
+    fn description(&self) -> &str {
+        "List files referenced in the current conversation"
+    }
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         use std::collections::HashSet;
         // Scan message content for file paths (simple heuristic)
         let mut files: HashSet<String> = HashSet::new();
-        let path_re = regex::Regex::new(r#"(?m)([A-Za-z]:[\\/][^\s,;:"'<>]+|/[^\s,;:"'<>]{3,})"#).ok();
+        let path_re =
+            regex::Regex::new(r#"(?m)([A-Za-z]:[\\/][^\s,;:"'<>]+|/[^\s,;:"'<>]{3,})"#).ok();
 
         for msg in &ctx.messages {
             let text = msg.get_all_text();
@@ -4136,7 +4525,11 @@ impl SlashCommand for FilesCommand {
         CommandResult::Message(format!(
             "Referenced files ({}):\n{}",
             sorted.len(),
-            sorted.iter().map(|f| format!("  {}", f)).collect::<Vec<_>>().join("\n")
+            sorted
+                .iter()
+                .map(|f| format!("  {}", f))
+                .collect::<Vec<_>>()
+                .join("\n")
         ))
     }
 }
@@ -4145,8 +4538,12 @@ impl SlashCommand for FilesCommand {
 
 #[async_trait]
 impl SlashCommand for RenameCommand {
-    fn name(&self) -> &str { "rename" }
-    fn description(&self) -> &str { "Rename the current session" }
+    fn name(&self) -> &str {
+        "rename"
+    }
+    fn description(&self) -> &str {
+        "Rename the current session"
+    }
     fn help(&self) -> &str {
         "Usage: /rename [new name]\n\n\
          With a name: sets the session title immediately.\n\
@@ -4178,12 +4575,18 @@ impl SlashCommand for RenameCommand {
             .take(20)
             .filter_map(|m| {
                 let text = m.get_all_text();
-                if text.is_empty() { return None; }
+                if text.is_empty() {
+                    return None;
+                }
                 let role = match m.role {
                     claurst_core::types::Role::User => "User",
                     claurst_core::types::Role::Assistant => "Assistant",
                 };
-                Some(format!("{}: {}", role, text.chars().take(300).collect::<String>()))
+                Some(format!(
+                    "{}: {}",
+                    role,
+                    text.chars().take(300).collect::<String>()
+                ))
             })
             .collect::<Vec<_>>()
             .join("\n");
@@ -4210,25 +4613,29 @@ impl SlashCommand for RenameCommand {
             Examples: fix-login-bug, add-auth-feature, refactor-api-client. \
             Respond with ONLY the name, nothing else.";
 
-        let request = claurst_api::CreateMessageRequest::builder(
-            "claude-haiku-4-5".to_string(),
-            64,
-        )
-        .system_text(system_prompt)
-        .add_message(claurst_api::ApiMessage {
-            role: "user".to_string(),
-            content: serde_json::Value::String(
-                format!("Conversation to name:\n\n{}", &excerpt[..excerpt.len().min(2000)])
-            ),
-        })
-        .build();
+        let request =
+            claurst_api::CreateMessageRequest::builder("claude-haiku-4-5".to_string(), 64)
+                .system_text(system_prompt)
+                .add_message(claurst_api::ApiMessage {
+                    role: "user".to_string(),
+                    content: serde_json::Value::String(format!(
+                        "Conversation to name:\n\n{}",
+                        &excerpt[..excerpt.len().min(2000)]
+                    )),
+                })
+                .build();
 
         match client.create_message(request).await {
             Ok(response) => {
                 // Extract text from the response content blocks.
-                let raw_text: String = response.content.iter()
+                let raw_text: String = response
+                    .content
+                    .iter()
                     .filter_map(|block| {
-                        block.get("text").and_then(|v| v.as_str()).map(str::to_string)
+                        block
+                            .get("text")
+                            .and_then(|v| v.as_str())
+                            .map(str::to_string)
                     })
                     .collect::<Vec<_>>()
                     .join("")
@@ -4246,7 +4653,8 @@ impl SlashCommand for RenameCommand {
                 if cleaned.is_empty() {
                     return CommandResult::Error(
                         "Could not generate a valid name from conversation. \
-                         Use /rename <name> to set manually.".to_string(),
+                         Use /rename <name> to set manually."
+                            .to_string(),
                     );
                 }
 
@@ -4264,8 +4672,12 @@ impl SlashCommand for RenameCommand {
 
 #[async_trait]
 impl SlashCommand for EffortCommand {
-    fn name(&self) -> &str { "effort" }
-    fn description(&self) -> &str { "Set the model's thinking effort (low | normal | high)" }
+    fn name(&self) -> &str {
+        "effort"
+    }
+    fn description(&self) -> &str {
+        "Set the model's thinking effort (low | normal | high)"
+    }
     fn help(&self) -> &str {
         "Usage: /effort [low|normal|high]\n\
          Sets how much computation the model uses for reasoning.\n\
@@ -4302,8 +4714,12 @@ impl SlashCommand for EffortCommand {
 
 #[async_trait]
 impl SlashCommand for SummaryCommand {
-    fn name(&self) -> &str { "summary" }
-    fn description(&self) -> &str { "Generate a brief summary of the conversation so far" }
+    fn name(&self) -> &str {
+        "summary"
+    }
+    fn description(&self) -> &str {
+        "Generate a brief summary of the conversation so far"
+    }
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         let count = ctx.messages.len();
@@ -4324,8 +4740,12 @@ impl SlashCommand for SummaryCommand {
 
 #[async_trait]
 impl SlashCommand for CommitCommand {
-    fn name(&self) -> &str { "commit" }
-    fn description(&self) -> &str { "Ask Claurst to commit staged changes" }
+    fn name(&self) -> &str {
+        "commit"
+    }
+    fn description(&self) -> &str {
+        "Ask Claurst to commit staged changes"
+    }
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let extra = if args.trim().is_empty() {
@@ -4352,7 +4772,7 @@ impl SlashCommand for CommitCommand {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
 struct UiSettings {
     #[serde(default)]
-    pub editor_mode: Option<String>,       // "vim" or "normal"
+    pub editor_mode: Option<String>, // "vim" or "normal"
     #[serde(default)]
     pub fast_mode: Option<bool>,
     #[serde(default)]
@@ -4414,9 +4834,15 @@ where
 
 #[async_trait]
 impl SlashCommand for RemoteControlCommand {
-    fn name(&self) -> &str { "remote-control" }
-    fn aliases(&self) -> Vec<&str> { vec!["rc"] }
-    fn description(&self) -> &str { "Show or manage the remote control (Bridge) connection" }
+    fn name(&self) -> &str {
+        "remote-control"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["rc"]
+    }
+    fn description(&self) -> &str {
+        "Show or manage the remote control (Bridge) connection"
+    }
     fn help(&self) -> &str {
         "Usage: /remote-control [start|stop|status]\n\n\
          The Bridge feature lets you connect your local Claurst CLI to the\n\
@@ -4453,8 +4879,11 @@ impl SlashCommand for RemoteControlCommand {
                     "not set (required to connect)"
                 };
 
-                let startup_status =
-                    if remote_at_startup { "enabled at startup" } else { "disabled" };
+                let startup_status = if remote_at_startup {
+                    "enabled at startup"
+                } else {
+                    "disabled"
+                };
 
                 // Active session info from context
                 let session_section = if let Some(ref url) = ctx.remote_session_url {
@@ -4562,8 +4991,12 @@ impl SlashCommand for RemoteControlCommand {
 
 #[async_trait]
 impl SlashCommand for RemoteEnvCommand {
-    fn name(&self) -> &str { "remote-env" }
-    fn description(&self) -> &str { "Show and manage environment variables for remote sessions" }
+    fn name(&self) -> &str {
+        "remote-env"
+    }
+    fn description(&self) -> &str {
+        "Show and manage environment variables for remote sessions"
+    }
     fn help(&self) -> &str {
         "Usage: /remote-env [set <KEY> <VALUE> | unset <KEY> | list]\n\n\
          Manages env vars stored in config that are forwarded to remote Claurst sessions.\n\
@@ -4629,9 +5062,7 @@ impl SlashCommand for RemoteEnvCommand {
             }
             "unset" | "remove" | "delete" => {
                 if key.is_empty() {
-                    return CommandResult::Error(
-                        "Usage: /remote-env unset <KEY>".to_string(),
-                    );
+                    return CommandResult::Error("Usage: /remote-env unset <KEY>".to_string());
                 }
                 if !ctx.config.env.contains_key(key) {
                     return CommandResult::Message(format!("Key '{}' is not set.", key));
@@ -4661,8 +5092,12 @@ impl SlashCommand for RemoteEnvCommand {
 
 #[async_trait]
 impl SlashCommand for ContextCommand {
-    fn name(&self) -> &str { "context" }
-    fn description(&self) -> &str { "Show context window usage (tokens used / available)" }
+    fn name(&self) -> &str {
+        "context"
+    }
+    fn description(&self) -> &str {
+        "Show context window usage (tokens used / available)"
+    }
     fn help(&self) -> &str {
         "Usage: /context\n\n\
          Displays the current context window utilization:\n\
@@ -4728,8 +5163,12 @@ impl SlashCommand for ContextCommand {
 
 #[async_trait]
 impl SlashCommand for CopyCommand {
-    fn name(&self) -> &str { "copy" }
-    fn description(&self) -> &str { "Copy the last assistant response to the clipboard" }
+    fn name(&self) -> &str {
+        "copy"
+    }
+    fn description(&self) -> &str {
+        "Copy the last assistant response to the clipboard"
+    }
     fn help(&self) -> &str {
         "Usage: /copy [n]\n\n\
          Copies the most recent assistant response to the system clipboard.\n\
@@ -4814,6 +5253,7 @@ impl SlashCommand for CopyCommand {
 
 mod chrome_cdp {
     use base64::Engine as _;
+    use futures::{SinkExt, StreamExt};
     use once_cell::sync::Lazy;
     use parking_lot::Mutex;
     use serde_json::{json, Value};
@@ -4822,7 +5262,6 @@ mod chrome_cdp {
     use tokio_tungstenite::{
         connect_async, tungstenite::Message as WsMessage, MaybeTlsStream, WebSocketStream,
     };
-    use futures::{SinkExt, StreamExt};
 
     // -----------------------------------------------------------------------
     // Global session state
@@ -4916,9 +5355,9 @@ mod chrome_cdp {
         let ws_url = tabs
             .as_array()
             .and_then(|arr| {
-                arr.iter().find(|t| t["type"] == "page").and_then(|t| {
-                    t["webSocketDebuggerUrl"].as_str().map(|s| s.to_string())
-                })
+                arr.iter()
+                    .find(|t| t["type"] == "page")
+                    .and_then(|t| t["webSocketDebuggerUrl"].as_str().map(|s| s.to_string()))
             })
             .ok_or_else(|| {
                 anyhow::anyhow!(
@@ -4937,11 +5376,15 @@ mod chrome_cdp {
             })
             .unwrap_or_default();
 
-        let (ws, _) = connect_async(&ws_url).await.map_err(|e| {
-            anyhow::anyhow!("WebSocket connect to {} failed: {}", ws_url, e)
-        })?;
+        let (ws, _) = connect_async(&ws_url)
+            .await
+            .map_err(|e| anyhow::anyhow!("WebSocket connect to {} failed: {}", ws_url, e))?;
 
-        let mut session = ChromeSession { ws, port, tab_url: tab_url.clone() };
+        let mut session = ChromeSession {
+            ws,
+            port,
+            tab_url: tab_url.clone(),
+        };
         // Enable Page domain so captureScreenshot etc. work.
         cdp_call(&mut session.ws, "Page.enable", json!({})).await?;
         // Enable Runtime domain for eval/click/fill.
@@ -5135,14 +5578,15 @@ mod chrome_cdp {
         store_session(s);
         result
     }
-
 }
 
 // ---- SlashCommand impl -------------------------------------------------------
 
 #[async_trait]
 impl SlashCommand for ChromeCommand {
-    fn name(&self) -> &str { "chrome" }
+    fn name(&self) -> &str {
+        "chrome"
+    }
     fn description(&self) -> &str {
         "Browser automation via Chrome DevTools Protocol (CDP)"
     }
@@ -5175,10 +5619,7 @@ impl SlashCommand for ChromeCommand {
                     match p.parse() {
                         Ok(n) => n,
                         Err(_) => {
-                            return CommandResult::Error(format!(
-                                "Invalid port number: {}",
-                                p
-                            ));
+                            return CommandResult::Error(format!("Invalid port number: {}", p));
                         }
                     }
                 } else if rest.is_empty() {
@@ -5304,9 +5745,15 @@ impl SlashCommand for ChromeCommand {
 
 #[async_trait]
 impl SlashCommand for VimCommand {
-    fn name(&self) -> &str { "vim" }
-    fn aliases(&self) -> Vec<&str> { vec!["vi"] }
-    fn description(&self) -> &str { "Toggle vim keybinding mode on/off" }
+    fn name(&self) -> &str {
+        "vim"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["vi"]
+    }
+    fn description(&self) -> &str {
+        "Toggle vim keybinding mode on/off"
+    }
     fn help(&self) -> &str {
         "Usage: /vim [on|off]\n\n\
          Toggles vim keybinding mode in the REPL input.\n\
@@ -5323,7 +5770,11 @@ impl SlashCommand for VimCommand {
             "off" | "normal" => "normal",
             "" => {
                 // Toggle
-                if current_mode == "vim" { "normal" } else { "vim" }
+                if current_mode == "vim" {
+                    "normal"
+                } else {
+                    "vim"
+                }
             }
             other => {
                 return CommandResult::Error(format!(
@@ -5354,8 +5805,12 @@ impl SlashCommand for VimCommand {
 
 #[async_trait]
 impl SlashCommand for VoiceCommand {
-    fn name(&self) -> &str { "voice" }
-    fn description(&self) -> &str { "Toggle voice input mode on/off" }
+    fn name(&self) -> &str {
+        "voice"
+    }
+    fn description(&self) -> &str {
+        "Toggle voice input mode on/off"
+    }
     fn help(&self) -> &str {
         "Usage: /voice [on|off]\n\n\
          Enables or disables voice input (hold-to-talk).\n\
@@ -5403,9 +5858,15 @@ impl SlashCommand for VoiceCommand {
 
 #[async_trait]
 impl SlashCommand for UpgradeCommand {
-    fn name(&self) -> &str { "update" }
-    fn aliases(&self) -> Vec<&str> { vec!["upgrade"] }
-    fn description(&self) -> &str { "Check for updates and download the latest release" }
+    fn name(&self) -> &str {
+        "update"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["upgrade"]
+    }
+    fn description(&self) -> &str {
+        "Check for updates and download the latest release"
+    }
     fn help(&self) -> &str {
         "Usage: /update\n\n\
          Checks GitHub releases for the latest version of Claurst.\n\
@@ -5439,8 +5900,7 @@ impl SlashCommand for UpgradeCommand {
 
         match resp {
             Ok(r) if r.status().is_success() => {
-                let json: serde_json::Value =
-                    r.json().await.unwrap_or(serde_json::Value::Null);
+                let json: serde_json::Value = r.json().await.unwrap_or(serde_json::Value::Null);
 
                 let tag = json
                     .get("tag_name")
@@ -5492,8 +5952,12 @@ impl SlashCommand for UpgradeCommand {
 
 #[async_trait]
 impl SlashCommand for ReleaseNotesCommand {
-    fn name(&self) -> &str { "release-notes" }
-    fn description(&self) -> &str { "Show release notes for the current version" }
+    fn name(&self) -> &str {
+        "release-notes"
+    }
+    fn description(&self) -> &str {
+        "Show release notes for the current version"
+    }
     fn help(&self) -> &str {
         "Usage: /release-notes [version]\n\n\
          Fetches and displays release notes from GitHub.\n\
@@ -5534,8 +5998,7 @@ impl SlashCommand for ReleaseNotesCommand {
 
         match client.get(&url).send().await {
             Ok(r) if r.status().is_success() => {
-                let json: serde_json::Value =
-                    r.json().await.unwrap_or(serde_json::Value::Null);
+                let json: serde_json::Value = r.json().await.unwrap_or(serde_json::Value::Null);
 
                 let body = json
                     .get("body")
@@ -5547,10 +6010,7 @@ impl SlashCommand for ReleaseNotesCommand {
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown date");
 
-                let html_url = json
-                    .get("html_url")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
+                let html_url = json.get("html_url").and_then(|v| v.as_str()).unwrap_or("");
 
                 CommandResult::Message(format!(
                     "Release Notes: Claurst {tag}\n\
@@ -5582,8 +6042,12 @@ impl SlashCommand for ReleaseNotesCommand {
 
 #[async_trait]
 impl SlashCommand for RateLimitOptionsCommand {
-    fn name(&self) -> &str { "rate-limit-options" }
-    fn description(&self) -> &str { "Show rate limit tiers and current rate limit status" }
+    fn name(&self) -> &str {
+        "rate-limit-options"
+    }
+    fn description(&self) -> &str {
+        "Show rate limit tiers and current rate limit status"
+    }
     fn help(&self) -> &str {
         "Usage: /rate-limit-options\n\n\
          Displays available rate limit tiers and the current tier for your account.\n\
@@ -5599,7 +6063,11 @@ impl SlashCommand for RateLimitOptionsCommand {
                     "Account type:    {}\n\
                      Scopes:          {}",
                     sub_type,
-                    if tokens.scopes.is_empty() { "none".to_string() } else { tokens.scopes.join(", ") }
+                    if tokens.scopes.is_empty() {
+                        "none".to_string()
+                    } else {
+                        tokens.scopes.join(", ")
+                    }
                 )
             }
             None => {
@@ -5637,8 +6105,12 @@ impl SlashCommand for RateLimitOptionsCommand {
 
 #[async_trait]
 impl SlashCommand for StatuslineCommand {
-    fn name(&self) -> &str { "statusline" }
-    fn description(&self) -> &str { "Configure what is shown in the status line" }
+    fn name(&self) -> &str {
+        "statusline"
+    }
+    fn description(&self) -> &str {
+        "Configure what is shown in the status line"
+    }
     fn help(&self) -> &str {
         "Usage: /statusline [show|hide] [cost|tokens|model|time|all]\n\n\
          Controls which items appear in the TUI status bar at the bottom.\n\
@@ -5692,10 +6164,12 @@ impl SlashCommand for StatuslineCommand {
                 s.statusline_show_model = Some(show);
                 s.statusline_show_time = Some(show);
             }) {
-                Ok(_) => return CommandResult::Message(format!(
-                    "Status line: all items {}.",
-                    if show { "shown" } else { "hidden" }
-                )),
+                Ok(_) => {
+                    return CommandResult::Message(format!(
+                        "Status line: all items {}.",
+                        if show { "shown" } else { "hidden" }
+                    ))
+                }
                 Err(e) => return CommandResult::Error(format!("Failed to save: {}", e)),
             }
         }
@@ -5725,15 +6199,23 @@ impl SlashCommand for StatuslineCommand {
 }
 
 fn fmt_bool(v: bool) -> &'static str {
-    if v { "on" } else { "off" }
+    if v {
+        "on"
+    } else {
+        "off"
+    }
 }
 
 // ---- /security-review ----------------------------------------------------
 
 #[async_trait]
 impl SlashCommand for SecurityReviewCommand {
-    fn name(&self) -> &str { "security-review" }
-    fn description(&self) -> &str { "Run a security review of the current project" }
+    fn name(&self) -> &str {
+        "security-review"
+    }
+    fn description(&self) -> &str {
+        "Run a security review of the current project"
+    }
     fn help(&self) -> &str {
         "Usage: /security-review [path]\n\n\
          Asks Claurst to perform a security review of the codebase.\n\
@@ -5777,8 +6259,12 @@ impl SlashCommand for SecurityReviewCommand {
 
 #[async_trait]
 impl SlashCommand for TerminalSetupCommand {
-    fn name(&self) -> &str { "terminal-setup" }
-    fn description(&self) -> &str { "Help configure your terminal for optimal Claurst use" }
+    fn name(&self) -> &str {
+        "terminal-setup"
+    }
+    fn description(&self) -> &str {
+        "Help configure your terminal for optimal Claurst use"
+    }
     fn help(&self) -> &str {
         "Usage: /terminal-setup\n\n\
          Diagnoses your terminal environment and gives recommendations for\n\
@@ -5816,10 +6302,15 @@ impl SlashCommand for TerminalSetupCommand {
         // Check if UNICODE is likely supported
         let lang = std::env::var("LANG").unwrap_or_default();
         let lc_all = std::env::var("LC_ALL").unwrap_or_default();
-        let unicode_env = lang.to_lowercase().contains("utf") || lc_all.to_lowercase().contains("utf");
+        let unicode_env =
+            lang.to_lowercase().contains("utf") || lc_all.to_lowercase().contains("utf");
         checks.push(format!(
             "Unicode/UTF-8: {}",
-            if unicode_env { "likely supported (LANG/LC_ALL contains UTF)" } else { "check LANG env var" }
+            if unicode_env {
+                "likely supported (LANG/LC_ALL contains UTF)"
+            } else {
+                "check LANG env var"
+            }
         ));
 
         // Check for known good terminals
@@ -5827,11 +6318,15 @@ impl SlashCommand for TerminalSetupCommand {
             term_program.to_lowercase().as_str(),
             "iterm.app" | "iterm2" | "hyper" | "warp" | "alacritty" | "kitty" | "wezterm"
         ) || term_program.to_lowercase().contains("vscode")
-          || term_program.to_lowercase().contains("terminal");
+            || term_program.to_lowercase().contains("terminal");
 
         checks.push(format!(
             "Terminal type: {}",
-            if is_good_terminal { "well-known terminal (good)" } else { "verify settings below" }
+            if is_good_terminal {
+                "well-known terminal (good)"
+            } else {
+                "verify settings below"
+            }
         ));
 
         // Shell detection
@@ -5839,8 +6334,8 @@ impl SlashCommand for TerminalSetupCommand {
         checks.push(format!("Shell:         {}", shell));
 
         // Check for Nerd Fonts (heuristic: environment variable set by some terminals)
-        let nerd_font = std::env::var("NERD_FONT").is_ok()
-            || std::env::var("TERM_NERD_FONT").is_ok();
+        let nerd_font =
+            std::env::var("NERD_FONT").is_ok() || std::env::var("TERM_NERD_FONT").is_ok();
 
         CommandResult::Message(format!(
             "Terminal Setup Diagnostic\n\
@@ -5876,8 +6371,12 @@ impl SlashCommand for TerminalSetupCommand {
 
 #[async_trait]
 impl SlashCommand for ExtraUsageCommand {
-    fn name(&self) -> &str { "extra-usage" }
-    fn description(&self) -> &str { "Show detailed usage statistics: calls, cache, tools" }
+    fn name(&self) -> &str {
+        "extra-usage"
+    }
+    fn description(&self) -> &str {
+        "Show detailed usage statistics: calls, cache, tools"
+    }
     fn help(&self) -> &str {
         "Usage: /extra-usage\n\n\
          Displays extended usage statistics beyond /cost:\n\
@@ -5896,7 +6395,9 @@ impl SlashCommand for ExtraUsageCommand {
         let cost = ctx.cost_tracker.total_cost_usd();
 
         // Estimate API calls from messages (each assistant message ~ 1 API call)
-        let api_calls = ctx.messages.iter()
+        let api_calls = ctx
+            .messages
+            .iter()
             .filter(|m| m.role == claurst_core::types::Role::Assistant)
             .count();
         let api_calls = api_calls.max(1); // at least 1 if we have any data
@@ -5950,7 +6451,11 @@ impl SlashCommand for ExtraUsageCommand {
                 "No cache activity"
             },
             cost = cost,
-            cost_per_k = if total > 0 { cost / (total as f64 / 1000.0) } else { 0.0 },
+            cost_per_k = if total > 0 {
+                cost / (total as f64 / 1000.0)
+            } else {
+                0.0
+            },
         ))
     }
 }
@@ -5959,8 +6464,12 @@ impl SlashCommand for ExtraUsageCommand {
 
 #[async_trait]
 impl SlashCommand for AdvisorCommand {
-    fn name(&self) -> &str { "advisor" }
-    fn description(&self) -> &str { "Set or unset the server-side advisor model" }
+    fn name(&self) -> &str {
+        "advisor"
+    }
+    fn description(&self) -> &str {
+        "Set or unset the server-side advisor model"
+    }
     fn help(&self) -> &str {
         "Usage: /advisor [<model>|off|unset]\n\n\
          Sets the advisor model used for server-side suggestions.\n\
@@ -6023,8 +6532,12 @@ impl SlashCommand for AdvisorCommand {
 
 #[async_trait]
 impl SlashCommand for InstallSlackAppCommand {
-    fn name(&self) -> &str { "install-slack-app" }
-    fn description(&self) -> &str { "Install the Claurst Slack integration" }
+    fn name(&self) -> &str {
+        "install-slack-app"
+    }
+    fn description(&self) -> &str {
+        "Install the Claurst Slack integration"
+    }
     fn help(&self) -> &str {
         "Usage: /install-slack-app\n\n\
          Opens instructions for installing the Claurst Slack app.\n\
@@ -6054,9 +6567,15 @@ impl SlashCommand for InstallSlackAppCommand {
 
 #[async_trait]
 impl SlashCommand for FastCommand {
-    fn name(&self) -> &str { "fast" }
-    fn aliases(&self) -> Vec<&str> { vec!["speed"] }
-    fn description(&self) -> &str { "Toggle fast mode (uses a faster/cheaper model)" }
+    fn name(&self) -> &str {
+        "fast"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["speed"]
+    }
+    fn description(&self) -> &str {
+        "Toggle fast mode (uses a faster/cheaper model)"
+    }
     fn help(&self) -> &str {
         "Usage: /fast [on|off]\n\n\
          Fast mode switches to a faster, more economical model variant\n\
@@ -6085,7 +6604,10 @@ impl SlashCommand for FastCommand {
         }
 
         let fast_model = "claude-haiku-4-5";
-        let normal_model = ctx.config.model.as_deref()
+        let normal_model = ctx
+            .config
+            .model
+            .as_deref()
             .unwrap_or(claurst_core::constants::DEFAULT_MODEL);
 
         if enable {
@@ -6118,9 +6640,15 @@ impl SlashCommand for FastCommand {
 
 #[async_trait]
 impl SlashCommand for ThinkBackCommand {
-    fn name(&self) -> &str { "think-back" }
-    fn aliases(&self) -> Vec<&str> { vec!["thinkback"] }
-    fn description(&self) -> &str { "Show thinking traces from previous responses in this session" }
+    fn name(&self) -> &str {
+        "think-back"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["thinkback"]
+    }
+    fn description(&self) -> &str {
+        "Show thinking traces from previous responses in this session"
+    }
     fn help(&self) -> &str {
         "Usage: /think-back [n]\n\n\
          Displays the thinking/reasoning traces from the most recent model responses.\n\
@@ -6152,7 +6680,11 @@ impl SlashCommand for ThinkBackCommand {
                     })
                     .collect::<Vec<_>>()
                     .join("\n\n");
-                if thinking.is_empty() { None } else { Some((idx, thinking)) }
+                if thinking.is_empty() {
+                    None
+                } else {
+                    Some((idx, thinking))
+                }
             })
             .collect();
 
@@ -6188,8 +6720,12 @@ impl SlashCommand for ThinkBackCommand {
 
 #[async_trait]
 impl SlashCommand for ThinkBackPlayCommand {
-    fn name(&self) -> &str { "thinkback-play" }
-    fn description(&self) -> &str { "Replay a thinking trace as an animated walkthrough" }
+    fn name(&self) -> &str {
+        "thinkback-play"
+    }
+    fn description(&self) -> &str {
+        "Replay a thinking trace as an animated walkthrough"
+    }
     fn help(&self) -> &str {
         "Usage: /thinkback-play [n]\n\n\
          Replays a previous thinking trace, formatted for easy reading.\n\
@@ -6219,7 +6755,11 @@ impl SlashCommand for ThinkBackPlayCommand {
                     })
                     .collect::<Vec<_>>()
                     .join("\n\n");
-                if t.is_empty() { None } else { Some(t) }
+                if t.is_empty() {
+                    None
+                } else {
+                    Some(t)
+                }
             })
             .collect();
 
@@ -6258,10 +6798,18 @@ impl SlashCommand for ThinkBackPlayCommand {
 
 #[async_trait]
 impl SlashCommand for FeedbackCommand {
-    fn name(&self) -> &str { "report" }
-    fn aliases(&self) -> Vec<&str> { vec![] }
-    fn description(&self) -> &str { "Open the GitHub issues page to report a bug or request a feature" }
-    fn hidden(&self) -> bool { true } // surfaced via BugCommand alias; hidden to avoid duplicate
+    fn name(&self) -> &str {
+        "report"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec![]
+    }
+    fn description(&self) -> &str {
+        "Open the GitHub issues page to report a bug or request a feature"
+    }
+    fn hidden(&self) -> bool {
+        true
+    } // surfaced via BugCommand alias; hidden to avoid duplicate
     fn help(&self) -> &str {
         "Usage: /report [description]\n\n\
          Opens the GitHub issues tracker. If a description is provided,\n\
@@ -6275,19 +6823,12 @@ impl SlashCommand for FeedbackCommand {
             url.to_string()
         } else {
             // Append as a body query param
-            format!(
-                "{}?body={}",
-                url,
-                urlencoding::encode(report)
-            )
+            format!("{}?body={}", url, urlencoding::encode(report))
         };
 
         match open_with_system(&display_url) {
             Ok(_) => CommandResult::Message(format!("Opened issue tracker: {}", url)),
-            Err(_) => CommandResult::Message(format!(
-                "Please visit {} to submit a report.",
-                url
-            )),
+            Err(_) => CommandResult::Message(format!("Please visit {} to submit a report.", url)),
         }
     }
 }
@@ -6296,9 +6837,15 @@ impl SlashCommand for FeedbackCommand {
 
 #[async_trait]
 impl SlashCommand for ColorSetCommand {
-    fn name(&self) -> &str { "color-set" }
-    fn hidden(&self) -> bool { true }
-    fn description(&self) -> &str { "Internal: set prompt color — use /color instead" }
+    fn name(&self) -> &str {
+        "color-set"
+    }
+    fn hidden(&self) -> bool {
+        true
+    }
+    fn description(&self) -> &str {
+        "Internal: set prompt color — use /color instead"
+    }
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let color = args.trim();
@@ -6317,10 +6864,11 @@ impl SlashCommand for ColorSetCommand {
         } else {
             // Validate hex or named color
             let known_colors = [
-                "red", "green", "blue", "yellow", "cyan", "magenta",
-                "white", "orange", "purple", "pink", "gray", "grey",
+                "red", "green", "blue", "yellow", "cyan", "magenta", "white", "orange", "purple",
+                "pink", "gray", "grey",
             ];
-            let is_hex = color.starts_with('#') && (color.len() == 4 || color.len() == 7)
+            let is_hex = color.starts_with('#')
+                && (color.len() == 4 || color.len() == 7)
                 && color[1..].chars().all(|c| c.is_ascii_hexdigit());
             if !is_hex && !known_colors.contains(&color.to_lowercase().as_str()) {
                 return CommandResult::Error(format!(
@@ -6346,8 +6894,12 @@ impl SlashCommand for ColorSetCommand {
 
 #[async_trait]
 impl SlashCommand for SearchCommand {
-    fn name(&self) -> &str { "search" }
-    fn description(&self) -> &str { "Search across all sessions" }
+    fn name(&self) -> &str {
+        "search"
+    }
+    fn description(&self) -> &str {
+        "Search across all sessions"
+    }
     fn help(&self) -> &str {
         "Usage: /search <query>\n\n\
          Searches session titles and message content in the local SQLite\n\
@@ -6381,19 +6933,11 @@ impl SlashCommand for SearchCommand {
 
         let results = match store.search_sessions(query) {
             Ok(r) => r,
-            Err(e) => {
-                return CommandResult::Error(format!(
-                    "Search failed: {}",
-                    e
-                ))
-            }
+            Err(e) => return CommandResult::Error(format!("Search failed: {}", e)),
         };
 
         if results.is_empty() {
-            return CommandResult::Message(format!(
-                "No sessions found matching \"{}\".",
-                query
-            ));
+            return CommandResult::Message(format!("No sessions found matching \"{}\".", query));
         }
 
         let mut out = format!(
@@ -6421,8 +6965,12 @@ impl SlashCommand for SearchCommand {
 
 #[async_trait]
 impl SlashCommand for ShareCommand {
-    fn name(&self) -> &str { "share" }
-    fn description(&self) -> &str { "Create a shareable URL for the current session" }
+    fn name(&self) -> &str {
+        "share"
+    }
+    fn description(&self) -> &str {
+        "Create a shareable URL for the current session"
+    }
     fn help(&self) -> &str {
         "Usage: /share\n\n\
          Attempts to create a public share link for the current conversation\n\
@@ -6447,10 +6995,7 @@ impl SlashCommand for ShareCommand {
         let messages_json = match serde_json::to_value(&ctx.messages) {
             Ok(v) => v,
             Err(e) => {
-                return CommandResult::Error(format!(
-                    "Failed to serialize session messages: {}",
-                    e
-                ))
+                return CommandResult::Error(format!("Failed to serialize session messages: {}", e))
             }
         };
 
@@ -6465,12 +7010,7 @@ impl SlashCommand for ShareCommand {
             .build()
         {
             Ok(c) => c,
-            Err(e) => {
-                return CommandResult::Error(format!(
-                    "Failed to build HTTP client: {}",
-                    e
-                ))
-            }
+            Err(e) => return CommandResult::Error(format!("Failed to build HTTP client: {}", e)),
         };
 
         let base_url = std::env::var("ANTHROPIC_BASE_URL")
@@ -6478,13 +7018,9 @@ impl SlashCommand for ShareCommand {
         let url = format!("{}/api/claude_code/share_session", base_url);
 
         let req = if use_bearer {
-            client
-                .post(&url)
-                .bearer_auth(&credential)
+            client.post(&url).bearer_auth(&credential)
         } else {
-            client
-                .post(&url)
-                .header("x-api-key", &credential)
+            client.post(&url).header("x-api-key", &credential)
         };
 
         let resp = req
@@ -6595,8 +7131,12 @@ mod teleport_bundle {
 
 #[async_trait]
 impl SlashCommand for TeleportCommand {
-    fn name(&self) -> &str { "teleport" }
-    fn description(&self) -> &str { "Export/import/link session context as a portable bundle" }
+    fn name(&self) -> &str {
+        "teleport"
+    }
+    fn description(&self) -> &str {
+        "Export/import/link session context as a portable bundle"
+    }
     fn help(&self) -> &str {
         "Usage:\n\
          \n\
@@ -6669,7 +7209,9 @@ impl SlashCommand for TeleportCommand {
                                         for key in &candidates {
                                             if let Some(v) = input.get(key) {
                                                 if let Some(s) = v.as_str() {
-                                                    if !s.is_empty() && !seen.contains(&s.to_string()) {
+                                                    if !s.is_empty()
+                                                        && !seen.contains(&s.to_string())
+                                                    {
                                                         seen.push(s.to_string());
                                                     }
                                                 }
@@ -6720,7 +7262,11 @@ impl SlashCommand for TeleportCommand {
                             action: PermissionAction::Deny,
                         });
                     }
-                    TeleportPermissions { allowed, denied, rules }
+                    TeleportPermissions {
+                        allowed,
+                        denied,
+                        rules,
+                    }
                 };
 
                 // ---- build bundle -----------------------------------------
@@ -6740,7 +7286,9 @@ impl SlashCommand for TeleportCommand {
                 // ---- serialize and write ----------------------------------
                 let json = match serde_json::to_string_pretty(&bundle) {
                     Ok(j) => j,
-                    Err(e) => return CommandResult::Error(format!("Failed to serialize bundle: {}", e)),
+                    Err(e) => {
+                        return CommandResult::Error(format!("Failed to serialize bundle: {}", e))
+                    }
                 };
 
                 if let Err(e) = std::fs::write(&output_path, &json) {
@@ -6770,28 +7318,30 @@ impl SlashCommand for TeleportCommand {
 
             "import" => {
                 if rest.is_empty() {
-                    return CommandResult::Error(
-                        "Usage: /teleport import <file>".to_string(),
-                    );
+                    return CommandResult::Error("Usage: /teleport import <file>".to_string());
                 }
 
                 let path = std::path::PathBuf::from(rest);
 
                 let data = match std::fs::read_to_string(&path) {
                     Ok(s) => s,
-                    Err(e) => return CommandResult::Error(format!(
-                        "Cannot read teleport bundle '{}': {}",
-                        path.display(),
-                        e
-                    )),
+                    Err(e) => {
+                        return CommandResult::Error(format!(
+                            "Cannot read teleport bundle '{}': {}",
+                            path.display(),
+                            e
+                        ))
+                    }
                 };
 
                 let bundle: TeleportBundle = match serde_json::from_str(&data) {
                     Ok(b) => b,
-                    Err(e) => return CommandResult::Error(format!(
-                        "Failed to parse teleport bundle: {}",
-                        e
-                    )),
+                    Err(e) => {
+                        return CommandResult::Error(format!(
+                            "Failed to parse teleport bundle: {}",
+                            e
+                        ))
+                    }
                 };
 
                 // ---- validate version ------------------------------------
@@ -6845,7 +7395,11 @@ impl SlashCommand for TeleportCommand {
                     exported_at,
                     msg_count,
                     working_dir_display,
-                    if dir_restored { " (restored)" } else { " (path not found, skipped)" },
+                    if dir_restored {
+                        " (restored)"
+                    } else {
+                        " (path not found, skipped)"
+                    },
                     allowed_count,
                     denied_count,
                     files_count,
@@ -6854,8 +7408,8 @@ impl SlashCommand for TeleportCommand {
 
             "link" => {
                 // ---- build a minimal bundle for the link (no env vars) ---
-                use teleport_bundle::TeleportBundle;
                 use base64::Engine as _;
+                use teleport_bundle::TeleportBundle;
 
                 let permissions = {
                     let allowed = ctx.config.allowed_tools.clone();
@@ -6876,7 +7430,11 @@ impl SlashCommand for TeleportCommand {
                             action: PermissionAction::Deny,
                         });
                     }
-                    TeleportPermissions { allowed, denied, rules }
+                    TeleportPermissions {
+                        allowed,
+                        denied,
+                        rules,
+                    }
                 };
 
                 let bundle = TeleportBundle {
@@ -6887,22 +7445,28 @@ impl SlashCommand for TeleportCommand {
                     permissions,
                     model: ctx.config.model.clone(),
                     effort: None,
-                    files: Vec::new(), // keep link compact
+                    files: Vec::new(),                     // keep link compact
                     env: std::collections::HashMap::new(), // omit env for security
                     exported_at: chrono::Utc::now().to_rfc3339(),
                 };
 
                 let json = match serde_json::to_string(&bundle) {
                     Ok(j) => j,
-                    Err(e) => return CommandResult::Error(format!("Failed to serialize bundle: {}", e)),
+                    Err(e) => {
+                        return CommandResult::Error(format!("Failed to serialize bundle: {}", e))
+                    }
                 };
 
-                let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(json.as_bytes());
+                let encoded =
+                    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(json.as_bytes());
                 let link = format!("teleport://{}", encoded);
 
                 // Warn if the link is very long.
                 let size_hint = if link.len() > 8192 {
-                    format!("\n(Link is {} bytes — consider /teleport export for large sessions)", link.len())
+                    format!(
+                        "\n(Link is {} bytes — consider /teleport export for large sessions)",
+                        link.len()
+                    )
                 } else {
                     String::new()
                 };
@@ -6910,9 +7474,7 @@ impl SlashCommand for TeleportCommand {
                 CommandResult::Message(format!(
                     "Teleport link generated for session {}:\n\n{}{}\n\n\
                      Share this link or use: /teleport import <link-url>",
-                    ctx.session_id,
-                    link,
-                    size_hint,
+                    ctx.session_id, link, size_hint,
                 ))
             }
 
@@ -6923,7 +7485,8 @@ impl SlashCommand for TeleportCommand {
                      \x20 /teleport export [--output <file>]   export session to .teleport bundle\n\
                      \x20 /teleport import <file>              restore a .teleport bundle\n\
                      \x20 /teleport link                       generate a teleport:// deep link\n\
-                     \nSee /help teleport for details.".to_string()
+                     \nSee /help teleport for details."
+                        .to_string(),
                 )
             }
 
@@ -6939,8 +7502,12 @@ impl SlashCommand for TeleportCommand {
 
 #[async_trait]
 impl SlashCommand for BtwCommand {
-    fn name(&self) -> &str { "btw" }
-    fn description(&self) -> &str { "Ask a side question without adding it to conversation history" }
+    fn name(&self) -> &str {
+        "btw"
+    }
+    fn description(&self) -> &str {
+        "Ask a side question without adding it to conversation history"
+    }
     fn help(&self) -> &str {
         "Usage: /btw <question>\n\n\
          Submits a background question to the model without it becoming part of\n\
@@ -6972,9 +7539,15 @@ impl SlashCommand for BtwCommand {
 
 #[async_trait]
 impl SlashCommand for CtxVizCommand {
-    fn name(&self) -> &str { "ctx-viz" }
-    fn aliases(&self) -> Vec<&str> { vec!["context-visualizer", "ctx"] }
-    fn description(&self) -> &str { "Visualize context window usage breakdown by category" }
+    fn name(&self) -> &str {
+        "ctx-viz"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["context-visualizer", "ctx"]
+    }
+    fn description(&self) -> &str {
+        "Visualize context window usage breakdown by category"
+    }
     fn help(&self) -> &str {
         "Usage: /ctx-viz\n\n\
          Shows a detailed breakdown of how the context window is being used:\n\
@@ -6990,16 +7563,17 @@ impl SlashCommand for CtxVizCommand {
 
         // Estimate system prompt tokens: rough chars/4 approximation
         // Build a minimal system prompt to estimate its size.
-        let sys_prompt_chars: usize = ctx.config.custom_system_prompt
+        let sys_prompt_chars: usize = ctx
+            .config
+            .custom_system_prompt
             .as_deref()
             .map(|s| s.len())
             .unwrap_or(2400 * 4); // fallback: ~2400 tokens worth
         let sys_prompt_tokens = (sys_prompt_chars / 4).max(1) as u64;
 
         // Estimate conversation tokens from messages
-        let (conv_chars, tool_chars): (usize, usize) = ctx.messages.iter().fold(
-            (0, 0),
-            |(conv, tool), msg| {
+        let (conv_chars, tool_chars): (usize, usize) =
+            ctx.messages.iter().fold((0, 0), |(conv, tool), msg| {
                 let text = msg.get_all_text();
                 // Heuristic: if the message looks like a tool result, count separately
                 if msg.role == claurst_core::types::Role::User && text.starts_with('[') {
@@ -7007,8 +7581,7 @@ impl SlashCommand for CtxVizCommand {
                 } else {
                     (conv + text.len(), tool)
                 }
-            },
-        );
+            });
 
         let conv_tokens = (conv_chars / 4) as u64;
         let tool_tokens = (tool_chars / 4) as u64;
@@ -7046,9 +7619,15 @@ impl SlashCommand for CtxVizCommand {
 
 #[async_trait]
 impl SlashCommand for SandboxToggleCommand {
-    fn name(&self) -> &str { "sandbox-toggle" }
-    fn aliases(&self) -> Vec<&str> { vec!["sandbox"] }
-    fn description(&self) -> &str { "Enable or disable sandboxed execution of shell commands" }
+    fn name(&self) -> &str {
+        "sandbox-toggle"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["sandbox"]
+    }
+    fn description(&self) -> &str {
+        "Enable or disable sandboxed execution of shell commands"
+    }
     fn help(&self) -> &str {
         "Usage: /sandbox-toggle [on|off|exclude <pattern>|status]\n\n\
          Toggles sandboxed execution of bash/shell commands.\n\
@@ -7069,14 +7648,18 @@ impl SlashCommand for SandboxToggleCommand {
 
         // Platform support check: sandbox requires macOS or Linux (not Windows native).
         let platform = std::env::consts::OS;
-        let is_wsl = std::env::var("WSL_DISTRO_NAME").is_ok()
-            || std::env::var("WSL_INTEROP").is_ok();
+        let is_wsl =
+            std::env::var("WSL_DISTRO_NAME").is_ok() || std::env::var("WSL_INTEROP").is_ok();
         let is_supported = matches!(platform, "linux" | "macos") || is_wsl;
 
         // Handle subcommand: status
         if args == "status" {
             let ui = load_ui_settings();
-            let mode = if ui.sandbox_mode.unwrap_or(false) { "enabled" } else { "disabled" };
+            let mode = if ui.sandbox_mode.unwrap_or(false) {
+                "enabled"
+            } else {
+                "disabled"
+            };
             let excl = if ui.sandbox_excluded_commands.is_empty() {
                 "(none)".to_string()
             } else {
@@ -7089,7 +7672,10 @@ impl SlashCommand for SandboxToggleCommand {
             let platform_note = if is_supported {
                 format!("\u{2713} Supported on this platform ({})", platform)
             } else {
-                format!("\u{2717} Not supported on this platform ({}). Requires macOS, Linux, or WSL2.", platform)
+                format!(
+                    "\u{2717} Not supported on this platform ({}). Requires macOS, Linux, or WSL2.",
+                    platform
+                )
             };
             return CommandResult::Message(format!(
                 "Sandbox mode: {}\n\
@@ -7106,7 +7692,8 @@ impl SlashCommand for SandboxToggleCommand {
             if rest.is_empty() {
                 return CommandResult::Error(
                     "Usage: /sandbox-toggle exclude <command-pattern>\n\
-                     Example: /sandbox-toggle exclude \"npm run test:*\"".to_string()
+                     Example: /sandbox-toggle exclude \"npm run test:*\""
+                        .to_string(),
                 );
             }
             // Strip surrounding quotes if present
@@ -7133,8 +7720,13 @@ impl SlashCommand for SandboxToggleCommand {
         }
 
         // Platform guard for toggling on/off
-        if !is_supported && (args == "on" || args == "enable" || args == "enabled"
-            || args == "true" || args == "1" || args.is_empty())
+        if !is_supported
+            && (args == "on"
+                || args == "enable"
+                || args == "enabled"
+                || args == "true"
+                || args == "1"
+                || args.is_empty())
         {
             let msg = if is_wsl {
                 "Error: Sandboxing requires WSL2. WSL1 is not supported.".to_string()
@@ -7146,8 +7738,11 @@ impl SlashCommand for SandboxToggleCommand {
                 )
             };
             // Only hard-block enabling; allow off/status even on unsupported platforms.
-            if args != "off" && args != "disable" && args != "disabled"
-                && args != "false" && args != "0"
+            if args != "off"
+                && args != "disable"
+                && args != "disabled"
+                && args != "false"
+                && args != "0"
             {
                 return CommandResult::Error(msg);
             }
@@ -7187,8 +7782,12 @@ impl SlashCommand for SandboxToggleCommand {
 
 #[async_trait]
 impl SlashCommand for HeapdumpCommand {
-    fn name(&self) -> &str { "heapdump" }
-    fn description(&self) -> &str { "Show process memory and diagnostic information" }
+    fn name(&self) -> &str {
+        "heapdump"
+    }
+    fn description(&self) -> &str {
+        "Show process memory and diagnostic information"
+    }
     fn help(&self) -> &str {
         "Usage: /heapdump\n\n\
          Displays a diagnostic snapshot of the current process:\n\
@@ -7245,8 +7844,12 @@ impl SlashCommand for HeapdumpCommand {
 
 #[async_trait]
 impl SlashCommand for InsightsCommand {
-    fn name(&self) -> &str { "insights" }
-    fn description(&self) -> &str { "Generate a session analysis report with conversation statistics" }
+    fn name(&self) -> &str {
+        "insights"
+    }
+    fn description(&self) -> &str {
+        "Generate a session analysis report with conversation statistics"
+    }
     fn help(&self) -> &str {
         "Usage: /insights\n\n\
          Analyses the current conversation and prints a statistics report:\n\
@@ -7257,10 +7860,12 @@ impl SlashCommand for InsightsCommand {
         let messages = &ctx.messages;
 
         // Count turns (user / assistant pairs)
-        let user_turns: usize = messages.iter()
+        let user_turns: usize = messages
+            .iter()
             .filter(|m| matches!(m.role, claurst_core::types::Role::User))
             .count();
-        let assistant_turns: usize = messages.iter()
+        let assistant_turns: usize = messages
+            .iter()
             .filter(|m| matches!(m.role, claurst_core::types::Role::Assistant))
             .count();
         let total_turns = user_turns.min(assistant_turns);
@@ -7332,8 +7937,12 @@ impl SlashCommand for InsightsCommand {
 
 #[async_trait]
 impl SlashCommand for UltrareviewCommand {
-    fn name(&self) -> &str { "ultrareview" }
-    fn description(&self) -> &str { "Run an exhaustive multi-dimensional code review" }
+    fn name(&self) -> &str {
+        "ultrareview"
+    }
+    fn description(&self) -> &str {
+        "Run an exhaustive multi-dimensional code review"
+    }
     fn help(&self) -> &str {
         "Usage: /ultrareview [path]\n\n\
          Runs a comprehensive code review that goes beyond /review and\n\
@@ -7436,13 +8045,21 @@ impl SlashCommand for UltrareviewCommand {
 
 #[async_trait]
 impl SlashCommand for NamedCommandAdapter {
-    fn name(&self) -> &str { self.slash_name }
+    fn name(&self) -> &str {
+        self.slash_name
+    }
 
-    fn aliases(&self) -> Vec<&str> { self.slash_aliases.to_vec() }
+    fn aliases(&self) -> Vec<&str> {
+        self.slash_aliases.to_vec()
+    }
 
-    fn description(&self) -> &str { self.slash_description }
+    fn description(&self) -> &str {
+        self.slash_description
+    }
 
-    fn help(&self) -> &str { self.slash_help }
+    fn help(&self) -> &str {
+        self.slash_help
+    }
 
     async fn execute(&self, args: &str, ctx: &mut CommandContext) -> CommandResult {
         execute_named_command_from_slash(self.target_name, args, ctx)
@@ -7453,8 +8070,12 @@ impl SlashCommand for NamedCommandAdapter {
 
 #[async_trait]
 impl SlashCommand for UndoCommand {
-    fn name(&self) -> &str { "undo" }
-    fn description(&self) -> &str { "Revert file changes made by a tool call in this session" }
+    fn name(&self) -> &str {
+        "undo"
+    }
+    fn description(&self) -> &str {
+        "Revert file changes made by a tool call in this session"
+    }
     fn help(&self) -> &str {
         "Usage: /undo [<tool_use_id>]\n\n\
          Without an argument, lists all tool calls that modified files in this session.\n\n\
@@ -7528,8 +8149,12 @@ impl SlashCommand for UndoCommand {
 
 #[async_trait]
 impl SlashCommand for ProvidersCommand {
-    fn name(&self) -> &str { "providers" }
-    fn description(&self) -> &str { "List available AI providers and their status" }
+    fn name(&self) -> &str {
+        "providers"
+    }
+    fn description(&self) -> &str {
+        "List available AI providers and their status"
+    }
     fn help(&self) -> &str {
         "Usage: /providers\n\nList all providers registered in the model registry with their\nmodel counts, context windows, and pricing information."
     }
@@ -7559,15 +8184,23 @@ impl SlashCommand for ProvidersCommand {
         let mut lines = vec!["Available providers:\n".to_string()];
         for provider in &provider_keys {
             let models = &by_provider[provider];
-            lines.push(format!("\n{} ({} model{})", provider.to_uppercase(), models.len(),
-                if models.len() == 1 { "" } else { "s" }));
+            lines.push(format!(
+                "\n{} ({} model{})",
+                provider.to_uppercase(),
+                models.len(),
+                if models.len() == 1 { "" } else { "s" }
+            ));
             for m in models.iter().take(3) {
                 let cost_str = match (m.cost_input, m.cost_output) {
                     (Some(i), Some(o)) => format!("${:.2}/${:.2} per 1M", i, o),
                     _ => "free/local".to_string(),
                 };
-                lines.push(format!("  {} — {}K ctx, {}",
-                    m.info.id, m.info.context_window / 1000, cost_str));
+                lines.push(format!(
+                    "  {} — {}K ctx, {}",
+                    m.info.id,
+                    m.info.context_window / 1000,
+                    cost_str
+                ));
             }
             if models.len() > 3 {
                 lines.push(format!("  ... and {} more", models.len() - 3));
@@ -7582,8 +8215,12 @@ impl SlashCommand for ProvidersCommand {
 
 #[async_trait]
 impl SlashCommand for ConnectCommand {
-    fn name(&self) -> &str { "connect" }
-    fn description(&self) -> &str { "Connect an AI provider" }
+    fn name(&self) -> &str {
+        "connect"
+    }
+    fn description(&self) -> &str {
+        "Connect an AI provider"
+    }
     fn help(&self) -> &str {
         "Usage: /connect\n\nOpens the interactive provider picker dialog.\nSelect a provider to see setup instructions."
     }
@@ -7598,8 +8235,12 @@ impl SlashCommand for ConnectCommand {
 
 #[async_trait]
 impl SlashCommand for AgentCommand {
-    fn name(&self) -> &str { "agent" }
-    fn description(&self) -> &str { "List available agents or get info about a specific agent" }
+    fn name(&self) -> &str {
+        "agent"
+    }
+    fn description(&self) -> &str {
+        "List available agents or get info about a specific agent"
+    }
     fn help(&self) -> &str {
         "Usage: /agent [name]\n\nWithout arguments, lists all available named agents.\nWith a name, shows details for that agent.\n\nTo use an agent, start Claurst with: --agent <name>"
     }
@@ -7657,9 +8298,7 @@ impl SlashCommand for AgentCommand {
             if let Some(ref prompt) = def.prompt {
                 output.push_str(&format!("\nSystem prompt prefix:\n  {}\n", prompt));
             }
-            output.push_str(&format!(
-                "\nTo activate: claude --agent {}", agent_name
-            ));
+            output.push_str(&format!("\nTo activate: claude --agent {}", agent_name));
             CommandResult::Message(output)
         } else {
             CommandResult::Error(format!(
@@ -7857,9 +8496,9 @@ pub fn all_commands() -> Vec<Box<dyn SlashCommand>> {
 /// Find a command by name or alias.
 pub fn find_command(name: &str) -> Option<Box<dyn SlashCommand>> {
     let name = name.trim_start_matches('/');
-    all_commands().into_iter().find(|c| {
-        c.name() == name || c.aliases().contains(&name)
-    })
+    all_commands()
+        .into_iter()
+        .find(|c| c.name() == name || c.aliases().contains(&name))
 }
 
 /// Build `HelpEntry` values for all non-hidden commands, suitable for
@@ -7889,15 +8528,22 @@ struct TemplateCommand {
 
 #[async_trait]
 impl SlashCommand for TemplateCommand {
-    fn name(&self) -> &str { &self.name }
+    fn name(&self) -> &str {
+        &self.name
+    }
     fn description(&self) -> &str {
-        self.template.description.as_deref().unwrap_or("Custom command")
+        self.template
+            .description
+            .as_deref()
+            .unwrap_or("Custom command")
     }
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let mut words = args.split_whitespace();
         let arg1 = words.next().unwrap_or("");
         let arg2 = words.next().unwrap_or("");
-        let prompt = self.template.template
+        let prompt = self
+            .template
+            .template
             .replace("$ARGUMENTS", args)
             .replace("$1", arg1)
             .replace("$2", arg2);
@@ -7908,12 +8554,16 @@ impl SlashCommand for TemplateCommand {
 /// Build slash commands from user-defined command templates stored in
 /// `settings.commands`.
 pub fn commands_from_settings(settings: &claurst_core::Settings) -> Vec<Box<dyn SlashCommand>> {
-    settings.commands.iter().map(|(name, template)| {
-        Box::new(TemplateCommand {
-            name: name.clone(),
-            template: template.clone(),
-        }) as Box<dyn SlashCommand>
-    }).collect()
+    settings
+        .commands
+        .iter()
+        .map(|(name, template)| {
+            Box::new(TemplateCommand {
+                name: name.clone(),
+                template: template.clone(),
+            }) as Box<dyn SlashCommand>
+        })
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -7929,14 +8579,19 @@ struct SkillCommand {
 
 #[async_trait]
 impl SlashCommand for SkillCommand {
-    fn name(&self) -> &str { &self.name }
-    fn description(&self) -> &str { &self.description }
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn description(&self) -> &str {
+        &self.description
+    }
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let mut words = args.split_whitespace();
         let arg1 = words.next().unwrap_or("");
         let arg2 = words.next().unwrap_or("");
-        let prompt = self.template
+        let prompt = self
+            .template
             .replace("$ARGUMENTS", args)
             .replace("$1", arg1)
             .replace("$2", arg2);
@@ -7957,10 +8612,8 @@ pub fn commands_from_discovered_skills(
     let discovered = claurst_core::discover_skills(cwd, skills_config);
     // Build a set of built-in command names so we can skip collisions.
     let all_cmds = all_commands();
-    let builtin_names: std::collections::HashSet<&str> = all_cmds
-        .iter()
-        .map(|c| c.name())
-        .collect();
+    let builtin_names: std::collections::HashSet<&str> =
+        all_cmds.iter().map(|c| c.name()).collect();
 
     discovered
         .into_values()
@@ -7976,11 +8629,10 @@ pub fn commands_from_discovered_skills(
 }
 
 /// Execute a slash command string (with leading /).
-pub async fn execute_command(
-    input: &str,
-    ctx: &mut CommandContext,
-) -> Option<CommandResult> {
-    if !claurst_tui::input::is_slash_command(input) { return None; }
+pub async fn execute_command(input: &str, ctx: &mut CommandContext) -> Option<CommandResult> {
+    if !claurst_tui::input::is_slash_command(input) {
+        return None;
+    }
     let (name, args) = claurst_tui::input::parse_slash_command(input);
 
     // First check built-in commands.
@@ -7991,7 +8643,10 @@ pub async fn execute_command(
     // Check user-defined command templates from settings.
     let cmd_name = name.trim_start_matches('/');
     if let Some(tmpl) = ctx.config.commands.get(cmd_name).cloned() {
-        let tc = TemplateCommand { name: cmd_name.to_string(), template: tmpl };
+        let tc = TemplateCommand {
+            name: cmd_name.to_string(),
+            template: tmpl,
+        };
         return Some(tc.execute(args, ctx).await);
     }
 
@@ -8107,13 +8762,41 @@ mod tests {
     #[test]
     fn test_core_commands_present() {
         let expected = [
-            "help", "clear", "compact", "cost", "exit", "model",
-            "config", "version", "status", "diff", "memory", "hooks",
-            "permissions", "plan", "tasks", "session", "login", "logout", "refresh",
-            "feedback", "usage", "plugin", "reload-plugins",
-            "add-dir", "agents", "branch", "tag",
-            "passes", "ide", "pr-comments", "desktop", "mobile",
-            "install-github-app", "web-setup", "stickers",
+            "help",
+            "clear",
+            "compact",
+            "cost",
+            "exit",
+            "model",
+            "config",
+            "version",
+            "status",
+            "diff",
+            "memory",
+            "hooks",
+            "permissions",
+            "plan",
+            "tasks",
+            "session",
+            "login",
+            "logout",
+            "refresh",
+            "feedback",
+            "usage",
+            "plugin",
+            "reload-plugins",
+            "add-dir",
+            "agents",
+            "branch",
+            "tag",
+            "passes",
+            "ide",
+            "pr-comments",
+            "desktop",
+            "mobile",
+            "install-github-app",
+            "web-setup",
+            "stickers",
         ];
         for name in &expected {
             assert!(

--- a/src-rust/crates/commands/src/lib.rs
+++ b/src-rust/crates/commands/src/lib.rs
@@ -9,9 +9,9 @@ use claurst_core::config::{Config, Settings, Theme};
 use claurst_core::cost::CostTracker;
 use claurst_core::types::Message;
 use std::collections::BTreeMap;
+use std::sync::Arc;
 #[allow(unused_imports)]
 use std::path::PathBuf;
-use std::sync::Arc;
 
 // ---------------------------------------------------------------------------
 // Core trait
@@ -304,7 +304,10 @@ fn generate_keybindings_template() -> anyhow::Result<String> {
             .collect(),
     };
 
-    Ok(format!("{}\n", serde_json::to_string_pretty(&template)?))
+    Ok(format!(
+        "{}\n",
+        serde_json::to_string_pretty(&template)?
+    ))
 }
 
 fn parse_theme(name: &str) -> Option<Theme> {
@@ -386,37 +389,31 @@ fn command_category(name: &str) -> &'static str {
         "clear" | "compact" | "rewind" | "summary" | "export" | "rename" | "branch" | "fork" => {
             "Conversation"
         }
-        "model" | "config" | "theme" | "color" | "vim" | "fast" | "effort" | "voice"
-        | "statusline" | "output-style" | "keybindings" | "privacy-settings"
-        | "rate-limit-options" | "sandbox-toggle" => "Settings",
+        "model" | "config" | "theme" | "color" | "vim" | "fast" | "effort"
+        | "voice" | "statusline" | "output-style" | "keybindings"
+        | "privacy-settings" | "rate-limit-options" | "sandbox-toggle" => "Settings",
         "cost" | "stats" | "usage" | "extra-usage" | "context" | "ctx-viz" => "Usage & Cost",
         "status" | "doctor" | "terminal-setup" | "version" | "update" | "upgrade"
         | "release-notes" => "System",
         "login" | "logout" | "refresh" | "permissions" => "Auth & Permissions",
-        "memory" | "files" | "diff" | "init" | "commit" | "review" | "security-review" => "Project",
+        "memory" | "files" | "diff" | "init" | "commit" | "review"
+        | "security-review" => "Project",
         "mcp" | "hooks" | "ide" | "chrome" => "Integrations",
-        "session" | "resume" | "remote-control" | "remote-env" | "share" | "teleport" => {
-            "Sessions & Remote"
-        }
+        "session" | "resume" | "remote-control" | "remote-env"
+        | "share" | "teleport" => "Sessions & Remote",
         "help" | "exit" | "feedback" | "bug" => "General",
         "think-back" | "thinkback-play" | "thinking" | "plan" | "tasks" => "AI & Thinking",
-        "copy" | "skills" | "agents" | "plugin" | "reload-plugins" | "stickers" | "passes"
-        | "desktop" | "mobile" | "btw" => "Tools & Extras",
+        "copy" | "skills" | "agents" | "plugin" | "reload-plugins"
+        | "stickers" | "passes" | "desktop" | "mobile" | "btw" => "Tools & Extras",
         _ => "Other",
     }
 }
 
 #[async_trait]
 impl SlashCommand for HelpCommand {
-    fn name(&self) -> &str {
-        "help"
-    }
-    fn aliases(&self) -> Vec<&str> {
-        vec!["h", "?"]
-    }
-    fn description(&self) -> &str {
-        "Show available commands and usage information"
-    }
+    fn name(&self) -> &str { "help" }
+    fn aliases(&self) -> Vec<&str> { vec!["h", "?"] }
+    fn description(&self) -> &str { "Show available commands and usage information" }
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         if !args.is_empty() {
@@ -428,11 +425,7 @@ impl SlashCommand for HelpCommand {
                 } else {
                     format!(
                         "\nAliases: {}",
-                        aliases
-                            .iter()
-                            .map(|a| format!("/{}", a))
-                            .collect::<Vec<_>>()
-                            .join(", ")
+                        aliases.iter().map(|a| format!("/{}", a)).collect::<Vec<_>>().join(", ")
                     )
                 };
                 return CommandResult::Message(format!(
@@ -477,18 +470,13 @@ impl SlashCommand for HelpCommand {
             } else {
                 format!(
                     " ({})",
-                    aliases
-                        .iter()
-                        .map(|a| format!("/{}", a))
-                        .collect::<Vec<_>>()
-                        .join(", ")
+                    aliases.iter().map(|a| format!("/{}", a)).collect::<Vec<_>>().join(", ")
                 )
             };
-            by_cat.entry(cat).or_default().push(format!(
-                "  /{:<20} {}",
-                format!("{}{}", cmd.name(), alias_str),
-                cmd.description()
-            ));
+            by_cat
+                .entry(cat)
+                .or_default()
+                .push(format!("  /{:<20} {}", format!("{}{}", cmd.name(), alias_str), cmd.description()));
         }
 
         let mut output = String::from("Claurst — Slash Commands\n");
@@ -512,15 +500,9 @@ impl SlashCommand for HelpCommand {
 
 #[async_trait]
 impl SlashCommand for ClearCommand {
-    fn name(&self) -> &str {
-        "clear"
-    }
-    fn aliases(&self) -> Vec<&str> {
-        vec!["c", "reset", "new"]
-    }
-    fn description(&self) -> &str {
-        "Clear the conversation history"
-    }
+    fn name(&self) -> &str { "clear" }
+    fn aliases(&self) -> Vec<&str> { vec!["c", "reset", "new"] }
+    fn description(&self) -> &str { "Clear the conversation history" }
 
     async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
         CommandResult::ClearConversation
@@ -531,12 +513,8 @@ impl SlashCommand for ClearCommand {
 
 #[async_trait]
 impl SlashCommand for CompactCommand {
-    fn name(&self) -> &str {
-        "compact"
-    }
-    fn description(&self) -> &str {
-        "Compact the conversation to reduce token usage"
-    }
+    fn name(&self) -> &str { "compact" }
+    fn description(&self) -> &str { "Compact the conversation to reduce token usage" }
 
     async fn execute(&self, args: &str, ctx: &mut CommandContext) -> CommandResult {
         let msg_count = ctx.messages.len();
@@ -560,12 +538,8 @@ impl SlashCommand for CompactCommand {
 
 #[async_trait]
 impl SlashCommand for CostCommand {
-    fn name(&self) -> &str {
-        "cost"
-    }
-    fn description(&self) -> &str {
-        "Show token usage and cost for this session"
-    }
+    fn name(&self) -> &str { "cost" }
+    fn description(&self) -> &str { "Show token usage and cost for this session" }
     fn help(&self) -> &str {
         "Usage: /cost\n\n\
          Shows per-category token counts and the estimated cost for this session.\n\
@@ -587,10 +561,10 @@ impl SlashCommand for CostCommand {
         let cost = tracker.total_cost_usd();
 
         // Per-category cost breakdown.
-        let input_cost = (input as f64 * pricing.input_per_mtk) / 1_000_000.0;
-        let output_cost = (output as f64 * pricing.output_per_mtk) / 1_000_000.0;
-        let cc_cost = (cache_create as f64 * pricing.cache_creation_per_mtk) / 1_000_000.0;
-        let cr_cost = (cache_read as f64 * pricing.cache_read_per_mtk) / 1_000_000.0;
+        let input_cost    = (input as f64 * pricing.input_per_mtk) / 1_000_000.0;
+        let output_cost   = (output as f64 * pricing.output_per_mtk) / 1_000_000.0;
+        let cc_cost       = (cache_create as f64 * pricing.cache_creation_per_mtk) / 1_000_000.0;
+        let cr_cost       = (cache_read as f64 * pricing.cache_read_per_mtk) / 1_000_000.0;
 
         // Pricing info line.
         let pricing_line = format!(
@@ -604,12 +578,10 @@ impl SlashCommand for CostCommand {
         // Cache savings note: how much input cost was avoided by using cache-read
         // instead of re-sending those tokens as normal input.
         let savings = if cache_read > 0 {
-            let saved = (cache_read as f64 * (pricing.input_per_mtk - pricing.cache_read_per_mtk))
-                / 1_000_000.0;
-            format!(
-                "\n  Cache savings:  ${:.4}  ({} tokens served from cache)",
-                saved, cache_read
-            )
+            let saved =
+                (cache_read as f64 * (pricing.input_per_mtk - pricing.cache_read_per_mtk))
+                    / 1_000_000.0;
+            format!("\n  Cache savings:  ${:.4}  ({} tokens served from cache)", saved, cache_read)
         } else {
             String::new()
         };
@@ -647,15 +619,9 @@ impl SlashCommand for CostCommand {
 
 #[async_trait]
 impl SlashCommand for ExitCommand {
-    fn name(&self) -> &str {
-        "exit"
-    }
-    fn aliases(&self) -> Vec<&str> {
-        vec!["quit", "q"]
-    }
-    fn description(&self) -> &str {
-        "Exit Claurst"
-    }
+    fn name(&self) -> &str { "exit" }
+    fn aliases(&self) -> Vec<&str> { vec!["quit", "q"] }
+    fn description(&self) -> &str { "Exit Claurst" }
 
     async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
         CommandResult::Exit
@@ -666,12 +632,8 @@ impl SlashCommand for ExitCommand {
 
 #[async_trait]
 impl SlashCommand for ModelCommand {
-    fn name(&self) -> &str {
-        "model"
-    }
-    fn description(&self) -> &str {
-        "Show or change the current model"
-    }
+    fn name(&self) -> &str { "model" }
+    fn description(&self) -> &str { "Show or change the current model" }
     fn help(&self) -> &str {
         "Usage: /model [<model-id>]\n\n\
          Without arguments, shows the current model.\n\n\
@@ -688,7 +650,10 @@ impl SlashCommand for ModelCommand {
     async fn execute(&self, args: &str, ctx: &mut CommandContext) -> CommandResult {
         let args = args.trim();
         if args.is_empty() {
-            CommandResult::Message(format!("Current model: {}", ctx.config.effective_model()))
+            CommandResult::Message(format!(
+                "Current model: {}",
+                ctx.config.effective_model()
+            ))
         } else {
             // Accept both "provider/model" and bare model names.
             // The config stores the full string (including provider prefix when present)
@@ -717,15 +682,9 @@ impl SlashCommand for ModelCommand {
 
 #[async_trait]
 impl SlashCommand for ConfigCommand {
-    fn name(&self) -> &str {
-        "config"
-    }
-    fn aliases(&self) -> Vec<&str> {
-        vec!["settings"]
-    }
-    fn description(&self) -> &str {
-        "Show or modify configuration settings"
-    }
+    fn name(&self) -> &str { "config" }
+    fn aliases(&self) -> Vec<&str> { vec!["settings"] }
+    fn description(&self) -> &str { "Show or modify configuration settings" }
 
     async fn execute(&self, args: &str, ctx: &mut CommandContext) -> CommandResult {
         let args = args.trim();
@@ -744,9 +703,10 @@ impl SlashCommand for ConfigCommand {
                     "output-style = {}",
                     current_output_style_name(&ctx.config)
                 )),
-                "model" => {
-                    CommandResult::Message(format!("model = {}", ctx.config.effective_model()))
-                }
+                "model" => CommandResult::Message(format!(
+                    "model = {}",
+                    ctx.config.effective_model()
+                )),
                 "permission-mode" | "permission_mode" => CommandResult::Message(format!(
                     "permission-mode = {:?}",
                     ctx.config.permission_mode
@@ -760,8 +720,7 @@ impl SlashCommand for ConfigCommand {
                 "model" => {
                     let mut new_config = ctx.config.clone();
                     new_config.model = None;
-                    if let Err(err) =
-                        save_settings_mutation(|settings| settings.config.model = None)
+                    if let Err(err) = save_settings_mutation(|settings| settings.config.model = None)
                     {
                         return CommandResult::Error(format!(
                             "Failed to save configuration: {}",
@@ -832,7 +791,8 @@ impl SlashCommand for ConfigCommand {
                 }
 
                 let mut new_config = ctx.config.clone();
-                new_config.output_style = (normalized != "default").then(|| normalized.clone());
+                new_config.output_style =
+                    (normalized != "default").then(|| normalized.clone());
                 if let Err(err) = save_settings_mutation(|settings| {
                     settings.config.output_style =
                         (normalized != "default").then(|| normalized.clone());
@@ -865,7 +825,10 @@ impl SlashCommand for ConfigCommand {
                 }) {
                     return CommandResult::Error(format!("Failed to save configuration: {}", err));
                 }
-                CommandResult::ConfigChangeMessage(new_config, format!("Model set to {}.", value))
+                CommandResult::ConfigChangeMessage(
+                    new_config,
+                    format!("Model set to {}.", value),
+                )
             }
             "permission-mode" | "permission_mode" => {
                 let mode = match value.trim().to_lowercase().as_str() {
@@ -906,12 +869,8 @@ impl SlashCommand for ConfigCommand {
 
 #[async_trait]
 impl SlashCommand for ColorCommand {
-    fn name(&self) -> &str {
-        "color"
-    }
-    fn description(&self) -> &str {
-        "Set or show the prompt bar color for this session"
-    }
+    fn name(&self) -> &str { "color" }
+    fn description(&self) -> &str { "Set or show the prompt bar color for this session" }
     fn help(&self) -> &str {
         "Usage: /color [<name|#RRGGBB|default>]\n\n\
          Sets the accent color for the prompt bar in this session.\n\
@@ -938,11 +897,10 @@ impl SlashCommand for ColorCommand {
             None
         } else {
             let known_colors = [
-                "red", "green", "blue", "yellow", "cyan", "magenta", "white", "orange", "purple",
-                "pink", "gray", "grey",
+                "red", "green", "blue", "yellow", "cyan", "magenta",
+                "white", "orange", "purple", "pink", "gray", "grey",
             ];
-            let is_hex = color.starts_with('#')
-                && (color.len() == 4 || color.len() == 7)
+            let is_hex = color.starts_with('#') && (color.len() == 4 || color.len() == 7)
                 && color[1..].chars().all(|c| c.is_ascii_hexdigit());
             if !is_hex && !known_colors.contains(&color.to_lowercase().as_str()) {
                 return CommandResult::Error(format!(
@@ -968,12 +926,8 @@ impl SlashCommand for ColorCommand {
 
 #[async_trait]
 impl SlashCommand for ThemeCommand {
-    fn name(&self) -> &str {
-        "theme"
-    }
-    fn description(&self) -> &str {
-        "Show or change the current theme"
-    }
+    fn name(&self) -> &str { "theme" }
+    fn description(&self) -> &str { "Show or change the current theme" }
     fn help(&self) -> &str {
         "Usage: /theme [default|dark|light]\n\
          Without arguments, shows the active theme. With an argument, updates the theme for this and future sessions."
@@ -989,12 +943,15 @@ impl SlashCommand for ThemeCommand {
         }
 
         let Some(theme) = parse_theme(args) else {
-            return CommandResult::Error("Theme must be one of: default, dark, light".to_string());
+            return CommandResult::Error(
+                "Theme must be one of: default, dark, light".to_string(),
+            );
         };
 
         let mut new_config = ctx.config.clone();
         new_config.theme = theme.clone();
-        if let Err(err) = save_settings_mutation(|settings| settings.config.theme = theme.clone()) {
+        if let Err(err) = save_settings_mutation(|settings| settings.config.theme = theme.clone())
+        {
             return CommandResult::Error(format!("Failed to save theme: {}", err));
         }
 
@@ -1009,12 +966,8 @@ impl SlashCommand for ThemeCommand {
 
 #[async_trait]
 impl SlashCommand for OutputStyleCommand {
-    fn name(&self) -> &str {
-        "output-style"
-    }
-    fn description(&self) -> &str {
-        "Show or switch the current output style"
-    }
+    fn name(&self) -> &str { "output-style" }
+    fn description(&self) -> &str { "Show or switch the current output style" }
     fn help(&self) -> &str {
         "Usage: /output-style [style-name]\n\n\
          With no argument: list available styles and show the current one.\n\
@@ -1052,7 +1005,8 @@ impl SlashCommand for OutputStyleCommand {
         let mut new_config = ctx.config.clone();
         new_config.output_style = (normalized != "default").then(|| normalized.clone());
         if let Err(err) = save_settings_mutation(|settings| {
-            settings.config.output_style = (normalized != "default").then(|| normalized.clone());
+            settings.config.output_style =
+                (normalized != "default").then(|| normalized.clone());
         }) {
             return CommandResult::Error(format!("Failed to save configuration: {}", err));
         }
@@ -1071,12 +1025,8 @@ impl SlashCommand for OutputStyleCommand {
 
 #[async_trait]
 impl SlashCommand for KeybindingsCommand {
-    fn name(&self) -> &str {
-        "keybindings"
-    }
-    fn description(&self) -> &str {
-        "Create or open ~/.claurst/keybindings.json"
-    }
+    fn name(&self) -> &str { "keybindings" }
+    fn description(&self) -> &str { "Create or open ~/.claurst/keybindings.json" }
 
     async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let config_dir = Settings::config_dir();
@@ -1141,12 +1091,8 @@ impl SlashCommand for KeybindingsCommand {
 
 #[async_trait]
 impl SlashCommand for PrivacySettingsCommand {
-    fn name(&self) -> &str {
-        "privacy-settings"
-    }
-    fn description(&self) -> &str {
-        "Open Claurst privacy settings"
-    }
+    fn name(&self) -> &str { "privacy-settings" }
+    fn description(&self) -> &str { "Open Claurst privacy settings" }
 
     async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let url = "https://claude.ai/settings/data-privacy-controls";
@@ -1162,18 +1108,15 @@ impl SlashCommand for PrivacySettingsCommand {
 
 #[async_trait]
 impl SlashCommand for VersionCommand {
-    fn name(&self) -> &str {
-        "version"
-    }
-    fn aliases(&self) -> Vec<&str> {
-        vec!["v"]
-    }
-    fn description(&self) -> &str {
-        "Show version information"
-    }
+    fn name(&self) -> &str { "version" }
+    fn aliases(&self) -> Vec<&str> { vec!["v"] }
+    fn description(&self) -> &str { "Show version information" }
 
     async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
-        CommandResult::Message(format!("Claurst v{}", claurst_core::constants::APP_VERSION))
+        CommandResult::Message(format!(
+            "Claurst v{}",
+            claurst_core::constants::APP_VERSION
+        ))
     }
 }
 
@@ -1181,15 +1124,9 @@ impl SlashCommand for VersionCommand {
 
 #[async_trait]
 impl SlashCommand for ResumeCommand {
-    fn name(&self) -> &str {
-        "resume"
-    }
-    fn aliases(&self) -> Vec<&str> {
-        vec!["r", "continue"]
-    }
-    fn description(&self) -> &str {
-        "Resume a previous conversation"
-    }
+    fn name(&self) -> &str { "resume" }
+    fn aliases(&self) -> Vec<&str> { vec!["r", "continue"] }
+    fn description(&self) -> &str { "Resume a previous conversation" }
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         if args.is_empty() {
@@ -1199,7 +1136,10 @@ impl SlashCommand for ResumeCommand {
             }
             let mut output = String::from("Recent sessions:\n\n");
             for (i, session) in sessions.iter().take(10).enumerate() {
-                let title = session.title.as_deref().unwrap_or("(untitled)");
+                let title = session
+                    .title
+                    .as_deref()
+                    .unwrap_or("(untitled)");
                 let id_short = &session.id[..session.id.len().min(8)];
                 output.push_str(&format!(
                     "  {}. {} - {} ({} messages)\n",
@@ -1214,9 +1154,11 @@ impl SlashCommand for ResumeCommand {
         } else {
             match claurst_core::history::load_session(args.trim()).await {
                 Ok(session) => CommandResult::ResumeSession(session),
-                Err(e) => {
-                    CommandResult::Error(format!("Failed to load session {}: {}", args.trim(), e))
-                }
+                Err(e) => CommandResult::Error(format!(
+                    "Failed to load session {}: {}",
+                    args.trim(),
+                    e
+                )),
             }
         }
     }
@@ -1226,12 +1168,8 @@ impl SlashCommand for ResumeCommand {
 
 #[async_trait]
 impl SlashCommand for StatusCommand {
-    fn name(&self) -> &str {
-        "status"
-    }
-    fn description(&self) -> &str {
-        "Show comprehensive system and session status"
-    }
+    fn name(&self) -> &str { "status" }
+    fn description(&self) -> &str { "Show comprehensive system and session status" }
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         // Auth status
@@ -1317,12 +1255,8 @@ impl SlashCommand for StatusCommand {
 
 #[async_trait]
 impl SlashCommand for DiffCommand {
-    fn name(&self) -> &str {
-        "diff"
-    }
-    fn description(&self) -> &str {
-        "Show git diff of changes in the working directory"
-    }
+    fn name(&self) -> &str { "diff" }
+    fn description(&self) -> &str { "Show git diff of changes in the working directory" }
     fn help(&self) -> &str {
         "Usage: /diff [--stat|--staged|<ref>]\n\n\
          Shows git diff output for the current working directory.\n\n\
@@ -1393,12 +1327,8 @@ impl SlashCommand for DiffCommand {
 
 #[async_trait]
 impl SlashCommand for MemoryCommand {
-    fn name(&self) -> &str {
-        "memory"
-    }
-    fn description(&self) -> &str {
-        "View, edit, or clear AGENTS.md memory files"
-    }
+    fn name(&self) -> &str { "memory" }
+    fn description(&self) -> &str { "View, edit, or clear AGENTS.md memory files" }
     fn help(&self) -> &str {
         "Usage: /memory [edit|clear] [global]\n\n\
          Shows the content of AGENTS.md files that provide project context to Claurst.\n\
@@ -1434,10 +1364,7 @@ impl SlashCommand for MemoryCommand {
 
         // ---- /memory edit [global|project] ------------------------------------
         if cmd == "edit" || cmd.starts_with("edit ") {
-            let target_hint = cmd
-                .strip_prefix("edit")
-                .map(|s| s.trim())
-                .unwrap_or("project");
+            let target_hint = cmd.strip_prefix("edit").map(|s| s.trim()).unwrap_or("project");
             let target = match target_hint {
                 "global" => {
                     // Ensure global dir exists
@@ -1478,10 +1405,11 @@ impl SlashCommand for MemoryCommand {
             } else if let Ok(ed) = std::env::var("EDITOR") {
                 format!("Using $EDITOR=\"{}\".", ed)
             } else {
-                "To use a different editor, set the $EDITOR or $VISUAL environment variable."
-                    .to_string()
+                "To use a different editor, set the $EDITOR or $VISUAL environment variable.".to_string()
             };
-            let spawn_result = std::process::Command::new(&editor).arg(&target).status();
+            let spawn_result = std::process::Command::new(&editor)
+                .arg(&target)
+                .status();
             return match spawn_result {
                 Ok(_) => CommandResult::Message(format!(
                     "Opened {} in your editor.\n{}",
@@ -1490,20 +1418,14 @@ impl SlashCommand for MemoryCommand {
                 )),
                 Err(e) => CommandResult::Message(format!(
                     "Could not launch '{}': {}. Edit {} manually.\n{}",
-                    editor,
-                    e,
-                    target.display(),
-                    editor_hint
+                    editor, e, target.display(), editor_hint
                 )),
             };
         }
 
         // ---- /memory clear [global|project] -----------------------------------
         if cmd == "clear" || cmd.starts_with("clear ") {
-            let target_hint = cmd
-                .strip_prefix("clear")
-                .map(|s| s.trim())
-                .unwrap_or("project");
+            let target_hint = cmd.strip_prefix("clear").map(|s| s.trim()).unwrap_or("project");
             let (label, target) = match target_hint {
                 "global" => ("global (~/.claurst/AGENTS.md)", global_path.clone()),
                 _ => {
@@ -1527,9 +1449,9 @@ impl SlashCommand for MemoryCommand {
                     label,
                     target.display()
                 )),
-                Err(e) => {
-                    CommandResult::Error(format!("Failed to clear {}: {}", target.display(), e))
-                }
+                Err(e) => CommandResult::Error(format!(
+                    "Failed to clear {}: {}", target.display(), e
+                )),
             };
         }
 
@@ -1553,11 +1475,7 @@ impl SlashCommand for MemoryCommand {
                             lines = lines,
                             chars = chars,
                             content = if content.len() > 2000 {
-                                format!(
-                                    "{}…\n(truncated — file is {} chars)",
-                                    &content[..2000],
-                                    chars
-                                )
+                                format!("{}…\n(truncated — file is {} chars)", &content[..2000], chars)
                             } else {
                                 content.clone()
                             }
@@ -1565,9 +1483,7 @@ impl SlashCommand for MemoryCommand {
                     }
                     Err(e) => output.push_str(&format!(
                         "\n[{label}] — Error reading {}: {}\n",
-                        path.display(),
-                        e,
-                        label = label
+                        path.display(), e, label = label
                     )),
                 }
             }
@@ -1577,7 +1493,7 @@ impl SlashCommand for MemoryCommand {
             output.push_str(
                 "\nNo AGENTS.md files found.\n\
                  Use /init to create one in the current project.\n\
-                 Use /memory edit to create and open a memory file.",
+                 Use /memory edit to create and open a memory file."
             );
         } else {
             output.push_str(
@@ -1585,7 +1501,7 @@ impl SlashCommand for MemoryCommand {
                  /memory edit          — edit project AGENTS.md\n\
                  /memory edit global   — edit global ~/.claurst/AGENTS.md\n\
                  /memory clear         — clear project AGENTS.md\n\
-                 /memory clear global  — clear global AGENTS.md",
+                 /memory clear global  — clear global AGENTS.md"
             );
         }
 
@@ -1597,18 +1513,10 @@ impl SlashCommand for MemoryCommand {
 
 #[async_trait]
 impl SlashCommand for BugCommand {
-    fn name(&self) -> &str {
-        "feedback"
-    }
-    fn aliases(&self) -> Vec<&str> {
-        vec!["bug"]
-    }
-    fn description(&self) -> &str {
-        "Submit feedback about Claurst"
-    }
-    fn help(&self) -> &str {
-        "Usage: /feedback [report]"
-    }
+    fn name(&self) -> &str { "feedback" }
+    fn aliases(&self) -> Vec<&str> { vec!["bug"] }
+    fn description(&self) -> &str { "Submit feedback about Claurst" }
+    fn help(&self) -> &str { "Usage: /feedback [report]" }
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let report = args.trim();
@@ -1630,12 +1538,8 @@ impl SlashCommand for BugCommand {
 
 #[async_trait]
 impl SlashCommand for UsageCommand {
-    fn name(&self) -> &str {
-        "usage"
-    }
-    fn description(&self) -> &str {
-        "Show API usage, quotas, and rate limit status"
-    }
+    fn name(&self) -> &str { "usage" }
+    fn description(&self) -> &str { "Show API usage, quotas, and rate limit status" }
     fn help(&self) -> &str {
         "Usage: /usage\n\n\
          Shows current session API usage and account quota information.\n\
@@ -1696,15 +1600,9 @@ impl SlashCommand for UsageCommand {
 
 #[async_trait]
 impl SlashCommand for PluginCommand {
-    fn name(&self) -> &str {
-        "plugin"
-    }
-    fn aliases(&self) -> Vec<&str> {
-        vec!["plugins"]
-    }
-    fn description(&self) -> &str {
-        "Manage plugins"
-    }
+    fn name(&self) -> &str { "plugin" }
+    fn aliases(&self) -> Vec<&str> { vec!["plugins"] }
+    fn description(&self) -> &str { "Manage plugins" }
     fn help(&self) -> &str {
         "Usage: /plugin [list|info <name>|enable <name>|disable <name>|install <path>|reload]\n\
          Manage Claurst plugins.\n\n\
@@ -1723,7 +1621,9 @@ impl SlashCommand for PluginCommand {
 
         // Helper: prefer the already-loaded global registry, falling back to a
         // fresh disk scan so the command still works without the global being set.
-        async fn get_registry(project_dir: &std::path::Path) -> claurst_plugins::PluginRegistry {
+        async fn get_registry(
+            project_dir: &std::path::Path,
+        ) -> claurst_plugins::PluginRegistry {
             if let Some(global) = claurst_plugins::global_plugin_registry() {
                 let mut reg = claurst_plugins::PluginRegistry::new();
                 for p in global.all() {
@@ -1804,7 +1704,9 @@ impl SlashCommand for PluginCommand {
                 )
             }
             claurst_plugins::PluginSubCommand::Install(path) => {
-                let result = claurst_plugins::install_plugin_from_path(std::path::Path::new(&path));
+                let result = claurst_plugins::install_plugin_from_path(
+                    std::path::Path::new(&path),
+                );
                 match result {
                     Ok(name) => CommandResult::Message(format!(
                         "Plugin '{}' installed successfully. Run `/plugin reload` to activate it.",
@@ -1819,8 +1721,9 @@ impl SlashCommand for PluginCommand {
                     claurst_plugins::reload_plugins(&old_registry, &project_dir, &[]).await;
                 CommandResult::Message(claurst_plugins::format_reload_summary(&new_registry, &diff))
             }
-            claurst_plugins::PluginSubCommand::Help => CommandResult::Message(
-                "Plugin commands:\n\
+            claurst_plugins::PluginSubCommand::Help => {
+                CommandResult::Message(
+                    "Plugin commands:\n\
                      /plugin              — list all installed plugins\n\
                      /plugin list         — list all installed plugins\n\
                      /plugin info <name>  — show plugin details\n\
@@ -1828,8 +1731,9 @@ impl SlashCommand for PluginCommand {
                      /plugin disable <name>  — disable a plugin\n\
                      /plugin install <path>  — install plugin from local path\n\
                      /plugin reload       — reload plugins from disk"
-                    .to_string(),
-            ),
+                        .to_string(),
+                )
+            }
         }
     }
 }
@@ -1838,12 +1742,8 @@ impl SlashCommand for PluginCommand {
 
 #[async_trait]
 impl SlashCommand for ReloadPluginsCommand {
-    fn name(&self) -> &str {
-        "reload-plugins"
-    }
-    fn description(&self) -> &str {
-        "Reload all plugins without restarting"
-    }
+    fn name(&self) -> &str { "reload-plugins" }
+    fn description(&self) -> &str { "Reload all plugins without restarting" }
     fn help(&self) -> &str {
         "Usage: /reload-plugins\n\
          Reloads all plugins and shows what changed."
@@ -1918,15 +1818,14 @@ impl SlashCommand for PluginSlashCommandAdapter {
                 } else {
                     format!("{} {}", command, args)
                 };
-                let cmd_result =
-                    std::process::Command::new(if cfg!(windows) { "cmd" } else { "sh" })
-                        .args(if cfg!(windows) {
-                            vec!["/C", &full_cmd]
-                        } else {
-                            vec!["-c", &full_cmd]
-                        })
-                        .env("CLAUDE_PLUGIN_ROOT", plugin_root)
-                        .output();
+                let cmd_result = std::process::Command::new(if cfg!(windows) { "cmd" } else { "sh" })
+                    .args(if cfg!(windows) {
+                        vec!["/C", &full_cmd]
+                    } else {
+                        vec!["-c", &full_cmd]
+                    })
+                    .env("CLAUDE_PLUGIN_ROOT", plugin_root)
+                    .output();
                 match cmd_result {
                     Ok(out) => {
                         let stdout = String::from_utf8_lossy(&out.stdout);
@@ -1948,12 +1847,8 @@ impl SlashCommand for PluginSlashCommandAdapter {
 
 #[async_trait]
 impl SlashCommand for DoctorCommand {
-    fn name(&self) -> &str {
-        "doctor"
-    }
-    fn description(&self) -> &str {
-        "Check system health and diagnose issues"
-    }
+    fn name(&self) -> &str { "doctor" }
+    fn description(&self) -> &str { "Check system health and diagnose issues" }
     fn help(&self) -> &str {
         "Usage: /doctor\n\
          Runs a comprehensive system diagnostics check:\n\
@@ -2024,10 +1919,7 @@ impl SlashCommand for DoctorCommand {
             }
         }
         // Show which model is active
-        lines.push(format!(
-            "  • Active model: {}",
-            ctx.config.effective_model()
-        ));
+        lines.push(format!("  • Active model: {}", ctx.config.effective_model()));
         lines.push(String::new());
 
         // ── Git ─────────────────────────────────────────────────────────────
@@ -2059,9 +1951,7 @@ impl SlashCommand for DoctorCommand {
                     .to_string();
                 lines.push(format!("  ✓ ripgrep: {first}"));
             }
-            _ => lines.push(
-                "  ⚠ ripgrep (rg) not found — Grep tool will fall back to built-in".to_string(),
-            ),
+            _ => lines.push("  ⚠ ripgrep (rg) not found — Grep tool will fall back to built-in".to_string()),
         }
         lines.push(String::new());
 
@@ -2138,10 +2028,10 @@ impl SlashCommand for DoctorCommand {
                         .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
                     {
                         Some(_) => lines.push(
-                            "  ⚠ settings.json is JSON but has unexpected structure".to_string(),
+                            "  ⚠ settings.json is JSON but has unexpected structure".to_string()
                         ),
                         None => lines.push(
-                            "  ✗ settings.json is invalid JSON — run /config to repair".to_string(),
+                            "  ✗ settings.json is invalid JSON — run /config to repair".to_string()
                         ),
                     }
                 }
@@ -2155,9 +2045,7 @@ impl SlashCommand for DoctorCommand {
         if claude_md.exists() {
             lines.push("  ✓ AGENTS.md present in working directory".to_string());
         } else {
-            lines.push(
-                "  • No AGENTS.md in working directory (run /init to create one)".to_string(),
-            );
+            lines.push("  • No AGENTS.md in working directory (run /init to create one)".to_string());
         }
         lines.push(String::new());
 
@@ -2172,19 +2060,13 @@ impl SlashCommand for DoctorCommand {
             for srv in ctx.config.mcp_servers.iter().take(12) {
                 let status_str = match statuses.get(&srv.name) {
                     Some(claurst_mcp::McpServerStatus::Connected { tool_count }) => {
-                        format!(
-                            "  ✓ {} — connected ({} tool{})",
-                            srv.name,
-                            tool_count,
-                            if *tool_count == 1 { "" } else { "s" }
-                        )
+                        format!("  ✓ {} — connected ({} tool{})",
+                            srv.name, tool_count, if *tool_count == 1 { "" } else { "s" })
                     }
                     Some(claurst_mcp::McpServerStatus::Connecting) => {
                         format!("  ⚠ {} — connecting…", srv.name)
                     }
-                    Some(claurst_mcp::McpServerStatus::Disconnected {
-                        last_error: Some(e),
-                    }) => {
+                    Some(claurst_mcp::McpServerStatus::Disconnected { last_error: Some(e) }) => {
                         format!("  ✗ {} — failed: {}", srv.name, e)
                     }
                     Some(claurst_mcp::McpServerStatus::Disconnected { last_error: None }) => {
@@ -2202,9 +2084,7 @@ impl SlashCommand for DoctorCommand {
             }
         } else {
             // No live manager — just show configured names
-            lines.push(format!(
-                "  ✓ {mcp_count} MCP server(s) configured (not yet connected):"
-            ));
+            lines.push(format!("  ✓ {mcp_count} MCP server(s) configured (not yet connected):"));
             for srv in ctx.config.mcp_servers.iter().take(8) {
                 lines.push(format!("    - {}", srv.name));
             }
@@ -2220,10 +2100,8 @@ impl SlashCommand for DoctorCommand {
         if hook_count == 0 {
             lines.push("  • No hooks configured".to_string());
         } else {
-            lines.push(format!(
-                "  ✓ {hook_count} hook(s) configured across {} event(s)",
-                ctx.config.hooks.len()
-            ));
+            lines.push(format!("  ✓ {hook_count} hook(s) configured across {} event(s)",
+                ctx.config.hooks.len()));
         }
         lines.push(String::new());
 
@@ -2237,21 +2115,15 @@ impl SlashCommand for DoctorCommand {
         let allowed_count = ctx.config.allowed_tools.len();
         let denied_count = ctx.config.disallowed_tools.len();
         // Tools not in allowed or denied lists require user confirmation
-        let explicit_tools: std::collections::HashSet<&str> = ctx
-            .config
-            .allowed_tools
-            .iter()
+        let explicit_tools: std::collections::HashSet<&str> = ctx.config.allowed_tools.iter()
             .chain(ctx.config.disallowed_tools.iter())
             .map(|s| s.as_str())
             .collect();
-        let confirm_count = all_tool_names
-            .iter()
+        let confirm_count = all_tool_names.iter()
             .filter(|n| !explicit_tools.contains(n.as_str()))
             .count();
         let mode_label = match ctx.config.permission_mode {
-            claurst_core::PermissionMode::BypassPermissions => {
-                "bypass-permissions (no confirmation required)"
-            }
+            claurst_core::PermissionMode::BypassPermissions => "bypass-permissions (no confirmation required)",
             claurst_core::PermissionMode::AcceptEdits => "accept-edits (file edits auto-approved)",
             claurst_core::PermissionMode::Plan => "plan (read-only, no writes)",
             claurst_core::PermissionMode::Default => "default (confirm destructive actions)",
@@ -2259,24 +2131,17 @@ impl SlashCommand for DoctorCommand {
         lines.push(format!("  • Mode: {mode_label}"));
         lines.push(format!("  • Total built-in tools: {total_tools}"));
         if allowed_count > 0 {
-            lines.push(format!(
-                "  ✓ Always allowed: {} tool(s) — {}",
+            lines.push(format!("  ✓ Always allowed: {} tool(s) — {}",
                 allowed_count,
-                ctx.config.allowed_tools.join(", ")
-            ));
+                ctx.config.allowed_tools.join(", ")));
         }
         if denied_count > 0 {
-            lines.push(format!(
-                "  ✗ Always denied: {} tool(s) — {}",
+            lines.push(format!("  ✗ Always denied: {} tool(s) — {}",
                 denied_count,
-                ctx.config.disallowed_tools.join(", ")
-            ));
+                ctx.config.disallowed_tools.join(", ")));
         }
         if ctx.config.permission_mode == claurst_core::PermissionMode::Default {
-            lines.push(format!(
-                "  ⚠ Require confirmation: {} tool(s)",
-                confirm_count
-            ));
+            lines.push(format!("  ⚠ Require confirmation: {} tool(s)", confirm_count));
         }
         lines.push(String::new());
 
@@ -2299,12 +2164,8 @@ impl SlashCommand for DoctorCommand {
 
 #[async_trait]
 impl SlashCommand for LoginCommand {
-    fn name(&self) -> &str {
-        "login"
-    }
-    fn description(&self) -> &str {
-        "Authenticate with Anthropic (OAuth PKCE flow)"
-    }
+    fn name(&self) -> &str { "login" }
+    fn description(&self) -> &str { "Authenticate with Anthropic (OAuth PKCE flow)" }
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         // `--console` flag → Console/API-key auth; default → Claude.ai subscription auth
@@ -2317,12 +2178,8 @@ impl SlashCommand for LoginCommand {
 
 #[async_trait]
 impl SlashCommand for LogoutCommand {
-    fn name(&self) -> &str {
-        "logout"
-    }
-    fn description(&self) -> &str {
-        "Clear stored OAuth tokens and API key"
-    }
+    fn name(&self) -> &str { "logout" }
+    fn description(&self) -> &str { "Clear stored OAuth tokens and API key" }
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         // Clear OAuth tokens file
@@ -2330,9 +2187,7 @@ impl SlashCommand for LogoutCommand {
             return CommandResult::Error(format!("Failed to clear OAuth tokens: {}", e));
         }
         // Also clear any API key stored in settings
-        let mut settings = claurst_core::config::Settings::load()
-            .await
-            .unwrap_or_default();
+        let mut settings = claurst_core::config::Settings::load().await.unwrap_or_default();
         settings.config.api_key = None;
         if let Err(e) = settings.save().await {
             return CommandResult::Error(format!("Failed to update settings: {}", e));
@@ -2346,12 +2201,8 @@ impl SlashCommand for LogoutCommand {
 
 #[async_trait]
 impl SlashCommand for RefreshCommand {
-    fn name(&self) -> &str {
-        "refresh"
-    }
-    fn description(&self) -> &str {
-        "Clear saved provider auth and model caches"
-    }
+    fn name(&self) -> &str { "refresh" }
+    fn description(&self) -> &str { "Clear saved provider auth and model caches" }
     fn help(&self) -> &str {
         "Usage: /refresh\n\n\
          Clears saved provider credentials, provider/model selection, and model caches, then rebuilds the live runtime state.\n\
@@ -2383,12 +2234,8 @@ fn parse_speech_level(args: &str) -> String {
 
 #[async_trait]
 impl SlashCommand for CavemanCommand {
-    fn name(&self) -> &str {
-        "caveman"
-    }
-    fn description(&self) -> &str {
-        "Caveman speech mode — why use many token when few token do trick"
-    }
+    fn name(&self) -> &str { "caveman" }
+    fn description(&self) -> &str { "Caveman speech mode — why use many token when few token do trick" }
     fn help(&self) -> &str {
         "Usage: /caveman [lite|full|ultra]\n\n\
          Activates caveman speech mode that cuts ~75% of output tokens.\n\
@@ -2399,21 +2246,14 @@ impl SlashCommand for CavemanCommand {
     }
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let level = parse_speech_level(args);
-        CommandResult::SpeechMode {
-            mode: Some("caveman".to_string()),
-            level,
-        }
+        CommandResult::SpeechMode { mode: Some("caveman".to_string()), level }
     }
 }
 
 #[async_trait]
 impl SlashCommand for RockyCommand {
-    fn name(&self) -> &str {
-        "rocky"
-    }
-    fn description(&self) -> &str {
-        "Rocky speech mode — Eridian alien engineer from Project Hail Mary. Save big token. Good good good."
-    }
+    fn name(&self) -> &str { "rocky" }
+    fn description(&self) -> &str { "Rocky speech mode — Eridian alien engineer from Project Hail Mary. Save big token. Good good good." }
     fn help(&self) -> &str {
         "Usage: /rocky [lite|full|ultra]\n\n\
          Speak like Rocky from Project Hail Mary. Saves big token. Amaze amaze amaze.\n\
@@ -2424,29 +2264,19 @@ impl SlashCommand for RockyCommand {
     }
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let level = parse_speech_level(args);
-        CommandResult::SpeechMode {
-            mode: Some("rocky".to_string()),
-            level,
-        }
+        CommandResult::SpeechMode { mode: Some("rocky".to_string()), level }
     }
 }
 
 #[async_trait]
 impl SlashCommand for NormalCommand {
-    fn name(&self) -> &str {
-        "normal"
-    }
-    fn description(&self) -> &str {
-        "Deactivate speech mode (caveman/rocky)"
-    }
+    fn name(&self) -> &str { "normal" }
+    fn description(&self) -> &str { "Deactivate speech mode (caveman/rocky)" }
     fn help(&self) -> &str {
         "Usage: /normal\n\nDeactivate any active speech mode and return to normal output."
     }
     async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
-        CommandResult::SpeechMode {
-            mode: None,
-            level: "full".to_string(),
-        }
+        CommandResult::SpeechMode { mode: None, level: "full".to_string() }
     }
 }
 
@@ -2454,12 +2284,8 @@ impl SlashCommand for NormalCommand {
 
 #[async_trait]
 impl SlashCommand for InitCommand {
-    fn name(&self) -> &str {
-        "init"
-    }
-    fn description(&self) -> &str {
-        "Initialize a new project with AGENTS.md"
-    }
+    fn name(&self) -> &str { "init" }
+    fn description(&self) -> &str { "Initialize a new project with AGENTS.md" }
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         let path = ctx.working_dir.join("AGENTS.md");
@@ -2478,7 +2304,10 @@ impl SlashCommand for InitCommand {
             - List important files and their purposes\n";
 
         match tokio::fs::write(&path, default_content).await {
-            Ok(()) => CommandResult::Message(format!("Created AGENTS.md at {}", path.display())),
+            Ok(()) => CommandResult::Message(format!(
+                "Created AGENTS.md at {}",
+                path.display()
+            )),
             Err(e) => CommandResult::Error(format!("Failed to create AGENTS.md: {}", e)),
         }
     }
@@ -2488,12 +2317,8 @@ impl SlashCommand for InitCommand {
 
 #[async_trait]
 impl SlashCommand for ReviewCommand {
-    fn name(&self) -> &str {
-        "review"
-    }
-    fn description(&self) -> &str {
-        "Review code changes via LLM and optionally post to GitHub PR"
-    }
+    fn name(&self) -> &str { "review" }
+    fn description(&self) -> &str { "Review code changes via LLM and optionally post to GitHub PR" }
     fn help(&self) -> &str {
         "Usage: /review [base-ref]\n\n\
          Runs `git diff <base>...HEAD` (or `git diff --cached` when no base is given),\n\
@@ -2537,7 +2362,10 @@ impl SlashCommand for ReviewCommand {
                 }
                 Ok(o) => {
                     let stderr = String::from_utf8_lossy(&o.stderr);
-                    return CommandResult::Error(format!("git diff failed: {}", stderr.trim()));
+                    return CommandResult::Error(format!(
+                        "git diff failed: {}",
+                        stderr.trim()
+                    ));
                 }
                 Err(e) => return CommandResult::Error(format!("Failed to run git: {}", e)),
             }
@@ -2655,7 +2483,9 @@ impl SlashCommand for ReviewCommand {
                 let (msg, _usage, _stop) = acc.finish();
                 let text = msg.get_all_text();
                 if text.is_empty() {
-                    return CommandResult::Error("LLM returned an empty review.".to_string());
+                    return CommandResult::Error(
+                        "LLM returned an empty review.".to_string(),
+                    );
                 }
                 text
             }
@@ -2707,11 +2537,14 @@ impl SlashCommand for ReviewCommand {
                         Ok(resp) => {
                             let status = resp.status().as_u16();
                             let body = resp.text().await.unwrap_or_default();
-                            github_post_result =
-                                Some(format!("\nGitHub API returned {}: {}", status, body));
+                            github_post_result = Some(format!(
+                                "\nGitHub API returned {}: {}",
+                                status, body
+                            ));
                         }
                         Err(e) => {
-                            github_post_result = Some(format!("\nFailed to post to GitHub: {}", e));
+                            github_post_result =
+                                Some(format!("\nFailed to post to GitHub: {}", e));
                         }
                     }
                 } else {
@@ -2823,12 +2656,8 @@ fn parse_github_remote_url(url: &str) -> Option<(String, String)> {
 
 #[async_trait]
 impl SlashCommand for HooksCommand {
-    fn name(&self) -> &str {
-        "hooks"
-    }
-    fn description(&self) -> &str {
-        "Show configured event hooks"
-    }
+    fn name(&self) -> &str { "hooks" }
+    fn description(&self) -> &str { "Show configured event hooks" }
     fn help(&self) -> &str {
         "Usage: /hooks\n\
          Show hooks configured in settings.json under 'hooks'.\n\
@@ -2867,12 +2696,8 @@ impl SlashCommand for HooksCommand {
 
 #[async_trait]
 impl SlashCommand for McpCommand {
-    fn name(&self) -> &str {
-        "mcp"
-    }
-    fn description(&self) -> &str {
-        "Show MCP server status and manage connections"
-    }
+    fn name(&self) -> &str { "mcp" }
+    fn description(&self) -> &str { "Show MCP server status and manage connections" }
     fn help(&self) -> &str {
         "Usage: /mcp [list|status|auth <server>|connect <server>|logs <server>|resources|prompts|get-prompt ...]\n\n\
          Manages Model Context Protocol (MCP) servers.\n\
@@ -3002,7 +2827,7 @@ impl SlashCommand for McpCommand {
                 output.push_str(
                     "\nNote: MCP manager is not active in this session.\n\
                      Restart Claurst to connect to MCP servers.\n\
-                     Use /mcp connect <server> to retry a single server.",
+                     Use /mcp connect <server> to retry a single server."
                 );
             }
             return CommandResult::Message(output);
@@ -3042,7 +2867,7 @@ impl SlashCommand for McpCommand {
         }
         output.push_str(
             "\nSubcommands: status | auth <server> | connect <server> | logs <server>\n\
-             Also: resources | prompts | get-prompt <server> <prompt> [key=val ...]",
+             Also: resources | prompts | get-prompt <server> <prompt> [key=val ...]"
         );
         CommandResult::Message(output)
     }
@@ -3057,29 +2882,15 @@ impl McpCommand {
     ///
     /// For stdio servers: shows env-var auth instructions.
     async fn handle_auth(server_name: &str, ctx: &CommandContext) -> CommandResult {
-        let srv = match ctx
-            .config
-            .mcp_servers
-            .iter()
-            .find(|s| s.name == server_name)
-        {
+        let srv = match ctx.config.mcp_servers.iter().find(|s| s.name == server_name) {
             Some(s) => s,
             None => {
-                let configured: Vec<&str> = ctx
-                    .config
-                    .mcp_servers
-                    .iter()
-                    .map(|s| s.name.as_str())
-                    .collect();
+                let configured: Vec<&str> = ctx.config.mcp_servers.iter().map(|s| s.name.as_str()).collect();
                 return CommandResult::Error(format!(
                     "No MCP server named '{}' is configured.\n\
                      Configured servers: {}",
                     server_name,
-                    if configured.is_empty() {
-                        "(none)".to_string()
-                    } else {
-                        configured.join(", ")
-                    }
+                    if configured.is_empty() { "(none)".to_string() } else { configured.join(", ") }
                 ));
             }
         };
@@ -3183,31 +2994,22 @@ impl McpCommand {
     fn handle_tools(server_filter: Option<&str>, ctx: &CommandContext) -> CommandResult {
         let manager = match ctx.mcp_manager.as_ref() {
             Some(m) => m,
-            None => {
-                return CommandResult::Message(
-                    "MCP manager is not active. No tool information available.\n\
-                 Restart Claurst to connect to MCP servers."
-                        .to_string(),
-                )
-            }
+            None => return CommandResult::Message(
+                "MCP manager is not active. No tool information available.\n\
+                 Restart Claurst to connect to MCP servers.".to_string()
+            ),
         };
 
         let all_tools = manager.all_tool_definitions();
         let tools: Vec<_> = if let Some(filter) = server_filter {
-            all_tools
-                .iter()
-                .filter(|(srv, _)| srv.as_str() == filter)
-                .collect()
+            all_tools.iter().filter(|(srv, _)| srv.as_str() == filter).collect()
         } else {
             all_tools.iter().collect()
         };
 
         if tools.is_empty() {
             return CommandResult::Message(if let Some(filter) = server_filter {
-                format!(
-                    "No tools available from server '{}' (not connected or has no tools).",
-                    filter
-                )
+                format!("No tools available from server '{}' (not connected or has no tools).", filter)
             } else {
                 "No tools available from any connected MCP server.".to_string()
             });
@@ -3226,16 +3028,9 @@ impl McpCommand {
                 last_server = server.as_str();
             }
             // Strip the "servername_" prefix for display
-            let bare = tool
-                .name
-                .strip_prefix(&format!("{}_", server))
-                .unwrap_or(&tool.name);
+            let bare = tool.name.strip_prefix(&format!("{}_", server)).unwrap_or(&tool.name);
             let preview: String = tool.description.chars().take(80).collect();
-            let ellipsis = if tool.description.len() > 80 {
-                "…"
-            } else {
-                ""
-            };
+            let ellipsis = if tool.description.len() > 80 { "…" } else { "" };
             out.push_str(&format!("  {}\n    {}{}\n", bare, preview, ellipsis));
         }
         CommandResult::Message(out)
@@ -3245,21 +3040,12 @@ impl McpCommand {
     async fn handle_connect(server_name: &str, ctx: &CommandContext) -> CommandResult {
         // Validate that the server is configured.
         if !ctx.config.mcp_servers.iter().any(|s| s.name == server_name) {
-            let names: Vec<&str> = ctx
-                .config
-                .mcp_servers
-                .iter()
-                .map(|s| s.name.as_str())
-                .collect();
+            let names: Vec<&str> = ctx.config.mcp_servers.iter().map(|s| s.name.as_str()).collect();
             return CommandResult::Error(format!(
                 "No MCP server named '{}' is configured.\n\
                  Configured servers: {}",
                 server_name,
-                if names.is_empty() {
-                    "(none)".to_string()
-                } else {
-                    names.join(", ")
-                }
+                if names.is_empty() { "(none)".to_string() } else { names.join(", ") }
             ));
         }
 
@@ -3279,17 +3065,21 @@ impl McpCommand {
                 let current = manager.server_status(server_name);
                 use claurst_mcp::McpServerStatus;
                 match current {
-                    McpServerStatus::Connected { tool_count } => CommandResult::Message(format!(
-                        "MCP server '{}' is already connected ({} tool{} available).",
-                        server_name,
-                        tool_count,
-                        if tool_count == 1 { "" } else { "s" }
-                    )),
-                    McpServerStatus::Connecting => CommandResult::Message(format!(
-                        "MCP server '{}' is already in the process of connecting.\n\
+                    McpServerStatus::Connected { tool_count } => {
+                        CommandResult::Message(format!(
+                            "MCP server '{}' is already connected ({} tool{} available).",
+                            server_name,
+                            tool_count,
+                            if tool_count == 1 { "" } else { "s" }
+                        ))
+                    }
+                    McpServerStatus::Connecting => {
+                        CommandResult::Message(format!(
+                            "MCP server '{}' is already in the process of connecting.\n\
                              Check back in a moment.",
-                        server_name
-                    )),
+                            server_name
+                        ))
+                    }
                     McpServerStatus::Disconnected { .. } | McpServerStatus::Failed { .. } => {
                         // The McpManager doesn't expose a reconnect method — it's built at
                         // startup.  Inform the user and suggest a restart.
@@ -3316,28 +3106,16 @@ impl McpCommand {
     fn handle_logs(server_name: &str, ctx: &CommandContext) -> CommandResult {
         // Validate server name.
         if !ctx.config.mcp_servers.iter().any(|s| s.name == server_name) {
-            let names: Vec<&str> = ctx
-                .config
-                .mcp_servers
-                .iter()
-                .map(|s| s.name.as_str())
-                .collect();
+            let names: Vec<&str> = ctx.config.mcp_servers.iter().map(|s| s.name.as_str()).collect();
             return CommandResult::Error(format!(
                 "No MCP server named '{}' is configured.\n\
                  Configured servers: {}",
                 server_name,
-                if names.is_empty() {
-                    "(none)".to_string()
-                } else {
-                    names.join(", ")
-                }
+                if names.is_empty() { "(none)".to_string() } else { names.join(", ") }
             ));
         }
 
-        let mut lines = vec![format!(
-            "MCP Server Logs — '{}'\n──────────────────────",
-            server_name
-        )];
+        let mut lines = vec![format!("MCP Server Logs — '{}'\n──────────────────────", server_name)];
 
         if let Some(manager) = &ctx.mcp_manager {
             use claurst_mcp::McpServerStatus;
@@ -3345,52 +3123,30 @@ impl McpCommand {
             lines.push(format!("Current status:  {}", status.display()));
 
             match &status {
-                McpServerStatus::Disconnected {
-                    last_error: Some(e),
-                } => {
+                McpServerStatus::Disconnected { last_error: Some(e) } => {
                     lines.push(format!("\nLast connection error:\n  {}", e));
                     lines.push(String::new());
                     lines.push("Troubleshooting:".to_string());
-                    lines.push(format!(
-                        "  /mcp auth {}    — check authentication",
-                        server_name
-                    ));
-                    lines.push(format!(
-                        "  /mcp connect {} — attempt reconnect",
-                        server_name
-                    ));
+                    lines.push(format!("  /mcp auth {}    — check authentication", server_name));
+                    lines.push(format!("  /mcp connect {} — attempt reconnect", server_name));
                 }
                 McpServerStatus::Failed { error, retry_at } => {
                     lines.push(format!("\nConnection failure:\n  {}", error));
-                    let retry_secs = retry_at
-                        .saturating_duration_since(std::time::Instant::now())
-                        .as_secs();
+                    let retry_secs = retry_at.saturating_duration_since(std::time::Instant::now()).as_secs();
                     if retry_secs > 0 {
                         lines.push(format!("  Automatic retry in {}s", retry_secs));
                     }
                     let _ = retry_at; // used above
                 }
                 McpServerStatus::Connected { tool_count } => {
-                    lines.push(format!(
-                        "\nServer is healthy — {} tool{} available.",
-                        tool_count,
-                        if *tool_count == 1 { "" } else { "s" }
-                    ));
+                    lines.push(format!("\nServer is healthy — {} tool{} available.", tool_count, if *tool_count == 1 { "" } else { "s" }));
                     // Show catalog info if available.
                     if let Some(catalog) = manager.server_catalog(server_name) {
                         if !catalog.resources.is_empty() {
-                            lines.push(format!(
-                                "Resources ({}): {}",
-                                catalog.resource_count,
-                                catalog.resources.join(", ")
-                            ));
+                            lines.push(format!("Resources ({}): {}", catalog.resource_count, catalog.resources.join(", ")));
                         }
                         if !catalog.prompts.is_empty() {
-                            lines.push(format!(
-                                "Prompts ({}): {}",
-                                catalog.prompt_count,
-                                catalog.prompts.join(", ")
-                            ));
+                            lines.push(format!("Prompts ({}): {}", catalog.prompt_count, catalog.prompts.join(", ")));
                         }
                     }
                 }
@@ -3417,12 +3173,9 @@ impl McpCommand {
 
         // Hint about log files.
         lines.push(String::new());
-        lines.push(
-            "Note: Detailed stdio output from MCP server processes is not\n\
+        lines.push("Note: Detailed stdio output from MCP server processes is not\n\
                     captured by the manager. Run the server command directly in a\n\
-                    terminal to see its full output."
-                .to_string(),
-        );
+                    terminal to see its full output.".to_string());
 
         CommandResult::Message(lines.join("\n"))
     }
@@ -3440,8 +3193,7 @@ impl McpCommand {
                 let resources = manager.list_all_resources(filter).await;
                 if resources.is_empty() {
                     return Some(CommandResult::Message(
-                        "No resources available (servers may not support resources/list)."
-                            .to_string(),
+                        "No resources available (servers may not support resources/list).".to_string()
                     ));
                 }
                 let mut out = format!("MCP Resources ({})\n──────────────────\n", resources.len());
@@ -3463,36 +3215,21 @@ impl McpCommand {
                 let prompts = manager.list_all_prompts(filter).await;
                 if prompts.is_empty() {
                     return Some(CommandResult::Message(
-                        "No prompt templates available (servers may not support prompts/list)."
-                            .to_string(),
+                        "No prompt templates available (servers may not support prompts/list).".to_string()
                     ));
                 }
-                let mut out = format!(
-                    "MCP Prompt Templates ({})\n─────────────────────────\n",
-                    prompts.len()
-                );
+                let mut out = format!("MCP Prompt Templates ({})\n─────────────────────────\n", prompts.len());
                 for p in &prompts {
                     let server = p.get("server").and_then(|v| v.as_str()).unwrap_or("?");
                     let name = p.get("name").and_then(|v| v.as_str()).unwrap_or("?");
                     let desc = p.get("description").and_then(|v| v.as_str()).unwrap_or("");
-                    let args: Vec<String> = p
-                        .get("arguments")
+                    let args: Vec<String> = p.get("arguments")
                         .and_then(|a| a.as_array())
-                        .map(|arr| {
-                            arr.iter()
-                                .filter_map(|a| {
-                                    a.get("name")
-                                        .and_then(|n| n.as_str())
-                                        .map(|s| s.to_string())
-                                })
-                                .collect()
-                        })
+                        .map(|arr| arr.iter()
+                            .filter_map(|a| a.get("name").and_then(|n| n.as_str()).map(|s| s.to_string()))
+                            .collect())
                         .unwrap_or_default();
-                    let args_display = if args.is_empty() {
-                        String::new()
-                    } else {
-                        format!(" ({})", args.join(", "))
-                    };
+                    let args_display = if args.is_empty() { String::new() } else { format!(" ({})", args.join(", ")) };
                     if desc.is_empty() {
                         out.push_str(&format!("  [{server}] {name}{args_display}\n"));
                     } else {
@@ -3506,22 +3243,13 @@ impl McpCommand {
                 // /mcp get-prompt <server> <prompt-name> [key=val key2=val2 ...]
                 let server = match parts.get(1) {
                     Some(s) => *s,
-                    None => {
-                        return Some(CommandResult::Error(
-                            "Usage: /mcp get-prompt <server> <prompt> [key=value ...]".to_string(),
-                        ))
-                    }
+                    None => return Some(CommandResult::Error("Usage: /mcp get-prompt <server> <prompt> [key=value ...]".to_string())),
                 };
                 let prompt_name = match parts.get(2) {
                     Some(p) => *p,
-                    None => {
-                        return Some(CommandResult::Error(
-                            "Usage: /mcp get-prompt <server> <prompt> [key=value ...]".to_string(),
-                        ))
-                    }
+                    None => return Some(CommandResult::Error("Usage: /mcp get-prompt <server> <prompt> [key=value ...]".to_string())),
                 };
-                let mut args: std::collections::HashMap<String, String> =
-                    std::collections::HashMap::new();
+                let mut args: std::collections::HashMap<String, String> = std::collections::HashMap::new();
                 if let Some(kv_str) = parts.get(3) {
                     for kv in kv_str.split_whitespace() {
                         if let Some((k, v)) = kv.split_once('=') {
@@ -3536,9 +3264,7 @@ impl McpCommand {
                         for msg in &result.messages {
                             let text = match &msg.content {
                                 claurst_mcp::PromptMessageContent::Text { text } => text.clone(),
-                                claurst_mcp::PromptMessageContent::Image { .. } => {
-                                    "[image]".to_string()
-                                }
+                                claurst_mcp::PromptMessageContent::Image { .. } => "[image]".to_string(),
                                 claurst_mcp::PromptMessageContent::Resource { resource } => {
                                     resource.to_string()
                                 }
@@ -3547,10 +3273,7 @@ impl McpCommand {
                         }
                         Some(CommandResult::UserMessage(injected.trim().to_string()))
                     }
-                    Err(e) => Some(CommandResult::Error(format!(
-                        "Failed to get prompt '{}' from '{}': {}",
-                        prompt_name, server, e
-                    ))),
+                    Err(e) => Some(CommandResult::Error(format!("Failed to get prompt '{}' from '{}': {}", prompt_name, server, e))),
                 }
             }
             _ => None,
@@ -3562,12 +3285,8 @@ impl McpCommand {
 
 #[async_trait]
 impl SlashCommand for PermissionsCommand {
-    fn name(&self) -> &str {
-        "permissions"
-    }
-    fn description(&self) -> &str {
-        "View or change tool permission settings"
-    }
+    fn name(&self) -> &str { "permissions" }
+    fn description(&self) -> &str { "View or change tool permission settings" }
     fn help(&self) -> &str {
         "Usage: /permissions [set <mode>|allow <tool>|deny <tool>|reset]\n\n\
          Modes: default, accept-edits, bypass-permissions, plan\n\n\
@@ -3602,7 +3321,9 @@ impl SlashCommand for PermissionsCommand {
                  Use /permissions set <mode> to change the permission mode.\n\
                  Use /permissions allow|deny <tool> to override individual tools.\n\
                  Use /permissions reset to clear all overrides.",
-                ctx.config.permission_mode, allowed_display, denied_display,
+                ctx.config.permission_mode,
+                allowed_display,
+                denied_display,
             ));
         }
 
@@ -3614,24 +3335,16 @@ impl SlashCommand for PermissionsCommand {
             "set" => {
                 let mode = match arg.to_lowercase().as_str() {
                     "default" => claurst_core::config::PermissionMode::Default,
-                    "accept-edits" | "accept_edits" => {
-                        claurst_core::config::PermissionMode::AcceptEdits
-                    }
-                    "bypass-permissions" | "bypass_permissions" => {
-                        claurst_core::config::PermissionMode::BypassPermissions
-                    }
+                    "accept-edits" | "accept_edits" => claurst_core::config::PermissionMode::AcceptEdits,
+                    "bypass-permissions" | "bypass_permissions" => claurst_core::config::PermissionMode::BypassPermissions,
                     "plan" => claurst_core::config::PermissionMode::Plan,
-                    _ => {
-                        return CommandResult::Error(
-                            "Mode must be: default, accept-edits, bypass-permissions, or plan"
-                                .to_string(),
-                        )
-                    }
+                    _ => return CommandResult::Error(
+                        "Mode must be: default, accept-edits, bypass-permissions, or plan".to_string()
+                    ),
                 };
                 let mut new_config = ctx.config.clone();
                 new_config.permission_mode = mode.clone();
-                if let Err(e) = save_settings_mutation(|s| s.config.permission_mode = mode.clone())
-                {
+                if let Err(e) = save_settings_mutation(|s| s.config.permission_mode = mode.clone()) {
                     return CommandResult::Error(format!("Failed to save: {}", e));
                 }
                 CommandResult::ConfigChangeMessage(
@@ -3708,12 +3421,8 @@ impl SlashCommand for PermissionsCommand {
 
 #[async_trait]
 impl SlashCommand for PlanCommand {
-    fn name(&self) -> &str {
-        "plan"
-    }
-    fn description(&self) -> &str {
-        "Enter plan mode – model outputs a plan for approval before acting"
-    }
+    fn name(&self) -> &str { "plan" }
+    fn description(&self) -> &str { "Enter plan mode – model outputs a plan for approval before acting" }
     fn help(&self) -> &str {
         "Usage: /plan [description]\n\n\
          Switches to plan mode where the model will create a detailed plan before executing.\n\
@@ -3724,7 +3433,7 @@ impl SlashCommand for PlanCommand {
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         if args.trim() == "exit" {
             return CommandResult::UserMessage(
-                "[Exiting plan mode. Resuming normal execution.]".to_string(),
+                "[Exiting plan mode. Resuming normal execution.]".to_string()
             );
         }
         let task_desc = if args.is_empty() {
@@ -3745,20 +3454,13 @@ impl SlashCommand for PlanCommand {
 
 #[async_trait]
 impl SlashCommand for TasksCommand {
-    fn name(&self) -> &str {
-        "tasks"
-    }
-    fn aliases(&self) -> Vec<&str> {
-        vec!["bashes"]
-    }
-    fn description(&self) -> &str {
-        "List and manage background tasks"
-    }
+    fn name(&self) -> &str { "tasks" }
+    fn aliases(&self) -> Vec<&str> { vec!["bashes"] }
+    fn description(&self) -> &str { "List and manage background tasks" }
 
     async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
         CommandResult::UserMessage(
-            "Please list all current tasks using the TaskList tool and show their status."
-                .to_string(),
+            "Please list all current tasks using the TaskList tool and show their status.".to_string()
         )
     }
 }
@@ -3767,15 +3469,9 @@ impl SlashCommand for TasksCommand {
 
 #[async_trait]
 impl SlashCommand for SessionCommand {
-    fn name(&self) -> &str {
-        "session"
-    }
-    fn aliases(&self) -> Vec<&str> {
-        vec!["remote"]
-    }
-    fn description(&self) -> &str {
-        "Show or manage conversation sessions"
-    }
+    fn name(&self) -> &str { "session" }
+    fn aliases(&self) -> Vec<&str> { vec!["remote"] }
+    fn description(&self) -> &str { "Show or manage conversation sessions" }
 
     async fn execute(&self, args: &str, ctx: &mut CommandContext) -> CommandResult {
         match args.trim() {
@@ -3839,11 +3535,7 @@ impl SlashCommand for SessionCommand {
                         for sess in sessions.iter().take(5) {
                             let updated = sess.updated_at.format("%Y-%m-%d %H:%M").to_string();
                             let id_short = &sess.id[..sess.id.len().min(8)];
-                            let marker = if sess.id == ctx.session_id {
-                                " ◀ current"
-                            } else {
-                                ""
-                            };
+                            let marker = if sess.id == ctx.session_id { " ◀ current" } else { "" };
                             output.push_str(&format!(
                                 "  {} | {} | {} messages | {}{}\n",
                                 id_short,
@@ -3853,18 +3545,13 @@ impl SlashCommand for SessionCommand {
                                 marker,
                             ));
                         }
-                        output.push_str(
-                            "\nUse /session list for all sessions, /resume <id> to switch.",
-                        );
+                        output.push_str("\nUse /session list for all sessions, /resume <id> to switch.");
                     }
 
                     CommandResult::Message(output)
                 }
             }
-            _ => CommandResult::Error(format!(
-                "Unknown subcommand: {}\n\nUsage: /session [list]",
-                args
-            )),
+            _ => CommandResult::Error(format!("Unknown subcommand: {}\n\nUsage: /session [list]", args)),
         }
     }
 }
@@ -3873,12 +3560,8 @@ impl SlashCommand for SessionCommand {
 
 #[async_trait]
 impl SlashCommand for ForkCommand {
-    fn name(&self) -> &str {
-        "fork"
-    }
-    fn description(&self) -> &str {
-        "Fork the current session into a new branch"
-    }
+    fn name(&self) -> &str { "fork" }
+    fn description(&self) -> &str { "Fork the current session into a new branch" }
     fn help(&self) -> &str {
         "Usage: /fork [message_index]\n\n\
          Fork the current session at the specified message index (or at the\n\
@@ -3905,7 +3588,9 @@ impl SlashCommand for ForkCommand {
             "Fork of {}",
             ctx.session_title.as_deref().unwrap_or("session")
         ));
-        new_session.working_dir = Some(ctx.working_dir.to_string_lossy().to_string());
+        new_session.working_dir = Some(
+            ctx.working_dir.to_string_lossy().to_string(),
+        );
 
         let new_id = new_session.id.clone();
         match claurst_core::history::save_session(&new_session).await {
@@ -3922,15 +3607,9 @@ impl SlashCommand for ForkCommand {
 
 #[async_trait]
 impl SlashCommand for ThinkingCommand {
-    fn name(&self) -> &str {
-        "thinking"
-    }
-    fn description(&self) -> &str {
-        "Toggle extended thinking mode"
-    }
-    fn aliases(&self) -> Vec<&str> {
-        vec!["think"]
-    }
+    fn name(&self) -> &str { "thinking" }
+    fn description(&self) -> &str { "Toggle extended thinking mode" }
+    fn aliases(&self) -> Vec<&str> { vec!["think"] }
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         // Extended thinking is configured through the model; just inform the user
@@ -3938,8 +3617,7 @@ impl SlashCommand for ThinkingCommand {
         if model.contains("claude-3-5") || model.contains("claude-3.5") {
             CommandResult::Message(
                 "Extended thinking is not available for Claude 3.5 models.\n\
-                 Use claude-opus-4-6 or claude-sonnet-4-6 for extended thinking."
-                    .to_string(),
+                 Use claude-opus-4-6 or claude-sonnet-4-6 for extended thinking.".to_string()
             )
         } else {
             CommandResult::Message(format!(
@@ -4018,12 +3696,7 @@ fn export_message_to_markdown(
                 'search: for next_msg in all_messages.iter().skip(msg_idx + 1) {
                     if let MessageContent::Blocks(next_blocks) = &next_msg.content {
                         for nb in next_blocks {
-                            if let ContentBlock::ToolResult {
-                                tool_use_id,
-                                content,
-                                is_error,
-                            } = nb
-                            {
+                            if let ContentBlock::ToolResult { tool_use_id, content, is_error } = nb {
                                 if tool_use_id.as_str() == *tool_id {
                                     let text = match content {
                                         ToolResultContent::Text(t) => t.clone(),
@@ -4039,27 +3712,17 @@ fn export_message_to_markdown(
                                             .collect::<Vec<_>>()
                                             .join(""),
                                     };
-                                    let label = if is_error.unwrap_or(false) {
-                                        "Error"
-                                    } else {
-                                        "Output"
-                                    };
-                                    found_output = Some(format!(
-                                        "**{}:** `{}`\n",
+                                    let label = if is_error.unwrap_or(false) { "Error" } else { "Output" };
+                                    found_output = Some(format!("**{}:** `{}`\n",
                                         label,
-                                        text.lines().next().unwrap_or(&text).trim()
-                                    ));
+                                        text.lines().next().unwrap_or(&text).trim()));
                                     break 'search;
                                 }
                             }
                         }
                     }
                 }
-                out.push_str(
-                    found_output
-                        .as_deref()
-                        .unwrap_or("**Output:** *(pending)*\n"),
-                );
+                out.push_str(found_output.as_deref().unwrap_or("**Output:** *(pending)*\n"));
             }
         }
     }
@@ -4073,10 +3736,7 @@ fn build_markdown_export(ctx: &CommandContext) -> String {
     out.push_str("# Conversation Export\n\n");
     out.push_str(&format!("- **Session ID:** {}\n", ctx.session_id));
     out.push_str(&format!("- **Model:** {}\n", ctx.config.effective_model()));
-    out.push_str(&format!(
-        "- **Exported:** {}\n",
-        chrono::Utc::now().to_rfc3339()
-    ));
+    out.push_str(&format!("- **Exported:** {}\n", chrono::Utc::now().to_rfc3339()));
     if let Some(ref title) = ctx.session_title {
         out.push_str(&format!("- **Title:** {}\n", title));
     }
@@ -4111,12 +3771,8 @@ fn build_json_export(ctx: &CommandContext) -> serde_json::Value {
 
 #[async_trait]
 impl SlashCommand for ExportCommand {
-    fn name(&self) -> &str {
-        "export"
-    }
-    fn description(&self) -> &str {
-        "Export conversation to markdown or JSON"
-    }
+    fn name(&self) -> &str { "export" }
+    fn description(&self) -> &str { "Export conversation to markdown or JSON" }
     fn help(&self) -> &str {
         "Usage: /export [--format markdown|json] [--output <file>]\n\n\
          Export the current conversation.\n\n\
@@ -4148,7 +3804,7 @@ impl SlashCommand for ExportCommand {
                         i += 2;
                     } else {
                         return CommandResult::Error(
-                            "--format requires a value: markdown or json".to_string(),
+                            "--format requires a value: markdown or json".to_string()
                         );
                     }
                 }
@@ -4157,7 +3813,9 @@ impl SlashCommand for ExportCommand {
                         output_path = Some(tokens[i + 1].to_string());
                         i += 2;
                     } else {
-                        return CommandResult::Error("--output requires a file path".to_string());
+                        return CommandResult::Error(
+                            "--output requires a file path".to_string()
+                        );
                     }
                 }
                 other if !other.starts_with('-') => {
@@ -4179,8 +3837,7 @@ impl SlashCommand for ExportCommand {
             Some("json") => "json",
             Some(other) => {
                 return CommandResult::Error(format!(
-                    "Unknown format '{}'. Use 'markdown' or 'json'.",
-                    other
+                    "Unknown format '{}'. Use 'markdown' or 'json'.", other
                 ));
             }
             None => {
@@ -4217,11 +3874,7 @@ impl SlashCommand for ExportCommand {
                     format!(
                         "{}.{}",
                         filename,
-                        if resolved_format == "markdown" {
-                            "md"
-                        } else {
-                            "json"
-                        }
+                        if resolved_format == "markdown" { "md" } else { "json" }
                     )
                 } else {
                     filename.to_string()
@@ -4240,9 +3893,9 @@ impl SlashCommand for ExportCommand {
                         ctx.messages.len(),
                         resolved_format,
                     )),
-                    Err(e) => {
-                        CommandResult::Error(format!("Failed to write {}: {}", path.display(), e))
-                    }
+                    Err(e) => CommandResult::Error(format!(
+                        "Failed to write {}: {}", path.display(), e
+                    )),
                 }
             }
             None => {
@@ -4257,15 +3910,9 @@ impl SlashCommand for ExportCommand {
 
 #[async_trait]
 impl SlashCommand for SkillsCommand {
-    fn name(&self) -> &str {
-        "skills"
-    }
-    fn aliases(&self) -> Vec<&str> {
-        vec!["skill"]
-    }
-    fn description(&self) -> &str {
-        "List available skills in .claurst/commands/"
-    }
+    fn name(&self) -> &str { "skills" }
+    fn aliases(&self) -> Vec<&str> { vec!["skill"] }
+    fn description(&self) -> &str { "List available skills in .claurst/commands/" }
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         let mut found: Vec<String> = Vec::new();
@@ -4323,13 +3970,15 @@ impl SlashCommand for SkillsCommand {
         }
 
         // Include discovered skills from .claurst/skills/ and configured paths/URLs.
-        let discovered = claurst_core::discover_skills(&ctx.working_dir, &ctx.config.skills);
+        let discovered = claurst_core::discover_skills(
+            &ctx.working_dir,
+            &ctx.config.skills,
+        );
 
         let mut output = if found.is_empty() && discovered.is_empty() {
             return CommandResult::Message(
                 "No skills found.\nCreate .md files in .claurst/commands/ to define skills.\n\
-                 Example: .claurst/commands/review.md"
-                    .to_string(),
+                 Example: .claurst/commands/review.md".to_string(),
             );
         } else if found.is_empty() {
             String::new()
@@ -4338,11 +3987,7 @@ impl SlashCommand for SkillsCommand {
             format!(
                 "Available skills ({}):\n{}",
                 found.len(),
-                found
-                    .iter()
-                    .map(|s| format!("  /{}", s))
-                    .collect::<Vec<_>>()
-                    .join("\n")
+                found.iter().map(|s| format!("  /{}", s)).collect::<Vec<_>>().join("\n")
             )
         };
 
@@ -4373,12 +4018,8 @@ impl SlashCommand for SkillsCommand {
 
 #[async_trait]
 impl SlashCommand for RewindCommand {
-    fn name(&self) -> &str {
-        "rewind"
-    }
-    fn description(&self) -> &str {
-        "Interactively select a message to rewind to"
-    }
+    fn name(&self) -> &str { "rewind" }
+    fn description(&self) -> &str { "Interactively select a message to rewind to" }
     fn help(&self) -> &str {
         "Usage: /rewind\n\
          Opens an interactive overlay to select the message to rewind to.\n\
@@ -4387,9 +4028,7 @@ impl SlashCommand for RewindCommand {
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         if ctx.messages.is_empty() {
-            return CommandResult::Message(
-                "Nothing to rewind — conversation is empty.".to_string(),
-            );
+            return CommandResult::Message("Nothing to rewind — conversation is empty.".to_string());
         }
         CommandResult::OpenRewindOverlay
     }
@@ -4399,12 +4038,8 @@ impl SlashCommand for RewindCommand {
 
 #[async_trait]
 impl SlashCommand for StatsCommand {
-    fn name(&self) -> &str {
-        "stats"
-    }
-    fn description(&self) -> &str {
-        "Show token usage and cost statistics"
-    }
+    fn name(&self) -> &str { "stats" }
+    fn description(&self) -> &str { "Show token usage and cost statistics" }
     fn help(&self) -> &str {
         "Usage: /stats\n\n\
          Shows detailed token usage and cost breakdown for the current session,\n\
@@ -4422,21 +4057,15 @@ impl SlashCommand for StatsCommand {
         let model = ctx.config.effective_model();
 
         // Count user/assistant turns separately.
-        let user_turns = ctx
-            .messages
-            .iter()
+        let user_turns = ctx.messages.iter()
             .filter(|m| m.role == claurst_core::types::Role::User)
             .count();
-        let assistant_turns = ctx
-            .messages
-            .iter()
+        let assistant_turns = ctx.messages.iter()
             .filter(|m| m.role == claurst_core::types::Role::Assistant)
             .count();
 
         // Count tool-use invocations.
-        let tool_calls: usize = ctx
-            .messages
-            .iter()
+        let tool_calls: usize = ctx.messages.iter()
             .map(|m| m.get_tool_use_blocks().len())
             .sum();
 
@@ -4487,19 +4116,14 @@ impl SlashCommand for StatsCommand {
 
 #[async_trait]
 impl SlashCommand for FilesCommand {
-    fn name(&self) -> &str {
-        "files"
-    }
-    fn description(&self) -> &str {
-        "List files referenced in the current conversation"
-    }
+    fn name(&self) -> &str { "files" }
+    fn description(&self) -> &str { "List files referenced in the current conversation" }
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         use std::collections::HashSet;
         // Scan message content for file paths (simple heuristic)
         let mut files: HashSet<String> = HashSet::new();
-        let path_re =
-            regex::Regex::new(r#"(?m)([A-Za-z]:[\\/][^\s,;:"'<>]+|/[^\s,;:"'<>]{3,})"#).ok();
+        let path_re = regex::Regex::new(r#"(?m)([A-Za-z]:[\\/][^\s,;:"'<>]+|/[^\s,;:"'<>]{3,})"#).ok();
 
         for msg in &ctx.messages {
             let text = msg.get_all_text();
@@ -4525,11 +4149,7 @@ impl SlashCommand for FilesCommand {
         CommandResult::Message(format!(
             "Referenced files ({}):\n{}",
             sorted.len(),
-            sorted
-                .iter()
-                .map(|f| format!("  {}", f))
-                .collect::<Vec<_>>()
-                .join("\n")
+            sorted.iter().map(|f| format!("  {}", f)).collect::<Vec<_>>().join("\n")
         ))
     }
 }
@@ -4538,12 +4158,8 @@ impl SlashCommand for FilesCommand {
 
 #[async_trait]
 impl SlashCommand for RenameCommand {
-    fn name(&self) -> &str {
-        "rename"
-    }
-    fn description(&self) -> &str {
-        "Rename the current session"
-    }
+    fn name(&self) -> &str { "rename" }
+    fn description(&self) -> &str { "Rename the current session" }
     fn help(&self) -> &str {
         "Usage: /rename [new name]\n\n\
          With a name: sets the session title immediately.\n\
@@ -4575,18 +4191,12 @@ impl SlashCommand for RenameCommand {
             .take(20)
             .filter_map(|m| {
                 let text = m.get_all_text();
-                if text.is_empty() {
-                    return None;
-                }
+                if text.is_empty() { return None; }
                 let role = match m.role {
                     claurst_core::types::Role::User => "User",
                     claurst_core::types::Role::Assistant => "Assistant",
                 };
-                Some(format!(
-                    "{}: {}",
-                    role,
-                    text.chars().take(300).collect::<String>()
-                ))
+                Some(format!("{}: {}", role, text.chars().take(300).collect::<String>()))
             })
             .collect::<Vec<_>>()
             .join("\n");
@@ -4613,29 +4223,25 @@ impl SlashCommand for RenameCommand {
             Examples: fix-login-bug, add-auth-feature, refactor-api-client. \
             Respond with ONLY the name, nothing else.";
 
-        let request =
-            claurst_api::CreateMessageRequest::builder("claude-haiku-4-5".to_string(), 64)
-                .system_text(system_prompt)
-                .add_message(claurst_api::ApiMessage {
-                    role: "user".to_string(),
-                    content: serde_json::Value::String(format!(
-                        "Conversation to name:\n\n{}",
-                        &excerpt[..excerpt.len().min(2000)]
-                    )),
-                })
-                .build();
+        let request = claurst_api::CreateMessageRequest::builder(
+            "claude-haiku-4-5".to_string(),
+            64,
+        )
+        .system_text(system_prompt)
+        .add_message(claurst_api::ApiMessage {
+            role: "user".to_string(),
+            content: serde_json::Value::String(
+                format!("Conversation to name:\n\n{}", &excerpt[..excerpt.len().min(2000)])
+            ),
+        })
+        .build();
 
         match client.create_message(request).await {
             Ok(response) => {
                 // Extract text from the response content blocks.
-                let raw_text: String = response
-                    .content
-                    .iter()
+                let raw_text: String = response.content.iter()
                     .filter_map(|block| {
-                        block
-                            .get("text")
-                            .and_then(|v| v.as_str())
-                            .map(str::to_string)
+                        block.get("text").and_then(|v| v.as_str()).map(str::to_string)
                     })
                     .collect::<Vec<_>>()
                     .join("")
@@ -4653,8 +4259,7 @@ impl SlashCommand for RenameCommand {
                 if cleaned.is_empty() {
                     return CommandResult::Error(
                         "Could not generate a valid name from conversation. \
-                         Use /rename <name> to set manually."
-                            .to_string(),
+                         Use /rename <name> to set manually.".to_string(),
                     );
                 }
 
@@ -4672,12 +4277,8 @@ impl SlashCommand for RenameCommand {
 
 #[async_trait]
 impl SlashCommand for EffortCommand {
-    fn name(&self) -> &str {
-        "effort"
-    }
-    fn description(&self) -> &str {
-        "Set the model's thinking effort (low | normal | high)"
-    }
+    fn name(&self) -> &str { "effort" }
+    fn description(&self) -> &str { "Set the model's thinking effort (low | normal | high)" }
     fn help(&self) -> &str {
         "Usage: /effort [low|normal|high]\n\
          Sets how much computation the model uses for reasoning.\n\
@@ -4714,12 +4315,8 @@ impl SlashCommand for EffortCommand {
 
 #[async_trait]
 impl SlashCommand for SummaryCommand {
-    fn name(&self) -> &str {
-        "summary"
-    }
-    fn description(&self) -> &str {
-        "Generate a brief summary of the conversation so far"
-    }
+    fn name(&self) -> &str { "summary" }
+    fn description(&self) -> &str { "Generate a brief summary of the conversation so far" }
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         let count = ctx.messages.len();
@@ -4740,12 +4337,8 @@ impl SlashCommand for SummaryCommand {
 
 #[async_trait]
 impl SlashCommand for CommitCommand {
-    fn name(&self) -> &str {
-        "commit"
-    }
-    fn description(&self) -> &str {
-        "Ask Claurst to commit staged changes"
-    }
+    fn name(&self) -> &str { "commit" }
+    fn description(&self) -> &str { "Ask Claurst to commit staged changes" }
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let extra = if args.trim().is_empty() {
@@ -4772,7 +4365,7 @@ impl SlashCommand for CommitCommand {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
 struct UiSettings {
     #[serde(default)]
-    pub editor_mode: Option<String>, // "vim" or "normal"
+    pub editor_mode: Option<String>,       // "vim" or "normal"
     #[serde(default)]
     pub fast_mode: Option<bool>,
     #[serde(default)]
@@ -4834,15 +4427,9 @@ where
 
 #[async_trait]
 impl SlashCommand for RemoteControlCommand {
-    fn name(&self) -> &str {
-        "remote-control"
-    }
-    fn aliases(&self) -> Vec<&str> {
-        vec!["rc"]
-    }
-    fn description(&self) -> &str {
-        "Show or manage the remote control (Bridge) connection"
-    }
+    fn name(&self) -> &str { "remote-control" }
+    fn aliases(&self) -> Vec<&str> { vec!["rc"] }
+    fn description(&self) -> &str { "Show or manage the remote control (Bridge) connection" }
     fn help(&self) -> &str {
         "Usage: /remote-control [start|stop|status]\n\n\
          The Bridge feature lets you connect your local Claurst CLI to the\n\
@@ -4879,11 +4466,8 @@ impl SlashCommand for RemoteControlCommand {
                     "not set (required to connect)"
                 };
 
-                let startup_status = if remote_at_startup {
-                    "enabled at startup"
-                } else {
-                    "disabled"
-                };
+                let startup_status =
+                    if remote_at_startup { "enabled at startup" } else { "disabled" };
 
                 // Active session info from context
                 let session_section = if let Some(ref url) = ctx.remote_session_url {
@@ -4991,12 +4575,8 @@ impl SlashCommand for RemoteControlCommand {
 
 #[async_trait]
 impl SlashCommand for RemoteEnvCommand {
-    fn name(&self) -> &str {
-        "remote-env"
-    }
-    fn description(&self) -> &str {
-        "Show and manage environment variables for remote sessions"
-    }
+    fn name(&self) -> &str { "remote-env" }
+    fn description(&self) -> &str { "Show and manage environment variables for remote sessions" }
     fn help(&self) -> &str {
         "Usage: /remote-env [set <KEY> <VALUE> | unset <KEY> | list]\n\n\
          Manages env vars stored in config that are forwarded to remote Claurst sessions.\n\
@@ -5062,7 +4642,9 @@ impl SlashCommand for RemoteEnvCommand {
             }
             "unset" | "remove" | "delete" => {
                 if key.is_empty() {
-                    return CommandResult::Error("Usage: /remote-env unset <KEY>".to_string());
+                    return CommandResult::Error(
+                        "Usage: /remote-env unset <KEY>".to_string(),
+                    );
                 }
                 if !ctx.config.env.contains_key(key) {
                     return CommandResult::Message(format!("Key '{}' is not set.", key));
@@ -5092,12 +4674,8 @@ impl SlashCommand for RemoteEnvCommand {
 
 #[async_trait]
 impl SlashCommand for ContextCommand {
-    fn name(&self) -> &str {
-        "context"
-    }
-    fn description(&self) -> &str {
-        "Show context window usage (tokens used / available)"
-    }
+    fn name(&self) -> &str { "context" }
+    fn description(&self) -> &str { "Show context window usage (tokens used / available)" }
     fn help(&self) -> &str {
         "Usage: /context\n\n\
          Displays the current context window utilization:\n\
@@ -5163,12 +4741,8 @@ impl SlashCommand for ContextCommand {
 
 #[async_trait]
 impl SlashCommand for CopyCommand {
-    fn name(&self) -> &str {
-        "copy"
-    }
-    fn description(&self) -> &str {
-        "Copy the last assistant response to the clipboard"
-    }
+    fn name(&self) -> &str { "copy" }
+    fn description(&self) -> &str { "Copy the last assistant response to the clipboard" }
     fn help(&self) -> &str {
         "Usage: /copy [n]\n\n\
          Copies the most recent assistant response to the system clipboard.\n\
@@ -5253,7 +4827,6 @@ impl SlashCommand for CopyCommand {
 
 mod chrome_cdp {
     use base64::Engine as _;
-    use futures::{SinkExt, StreamExt};
     use once_cell::sync::Lazy;
     use parking_lot::Mutex;
     use serde_json::{json, Value};
@@ -5262,6 +4835,7 @@ mod chrome_cdp {
     use tokio_tungstenite::{
         connect_async, tungstenite::Message as WsMessage, MaybeTlsStream, WebSocketStream,
     };
+    use futures::{SinkExt, StreamExt};
 
     // -----------------------------------------------------------------------
     // Global session state
@@ -5355,9 +4929,9 @@ mod chrome_cdp {
         let ws_url = tabs
             .as_array()
             .and_then(|arr| {
-                arr.iter()
-                    .find(|t| t["type"] == "page")
-                    .and_then(|t| t["webSocketDebuggerUrl"].as_str().map(|s| s.to_string()))
+                arr.iter().find(|t| t["type"] == "page").and_then(|t| {
+                    t["webSocketDebuggerUrl"].as_str().map(|s| s.to_string())
+                })
             })
             .ok_or_else(|| {
                 anyhow::anyhow!(
@@ -5376,15 +4950,11 @@ mod chrome_cdp {
             })
             .unwrap_or_default();
 
-        let (ws, _) = connect_async(&ws_url)
-            .await
-            .map_err(|e| anyhow::anyhow!("WebSocket connect to {} failed: {}", ws_url, e))?;
+        let (ws, _) = connect_async(&ws_url).await.map_err(|e| {
+            anyhow::anyhow!("WebSocket connect to {} failed: {}", ws_url, e)
+        })?;
 
-        let mut session = ChromeSession {
-            ws,
-            port,
-            tab_url: tab_url.clone(),
-        };
+        let mut session = ChromeSession { ws, port, tab_url: tab_url.clone() };
         // Enable Page domain so captureScreenshot etc. work.
         cdp_call(&mut session.ws, "Page.enable", json!({})).await?;
         // Enable Runtime domain for eval/click/fill.
@@ -5578,15 +5148,14 @@ mod chrome_cdp {
         store_session(s);
         result
     }
+
 }
 
 // ---- SlashCommand impl -------------------------------------------------------
 
 #[async_trait]
 impl SlashCommand for ChromeCommand {
-    fn name(&self) -> &str {
-        "chrome"
-    }
+    fn name(&self) -> &str { "chrome" }
     fn description(&self) -> &str {
         "Browser automation via Chrome DevTools Protocol (CDP)"
     }
@@ -5619,7 +5188,10 @@ impl SlashCommand for ChromeCommand {
                     match p.parse() {
                         Ok(n) => n,
                         Err(_) => {
-                            return CommandResult::Error(format!("Invalid port number: {}", p));
+                            return CommandResult::Error(format!(
+                                "Invalid port number: {}",
+                                p
+                            ));
                         }
                     }
                 } else if rest.is_empty() {
@@ -5745,15 +5317,9 @@ impl SlashCommand for ChromeCommand {
 
 #[async_trait]
 impl SlashCommand for VimCommand {
-    fn name(&self) -> &str {
-        "vim"
-    }
-    fn aliases(&self) -> Vec<&str> {
-        vec!["vi"]
-    }
-    fn description(&self) -> &str {
-        "Toggle vim keybinding mode on/off"
-    }
+    fn name(&self) -> &str { "vim" }
+    fn aliases(&self) -> Vec<&str> { vec!["vi"] }
+    fn description(&self) -> &str { "Toggle vim keybinding mode on/off" }
     fn help(&self) -> &str {
         "Usage: /vim [on|off]\n\n\
          Toggles vim keybinding mode in the REPL input.\n\
@@ -5770,11 +5336,7 @@ impl SlashCommand for VimCommand {
             "off" | "normal" => "normal",
             "" => {
                 // Toggle
-                if current_mode == "vim" {
-                    "normal"
-                } else {
-                    "vim"
-                }
+                if current_mode == "vim" { "normal" } else { "vim" }
             }
             other => {
                 return CommandResult::Error(format!(
@@ -5805,12 +5367,8 @@ impl SlashCommand for VimCommand {
 
 #[async_trait]
 impl SlashCommand for VoiceCommand {
-    fn name(&self) -> &str {
-        "voice"
-    }
-    fn description(&self) -> &str {
-        "Toggle voice input mode on/off"
-    }
+    fn name(&self) -> &str { "voice" }
+    fn description(&self) -> &str { "Toggle voice input mode on/off" }
     fn help(&self) -> &str {
         "Usage: /voice [on|off]\n\n\
          Enables or disables voice input (hold-to-talk).\n\
@@ -5858,15 +5416,9 @@ impl SlashCommand for VoiceCommand {
 
 #[async_trait]
 impl SlashCommand for UpgradeCommand {
-    fn name(&self) -> &str {
-        "update"
-    }
-    fn aliases(&self) -> Vec<&str> {
-        vec!["upgrade"]
-    }
-    fn description(&self) -> &str {
-        "Check for updates and download the latest release"
-    }
+    fn name(&self) -> &str { "update" }
+    fn aliases(&self) -> Vec<&str> { vec!["upgrade"] }
+    fn description(&self) -> &str { "Check for updates and download the latest release" }
     fn help(&self) -> &str {
         "Usage: /update\n\n\
          Checks GitHub releases for the latest version of Claurst.\n\
@@ -5900,7 +5452,8 @@ impl SlashCommand for UpgradeCommand {
 
         match resp {
             Ok(r) if r.status().is_success() => {
-                let json: serde_json::Value = r.json().await.unwrap_or(serde_json::Value::Null);
+                let json: serde_json::Value =
+                    r.json().await.unwrap_or(serde_json::Value::Null);
 
                 let tag = json
                     .get("tag_name")
@@ -5952,12 +5505,8 @@ impl SlashCommand for UpgradeCommand {
 
 #[async_trait]
 impl SlashCommand for ReleaseNotesCommand {
-    fn name(&self) -> &str {
-        "release-notes"
-    }
-    fn description(&self) -> &str {
-        "Show release notes for the current version"
-    }
+    fn name(&self) -> &str { "release-notes" }
+    fn description(&self) -> &str { "Show release notes for the current version" }
     fn help(&self) -> &str {
         "Usage: /release-notes [version]\n\n\
          Fetches and displays release notes from GitHub.\n\
@@ -5998,7 +5547,8 @@ impl SlashCommand for ReleaseNotesCommand {
 
         match client.get(&url).send().await {
             Ok(r) if r.status().is_success() => {
-                let json: serde_json::Value = r.json().await.unwrap_or(serde_json::Value::Null);
+                let json: serde_json::Value =
+                    r.json().await.unwrap_or(serde_json::Value::Null);
 
                 let body = json
                     .get("body")
@@ -6010,7 +5560,10 @@ impl SlashCommand for ReleaseNotesCommand {
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown date");
 
-                let html_url = json.get("html_url").and_then(|v| v.as_str()).unwrap_or("");
+                let html_url = json
+                    .get("html_url")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
 
                 CommandResult::Message(format!(
                     "Release Notes: Claurst {tag}\n\
@@ -6042,12 +5595,8 @@ impl SlashCommand for ReleaseNotesCommand {
 
 #[async_trait]
 impl SlashCommand for RateLimitOptionsCommand {
-    fn name(&self) -> &str {
-        "rate-limit-options"
-    }
-    fn description(&self) -> &str {
-        "Show rate limit tiers and current rate limit status"
-    }
+    fn name(&self) -> &str { "rate-limit-options" }
+    fn description(&self) -> &str { "Show rate limit tiers and current rate limit status" }
     fn help(&self) -> &str {
         "Usage: /rate-limit-options\n\n\
          Displays available rate limit tiers and the current tier for your account.\n\
@@ -6063,11 +5612,7 @@ impl SlashCommand for RateLimitOptionsCommand {
                     "Account type:    {}\n\
                      Scopes:          {}",
                     sub_type,
-                    if tokens.scopes.is_empty() {
-                        "none".to_string()
-                    } else {
-                        tokens.scopes.join(", ")
-                    }
+                    if tokens.scopes.is_empty() { "none".to_string() } else { tokens.scopes.join(", ") }
                 )
             }
             None => {
@@ -6105,12 +5650,8 @@ impl SlashCommand for RateLimitOptionsCommand {
 
 #[async_trait]
 impl SlashCommand for StatuslineCommand {
-    fn name(&self) -> &str {
-        "statusline"
-    }
-    fn description(&self) -> &str {
-        "Configure what is shown in the status line"
-    }
+    fn name(&self) -> &str { "statusline" }
+    fn description(&self) -> &str { "Configure what is shown in the status line" }
     fn help(&self) -> &str {
         "Usage: /statusline [show|hide] [cost|tokens|model|time|all]\n\n\
          Controls which items appear in the TUI status bar at the bottom.\n\
@@ -6164,12 +5705,10 @@ impl SlashCommand for StatuslineCommand {
                 s.statusline_show_model = Some(show);
                 s.statusline_show_time = Some(show);
             }) {
-                Ok(_) => {
-                    return CommandResult::Message(format!(
-                        "Status line: all items {}.",
-                        if show { "shown" } else { "hidden" }
-                    ))
-                }
+                Ok(_) => return CommandResult::Message(format!(
+                    "Status line: all items {}.",
+                    if show { "shown" } else { "hidden" }
+                )),
                 Err(e) => return CommandResult::Error(format!("Failed to save: {}", e)),
             }
         }
@@ -6199,23 +5738,15 @@ impl SlashCommand for StatuslineCommand {
 }
 
 fn fmt_bool(v: bool) -> &'static str {
-    if v {
-        "on"
-    } else {
-        "off"
-    }
+    if v { "on" } else { "off" }
 }
 
 // ---- /security-review ----------------------------------------------------
 
 #[async_trait]
 impl SlashCommand for SecurityReviewCommand {
-    fn name(&self) -> &str {
-        "security-review"
-    }
-    fn description(&self) -> &str {
-        "Run a security review of the current project"
-    }
+    fn name(&self) -> &str { "security-review" }
+    fn description(&self) -> &str { "Run a security review of the current project" }
     fn help(&self) -> &str {
         "Usage: /security-review [path]\n\n\
          Asks Claurst to perform a security review of the codebase.\n\
@@ -6259,12 +5790,8 @@ impl SlashCommand for SecurityReviewCommand {
 
 #[async_trait]
 impl SlashCommand for TerminalSetupCommand {
-    fn name(&self) -> &str {
-        "terminal-setup"
-    }
-    fn description(&self) -> &str {
-        "Help configure your terminal for optimal Claurst use"
-    }
+    fn name(&self) -> &str { "terminal-setup" }
+    fn description(&self) -> &str { "Help configure your terminal for optimal Claurst use" }
     fn help(&self) -> &str {
         "Usage: /terminal-setup\n\n\
          Diagnoses your terminal environment and gives recommendations for\n\
@@ -6302,15 +5829,10 @@ impl SlashCommand for TerminalSetupCommand {
         // Check if UNICODE is likely supported
         let lang = std::env::var("LANG").unwrap_or_default();
         let lc_all = std::env::var("LC_ALL").unwrap_or_default();
-        let unicode_env =
-            lang.to_lowercase().contains("utf") || lc_all.to_lowercase().contains("utf");
+        let unicode_env = lang.to_lowercase().contains("utf") || lc_all.to_lowercase().contains("utf");
         checks.push(format!(
             "Unicode/UTF-8: {}",
-            if unicode_env {
-                "likely supported (LANG/LC_ALL contains UTF)"
-            } else {
-                "check LANG env var"
-            }
+            if unicode_env { "likely supported (LANG/LC_ALL contains UTF)" } else { "check LANG env var" }
         ));
 
         // Check for known good terminals
@@ -6318,15 +5840,11 @@ impl SlashCommand for TerminalSetupCommand {
             term_program.to_lowercase().as_str(),
             "iterm.app" | "iterm2" | "hyper" | "warp" | "alacritty" | "kitty" | "wezterm"
         ) || term_program.to_lowercase().contains("vscode")
-            || term_program.to_lowercase().contains("terminal");
+          || term_program.to_lowercase().contains("terminal");
 
         checks.push(format!(
             "Terminal type: {}",
-            if is_good_terminal {
-                "well-known terminal (good)"
-            } else {
-                "verify settings below"
-            }
+            if is_good_terminal { "well-known terminal (good)" } else { "verify settings below" }
         ));
 
         // Shell detection
@@ -6334,8 +5852,8 @@ impl SlashCommand for TerminalSetupCommand {
         checks.push(format!("Shell:         {}", shell));
 
         // Check for Nerd Fonts (heuristic: environment variable set by some terminals)
-        let nerd_font =
-            std::env::var("NERD_FONT").is_ok() || std::env::var("TERM_NERD_FONT").is_ok();
+        let nerd_font = std::env::var("NERD_FONT").is_ok()
+            || std::env::var("TERM_NERD_FONT").is_ok();
 
         CommandResult::Message(format!(
             "Terminal Setup Diagnostic\n\
@@ -6371,12 +5889,8 @@ impl SlashCommand for TerminalSetupCommand {
 
 #[async_trait]
 impl SlashCommand for ExtraUsageCommand {
-    fn name(&self) -> &str {
-        "extra-usage"
-    }
-    fn description(&self) -> &str {
-        "Show detailed usage statistics: calls, cache, tools"
-    }
+    fn name(&self) -> &str { "extra-usage" }
+    fn description(&self) -> &str { "Show detailed usage statistics: calls, cache, tools" }
     fn help(&self) -> &str {
         "Usage: /extra-usage\n\n\
          Displays extended usage statistics beyond /cost:\n\
@@ -6395,9 +5909,7 @@ impl SlashCommand for ExtraUsageCommand {
         let cost = ctx.cost_tracker.total_cost_usd();
 
         // Estimate API calls from messages (each assistant message ~ 1 API call)
-        let api_calls = ctx
-            .messages
-            .iter()
+        let api_calls = ctx.messages.iter()
             .filter(|m| m.role == claurst_core::types::Role::Assistant)
             .count();
         let api_calls = api_calls.max(1); // at least 1 if we have any data
@@ -6451,11 +5963,7 @@ impl SlashCommand for ExtraUsageCommand {
                 "No cache activity"
             },
             cost = cost,
-            cost_per_k = if total > 0 {
-                cost / (total as f64 / 1000.0)
-            } else {
-                0.0
-            },
+            cost_per_k = if total > 0 { cost / (total as f64 / 1000.0) } else { 0.0 },
         ))
     }
 }
@@ -6464,12 +5972,8 @@ impl SlashCommand for ExtraUsageCommand {
 
 #[async_trait]
 impl SlashCommand for AdvisorCommand {
-    fn name(&self) -> &str {
-        "advisor"
-    }
-    fn description(&self) -> &str {
-        "Set or unset the server-side advisor model"
-    }
+    fn name(&self) -> &str { "advisor" }
+    fn description(&self) -> &str { "Set or unset the server-side advisor model" }
     fn help(&self) -> &str {
         "Usage: /advisor [<model>|off|unset]\n\n\
          Sets the advisor model used for server-side suggestions.\n\
@@ -6532,12 +6036,8 @@ impl SlashCommand for AdvisorCommand {
 
 #[async_trait]
 impl SlashCommand for InstallSlackAppCommand {
-    fn name(&self) -> &str {
-        "install-slack-app"
-    }
-    fn description(&self) -> &str {
-        "Install the Claurst Slack integration"
-    }
+    fn name(&self) -> &str { "install-slack-app" }
+    fn description(&self) -> &str { "Install the Claurst Slack integration" }
     fn help(&self) -> &str {
         "Usage: /install-slack-app\n\n\
          Opens instructions for installing the Claurst Slack app.\n\
@@ -6567,15 +6067,9 @@ impl SlashCommand for InstallSlackAppCommand {
 
 #[async_trait]
 impl SlashCommand for FastCommand {
-    fn name(&self) -> &str {
-        "fast"
-    }
-    fn aliases(&self) -> Vec<&str> {
-        vec!["speed"]
-    }
-    fn description(&self) -> &str {
-        "Toggle fast mode (uses a faster/cheaper model)"
-    }
+    fn name(&self) -> &str { "fast" }
+    fn aliases(&self) -> Vec<&str> { vec!["speed"] }
+    fn description(&self) -> &str { "Toggle fast mode (uses a faster/cheaper model)" }
     fn help(&self) -> &str {
         "Usage: /fast [on|off]\n\n\
          Fast mode switches to a faster, more economical model variant\n\
@@ -6604,10 +6098,7 @@ impl SlashCommand for FastCommand {
         }
 
         let fast_model = "claude-haiku-4-5";
-        let normal_model = ctx
-            .config
-            .model
-            .as_deref()
+        let normal_model = ctx.config.model.as_deref()
             .unwrap_or(claurst_core::constants::DEFAULT_MODEL);
 
         if enable {
@@ -6640,15 +6131,9 @@ impl SlashCommand for FastCommand {
 
 #[async_trait]
 impl SlashCommand for ThinkBackCommand {
-    fn name(&self) -> &str {
-        "think-back"
-    }
-    fn aliases(&self) -> Vec<&str> {
-        vec!["thinkback"]
-    }
-    fn description(&self) -> &str {
-        "Show thinking traces from previous responses in this session"
-    }
+    fn name(&self) -> &str { "think-back" }
+    fn aliases(&self) -> Vec<&str> { vec!["thinkback"] }
+    fn description(&self) -> &str { "Show thinking traces from previous responses in this session" }
     fn help(&self) -> &str {
         "Usage: /think-back [n]\n\n\
          Displays the thinking/reasoning traces from the most recent model responses.\n\
@@ -6680,11 +6165,7 @@ impl SlashCommand for ThinkBackCommand {
                     })
                     .collect::<Vec<_>>()
                     .join("\n\n");
-                if thinking.is_empty() {
-                    None
-                } else {
-                    Some((idx, thinking))
-                }
+                if thinking.is_empty() { None } else { Some((idx, thinking)) }
             })
             .collect();
 
@@ -6720,12 +6201,8 @@ impl SlashCommand for ThinkBackCommand {
 
 #[async_trait]
 impl SlashCommand for ThinkBackPlayCommand {
-    fn name(&self) -> &str {
-        "thinkback-play"
-    }
-    fn description(&self) -> &str {
-        "Replay a thinking trace as an animated walkthrough"
-    }
+    fn name(&self) -> &str { "thinkback-play" }
+    fn description(&self) -> &str { "Replay a thinking trace as an animated walkthrough" }
     fn help(&self) -> &str {
         "Usage: /thinkback-play [n]\n\n\
          Replays a previous thinking trace, formatted for easy reading.\n\
@@ -6755,11 +6232,7 @@ impl SlashCommand for ThinkBackPlayCommand {
                     })
                     .collect::<Vec<_>>()
                     .join("\n\n");
-                if t.is_empty() {
-                    None
-                } else {
-                    Some(t)
-                }
+                if t.is_empty() { None } else { Some(t) }
             })
             .collect();
 
@@ -6798,18 +6271,10 @@ impl SlashCommand for ThinkBackPlayCommand {
 
 #[async_trait]
 impl SlashCommand for FeedbackCommand {
-    fn name(&self) -> &str {
-        "report"
-    }
-    fn aliases(&self) -> Vec<&str> {
-        vec![]
-    }
-    fn description(&self) -> &str {
-        "Open the GitHub issues page to report a bug or request a feature"
-    }
-    fn hidden(&self) -> bool {
-        true
-    } // surfaced via BugCommand alias; hidden to avoid duplicate
+    fn name(&self) -> &str { "report" }
+    fn aliases(&self) -> Vec<&str> { vec![] }
+    fn description(&self) -> &str { "Open the GitHub issues page to report a bug or request a feature" }
+    fn hidden(&self) -> bool { true } // surfaced via BugCommand alias; hidden to avoid duplicate
     fn help(&self) -> &str {
         "Usage: /report [description]\n\n\
          Opens the GitHub issues tracker. If a description is provided,\n\
@@ -6823,12 +6288,19 @@ impl SlashCommand for FeedbackCommand {
             url.to_string()
         } else {
             // Append as a body query param
-            format!("{}?body={}", url, urlencoding::encode(report))
+            format!(
+                "{}?body={}",
+                url,
+                urlencoding::encode(report)
+            )
         };
 
         match open_with_system(&display_url) {
             Ok(_) => CommandResult::Message(format!("Opened issue tracker: {}", url)),
-            Err(_) => CommandResult::Message(format!("Please visit {} to submit a report.", url)),
+            Err(_) => CommandResult::Message(format!(
+                "Please visit {} to submit a report.",
+                url
+            )),
         }
     }
 }
@@ -6837,15 +6309,9 @@ impl SlashCommand for FeedbackCommand {
 
 #[async_trait]
 impl SlashCommand for ColorSetCommand {
-    fn name(&self) -> &str {
-        "color-set"
-    }
-    fn hidden(&self) -> bool {
-        true
-    }
-    fn description(&self) -> &str {
-        "Internal: set prompt color — use /color instead"
-    }
+    fn name(&self) -> &str { "color-set" }
+    fn hidden(&self) -> bool { true }
+    fn description(&self) -> &str { "Internal: set prompt color — use /color instead" }
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let color = args.trim();
@@ -6864,11 +6330,10 @@ impl SlashCommand for ColorSetCommand {
         } else {
             // Validate hex or named color
             let known_colors = [
-                "red", "green", "blue", "yellow", "cyan", "magenta", "white", "orange", "purple",
-                "pink", "gray", "grey",
+                "red", "green", "blue", "yellow", "cyan", "magenta",
+                "white", "orange", "purple", "pink", "gray", "grey",
             ];
-            let is_hex = color.starts_with('#')
-                && (color.len() == 4 || color.len() == 7)
+            let is_hex = color.starts_with('#') && (color.len() == 4 || color.len() == 7)
                 && color[1..].chars().all(|c| c.is_ascii_hexdigit());
             if !is_hex && !known_colors.contains(&color.to_lowercase().as_str()) {
                 return CommandResult::Error(format!(
@@ -6894,12 +6359,8 @@ impl SlashCommand for ColorSetCommand {
 
 #[async_trait]
 impl SlashCommand for SearchCommand {
-    fn name(&self) -> &str {
-        "search"
-    }
-    fn description(&self) -> &str {
-        "Search across all sessions"
-    }
+    fn name(&self) -> &str { "search" }
+    fn description(&self) -> &str { "Search across all sessions" }
     fn help(&self) -> &str {
         "Usage: /search <query>\n\n\
          Searches session titles and message content in the local SQLite\n\
@@ -6933,11 +6394,19 @@ impl SlashCommand for SearchCommand {
 
         let results = match store.search_sessions(query) {
             Ok(r) => r,
-            Err(e) => return CommandResult::Error(format!("Search failed: {}", e)),
+            Err(e) => {
+                return CommandResult::Error(format!(
+                    "Search failed: {}",
+                    e
+                ))
+            }
         };
 
         if results.is_empty() {
-            return CommandResult::Message(format!("No sessions found matching \"{}\".", query));
+            return CommandResult::Message(format!(
+                "No sessions found matching \"{}\".",
+                query
+            ));
         }
 
         let mut out = format!(
@@ -6965,12 +6434,8 @@ impl SlashCommand for SearchCommand {
 
 #[async_trait]
 impl SlashCommand for ShareCommand {
-    fn name(&self) -> &str {
-        "share"
-    }
-    fn description(&self) -> &str {
-        "Create a shareable URL for the current session"
-    }
+    fn name(&self) -> &str { "share" }
+    fn description(&self) -> &str { "Create a shareable URL for the current session" }
     fn help(&self) -> &str {
         "Usage: /share\n\n\
          Attempts to create a public share link for the current conversation\n\
@@ -6995,7 +6460,10 @@ impl SlashCommand for ShareCommand {
         let messages_json = match serde_json::to_value(&ctx.messages) {
             Ok(v) => v,
             Err(e) => {
-                return CommandResult::Error(format!("Failed to serialize session messages: {}", e))
+                return CommandResult::Error(format!(
+                    "Failed to serialize session messages: {}",
+                    e
+                ))
             }
         };
 
@@ -7010,7 +6478,12 @@ impl SlashCommand for ShareCommand {
             .build()
         {
             Ok(c) => c,
-            Err(e) => return CommandResult::Error(format!("Failed to build HTTP client: {}", e)),
+            Err(e) => {
+                return CommandResult::Error(format!(
+                    "Failed to build HTTP client: {}",
+                    e
+                ))
+            }
         };
 
         let base_url = std::env::var("ANTHROPIC_BASE_URL")
@@ -7018,9 +6491,13 @@ impl SlashCommand for ShareCommand {
         let url = format!("{}/api/claude_code/share_session", base_url);
 
         let req = if use_bearer {
-            client.post(&url).bearer_auth(&credential)
+            client
+                .post(&url)
+                .bearer_auth(&credential)
         } else {
-            client.post(&url).header("x-api-key", &credential)
+            client
+                .post(&url)
+                .header("x-api-key", &credential)
         };
 
         let resp = req
@@ -7131,12 +6608,8 @@ mod teleport_bundle {
 
 #[async_trait]
 impl SlashCommand for TeleportCommand {
-    fn name(&self) -> &str {
-        "teleport"
-    }
-    fn description(&self) -> &str {
-        "Export/import/link session context as a portable bundle"
-    }
+    fn name(&self) -> &str { "teleport" }
+    fn description(&self) -> &str { "Export/import/link session context as a portable bundle" }
     fn help(&self) -> &str {
         "Usage:\n\
          \n\
@@ -7209,9 +6682,7 @@ impl SlashCommand for TeleportCommand {
                                         for key in &candidates {
                                             if let Some(v) = input.get(key) {
                                                 if let Some(s) = v.as_str() {
-                                                    if !s.is_empty()
-                                                        && !seen.contains(&s.to_string())
-                                                    {
+                                                    if !s.is_empty() && !seen.contains(&s.to_string()) {
                                                         seen.push(s.to_string());
                                                     }
                                                 }
@@ -7262,11 +6733,7 @@ impl SlashCommand for TeleportCommand {
                             action: PermissionAction::Deny,
                         });
                     }
-                    TeleportPermissions {
-                        allowed,
-                        denied,
-                        rules,
-                    }
+                    TeleportPermissions { allowed, denied, rules }
                 };
 
                 // ---- build bundle -----------------------------------------
@@ -7286,9 +6753,7 @@ impl SlashCommand for TeleportCommand {
                 // ---- serialize and write ----------------------------------
                 let json = match serde_json::to_string_pretty(&bundle) {
                     Ok(j) => j,
-                    Err(e) => {
-                        return CommandResult::Error(format!("Failed to serialize bundle: {}", e))
-                    }
+                    Err(e) => return CommandResult::Error(format!("Failed to serialize bundle: {}", e)),
                 };
 
                 if let Err(e) = std::fs::write(&output_path, &json) {
@@ -7318,30 +6783,28 @@ impl SlashCommand for TeleportCommand {
 
             "import" => {
                 if rest.is_empty() {
-                    return CommandResult::Error("Usage: /teleport import <file>".to_string());
+                    return CommandResult::Error(
+                        "Usage: /teleport import <file>".to_string(),
+                    );
                 }
 
                 let path = std::path::PathBuf::from(rest);
 
                 let data = match std::fs::read_to_string(&path) {
                     Ok(s) => s,
-                    Err(e) => {
-                        return CommandResult::Error(format!(
-                            "Cannot read teleport bundle '{}': {}",
-                            path.display(),
-                            e
-                        ))
-                    }
+                    Err(e) => return CommandResult::Error(format!(
+                        "Cannot read teleport bundle '{}': {}",
+                        path.display(),
+                        e
+                    )),
                 };
 
                 let bundle: TeleportBundle = match serde_json::from_str(&data) {
                     Ok(b) => b,
-                    Err(e) => {
-                        return CommandResult::Error(format!(
-                            "Failed to parse teleport bundle: {}",
-                            e
-                        ))
-                    }
+                    Err(e) => return CommandResult::Error(format!(
+                        "Failed to parse teleport bundle: {}",
+                        e
+                    )),
                 };
 
                 // ---- validate version ------------------------------------
@@ -7395,11 +6858,7 @@ impl SlashCommand for TeleportCommand {
                     exported_at,
                     msg_count,
                     working_dir_display,
-                    if dir_restored {
-                        " (restored)"
-                    } else {
-                        " (path not found, skipped)"
-                    },
+                    if dir_restored { " (restored)" } else { " (path not found, skipped)" },
                     allowed_count,
                     denied_count,
                     files_count,
@@ -7408,8 +6867,8 @@ impl SlashCommand for TeleportCommand {
 
             "link" => {
                 // ---- build a minimal bundle for the link (no env vars) ---
-                use base64::Engine as _;
                 use teleport_bundle::TeleportBundle;
+                use base64::Engine as _;
 
                 let permissions = {
                     let allowed = ctx.config.allowed_tools.clone();
@@ -7430,11 +6889,7 @@ impl SlashCommand for TeleportCommand {
                             action: PermissionAction::Deny,
                         });
                     }
-                    TeleportPermissions {
-                        allowed,
-                        denied,
-                        rules,
-                    }
+                    TeleportPermissions { allowed, denied, rules }
                 };
 
                 let bundle = TeleportBundle {
@@ -7445,28 +6900,22 @@ impl SlashCommand for TeleportCommand {
                     permissions,
                     model: ctx.config.model.clone(),
                     effort: None,
-                    files: Vec::new(),                     // keep link compact
+                    files: Vec::new(), // keep link compact
                     env: std::collections::HashMap::new(), // omit env for security
                     exported_at: chrono::Utc::now().to_rfc3339(),
                 };
 
                 let json = match serde_json::to_string(&bundle) {
                     Ok(j) => j,
-                    Err(e) => {
-                        return CommandResult::Error(format!("Failed to serialize bundle: {}", e))
-                    }
+                    Err(e) => return CommandResult::Error(format!("Failed to serialize bundle: {}", e)),
                 };
 
-                let encoded =
-                    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(json.as_bytes());
+                let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(json.as_bytes());
                 let link = format!("teleport://{}", encoded);
 
                 // Warn if the link is very long.
                 let size_hint = if link.len() > 8192 {
-                    format!(
-                        "\n(Link is {} bytes — consider /teleport export for large sessions)",
-                        link.len()
-                    )
+                    format!("\n(Link is {} bytes — consider /teleport export for large sessions)", link.len())
                 } else {
                     String::new()
                 };
@@ -7474,7 +6923,9 @@ impl SlashCommand for TeleportCommand {
                 CommandResult::Message(format!(
                     "Teleport link generated for session {}:\n\n{}{}\n\n\
                      Share this link or use: /teleport import <link-url>",
-                    ctx.session_id, link, size_hint,
+                    ctx.session_id,
+                    link,
+                    size_hint,
                 ))
             }
 
@@ -7485,8 +6936,7 @@ impl SlashCommand for TeleportCommand {
                      \x20 /teleport export [--output <file>]   export session to .teleport bundle\n\
                      \x20 /teleport import <file>              restore a .teleport bundle\n\
                      \x20 /teleport link                       generate a teleport:// deep link\n\
-                     \nSee /help teleport for details."
-                        .to_string(),
+                     \nSee /help teleport for details.".to_string()
                 )
             }
 
@@ -7502,12 +6952,8 @@ impl SlashCommand for TeleportCommand {
 
 #[async_trait]
 impl SlashCommand for BtwCommand {
-    fn name(&self) -> &str {
-        "btw"
-    }
-    fn description(&self) -> &str {
-        "Ask a side question without adding it to conversation history"
-    }
+    fn name(&self) -> &str { "btw" }
+    fn description(&self) -> &str { "Ask a side question without adding it to conversation history" }
     fn help(&self) -> &str {
         "Usage: /btw <question>\n\n\
          Submits a background question to the model without it becoming part of\n\
@@ -7539,15 +6985,9 @@ impl SlashCommand for BtwCommand {
 
 #[async_trait]
 impl SlashCommand for CtxVizCommand {
-    fn name(&self) -> &str {
-        "ctx-viz"
-    }
-    fn aliases(&self) -> Vec<&str> {
-        vec!["context-visualizer", "ctx"]
-    }
-    fn description(&self) -> &str {
-        "Visualize context window usage breakdown by category"
-    }
+    fn name(&self) -> &str { "ctx-viz" }
+    fn aliases(&self) -> Vec<&str> { vec!["context-visualizer", "ctx"] }
+    fn description(&self) -> &str { "Visualize context window usage breakdown by category" }
     fn help(&self) -> &str {
         "Usage: /ctx-viz\n\n\
          Shows a detailed breakdown of how the context window is being used:\n\
@@ -7563,17 +7003,16 @@ impl SlashCommand for CtxVizCommand {
 
         // Estimate system prompt tokens: rough chars/4 approximation
         // Build a minimal system prompt to estimate its size.
-        let sys_prompt_chars: usize = ctx
-            .config
-            .custom_system_prompt
+        let sys_prompt_chars: usize = ctx.config.custom_system_prompt
             .as_deref()
             .map(|s| s.len())
             .unwrap_or(2400 * 4); // fallback: ~2400 tokens worth
         let sys_prompt_tokens = (sys_prompt_chars / 4).max(1) as u64;
 
         // Estimate conversation tokens from messages
-        let (conv_chars, tool_chars): (usize, usize) =
-            ctx.messages.iter().fold((0, 0), |(conv, tool), msg| {
+        let (conv_chars, tool_chars): (usize, usize) = ctx.messages.iter().fold(
+            (0, 0),
+            |(conv, tool), msg| {
                 let text = msg.get_all_text();
                 // Heuristic: if the message looks like a tool result, count separately
                 if msg.role == claurst_core::types::Role::User && text.starts_with('[') {
@@ -7581,7 +7020,8 @@ impl SlashCommand for CtxVizCommand {
                 } else {
                     (conv + text.len(), tool)
                 }
-            });
+            },
+        );
 
         let conv_tokens = (conv_chars / 4) as u64;
         let tool_tokens = (tool_chars / 4) as u64;
@@ -7619,15 +7059,9 @@ impl SlashCommand for CtxVizCommand {
 
 #[async_trait]
 impl SlashCommand for SandboxToggleCommand {
-    fn name(&self) -> &str {
-        "sandbox-toggle"
-    }
-    fn aliases(&self) -> Vec<&str> {
-        vec!["sandbox"]
-    }
-    fn description(&self) -> &str {
-        "Enable or disable sandboxed execution of shell commands"
-    }
+    fn name(&self) -> &str { "sandbox-toggle" }
+    fn aliases(&self) -> Vec<&str> { vec!["sandbox"] }
+    fn description(&self) -> &str { "Enable or disable sandboxed execution of shell commands" }
     fn help(&self) -> &str {
         "Usage: /sandbox-toggle [on|off|exclude <pattern>|status]\n\n\
          Toggles sandboxed execution of bash/shell commands.\n\
@@ -7648,18 +7082,14 @@ impl SlashCommand for SandboxToggleCommand {
 
         // Platform support check: sandbox requires macOS or Linux (not Windows native).
         let platform = std::env::consts::OS;
-        let is_wsl =
-            std::env::var("WSL_DISTRO_NAME").is_ok() || std::env::var("WSL_INTEROP").is_ok();
+        let is_wsl = std::env::var("WSL_DISTRO_NAME").is_ok()
+            || std::env::var("WSL_INTEROP").is_ok();
         let is_supported = matches!(platform, "linux" | "macos") || is_wsl;
 
         // Handle subcommand: status
         if args == "status" {
             let ui = load_ui_settings();
-            let mode = if ui.sandbox_mode.unwrap_or(false) {
-                "enabled"
-            } else {
-                "disabled"
-            };
+            let mode = if ui.sandbox_mode.unwrap_or(false) { "enabled" } else { "disabled" };
             let excl = if ui.sandbox_excluded_commands.is_empty() {
                 "(none)".to_string()
             } else {
@@ -7672,10 +7102,7 @@ impl SlashCommand for SandboxToggleCommand {
             let platform_note = if is_supported {
                 format!("\u{2713} Supported on this platform ({})", platform)
             } else {
-                format!(
-                    "\u{2717} Not supported on this platform ({}). Requires macOS, Linux, or WSL2.",
-                    platform
-                )
+                format!("\u{2717} Not supported on this platform ({}). Requires macOS, Linux, or WSL2.", platform)
             };
             return CommandResult::Message(format!(
                 "Sandbox mode: {}\n\
@@ -7692,8 +7119,7 @@ impl SlashCommand for SandboxToggleCommand {
             if rest.is_empty() {
                 return CommandResult::Error(
                     "Usage: /sandbox-toggle exclude <command-pattern>\n\
-                     Example: /sandbox-toggle exclude \"npm run test:*\""
-                        .to_string(),
+                     Example: /sandbox-toggle exclude \"npm run test:*\"".to_string()
                 );
             }
             // Strip surrounding quotes if present
@@ -7720,13 +7146,8 @@ impl SlashCommand for SandboxToggleCommand {
         }
 
         // Platform guard for toggling on/off
-        if !is_supported
-            && (args == "on"
-                || args == "enable"
-                || args == "enabled"
-                || args == "true"
-                || args == "1"
-                || args.is_empty())
+        if !is_supported && (args == "on" || args == "enable" || args == "enabled"
+            || args == "true" || args == "1" || args.is_empty())
         {
             let msg = if is_wsl {
                 "Error: Sandboxing requires WSL2. WSL1 is not supported.".to_string()
@@ -7738,11 +7159,8 @@ impl SlashCommand for SandboxToggleCommand {
                 )
             };
             // Only hard-block enabling; allow off/status even on unsupported platforms.
-            if args != "off"
-                && args != "disable"
-                && args != "disabled"
-                && args != "false"
-                && args != "0"
+            if args != "off" && args != "disable" && args != "disabled"
+                && args != "false" && args != "0"
             {
                 return CommandResult::Error(msg);
             }
@@ -7782,12 +7200,8 @@ impl SlashCommand for SandboxToggleCommand {
 
 #[async_trait]
 impl SlashCommand for HeapdumpCommand {
-    fn name(&self) -> &str {
-        "heapdump"
-    }
-    fn description(&self) -> &str {
-        "Show process memory and diagnostic information"
-    }
+    fn name(&self) -> &str { "heapdump" }
+    fn description(&self) -> &str { "Show process memory and diagnostic information" }
     fn help(&self) -> &str {
         "Usage: /heapdump\n\n\
          Displays a diagnostic snapshot of the current process:\n\
@@ -7844,12 +7258,8 @@ impl SlashCommand for HeapdumpCommand {
 
 #[async_trait]
 impl SlashCommand for InsightsCommand {
-    fn name(&self) -> &str {
-        "insights"
-    }
-    fn description(&self) -> &str {
-        "Generate a session analysis report with conversation statistics"
-    }
+    fn name(&self) -> &str { "insights" }
+    fn description(&self) -> &str { "Generate a session analysis report with conversation statistics" }
     fn help(&self) -> &str {
         "Usage: /insights\n\n\
          Analyses the current conversation and prints a statistics report:\n\
@@ -7860,12 +7270,10 @@ impl SlashCommand for InsightsCommand {
         let messages = &ctx.messages;
 
         // Count turns (user / assistant pairs)
-        let user_turns: usize = messages
-            .iter()
+        let user_turns: usize = messages.iter()
             .filter(|m| matches!(m.role, claurst_core::types::Role::User))
             .count();
-        let assistant_turns: usize = messages
-            .iter()
+        let assistant_turns: usize = messages.iter()
             .filter(|m| matches!(m.role, claurst_core::types::Role::Assistant))
             .count();
         let total_turns = user_turns.min(assistant_turns);
@@ -7937,12 +7345,8 @@ impl SlashCommand for InsightsCommand {
 
 #[async_trait]
 impl SlashCommand for UltrareviewCommand {
-    fn name(&self) -> &str {
-        "ultrareview"
-    }
-    fn description(&self) -> &str {
-        "Run an exhaustive multi-dimensional code review"
-    }
+    fn name(&self) -> &str { "ultrareview" }
+    fn description(&self) -> &str { "Run an exhaustive multi-dimensional code review" }
     fn help(&self) -> &str {
         "Usage: /ultrareview [path]\n\n\
          Runs a comprehensive code review that goes beyond /review and\n\
@@ -8045,21 +7449,13 @@ impl SlashCommand for UltrareviewCommand {
 
 #[async_trait]
 impl SlashCommand for NamedCommandAdapter {
-    fn name(&self) -> &str {
-        self.slash_name
-    }
+    fn name(&self) -> &str { self.slash_name }
 
-    fn aliases(&self) -> Vec<&str> {
-        self.slash_aliases.to_vec()
-    }
+    fn aliases(&self) -> Vec<&str> { self.slash_aliases.to_vec() }
 
-    fn description(&self) -> &str {
-        self.slash_description
-    }
+    fn description(&self) -> &str { self.slash_description }
 
-    fn help(&self) -> &str {
-        self.slash_help
-    }
+    fn help(&self) -> &str { self.slash_help }
 
     async fn execute(&self, args: &str, ctx: &mut CommandContext) -> CommandResult {
         execute_named_command_from_slash(self.target_name, args, ctx)
@@ -8070,12 +7466,8 @@ impl SlashCommand for NamedCommandAdapter {
 
 #[async_trait]
 impl SlashCommand for UndoCommand {
-    fn name(&self) -> &str {
-        "undo"
-    }
-    fn description(&self) -> &str {
-        "Revert file changes made by a tool call in this session"
-    }
+    fn name(&self) -> &str { "undo" }
+    fn description(&self) -> &str { "Revert file changes made by a tool call in this session" }
     fn help(&self) -> &str {
         "Usage: /undo [<tool_use_id>]\n\n\
          Without an argument, lists all tool calls that modified files in this session.\n\n\
@@ -8149,12 +7541,8 @@ impl SlashCommand for UndoCommand {
 
 #[async_trait]
 impl SlashCommand for ProvidersCommand {
-    fn name(&self) -> &str {
-        "providers"
-    }
-    fn description(&self) -> &str {
-        "List available AI providers and their status"
-    }
+    fn name(&self) -> &str { "providers" }
+    fn description(&self) -> &str { "List available AI providers and their status" }
     fn help(&self) -> &str {
         "Usage: /providers\n\nList all providers registered in the model registry with their\nmodel counts, context windows, and pricing information."
     }
@@ -8184,23 +7572,15 @@ impl SlashCommand for ProvidersCommand {
         let mut lines = vec!["Available providers:\n".to_string()];
         for provider in &provider_keys {
             let models = &by_provider[provider];
-            lines.push(format!(
-                "\n{} ({} model{})",
-                provider.to_uppercase(),
-                models.len(),
-                if models.len() == 1 { "" } else { "s" }
-            ));
+            lines.push(format!("\n{} ({} model{})", provider.to_uppercase(), models.len(),
+                if models.len() == 1 { "" } else { "s" }));
             for m in models.iter().take(3) {
                 let cost_str = match (m.cost_input, m.cost_output) {
                     (Some(i), Some(o)) => format!("${:.2}/${:.2} per 1M", i, o),
                     _ => "free/local".to_string(),
                 };
-                lines.push(format!(
-                    "  {} — {}K ctx, {}",
-                    m.info.id,
-                    m.info.context_window / 1000,
-                    cost_str
-                ));
+                lines.push(format!("  {} — {}K ctx, {}",
+                    m.info.id, m.info.context_window / 1000, cost_str));
             }
             if models.len() > 3 {
                 lines.push(format!("  ... and {} more", models.len() - 3));
@@ -8215,12 +7595,8 @@ impl SlashCommand for ProvidersCommand {
 
 #[async_trait]
 impl SlashCommand for ConnectCommand {
-    fn name(&self) -> &str {
-        "connect"
-    }
-    fn description(&self) -> &str {
-        "Connect an AI provider"
-    }
+    fn name(&self) -> &str { "connect" }
+    fn description(&self) -> &str { "Connect an AI provider" }
     fn help(&self) -> &str {
         "Usage: /connect\n\nOpens the interactive provider picker dialog.\nSelect a provider to see setup instructions."
     }
@@ -8235,12 +7611,8 @@ impl SlashCommand for ConnectCommand {
 
 #[async_trait]
 impl SlashCommand for AgentCommand {
-    fn name(&self) -> &str {
-        "agent"
-    }
-    fn description(&self) -> &str {
-        "List available agents or get info about a specific agent"
-    }
+    fn name(&self) -> &str { "agent" }
+    fn description(&self) -> &str { "List available agents or get info about a specific agent" }
     fn help(&self) -> &str {
         "Usage: /agent [name]\n\nWithout arguments, lists all available named agents.\nWith a name, shows details for that agent.\n\nTo use an agent, start Claurst with: --agent <name>"
     }
@@ -8298,7 +7670,9 @@ impl SlashCommand for AgentCommand {
             if let Some(ref prompt) = def.prompt {
                 output.push_str(&format!("\nSystem prompt prefix:\n  {}\n", prompt));
             }
-            output.push_str(&format!("\nTo activate: claude --agent {}", agent_name));
+            output.push_str(&format!(
+                "\nTo activate: claude --agent {}", agent_name
+            ));
             CommandResult::Message(output)
         } else {
             CommandResult::Error(format!(
@@ -8496,9 +7870,9 @@ pub fn all_commands() -> Vec<Box<dyn SlashCommand>> {
 /// Find a command by name or alias.
 pub fn find_command(name: &str) -> Option<Box<dyn SlashCommand>> {
     let name = name.trim_start_matches('/');
-    all_commands()
-        .into_iter()
-        .find(|c| c.name() == name || c.aliases().contains(&name))
+    all_commands().into_iter().find(|c| {
+        c.name() == name || c.aliases().contains(&name)
+    })
 }
 
 /// Build `HelpEntry` values for all non-hidden commands, suitable for
@@ -8528,22 +7902,15 @@ struct TemplateCommand {
 
 #[async_trait]
 impl SlashCommand for TemplateCommand {
-    fn name(&self) -> &str {
-        &self.name
-    }
+    fn name(&self) -> &str { &self.name }
     fn description(&self) -> &str {
-        self.template
-            .description
-            .as_deref()
-            .unwrap_or("Custom command")
+        self.template.description.as_deref().unwrap_or("Custom command")
     }
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let mut words = args.split_whitespace();
         let arg1 = words.next().unwrap_or("");
         let arg2 = words.next().unwrap_or("");
-        let prompt = self
-            .template
-            .template
+        let prompt = self.template.template
             .replace("$ARGUMENTS", args)
             .replace("$1", arg1)
             .replace("$2", arg2);
@@ -8554,16 +7921,12 @@ impl SlashCommand for TemplateCommand {
 /// Build slash commands from user-defined command templates stored in
 /// `settings.commands`.
 pub fn commands_from_settings(settings: &claurst_core::Settings) -> Vec<Box<dyn SlashCommand>> {
-    settings
-        .commands
-        .iter()
-        .map(|(name, template)| {
-            Box::new(TemplateCommand {
-                name: name.clone(),
-                template: template.clone(),
-            }) as Box<dyn SlashCommand>
-        })
-        .collect()
+    settings.commands.iter().map(|(name, template)| {
+        Box::new(TemplateCommand {
+            name: name.clone(),
+            template: template.clone(),
+        }) as Box<dyn SlashCommand>
+    }).collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -8579,19 +7942,14 @@ struct SkillCommand {
 
 #[async_trait]
 impl SlashCommand for SkillCommand {
-    fn name(&self) -> &str {
-        &self.name
-    }
-    fn description(&self) -> &str {
-        &self.description
-    }
+    fn name(&self) -> &str { &self.name }
+    fn description(&self) -> &str { &self.description }
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let mut words = args.split_whitespace();
         let arg1 = words.next().unwrap_or("");
         let arg2 = words.next().unwrap_or("");
-        let prompt = self
-            .template
+        let prompt = self.template
             .replace("$ARGUMENTS", args)
             .replace("$1", arg1)
             .replace("$2", arg2);
@@ -8612,8 +7970,10 @@ pub fn commands_from_discovered_skills(
     let discovered = claurst_core::discover_skills(cwd, skills_config);
     // Build a set of built-in command names so we can skip collisions.
     let all_cmds = all_commands();
-    let builtin_names: std::collections::HashSet<&str> =
-        all_cmds.iter().map(|c| c.name()).collect();
+    let builtin_names: std::collections::HashSet<&str> = all_cmds
+        .iter()
+        .map(|c| c.name())
+        .collect();
 
     discovered
         .into_values()
@@ -8629,10 +7989,11 @@ pub fn commands_from_discovered_skills(
 }
 
 /// Execute a slash command string (with leading /).
-pub async fn execute_command(input: &str, ctx: &mut CommandContext) -> Option<CommandResult> {
-    if !claurst_tui::input::is_slash_command(input) {
-        return None;
-    }
+pub async fn execute_command(
+    input: &str,
+    ctx: &mut CommandContext,
+) -> Option<CommandResult> {
+    if !claurst_tui::input::is_slash_command(input) { return None; }
     let (name, args) = claurst_tui::input::parse_slash_command(input);
 
     // First check built-in commands.
@@ -8643,10 +8004,7 @@ pub async fn execute_command(input: &str, ctx: &mut CommandContext) -> Option<Co
     // Check user-defined command templates from settings.
     let cmd_name = name.trim_start_matches('/');
     if let Some(tmpl) = ctx.config.commands.get(cmd_name).cloned() {
-        let tc = TemplateCommand {
-            name: cmd_name.to_string(),
-            template: tmpl,
-        };
+        let tc = TemplateCommand { name: cmd_name.to_string(), template: tmpl };
         return Some(tc.execute(args, ctx).await);
     }
 
@@ -8762,41 +8120,13 @@ mod tests {
     #[test]
     fn test_core_commands_present() {
         let expected = [
-            "help",
-            "clear",
-            "compact",
-            "cost",
-            "exit",
-            "model",
-            "config",
-            "version",
-            "status",
-            "diff",
-            "memory",
-            "hooks",
-            "permissions",
-            "plan",
-            "tasks",
-            "session",
-            "login",
-            "logout",
-            "refresh",
-            "feedback",
-            "usage",
-            "plugin",
-            "reload-plugins",
-            "add-dir",
-            "agents",
-            "branch",
-            "tag",
-            "passes",
-            "ide",
-            "pr-comments",
-            "desktop",
-            "mobile",
-            "install-github-app",
-            "web-setup",
-            "stickers",
+            "help", "clear", "compact", "cost", "exit", "model",
+            "config", "version", "status", "diff", "memory", "hooks",
+            "permissions", "plan", "tasks", "session", "login", "logout", "refresh",
+            "feedback", "usage", "plugin", "reload-plugins",
+            "add-dir", "agents", "branch", "tag",
+            "passes", "ide", "pr-comments", "desktop", "mobile",
+            "install-github-app", "web-setup", "stickers",
         ];
         for name in &expected {
             assert!(

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -253,6 +253,8 @@ fn is_openaiish_provider(provider_id: &str) -> bool {
             | "stepfun"
             | "fireworks"
             | "ollama"
+            | "codex"
+            | "openai-codex"
             | "lmstudio"
             | "lm-studio"
             | "llamacpp"
@@ -880,7 +882,7 @@ pub async fn run_query_loop(
                     "anthropic", "openai", "google", "groq", "mistral",
                     "deepseek", "xai", "cohere", "perplexity", "cerebras",
                     "openrouter", "togetherai", "together-ai", "deepinfra",
-                    "venice", "github-copilot", "ollama", "lmstudio",
+                    "venice", "github-copilot", "codex", "openai-codex", "ollama", "lmstudio",
                     "llamacpp", "azure", "amazon-bedrock", "huggingface",
                     "nvidia", "fireworks", "sambanova",
                 ];

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -1502,6 +1502,7 @@ impl App {
                 "xai",
                 "openrouter",
                 "github-copilot",
+                "codex",
                 "cohere",
                 "perplexity",
                 "togetherai",
@@ -2721,7 +2722,7 @@ impl App {
                                 self.device_auth_dialog.open(selected.id.clone(), selected.title.clone());
                                 self.device_auth_pending = Some("github-copilot".to_string());
                             }
-                            "openai-codex" => {
+                            "codex" | "openai-codex" => {
                                 // OpenAI Codex: browser OAuth flow (spawned by main loop)
                                 self.device_auth_dialog.open("openai-codex".into(), "OpenAI Codex".into());
                                 self.device_auth_pending = Some("openai-codex".to_string());

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -3314,7 +3314,7 @@ impl App {
                     | crate::prompt_input::VimMode::VisualBlock
             )
         {
-            use crate::image_paste::{read_clipboard_image, read_clipboard_text};
+            use crate::image_paste::{read_clipboard_image, read_clipboard_text, read_primary_text};
             if let Some(img) = read_clipboard_image() {
                 let label = img.label.clone();
                 let dims = img.dimensions;
@@ -3325,7 +3325,7 @@ impl App {
                     format!("Image attached: {}", label)
                 };
                 self.notifications.push(NotificationKind::Info, msg, Some(3));
-            } else if let Some(text) = read_clipboard_text() {
+            } else if let Some(text) = read_clipboard_text().or_else(read_primary_text) {
                 self.prompt_input.paste(&text);
             }
             return false;
@@ -4681,6 +4681,33 @@ impl App {
                     );
                 } else {
                     self.dismiss_context_menu();
+                }
+            }
+
+            // ---- Primary-selection paste into the prompt ---------------
+            MouseEventKind::Down(MouseButton::Middle) => {
+                let input_area = self.last_input_area.get();
+                let in_input = input_area.width > 0 && input_area.height > 0
+                    && mouse_event.row >= input_area.y
+                    && mouse_event.row < input_area.y.saturating_add(input_area.height)
+                    && mouse_event.column >= input_area.x
+                    && mouse_event.column < input_area.x.saturating_add(input_area.width);
+
+                if in_input {
+                    self.focus = FocusTarget::Input;
+                    self.clear_selection();
+                    if !matches!(
+                        self.prompt_input.vim_mode,
+                        crate::prompt_input::VimMode::Normal
+                            | crate::prompt_input::VimMode::Visual
+                            | crate::prompt_input::VimMode::VisualBlock
+                    ) {
+                        if let Some(text) = crate::image_paste::read_primary_text()
+                            .or_else(crate::image_paste::read_clipboard_text)
+                        {
+                            self.prompt_input.paste(&text);
+                        }
+                    }
                 }
             }
 

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -3327,7 +3327,14 @@ impl App {
                 self.notifications.push(NotificationKind::Info, msg, Some(3));
             } else if let Some(text) = read_clipboard_text().or_else(read_primary_text) {
                 self.prompt_input.paste(&text);
+                self.refresh_prompt_input();
             }
+            return false;
+        }
+
+        // ---- Shift+Insert — selection/clipboard paste fallback -------------
+        if key.code == KeyCode::Insert && key.modifiers.contains(KeyModifiers::SHIFT) {
+            let _ = self.paste_primary_into_prompt();
             return false;
         }
 
@@ -4544,6 +4551,37 @@ impl App {
         }
     }
 
+    fn prompt_can_accept_selection_paste(&self) -> bool {
+        !self.is_streaming
+            && self.permission_request.is_none()
+            && !self.history_search_overlay.visible
+            && self.history_search.is_none()
+            && !matches!(
+                self.prompt_input.vim_mode,
+                crate::prompt_input::VimMode::Normal
+                    | crate::prompt_input::VimMode::Visual
+                    | crate::prompt_input::VimMode::VisualBlock
+            )
+    }
+
+    fn paste_primary_into_prompt(&mut self) -> bool {
+        if !self.prompt_can_accept_selection_paste() {
+            return false;
+        }
+
+        if let Some(text) = crate::image_paste::read_primary_text()
+            .or_else(crate::image_paste::read_clipboard_text)
+        {
+            self.focus = FocusTarget::Input;
+            self.clear_selection();
+            self.prompt_input.paste(&text);
+            self.refresh_prompt_input();
+            return true;
+        }
+
+        false
+    }
+
     /// Process mouse events (trackpad scroll, text selection, etc.).
     pub fn handle_mouse_event(&mut self, mouse_event: MouseEvent) {
         use crossterm::event::MouseButton;
@@ -4686,29 +4724,7 @@ impl App {
 
             // ---- Primary-selection paste into the prompt ---------------
             MouseEventKind::Down(MouseButton::Middle) => {
-                let input_area = self.last_input_area.get();
-                let in_input = input_area.width > 0 && input_area.height > 0
-                    && mouse_event.row >= input_area.y
-                    && mouse_event.row < input_area.y.saturating_add(input_area.height)
-                    && mouse_event.column >= input_area.x
-                    && mouse_event.column < input_area.x.saturating_add(input_area.width);
-
-                if in_input {
-                    self.focus = FocusTarget::Input;
-                    self.clear_selection();
-                    if !matches!(
-                        self.prompt_input.vim_mode,
-                        crate::prompt_input::VimMode::Normal
-                            | crate::prompt_input::VimMode::Visual
-                            | crate::prompt_input::VimMode::VisualBlock
-                    ) {
-                        if let Some(text) = crate::image_paste::read_primary_text()
-                            .or_else(crate::image_paste::read_clipboard_text)
-                        {
-                            self.prompt_input.paste(&text);
-                        }
-                    }
-                }
+                let _ = self.paste_primary_into_prompt();
             }
 
             // ---- Text selection / focus routing -------------------------

--- a/src-rust/crates/tui/src/image_paste.rs
+++ b/src-rust/crates/tui/src/image_paste.rs
@@ -49,6 +49,18 @@ pub fn read_clipboard_text() -> Option<String> {
     }
 }
 
+/// Read text from the primary selection when supported (Linux/X11/Wayland).
+pub fn read_primary_text() -> Option<String> {
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    {
+        None
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        read_primary_text_linux()
+    }
+}
+
 #[cfg(target_os = "macos")]
 fn read_text_macos() -> Option<String> {
     let out = Command::new("pbpaste").output().ok()?;
@@ -61,13 +73,32 @@ fn read_text_macos() -> Option<String> {
 
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
 fn read_text_linux() -> Option<String> {
-    // Try xclip first, then wl-paste (Wayland)
-    for (prog, args) in &[
-        ("xclip", vec!["-selection", "clipboard", "-o"]),
-        ("xsel", vec!["--clipboard", "--output"]),
-        ("wl-paste", vec!["--no-newline"]),
-    ] {
-        if let Ok(out) = Command::new(prog).args(args).output() {
+    read_text_linux_selection(false)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn read_primary_text_linux() -> Option<String> {
+    read_text_linux_selection(true)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn read_text_linux_selection(primary: bool) -> Option<String> {
+    let commands: &[(&str, &[&str])] = if primary {
+        &[
+            ("wl-paste", &["--primary", "--no-newline"]),
+            ("xclip", &["-selection", "primary", "-o"]),
+            ("xsel", &["--primary", "--output"]),
+        ]
+    } else {
+        &[
+            ("wl-paste", &["--no-newline"]),
+            ("xclip", &["-selection", "clipboard", "-o"]),
+            ("xsel", &["--clipboard", "--output"]),
+        ]
+    };
+
+    for (prog, args) in commands {
+        if let Ok(out) = Command::new(prog).args(*args).output() {
             if out.status.success() && !out.stdout.is_empty() {
                 return Some(String::from_utf8_lossy(&out.stdout).into_owned());
             }
@@ -326,14 +357,32 @@ fn write_text_windows_w(text: &str) -> bool {
 
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
 fn write_text_linux_w(text: &str) -> bool {
+    let clipboard_ok = write_text_linux_selection(text, false);
+    let primary_ok = write_text_linux_selection(text, true);
+    clipboard_ok || primary_ok
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn write_text_linux_selection(text: &str, primary: bool) -> bool {
     use std::io::Write;
     use std::process::Stdio;
-    for (prog, args) in &[
-        ("xclip", vec!["-selection", "clipboard"]),
-        ("xsel", vec!["--clipboard", "--input"]),
-        ("wl-copy", vec![]),
-    ] {
-        if let Ok(mut child) = Command::new(prog).args(args).stdin(Stdio::piped()).spawn() {
+
+    let commands: &[(&str, &[&str])] = if primary {
+        &[
+            ("wl-copy", &["--primary"]),
+            ("xclip", &["-selection", "primary"]),
+            ("xsel", &["--primary", "--input"]),
+        ]
+    } else {
+        &[
+            ("wl-copy", &[]),
+            ("xclip", &["-selection", "clipboard"]),
+            ("xsel", &["--clipboard", "--input"]),
+        ]
+    };
+
+    for (prog, args) in commands {
+        if let Ok(mut child) = Command::new(prog).args(*args).stdin(Stdio::piped()).spawn() {
             if let Some(mut stdin) = child.stdin.take() {
                 let _ = stdin.write_all(text.as_bytes());
             }

--- a/src-rust/crates/tui/src/model_picker.rs
+++ b/src-rust/crates/tui/src/model_picker.rs
@@ -332,6 +332,14 @@ pub fn models_for_provider(provider_id: &str) -> Vec<ModelEntry> {
             model_entry("google/gemini-2.5-pro", "Gemini 2.5 Pro", "via OpenRouter"),
             model_entry("meta-llama/llama-3.3-70b-instruct", "Llama 3.3 70B", "via OpenRouter"),
         ],
+        "codex" | "openai-codex" => vec![
+            model_entry("gpt-5.2-codex", "GPT-5.2 Codex", "OAuth-backed Codex default"),
+            model_entry("gpt-5.1-codex", "GPT-5.1 Codex", "Previous Codex generation"),
+            model_entry("gpt-5.1-codex-mini", "GPT-5.1 Codex Mini", "Smaller Codex model"),
+            model_entry("gpt-5.1-codex-max", "GPT-5.1 Codex Max", "Larger Codex model"),
+            model_entry("gpt-5.4", "GPT-5.4", "General frontier model via Codex auth"),
+            model_entry("gpt-5.2", "GPT-5.2", "General model via Codex auth"),
+        ],
         "github-copilot" => vec![
             model_entry("claude-sonnet-4.6", "Claude Sonnet 4.6", "via Copilot"),
             model_entry("claude-sonnet-4.5", "Claude Sonnet 4.5", "via Copilot"),
@@ -410,6 +418,8 @@ pub fn default_model_for_provider(provider_id: &str) -> String {
         "xai" => "xai/grok-2".to_string(),
         "openrouter" => "openrouter/anthropic/claude-sonnet-4".to_string(),
         "github-copilot" => "github-copilot/gpt-4o".to_string(),
+        "codex" => "codex/gpt-5.2-codex".to_string(),
+        "openai-codex" => "openai-codex/gpt-5.2-codex".to_string(),
         "cohere" => "cohere/command-r-plus".to_string(),
         "perplexity" => "perplexity/sonar-pro".to_string(),
         "togetherai" | "together-ai" => "togetherai/meta-llama/Llama-3.3-70B-Instruct-Turbo".to_string(),


### PR DESCRIPTION
  This fixes several issues in the ChatGPT Codex provider path:

  - normalize provider selection so Codex uses the correct provider id
  - clean up Codex model selection/default model handling
  - send top-level `instructions` from the system prompt
  - send `stream: true` on the streaming path
  - remove unsupported `max_output_tokens` from Codex requests
  - handle the actual Codex SSE event flow, including `response.output_text.delta` and `response.output_text.done`

  Context:
  The adapter was previously shaped more like a generic Responses client, but the live ChatGPT Codex endpoint behaves differently in a few important ways:
  - it requires `instructions`
  - it requires `stream: true` for the streaming path
  - it rejects `max_output_tokens`
  - streamed text arrives via `response.output_text.delta` / `done`, not via `response.completed.output`

  This patch is based on testing against the live endpoint and fixes the blank/no-output behavior that followed from the old parser assumptions.