### PR TITLE
feat: enable custom OpenAI compatible providers with custom models

### DIFF
--- a/src-rust/Cargo.lock
+++ b/src-rust/Cargo.lock
@@ -870,6 +870,7 @@ dependencies = [
  "enigo",
  "futures",
  "glob",
+ "image",
  "nix 0.29.0",
  "once_cell",
  "open",

--- a/src-rust/crates/api/src/providers/openai_compat_providers.rs
+++ b/src-rust/crates/api/src/providers/openai_compat_providers.rs
@@ -10,6 +10,43 @@ use claurst_core::provider_id::ProviderId;
 
 use super::openai_compat::{OpenAiCompatProvider, ProviderQuirks};
 
+pub fn provider_for_id(provider_id: &str) -> Option<OpenAiCompatProvider> {
+    match provider_id {
+        "ollama" => Some(ollama()),
+        "lmstudio" | "lm-studio" => Some(lm_studio()),
+        "llamacpp" | "llama-cpp" | "llama-server" => Some(llama_cpp()),
+        "deepseek" => Some(deepseek()),
+        "groq" => Some(groq()),
+        "xai" => Some(xai()),
+        "deepinfra" => Some(deepinfra()),
+        "cerebras" => Some(cerebras()),
+        "togetherai" | "together-ai" => Some(together_ai()),
+        "perplexity" => Some(perplexity()),
+        "venice" => Some(venice()),
+        "qwen" => Some(qwen()),
+        "mistral" => Some(mistral()),
+        "openrouter" => Some(openrouter()),
+        "sambanova" => Some(sambanova()),
+        "huggingface" => Some(huggingface()),
+        "nvidia" => Some(nvidia()),
+        "siliconflow" => Some(siliconflow()),
+        "moonshot" | "moonshotai" => Some(moonshot()),
+        "zhipu" | "zhipuai" => Some(zhipu()),
+        "zai" => Some(zai()),
+        "nebius" => Some(nebius()),
+        "novita" => Some(novita()),
+        "ovhcloud" => Some(ovhcloud()),
+        "scaleway" => Some(scaleway()),
+        "vultr" | "vultr-ai" => Some(vultr_ai()),
+        "baseten" => Some(baseten()),
+        "friendli" => Some(friendli()),
+        "upstage" => Some(upstage()),
+        "stepfun" => Some(stepfun()),
+        "fireworks" => Some(fireworks()),
+        _ => None,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Local / self-hosted providers (no API key required)
 // ---------------------------------------------------------------------------

--- a/src-rust/crates/api/src/registry.rs
+++ b/src-rust/crates/api/src/registry.rs
@@ -16,6 +16,38 @@ use crate::providers::{
     CopilotProvider, GoogleProvider, MinimaxProvider, OpenAiProvider,
 };
 
+fn normalize_openai_compat_base(override_base: &str) -> String {
+    let trimmed = override_base.trim_end_matches('/');
+    if trimmed.ends_with("/v1") {
+        trimmed.to_string()
+    } else {
+        format!("{}/v1", trimmed)
+    }
+}
+
+fn normalize_openai_base(override_base: &str) -> String {
+    let trimmed = override_base.trim_end_matches('/');
+    if trimmed.ends_with("/v1") {
+        trimmed.trim_end_matches("/v1").to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+pub fn resolve_provider_api_base(
+    config: &claurst_core::config::Config,
+    provider_id: &str,
+) -> Option<String> {
+    let base = config.resolve_provider_api_base(provider_id)?;
+    if provider_id == "openai" {
+        Some(normalize_openai_base(&base))
+    } else if crate::providers::openai_compat_providers::provider_for_id(provider_id).is_some() {
+        Some(normalize_openai_compat_base(&base))
+    } else {
+        Some(base)
+    }
+}
+
 /// Registry of all available LLM providers.
 /// Holds `Arc<dyn LlmProvider>` for each registered provider.
 pub struct ProviderRegistry {
@@ -25,6 +57,10 @@ pub struct ProviderRegistry {
 
 fn provider_from_key(provider_id: &str, key: String) -> Option<Arc<dyn LlmProvider>> {
     use crate::providers::openai_compat_providers as p;
+
+    if let Some(provider) = p::provider_for_id(provider_id) {
+        return Some(Arc::new(provider.with_api_key(key)));
+    }
 
     match provider_id {
         "anthropic" => Some(Arc::new(AnthropicProvider::from_config(
@@ -40,34 +76,6 @@ fn provider_from_key(provider_id: &str, key: String) -> Option<Arc<dyn LlmProvid
             CodexProvider::from_stored().map(|p| Arc::new(p) as Arc<dyn LlmProvider>)
         }
         "cohere" => Some(Arc::new(CohereProvider::new(key))),
-        "groq" => Some(Arc::new(p::groq().with_api_key(key))),
-        "mistral" => Some(Arc::new(p::mistral().with_api_key(key))),
-        "deepseek" => Some(Arc::new(p::deepseek().with_api_key(key))),
-        "xai" => Some(Arc::new(p::xai().with_api_key(key))),
-        "openrouter" => Some(Arc::new(p::openrouter().with_api_key(key))),
-        "togetherai" | "together-ai" => Some(Arc::new(p::together_ai().with_api_key(key))),
-        "perplexity" => Some(Arc::new(p::perplexity().with_api_key(key))),
-        "cerebras" => Some(Arc::new(p::cerebras().with_api_key(key))),
-        "deepinfra" => Some(Arc::new(p::deepinfra().with_api_key(key))),
-        "venice" => Some(Arc::new(p::venice().with_api_key(key))),
-        "huggingface" => Some(Arc::new(p::huggingface().with_api_key(key))),
-        "nvidia" => Some(Arc::new(p::nvidia().with_api_key(key))),
-        "siliconflow" => Some(Arc::new(p::siliconflow().with_api_key(key))),
-        "sambanova" => Some(Arc::new(p::sambanova().with_api_key(key))),
-        "moonshot" | "moonshotai" => Some(Arc::new(p::moonshot().with_api_key(key))),
-        "zhipu" | "zhipuai" => Some(Arc::new(p::zhipu().with_api_key(key))),
-        "zai" => Some(Arc::new(p::zai().with_api_key(key))),
-        "qwen" => Some(Arc::new(p::qwen().with_api_key(key))),
-        "nebius" => Some(Arc::new(p::nebius().with_api_key(key))),
-        "novita" => Some(Arc::new(p::novita().with_api_key(key))),
-        "ovhcloud" => Some(Arc::new(p::ovhcloud().with_api_key(key))),
-        "scaleway" => Some(Arc::new(p::scaleway().with_api_key(key))),
-        "vultr" | "vultr-ai" => Some(Arc::new(p::vultr_ai().with_api_key(key))),
-        "baseten" => Some(Arc::new(p::baseten().with_api_key(key))),
-        "friendli" => Some(Arc::new(p::friendli().with_api_key(key))),
-        "upstage" => Some(Arc::new(p::upstage().with_api_key(key))),
-        "stepfun" => Some(Arc::new(p::stepfun().with_api_key(key))),
-        "fireworks" => Some(Arc::new(p::fireworks().with_api_key(key))),
         _ => None,
     }
 }
@@ -82,9 +90,7 @@ pub fn provider_from_config(
     }
 
     let api_key = config.resolve_provider_api_key(provider_id);
-    let api_base = config
-        .resolve_provider_api_base(provider_id)
-        .filter(|base| !base.is_empty());
+    let api_base = resolve_provider_api_base(config, provider_id).filter(|base| !base.is_empty());
 
     use crate::providers;
 

--- a/src-rust/crates/core/src/context_collapse.rs
+++ b/src-rust/crates/core/src/context_collapse.rs
@@ -5,7 +5,7 @@
 //!
 //! Gated behind `cached_microcompact` feature flag.
 
-use crate::types::Message;
+use crate::types::{Message, Role};
 use serde::{Deserialize, Serialize};
 
 /// Strategy for collapsing a conversation when it exceeds token limits.

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -1227,6 +1227,11 @@ pub mod config {
                         .and_then(|provider| provider.api_key.clone())
                         .filter(|key| !key.is_empty())
                 })
+                .or_else(|| {
+                    api_key_env_vars_for_provider(provider_id)
+                        .iter()
+                        .find_map(|var| std::env::var(var).ok().filter(|v| !v.is_empty()))
+                })
                 .or_else(|| crate::AuthStore::load().api_key_for(provider_id))
         }
 

--- a/src-rust/crates/query/src/agent_tool.rs
+++ b/src-rust/crates/query/src/agent_tool.rs
@@ -17,7 +17,7 @@
 
 use async_trait::async_trait;
 use claurst_api::client::ClientConfig;
-use claurst_api::AnthropicClient;
+use claurst_api::{AnthropicClient, ModelRegistry, ProviderRegistry};
 use claurst_core::types::Message;
 use claurst_tools::{PermissionLevel, Tool, ToolContext, ToolResult};
 use dashmap::DashMap;
@@ -126,6 +126,39 @@ async fn remove_worktree(git_root: &Path, worktree_dir: &Path) {
 
 pub struct AgentTool;
 
+fn build_model_registry() -> ModelRegistry {
+    let mut registry = ModelRegistry::new();
+    if let Some(cache_dir) = dirs::cache_dir() {
+        let cache_path = cache_dir.join("claurst").join("models_dev.json");
+        registry.load_cache(&cache_path);
+    }
+    registry
+}
+
+fn resolve_subagent_model(params: &AgentInput, ctx: &ToolContext) -> String {
+    let base_model = params
+        .model
+        .clone()
+        .filter(|m| !m.is_empty())
+        .or_else(|| {
+            ctx.managed_agent_config.as_ref()
+                .map(|c| c.executor_model.clone())
+                .filter(|m| !m.is_empty())
+        })
+        .unwrap_or_else(|| ctx.config.effective_model().to_string());
+
+    if base_model.contains('/') {
+        base_model
+    } else {
+        let provider_id = ctx.config.selected_provider_id();
+        if provider_id != "anthropic" {
+            format!("{}/{}", provider_id, base_model)
+        } else {
+            base_model
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct AgentInput {
     /// Short description of the agent's task (used for logging).
@@ -226,27 +259,26 @@ impl Tool for AgentTool {
 
         info!(description = %params.description, "Spawning sub-agent");
 
-        // Resolve API key from environment.
-        let api_key = match std::env::var("ANTHROPIC_API_KEY")
-            .ok()
-            .filter(|k| !k.is_empty())
-        {
-            Some(k) => k,
-            None => {
-                return ToolResult::error(
-                    "ANTHROPIC_API_KEY not set - cannot spawn sub-agent".to_string(),
-                )
-            }
-        };
-
-        // Dedicated Anthropic client for the sub-agent.
+        let anthropic_key = ctx.config.resolve_anthropic_api_key().unwrap_or_default();
+        let anthropic_base = ctx.config.resolve_anthropic_api_base();
         let client = match AnthropicClient::new(ClientConfig {
-            api_key,
+            api_key: anthropic_key.clone(),
+            api_base: anthropic_base,
             ..Default::default()
         }) {
             Ok(c) => Arc::new(c),
             Err(e) => return ToolResult::error(format!("Failed to create client: {}", e)),
         };
+
+        let provider_registry = ProviderRegistry::from_config(
+            &ctx.config,
+            ClientConfig {
+                api_key: anthropic_key,
+                api_base: ctx.config.resolve_anthropic_api_base(),
+                ..Default::default()
+            },
+        );
+        let model_registry = Arc::new(build_model_registry());
 
         // Build the tool list for the sub-agent.
         // Always exclude AgentTool itself to prevent unbounded recursion.
@@ -261,16 +293,8 @@ impl Tool for AgentTool {
                 .collect()
         };
 
-        // Resolve model: explicit override > managed config executor model > default.
-        let model = params
-            .model
-            .filter(|m| !m.is_empty())
-            .or_else(|| {
-                ctx.managed_agent_config.as_ref()
-                    .map(|c| c.executor_model.clone())
-                    .filter(|m| !m.is_empty())
-            })
-            .unwrap_or_else(|| claurst_core::constants::DEFAULT_MODEL.to_string());
+        // Resolve model: explicit override > managed config executor model > provider default.
+        let model = resolve_subagent_model(&params, ctx);
 
         let system_prompt = params.system_prompt.unwrap_or_else(|| {
             let mut prompt = "You are a specialized AI agent helping with a specific sub-task. \
@@ -374,10 +398,10 @@ impl Tool for AgentTool {
             skill_index: None,
             max_budget_usd: None,
             fallback_model: None,
-            provider_registry: None,
+            provider_registry: Some(Arc::new(provider_registry)),
             agent_name: None,
             agent_definition: None,
-            model_registry: None,
+            model_registry: Some(model_registry),
             managed_agents: None,
         };
         // -----------------------------------------------------------------------
@@ -546,22 +570,11 @@ pub fn init_team_swarm_runner() {
          ctx: Arc<claurst_tools::ToolContext>| {
             // We must return a Pin<Box<dyn Future<...> + Send>>.
             Box::pin(async move {
-                // Resolve API key.
-                let api_key = match std::env::var("ANTHROPIC_API_KEY")
-                    .ok()
-                    .filter(|k| !k.is_empty())
-                {
-                    Some(k) => k,
-                    None => {
-                        return format!(
-                            "[Agent '{}' failed: ANTHROPIC_API_KEY not set]",
-                            description
-                        )
-                    }
-                };
-
+                let anthropic_key = ctx.config.resolve_anthropic_api_key().unwrap_or_default();
+                let anthropic_base = ctx.config.resolve_anthropic_api_base();
                 let client = match claurst_api::AnthropicClient::new(claurst_api::client::ClientConfig {
-                    api_key,
+                    api_key: anthropic_key.clone(),
+                    api_base: anthropic_base,
                     ..Default::default()
                 }) {
                     Ok(c) => Arc::new(c),
@@ -572,6 +585,16 @@ pub fn init_team_swarm_runner() {
                         )
                     }
                 };
+
+                let provider_registry = ProviderRegistry::from_config(
+                    &ctx.config,
+                    claurst_api::client::ClientConfig {
+                        api_key: anthropic_key,
+                        api_base: ctx.config.resolve_anthropic_api_base(),
+                        ..Default::default()
+                    },
+                );
+                let model_registry = Arc::new(build_model_registry());
 
                 // Build the tool list, filtering to the allowlist if provided.
                 let all = claurst_tools::all_tools();
@@ -586,7 +609,19 @@ pub fn init_team_swarm_runner() {
                             .collect()
                     };
 
-                let model = claurst_core::constants::DEFAULT_MODEL.to_string();
+                let model = resolve_subagent_model(
+                    &AgentInput {
+                        description: description.clone(),
+                        prompt: prompt.clone(),
+                        tools: tools.clone(),
+                        system_prompt: system.clone(),
+                        max_turns,
+                        model: None,
+                        isolation: None,
+                        run_in_background: false,
+                    },
+                    &ctx,
+                );
 
                 let system_prompt = system.unwrap_or_else(|| {
                     "You are a specialized AI agent helping with a specific sub-task. \
@@ -602,6 +637,8 @@ pub fn init_team_swarm_runner() {
                     working_directory: Some(ctx.working_dir.display().to_string()),
                     output_style: ctx.config.effective_output_style(),
                     output_style_prompt: ctx.config.resolve_output_style_prompt(),
+                    provider_registry: Some(Arc::new(provider_registry)),
+                    model_registry: Some(model_registry),
                     ..Default::default()
                 };
 

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -979,37 +979,17 @@ pub async fn run_query_loop(
 
                 let mut provider = runtime_provider.or(registry_provider);
 
-                // If the user supplied api_base for a local provider (Ollama, LM Studio,
-                // llama.cpp), rebuild the provider with the override URL.  These providers
-                // are always constructed with a hardcoded default URL, so without this
-                // the api_base setting would be silently ignored.
-                if let Some(override_base) = tool_ctx.config.provider_configs
-                    .get(&provider_id_str)
-                    .and_then(|pc| pc.api_base.as_deref())
-                {
-                    use claurst_api::providers::openai_compat_providers;
-                    let trimmed = override_base.trim_end_matches('/');
-                    // Avoid double /v1 suffix: only append if not already present.
-                    let base_url = if trimmed.ends_with("/v1") {
-                        trimmed.to_string()
-                    } else {
-                        format!("{}/v1", trimmed)
-                    };
-                    let overridden: Option<std::sync::Arc<dyn claurst_api::LlmProvider>> =
-                        match provider_id_str.as_str() {
-                            "ollama" => Some(std::sync::Arc::new(
-                                openai_compat_providers::ollama().with_base_url(base_url),
-                            )),
-                            "lmstudio" | "lm-studio" => Some(std::sync::Arc::new(
-                                openai_compat_providers::lm_studio().with_base_url(base_url),
-                            )),
-                            "llamacpp" | "llama-cpp" | "llama-server" => Some(std::sync::Arc::new(
-                                openai_compat_providers::llama_cpp().with_base_url(base_url),
-                            )),
-                            _ => None,
-                        };
-                    if overridden.is_some() {
-                        provider = overridden;
+                // Rebuild providers using the unified base resolver so overrides
+                // from settings/env/defaults are applied consistently.
+                if let Some(_) = claurst_api::registry::resolve_provider_api_base(
+                    &tool_ctx.config,
+                    &provider_id_str,
+                ) {
+                    if let Some(overridden) = claurst_api::registry::provider_from_config(
+                        &tool_ctx.config,
+                        &provider_id_str,
+                    ) {
+                        provider = Some(overridden);
                     }
                 }
                 if let Some(provider) = provider {

--- a/src-rust/crates/tools/Cargo.toml
+++ b/src-rust/crates/tools/Cargo.toml
@@ -35,6 +35,7 @@ base64 = { workspace = true }
 open = { workspace = true }
 enigo = { workspace = true, optional = true }
 xcap = { workspace = true, optional = true }
+image = { workspace = true, optional = true }
 
 # PTY support — used by PtyBashTool on Unix
 portable-pty = "0.9"
@@ -43,4 +44,4 @@ portable-pty = "0.9"
 nix = { workspace = true }
 
 [features]
-computer-use = ["dep:enigo", "dep:xcap"]
+computer-use = ["dep:enigo", "dep:xcap", "dep:image"]

--- a/src-rust/crates/tui/src/model_picker.rs
+++ b/src-rust/crates/tui/src/model_picker.rs
@@ -579,6 +579,15 @@ impl ModelPickerState {
     /// in the correct provider-aware format.
     pub fn confirm(&mut self) -> Option<(String, Option<EffortLevel>)> {
         let filtered = self.filtered_models();
+        let custom = self.filter.trim();
+        if filtered.is_empty() {
+            if custom.is_empty() {
+                return None;
+            }
+            let id = custom.to_string();
+            self.close();
+            return Some((id, None));
+        }
         let entry = filtered.get(self.selected_idx)?;
         let id = entry.id.clone();
         let effort = if model_supports_effort(&id) { Some(self.effort_level) } else { None };
@@ -865,6 +874,12 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
 
     if filtered.is_empty() {
         lines.push(Line::from(vec![Span::styled(" No results found", Style::default().fg(dim))]));
+        if !state.filter.trim().is_empty() {
+            lines.push(Line::from(vec![Span::styled(
+                " Press Enter to use custom model",
+                Style::default().fg(Color::Rgb(200, 200, 200)),
+            )]));
+        }
     } else {
         for (i, model) in filtered.iter().enumerate() {
             let is_selected = i == state.selected_idx;
@@ -1069,14 +1084,14 @@ mod tests {
         assert!(!p.visible, "picker should be closed after confirm");
     }
 
-    // 9. confirm() on empty filter list returns None.
+    // 9. confirm() on empty filter list uses custom model when filter is set.
     #[test]
     fn confirm_empty_filter_returns_none() {
         let mut p = make_picker_with_current("claude-opus-4-6");
         p.filter = "zzznomatch999".to_string();
         p.selected_idx = 0;
         let result = p.confirm();
-        assert!(result.is_none());
+        assert_eq!(result.map(|(id, _)| id), Some("zzznomatch999".to_string()));
     }
 
     // 10. close() clears filter and hides overlay.


### PR DESCRIPTION
- add a dynamic resolution and overrides based on provided base url and api key to the hardcoded OpenAI-based providers
- fix provider delegation in sub-agent tool to inherit the custom openai provider from main agent (tested only for the custom base URL of that one service I have)
- move the openai-compatible provider resolution to a separate file (improved readability)
- allow specifying a custom model string in the model picker, if the hardcoded selection does not match the provider (otherwise, the custom base URL will not be useful if there are different model IDs in the custom provider, and I also find it a no brainer to have this)
- fix missing dependencies required for build

All of these are minimal changes to make the custom provider work.