### PR TITLE
feat: add devcontainer setup with Dockerfile and configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM rust:1-bullseye
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gnupg2 libasound2-dev libxdo-dev pkg-config \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+{
+  "name": "claurst-rust",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "installZsh": false,
+      "username": "vscode",
+      "uid": "1000",
+      "gid": "1000"
+    },
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
+  },
+  "remoteUser": "vscode",
+  "mounts": [
+    "source=claurst-cargo-registry,target=/usr/local/cargo/registry,type=volume",
+    "source=claurst-cargo-git,target=/usr/local/cargo/git,type=volume",
+    "source=${localWorkspaceFolder}/.claurst,target=/home/vscode/.claurst,type=bind"
+  ],
+  "remoteEnv": {
+    "GNUPGHOME": "/home/vscode/.gnupg",
+    "PATH": "${containerWorkspaceFolder}/src-rust/target/debug:${containerWorkspaceFolder}/src-rust/target/release:${containerEnv:PATH}"
+  },
+  "postCreateCommand": "mkdir -p /home/vscode/.gnupg && chmod 700 /home/vscode/.gnupg && sudo chown -R vscode:vscode /usr/local/cargo",
+  "customizations": {
+    "vscode": {
+      "extensions": [],
+      "settings": {
+        "terminal.integrated.inheritEnv": true
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,9 @@ refs/
 
 # Git
 .gitignore
+.gitattributes
+
+# VSCode / unsolicited devcontainers mounts
+.vscode/
+.claurst/
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,27 @@ It's fast, it's memory-efficient, it's yours to run however you want, and there'
 
 ## Getting Started
 
+### Devcontainer setup
+
+After cloning this repository, open it in VS Code and use Reopen in Container to start the development environment.
+
+Prerequisites:
+- Docker installed on your host machine: https://www.docker.com/products/docker-desktop/
+
+GPG and SSH forwarding is enabled in the devcontainer, given you have it set up on your host machine. Follow [this guide](https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials) if you need help with that.
+
+### Devcontainer features
+
+- Base image: `rust:1-bullseye`.
+- Preinstalled build dependencies: `gnupg2`, `libasound2-dev`, `libxdo-dev`, and `pkg-config`.
+- Devcontainer features enabled: `common-utils` (with `vscode` user `uid/gid 1000` and Zsh install disabled), `git`, and `docker-outside-of-docker` (`moby: false`).
+- Runs as `vscode` user by default.
+- Persistent Cargo caches via named volumes for `/usr/local/cargo/registry` and `/usr/local/cargo/git`.
+- Binds local `.claurst` into `/home/vscode/.claurst` for local settings/session history access.
+- Sets `GNUPGHOME=/home/vscode/.gnupg` and prepends `src-rust/target/debug` and `src-rust/target/release` to `PATH`.
+- Post-create setup creates and permissions `.gnupg`, and fixes ownership for `/usr/local/cargo`.
+- VS Code setting `terminal.integrated.inheritEnv` is enabled.
+
 ### Download a release binary
 
 Grab the latest binary for your platform from [**GitHub Releases**](https://github.com/kuberwastaken/claurst/releases):

--- a/README.md
+++ b/README.md
@@ -33,30 +33,9 @@ It's fast, it's memory-efficient, it's yours to run however you want, and there'
 
 ---
 
-## Getting Started
+# Getting Started
 
-### Devcontainer setup
-
-After cloning this repository, open it in VS Code and use Reopen in Container to start the development environment.
-
-Prerequisites:
-- Docker installed on your host machine: https://www.docker.com/products/docker-desktop/
-
-GPG and SSH forwarding is enabled in the devcontainer, given you have it set up on your host machine. Follow [this guide](https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials) if you need help with that.
-
-### Devcontainer features
-
-- Base image: `rust:1-bullseye`.
-- Preinstalled build dependencies: `gnupg2`, `libasound2-dev`, `libxdo-dev`, and `pkg-config`.
-- Devcontainer features enabled: `common-utils` (with `vscode` user `uid/gid 1000` and Zsh install disabled), `git`, and `docker-outside-of-docker` (`moby: false`).
-- Runs as `vscode` user by default.
-- Persistent Cargo caches via named volumes for `/usr/local/cargo/registry` and `/usr/local/cargo/git`.
-- Binds local `.claurst` into `/home/vscode/.claurst` for local settings/session history access.
-- Sets `GNUPGHOME=/home/vscode/.gnupg` and prepends `src-rust/target/debug` and `src-rust/target/release` to `PATH`.
-- Post-create setup creates and permissions `.gnupg`, and fixes ownership for `/usr/local/cargo`.
-- VS Code setting `terminal.integrated.inheritEnv` is enabled.
-
-### Download a release binary
+## Download a release binary
 
 Grab the latest binary for your platform from [**GitHub Releases**](https://github.com/kuberwastaken/claurst/releases):
 
@@ -69,16 +48,6 @@ Grab the latest binary for your platform from [**GitHub Releases**](https://gith
 | **macOS** Apple Silicon | `claurst-macos-aarch64.tar.gz` |
 
 ### And you're done.
-
-Just install and run this from anywhere, that easy.
-
-```bash
-# Start Claurst
-claurst
-
-# Or run a one-shot headless query
-claurst -p "explain this codebase"
-```
 
 ## Build from source
 
@@ -102,6 +71,37 @@ claurst
 # Or run a one-shot headless query
 claurst -p "explain this codebase"
 ```
+
+Just install and run this from anywhere, that easy.
+
+```bash
+# Start Claurst
+claurst
+
+# Or run a one-shot headless query
+claurst -p "explain this codebase"
+```
+
+## Devcontainer setup
+
+After cloning this repository, open it in VS Code and use Reopen in Container to start the development environment.
+
+Prerequisites:
+- Docker installed on your host machine: https://www.docker.com/products/docker-desktop/
+
+GPG and SSH forwarding is enabled in the devcontainer, given you have it set up on your host machine. Follow [this guide](https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials) if you need help with that.
+
+### Devcontainer features
+
+- Base image: `rust:1-bullseye`.
+- Preinstalled build dependencies: `gnupg2`, `libasound2-dev`, `libxdo-dev`, and `pkg-config`.
+- Devcontainer features enabled: `common-utils` (with `vscode` user `uid/gid 1000` and Zsh install disabled), `git`, and `docker-outside-of-docker` (`moby: false`).
+- Runs as `vscode` user by default.
+- Persistent Cargo caches via named volumes for `/usr/local/cargo/registry` and `/usr/local/cargo/git`.
+- Binds local `.claurst` into `/home/vscode/.claurst` for local settings/session history access.
+- Sets `GNUPGHOME=/home/vscode/.gnupg` and prepends `src-rust/target/debug` and `src-rust/target/release` to `PATH`.
+- Post-create setup creates and permissions `.gnupg`, and fixes ownership for `/usr/local/cargo`.
+- VS Code setting `terminal.integrated.inheritEnv` is enabled.
 
 ## Documentation
 


### PR DESCRIPTION
- Add a Dockerfile from base Rust image with a few tools required by the build
- Add a devcontainer.json to enable easy development setup on any machine with DOcker installed
- The setup includes SSH and GPG forwarding, given the user has fullfilled the prerequisites on the host machine
- .claurst is mounted to the project directory to enable quick access to the setting and session history