### PR TITLE
fix: make voice/ALSA dependency optional for Raspberry Pi builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ cargo build --release --package claurst
 # Binary is at target/release/claurst
 ```
 
+**Raspberry Pi / systems without ALSA** (e.g. Debian Trixie, headless servers):
+
+```bash
+# Build without voice/microphone support — no libasound2-dev required
+cargo build --release --package claurst --no-default-features
+```
+
 ### First run
 
 ```bash

--- a/src-rust/crates/cli/Cargo.toml
+++ b/src-rust/crates/cli/Cargo.toml
@@ -7,8 +7,12 @@ edition.workspace = true
 name = "claurst"
 path = "src/main.rs"
 
+[features]
+default = ["voice"]
+voice = ["claurst-core/voice", "claurst-tui/voice"]
+
 [dependencies]
-claurst-core = { workspace = true, features = ["voice"] }
+claurst-core = { workspace = true }
 claurst-api = { workspace = true }
 claurst-acp = { workspace = true }
 claurst-tools = { workspace = true }

--- a/src-rust/crates/core/Cargo.toml
+++ b/src-rust/crates/core/Cargo.toml
@@ -10,7 +10,7 @@ edition.workspace = true
 voice = ["dep:cpal"]
 
 # Experimental/feature-flagged capabilities
-default = ["voice", "ultraplan"]
+default = ["ultraplan"]
 
 # Interaction & UI features
 ultraplan = []


### PR DESCRIPTION
## Summary

- `cpal` (the audio capture library) uses ALSA on Linux, requiring `libasound2-dev` at compile time — this blocked builds on Raspberry Pi (Debian Trixie) and headless servers where ALSA is unavailable
- Moved `voice` out of `claurst-core`'s default features and into an optional, default-on feature in the CLI crate
- No change to existing builds — voice is still compiled in by default on supported platforms

## Changes

| File | Change |
|---|---|
| `src-rust/crates/core/Cargo.toml` | Removed `voice` from `default` features |
| `src-rust/crates/cli/Cargo.toml` | Added `[features]` with `default = ["voice"]` and pass-through to core/tui; dropped hardcoded `features = ["voice"]` on the core dep |
| `README.md` | Documented the no-ALSA build option |

## Build without ALSA (Raspberry Pi / headless)

```bash
cargo build --release --package claurst --no-default-features
```

Tested on Raspberry Pi (aarch64, Debian Trixie): build completes successfully with zero references to `cpal` or ALSA.

## Test plan

- [x] `cargo build --release --package claurst --no-default-features` — succeeds, no cpal/ALSA in build output
- [ ] `cargo build --release --package claurst` — standard build with voice still works (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)