### PR TITLE
feat: add MCP support with rmcp-backed stdio/http/sse transports and auth initiation (OAuth)

### DIFF
--- a/src-rust/Cargo.lock
+++ b/src-rust/Cargo.lock
@@ -785,8 +785,10 @@ dependencies = [
  "futures",
  "getrandom 0.2.17",
  "once_cell",
+ "open",
  "parking_lot",
  "reqwest",
+ "rmcp",
  "serde",
  "serde_json",
  "sha2",
@@ -1692,8 +1694,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2598,6 +2602,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2711,6 +2727,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64",
+ "chrono",
+ "getrandom 0.2.17",
+ "http",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror 1.0.69",
+ "url",
 ]
 
 [[package]]
@@ -3071,6 +3106,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "futures",
+ "indexmap",
+ "nix 0.31.2",
+ "tokio",
+ "tracing",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "profiling"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3405,9 +3454,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64",
  "bytes",
@@ -3448,6 +3497,31 @@ name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+
+[[package]]
+name = "rmcp"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures",
+ "http",
+ "oauth2",
+ "pin-project-lite",
+ "process-wrap",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+]
 
 [[package]]
 name = "rusqlite"
@@ -3657,6 +3731,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3813,6 +3898,19 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c5e6deb40826033bd7b11c7ef25ef71193fabd71f680f40dd16538a2704d2f4"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -4371,6 +4469,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -4559,9 +4658,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -4682,6 +4781,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.62.2",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4727,6 +4847,17 @@ dependencies = [
  "windows-link",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4800,6 +4931,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -4927,6 +5068,15 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/src-rust/Cargo.toml
+++ b/src-rust/Cargo.toml
@@ -30,8 +30,7 @@ async-trait = "0.1"
 async-stream = "0.3"
 
 # HTTP
-reqwest = { version = "0.12", features = ["json", "stream", "native-tls", "multipart"], default-features = false }
-reqwest-eventsource = "0.6"
+reqwest = { version = "0.13", features = ["json", "stream", "native-tls", "multipart", "form", "query"], default-features = false }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -397,6 +397,7 @@ async fn main() -> anyhow::Result<()> {
                     session_title: None,
                     remote_session_url: None,
                     mcp_manager: None,
+                    mcp_auth_runner: None,
                 };
                 // Collect remaining args after the command name
                 let rest: Vec<&str> = raw_args[2..].iter().map(|s| s.as_str()).collect();
@@ -425,11 +426,12 @@ async fn main() -> anyhow::Result<()> {
 
     // Setup logging
     let log_level = if cli.verbose { "debug" } else { "warn" };
+    let base_filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(log_level));
+    let log_filter = base_filter
+        .add_directive("rmcp::service::client=error".parse().expect("valid rmcp directive"));
     tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| EnvFilter::new(log_level)),
-        )
+        .with_env_filter(log_filter)
         .with_target(false)
         .without_time()
         .init();
@@ -784,8 +786,9 @@ async fn connect_mcp_manager_arc(
     }
 
     info!(count = config.mcp_servers.len(), "Connecting to MCP servers");
-    let mcp_manager = claurst_mcp::McpManager::connect_all(&config.mcp_servers).await;
-    Some(Arc::new(mcp_manager))
+    let mcp_manager = Arc::new(claurst_mcp::McpManager::connect_all(&config.mcp_servers).await);
+    mcp_manager.clone().spawn_notification_poll_loop();
+    Some(mcp_manager)
 }
 
 fn build_tools_with_mcp(
@@ -1503,6 +1506,7 @@ async fn run_interactive(
         session_title: session.title.clone(),
         remote_session_url: session.remote_session_url.clone(),
         mcp_manager: tool_ctx.mcp_manager.clone(),
+        mcp_auth_runner: None,
     };
 
     // tools is already Arc<Vec<...>> — share it across spawned tasks without copying.
@@ -1532,6 +1536,31 @@ async fn run_interactive(
     // so the main loop can update the device_auth_dialog state.
     let (device_auth_tx, mut device_auth_rx) = mpsc::channel::<DeviceAuthEvent>(8);
 
+    // MCP OAuth auth channel — background tasks send events here so the main
+    // loop can update status and trigger a reconnect after browser auth finishes.
+    enum McpAuthEvent {
+        /// Browser auth completed and the token was persisted successfully.
+        Completed(claurst_mcp::oauth::McpAuthResult),
+        /// Browser auth or token exchange failed.
+        Failed(String),
+    }
+    let (mcp_auth_tx, mut mcp_auth_rx) = mpsc::channel::<McpAuthEvent>(8);
+    // Build a non-blocking runner so `/mcp auth` can return immediately while
+    // the browser flow continues in the background.
+    let mcp_auth_runner: Arc<dyn Fn(claurst_mcp::oauth::McpAuthSession) + Send + Sync> = {
+        let tx = mcp_auth_tx.clone();
+        Arc::new(move |session| {
+            let tx = tx.clone();
+            tokio::spawn(async move {
+                let event = match claurst_mcp::oauth::run_mcp_auth_session(session).await {
+                    Ok(result) => McpAuthEvent::Completed(result),
+                    Err(err) => McpAuthEvent::Failed(err.to_string()),
+                };
+                let _ = tx.send(event).await;
+            });
+        })
+    };
+    cmd_ctx.mcp_auth_runner = Some(mcp_auth_runner.clone());
     'main: loop {
         app.frame_count = app.frame_count.wrapping_add(1);
         app.tick_rustle_pose();
@@ -1657,7 +1686,7 @@ async fn run_interactive(
                             let handled_by_tui = if skip_tui_for_args {
                                 false
                             } else {
-                                app.intercept_slash_command(&cmd_name)
+                                app.intercept_slash_command_with_args(&cmd_name, &cmd_args)
                             };
 
                             // Sync effort level when TUI cycled the visual indicator
@@ -1832,6 +1861,16 @@ async fn run_interactive(
                                     app.set_speech_mode(mode.as_deref(), &level);
                                     cmd_ctx.config = app.config.clone();
                                     tool_ctx.config = app.config.clone();
+                                }
+                                Some(CommandResult::McpAuthFlow {
+                                    server_name,
+                                    auth_url,
+                                    redirect_uri,
+                                }) => {
+                                    app.status_message = Some(format!(
+                                        "MCP OAuth — '{}' started. Complete authentication in your browser.\nURL: {}\nCallback URL: {}",
+                                        server_name, auth_url, redirect_uri
+                                    ));
                                 }
                                 Some(CommandResult::Message(msg)) => {
                                     // Suppress text output when TUI already opened an
@@ -2772,6 +2811,23 @@ async fn run_interactive(
             }
         }
 
+        while let Ok(evt) = mcp_auth_rx.try_recv() {
+            match evt {
+                McpAuthEvent::Completed(result) => {
+                    // Schedule a runtime rebuild so the newly persisted token is
+                    // picked up by the next MCP manager instance.
+                    app.pending_mcp_reconnect = true;
+                    app.status_message = Some(format!(
+                        "MCP OAuth — '{}' authentication completed; token saved to: {}",
+                        result.server_name,
+                        result.token_path.display()
+                    ));
+                }
+                McpAuthEvent::Failed(error) => {
+                    app.status_message = Some(format!("MCP OAuth failed: {}", error));
+                }
+            }
+        }
         // Check if query task is done; sync messages from the task
         let task_finished = current_query
             .as_ref()
@@ -2825,6 +2881,50 @@ async fn run_interactive(
                             let _ = store.save_message(&session.id, msg_id, role, &content_str, None);
                         }
                     }
+                }
+            }
+        }
+
+        if !app.is_streaming && current_query.is_none() {
+            if let Some(server_name) = app.take_pending_mcp_panel_auth() {
+                let server_config = cmd_ctx
+                    .config
+                    .mcp_servers
+                    .iter()
+                    .find(|server| server.name == server_name);
+                let supports_panel_auth = server_config.is_some_and(|server| {
+                    matches!(server.server_type.as_str(), "http" | "sse")
+                        && server.url.as_deref().is_some()
+                });
+
+                if !supports_panel_auth {
+                    app.status_message = Some(format!(
+                        "Selected MCP server '{}' does not support panel auth.",
+                        server_name
+                    ));
+                } else if let Some(manager) = app.mcp_manager.clone() {
+                    match manager.begin_auth(&server_name).await {
+                        Ok(session) => {
+                            let auth_url = session.auth_url.clone();
+                            let redirect_uri = session.redirect_uri.clone();
+                            mcp_auth_runner(session);
+                            app.status_message = Some(format!(
+                                "MCP auth — '{}' started. Complete authentication in your browser.\nURL: {}\nCallback URL: {}",
+                                server_name, auth_url, redirect_uri
+                            ));
+                        }
+                        Err(error) => {
+                            app.status_message = Some(format!(
+                                "MCP auth failed for '{}': {}",
+                                server_name, error
+                            ));
+                        }
+                    }
+                } else {
+                    app.status_message = Some(
+                        "MCP auth is unavailable because the MCP runtime is not connected."
+                            .to_string(),
+                    );
                 }
             }
         }

--- a/src-rust/crates/commands/src/lib.rs
+++ b/src-rust/crates/commands/src/lib.rs
@@ -30,6 +30,8 @@ pub struct CommandContext {
     // Note: config already contains hooks, mcp_servers, etc.
     /// Live MCP manager — present when servers are connected.
     pub mcp_manager: Option<Arc<claurst_mcp::McpManager>>,
+    /// Optional callback for starting an MCP OAuth flow in the background.
+    pub mcp_auth_runner: Option<Arc<dyn Fn(claurst_mcp::oauth::McpAuthSession) + Send + Sync>>,
 }
 
 /// Result of running a slash command.
@@ -43,6 +45,15 @@ pub enum CommandResult {
     ConfigChange(Config),
     /// Modify the configuration and show a specific status message.
     ConfigChangeMessage(Config, String),
+    /// Trigger a background MCP OAuth flow and request runtime reconnect on success.
+    McpAuthFlow {
+        /// The configured MCP server name.
+        server_name: String,
+        /// The browser URL shown to the user while the background flow runs.
+        auth_url: String,
+        /// The local callback URL waiting for the OAuth redirect.
+        redirect_uri: String,
+    },
     /// Clear the conversation.
     ClearConversation,
     /// Replace the conversation with a specific message list (used by /rewind).
@@ -2854,7 +2865,8 @@ impl SlashCommand for McpCommand {
             for srv in &ctx.config.mcp_servers {
                 let kind = match srv.server_type.as_str() {
                     "stdio" => "stdio",
-                    "sse" | "http" => "HTTP/SSE",
+                    "sse" => "sse",
+                    "http" => "http",
                     other => other,
                 };
                 let endpoint = srv
@@ -2871,7 +2883,7 @@ impl SlashCommand for McpCommand {
                     .unwrap_or_else(|| "unknown (manager not active)".to_string());
 
                 output.push_str(&format!(
-                    "  {name:20} [{kind:8}] {status}\n    endpoint: {endpoint}\n",
+                    "  {name:20} [{kind:10}] {status}\n    endpoint: {endpoint}\n",
                     name = srv.name,
                     kind = kind,
                     status = live_status,
@@ -2931,9 +2943,8 @@ impl SlashCommand for McpCommand {
 impl McpCommand {
     /// Handle `/mcp auth <server>` — initiate OAuth or show auth instructions.
     ///
-    /// For HTTP/SSE servers: calls `McpManager::initiate_auth()` to fetch OAuth
-    /// metadata, constructs the PKCE authorization URL, attempts to open it in
-    /// the system browser, and displays the URL for manual use.
+    /// For HTTP/SSE servers: runs the browser-based OAuth flow, stores the
+    /// resulting token, and requests the runtime to reconnect.
     ///
     /// For stdio servers: shows env-var auth instructions.
     async fn handle_auth(server_name: &str, ctx: &CommandContext) -> CommandResult {
@@ -2950,30 +2961,7 @@ impl McpCommand {
             }
         };
 
-        // If already connected, nothing to do.
-        if let Some(manager) = &ctx.mcp_manager {
-            use claurst_mcp::McpServerStatus;
-            match manager.server_status(server_name) {
-                McpServerStatus::Connected { tool_count } => {
-                    return CommandResult::Message(format!(
-                        "MCP server '{}' is already connected ({} tool{} available).\n\
-                         No authentication needed.",
-                        server_name,
-                        tool_count,
-                        if tool_count == 1 { "" } else { "s" }
-                    ));
-                }
-                McpServerStatus::Connecting => {
-                    return CommandResult::Message(format!(
-                        "MCP server '{}' is currently connecting — try again shortly.",
-                        server_name
-                    ));
-                }
-                _ => {}
-            }
-        }
-
-        let is_http = matches!(srv.server_type.as_str(), "sse" | "http" | "sse+oauth");
+        let is_http = matches!(srv.server_type.as_str(), "http" | "sse");
 
         if !is_http {
             // stdio — env-var / API-key auth
@@ -2998,27 +2986,59 @@ impl McpCommand {
             ));
         }
 
-        // HTTP/SSE — use initiate_auth() when the manager is available.
         if let Some(manager) = &ctx.mcp_manager {
-            match manager.initiate_auth(server_name).await {
-                Ok(auth_url) => {
-                    // Best-effort browser open.
-                    let _ = open::that(&auth_url);
+            use claurst_mcp::McpServerStatus;
+            if matches!(manager.server_status(server_name), McpServerStatus::Connecting) {
+                return CommandResult::Message(format!(
+                    "MCP server '{}' is currently connecting — try again shortly.",
+                    server_name
+                ));
+            }
+
+            if let Some(run_auth) = &ctx.mcp_auth_runner {
+                // In the interactive CLI/TUI we start browser auth in the background
+                // so the event loop stays responsive while waiting for the callback.
+                match manager.begin_auth(server_name).await {
+                    Ok(session) => {
+                        let auth_url = session.auth_url.clone();
+                        let redirect_uri = session.redirect_uri.clone();
+                        run_auth(session);
+                        return CommandResult::McpAuthFlow {
+                            server_name: server_name.to_string(),
+                            auth_url,
+                            redirect_uri,
+                        };
+                    }
+                    Err(e) => {
+                        let server_url = srv.url.as_deref().unwrap_or("(URL not configured)");
+                        return CommandResult::Message(format!(
+                            "MCP OAuth — '{}'\n\
+                             Could not initiate OAuth flow: {}\n\n\
+                             Manual authentication fallback:\n  Open {} in your browser and complete the OAuth flow.\n\
+                             Then run /mcp connect {} to reconnect.",
+                            server_name, e, server_url, server_name
+                        ));
+                    }
+                }
+            }
+
+            match manager.authenticate(server_name).await {
+                Ok(result) => {
                     return CommandResult::Message(format!(
                         "MCP OAuth — '{}'\n\
-                         Opening browser for authentication...\n\
-                         If the browser did not open, visit:\n\n  {}\n\n\
-                         After authorizing, the token will be saved to:\n  ~/.claurst/mcp-tokens/{}.json\n\n\
-                         Then run /mcp connect {} to reconnect.",
-                        server_name, auth_url, server_name, server_name
+                         Browser authentication completed; token saved to:\n  {}\n\n\
+                         The runtime will attempt to reload the MCP connection; if it still does not reconnect, run /mcp connect {} manually.",
+                        server_name,
+                        result.token_path.display(),
+                        server_name
                     ));
                 }
                 Err(e) => {
                     let server_url = srv.url.as_deref().unwrap_or("(URL not configured)");
                     return CommandResult::Message(format!(
                         "MCP OAuth — '{}'\n\
-                         Could not fetch OAuth metadata: {}\n\n\
-                         Manual authentication:\n  Open {} in your browser and complete the OAuth flow.\n\
+                         Could not complete OAuth flow: {}\n\n\
+                         Manual authentication fallback:\n  Open {} in your browser and complete the OAuth flow.\n\
                          Then run /mcp connect {} to reconnect.",
                         server_name, e, server_url, server_name
                     ));
@@ -8306,6 +8326,7 @@ mod tests {
             session_title: None,
             remote_session_url: None,
             mcp_manager: None,
+            mcp_auth_runner: None,
         }
     }
 

--- a/src-rust/crates/commands/src/named_commands.rs
+++ b/src-rust/crates/commands/src/named_commands.rs
@@ -1119,6 +1119,7 @@ mod tests {
             session_title: None,
             remote_session_url: None,
             mcp_manager: None,
+            mcp_auth_runner: None,
         }
     }
 

--- a/src-rust/crates/mcp/Cargo.toml
+++ b/src-rust/crates/mcp/Cargo.toml
@@ -26,4 +26,6 @@ base64 = { workspace = true }
 getrandom = { workspace = true }
 dirs = { workspace = true }
 chrono = { workspace = true }
+open = { workspace = true }
 urlencoding = { workspace = true }
+rmcp = { version = "1.4.0", default-features = false, features = ["client", "auth", "transport-child-process", "transport-streamable-http-client-reqwest", "reqwest-native-tls"] }

--- a/src-rust/crates/mcp/src/backend.rs
+++ b/src-rust/crates/mcp/src/backend.rs
@@ -1,0 +1,86 @@
+use crate::types::{
+    CallToolResult, GetPromptResult, McpPrompt, McpResource, McpTool,
+    ResourceContents, ServerCapabilities, ServerInfo,
+};
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// Backend implementation used by an `McpClient` instance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum McpBackendKind {
+    /// rmcp-backed implementation.
+    Rmcp,
+}
+
+/// Immutable view of the server state that upper layers depend on.
+#[derive(Debug, Clone)]
+pub struct McpClientSnapshot {
+    pub server_name: String,
+    pub server_info: Option<ServerInfo>,
+    pub capabilities: ServerCapabilities,
+    pub tools: Vec<McpTool>,
+    pub resources: Vec<McpResource>,
+    pub prompts: Vec<McpPrompt>,
+    pub instructions: Option<String>,
+}
+
+impl McpClientSnapshot {
+    /// Create an empty snapshot for a newly constructed client.
+    pub fn empty(server_name: impl Into<String>) -> Self {
+        Self {
+            server_name: server_name.into(),
+            server_info: None,
+            capabilities: ServerCapabilities::default(),
+            tools: vec![],
+            resources: vec![],
+            prompts: vec![],
+            instructions: None,
+        }
+    }
+}
+
+/// Protocol/session backend used by `McpClient`.
+///
+/// The goal is to keep upper layers stable (`McpManager`, CLI, tools, TUI)
+/// while allowing transport implementations to migrate independently.
+#[async_trait]
+pub trait McpClientBackend: Send + Sync {
+    fn kind(&self) -> McpBackendKind;
+
+    /// Return the latest server snapshot for populating `McpClient` fields.
+    fn snapshot(&self) -> McpClientSnapshot;
+
+    async fn list_tools(&self) -> anyhow::Result<Vec<McpTool>>;
+
+    async fn call_tool(
+        &self,
+        name: &str,
+        arguments: Option<Value>,
+    ) -> anyhow::Result<CallToolResult>;
+
+    async fn list_resources(&self) -> anyhow::Result<Vec<McpResource>>;
+
+    async fn read_resource(&self, uri: &str) -> anyhow::Result<ResourceContents>;
+
+    async fn list_prompts(&self) -> anyhow::Result<Vec<McpPrompt>>;
+
+    async fn get_prompt(
+        &self,
+        name: &str,
+        arguments: Option<HashMap<String, String>>,
+    ) -> anyhow::Result<GetPromptResult>;
+
+    async fn subscribe_resource(&self, uri: &str) -> anyhow::Result<()>;
+
+    async fn unsubscribe_resource(&self, uri: &str) -> anyhow::Result<()>;
+
+    /// Subscribe to raw notification payloads emitted by the backend.
+    fn subscribe_to_notifications(&self) -> BoxStream<'static, anyhow::Result<Value>>;
+}
+
+/// Pick the preferred backend for a configured transport type.
+pub fn preferred_backend_kind(_server_type: &str) -> McpBackendKind {
+    McpBackendKind::Rmcp
+}

--- a/src-rust/crates/mcp/src/connection_manager.rs
+++ b/src-rust/crates/mcp/src/connection_manager.rs
@@ -8,6 +8,7 @@
 
 use crate::client::McpClient;
 use crate::expand_server_config;
+use crate::oauth;
 use claurst_core::config::McpServerConfig;
 use dashmap::DashMap;
 use std::collections::HashMap;
@@ -115,6 +116,24 @@ impl McpConnectionManager {
         Ok(())
     }
 
+    async fn connect_expanded_config(name: &str, config: &McpServerConfig) -> anyhow::Result<McpClient> {
+        let auth_token = if matches!(config.server_type.as_str(), "sse" | "http") {
+            match config.url.as_deref() {
+                Some(server_url) => oauth::get_valid_mcp_access_token(name, server_url).await?,
+                None => {
+                    anyhow::bail!(
+                        "MCP server '{}' is configured as '{}' but missing URL",
+                        name,
+                        config.server_type
+                    )
+                }
+            }
+        } else {
+            None
+        };
+        McpClient::connect(config, auth_token).await
+    }
+
     // -----------------------------------------------------------------------
     // Connect / disconnect / restart
     // -----------------------------------------------------------------------
@@ -128,7 +147,6 @@ impl McpConnectionManager {
         let state_arc = entry.value().clone();
         drop(entry); // release dashmap read-guard
 
-        // Mark as connecting
         {
             let mut st = state_arc.lock().await;
             st.status = McpServerStatus::Connecting;
@@ -139,16 +157,16 @@ impl McpConnectionManager {
             expand_server_config(&st.config)
         };
 
-        debug!(server = %name, command = ?config.command, "Connecting to MCP server via stdio");
+        debug!(server = %name, transport = %config.server_type, command = ?config.command, url = ?config.url, "Connecting to MCP server");
 
-        match McpClient::connect_stdio(&config).await {
+        match Self::connect_expanded_config(name, &config).await {
             Ok(client) => {
                 let tool_count = client.tools.len();
                 let client_arc = Arc::new(client);
                 let mut st = state_arc.lock().await;
                 st.client = Some(client_arc);
                 st.status = McpServerStatus::Connected { tool_count };
-                info!(server = %name, tools = tool_count, "MCP server connected");
+                info!(server = %name, transport = %config.server_type, tools = tool_count, "MCP server connected");
                 Ok(())
             }
             Err(e) => {
@@ -165,7 +183,6 @@ impl McpConnectionManager {
 
     /// Disconnect a server and cancel its reconnect loop.
     pub async fn disconnect(&self, name: &str) {
-        // Cancel background reconnect task first
         {
             let mut handles = self.reconnect_handles.lock().await;
             if let Some(handle) = handles.remove(name) {
@@ -198,7 +215,6 @@ impl McpConnectionManager {
         self.state
             .get(name)
             .map(|e| {
-                // Best-effort non-blocking check via try_lock
                 e.value()
                     .try_lock()
                     .map(|st| st.client.is_some())
@@ -253,7 +269,6 @@ impl McpConnectionManager {
     ///
     /// Backoff: 1 s → 2 s → 4 s → … capped at 60 s.
     pub async fn start_reconnect_loop(&self, name: &str) {
-        // Don't start a second loop if one is already running.
         {
             let handles = self.reconnect_handles.lock().await;
             if handles.contains_key(name) {
@@ -286,7 +301,6 @@ impl McpConnectionManager {
         loop {
             let retry_at = Instant::now() + backoff;
 
-            // Update status to Failed with scheduled retry time
             if let Some(entry) = state.get(&name) {
                 if let Ok(mut st) = entry.value().try_lock() {
                     let prev_error = match &st.status {
@@ -309,33 +323,29 @@ impl McpConnectionManager {
 
             tokio::time::sleep(backoff).await;
 
-            // Try to reconnect
             let config = match state.get(&name) {
                 Some(entry) => match entry.value().try_lock() {
                     Ok(st) => expand_server_config(&st.config),
                     Err(_) => {
-                        // State locked by something else; back off and retry
                         backoff = (backoff * 2).min(MAX_BACKOFF);
                         continue;
                     }
                 },
                 None => {
-                    // Server was removed from the registry; stop loop
                     debug!(server = %name, "MCP server removed; stopping reconnect loop");
                     break;
                 }
             };
 
-            // Mark connecting
             if let Some(entry) = state.get(&name) {
                 if let Ok(mut st) = entry.value().try_lock() {
                     st.status = McpServerStatus::Connecting;
                 }
             }
 
-            info!(server = %name, attempt_backoff_secs = backoff.as_secs(), "Attempting MCP reconnect");
+            info!(server = %name, transport = %config.server_type, attempt_backoff_secs = backoff.as_secs(), "Attempting MCP reconnect");
 
-            match McpClient::connect_stdio(&config).await {
+            match Self::connect_expanded_config(&name, &config).await {
                 Ok(client) => {
                     let tool_count = client.tools.len();
                     let client_arc = Arc::new(client);
@@ -345,13 +355,12 @@ impl McpConnectionManager {
                             st.status = McpServerStatus::Connected { tool_count };
                         }
                     }
-                    info!(server = %name, tools = tool_count, "MCP server reconnected successfully");
-                    // Success — exit loop; caller can restart a new loop if needed
+                    info!(server = %name, transport = %config.server_type, tools = tool_count, "MCP server reconnected successfully");
                     break;
                 }
                 Err(e) => {
                     let msg = e.to_string();
-                    error!(server = %name, error = %msg, "MCP reconnect attempt failed");
+                    error!(server = %name, transport = %config.server_type, error = %msg, "MCP reconnect attempt failed");
                     if let Some(entry) = state.get(&name) {
                         if let Ok(mut st) = entry.value().try_lock() {
                             st.status = McpServerStatus::Disconnected {

--- a/src-rust/crates/mcp/src/lib.rs
+++ b/src-rust/crates/mcp/src/lib.rs
@@ -23,19 +23,17 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::process::{Child, ChildStdin, Command};
-use tokio::sync::{mpsc, oneshot, Mutex};
-use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, error, info, warn};
 
 pub use client::McpClient;
 pub use types::*;
 pub use connection_manager::{McpConnectionManager, McpServerStatus};
 
+pub mod backend;
 pub mod connection_manager;
 pub mod registry;
 pub mod oauth;
+pub mod rmcp_backend;
 
 // ---------------------------------------------------------------------------
 // Environment variable expansion
@@ -118,7 +116,8 @@ pub mod types {
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct JsonRpcRequest {
         pub jsonrpc: String,
-        pub id: Value,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub id: Option<Value>,
         pub method: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub params: Option<Value>,
@@ -128,7 +127,7 @@ pub mod types {
         pub fn new(id: impl Into<Value>, method: impl Into<String>, params: Option<Value>) -> Self {
             Self {
                 jsonrpc: "2.0".to_string(),
-                id: id.into(),
+                id: Some(id.into()),
                 method: method.into(),
                 params,
             }
@@ -137,12 +136,13 @@ pub mod types {
         pub fn notification(method: impl Into<String>, params: Option<Value>) -> Self {
             Self {
                 jsonrpc: "2.0".to_string(),
-                id: Value::Null,
+                id: None,
                 method: method.into(),
                 params,
             }
         }
     }
+
 
     /// A JSON-RPC 2.0 response.
     #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -165,46 +165,6 @@ pub mod types {
     }
 
     // ---- MCP protocol types ------------------------------------------------
-
-    /// MCP initialize request params.
-    #[derive(Debug, Clone, Serialize, Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    pub struct InitializeParams {
-        pub protocol_version: String,
-        pub capabilities: ClientCapabilities,
-        pub client_info: ClientInfo,
-    }
-
-    #[derive(Debug, Clone, Serialize, Deserialize)]
-    pub struct ClientCapabilities {
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub roots: Option<RootsCapability>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub sampling: Option<Value>,
-    }
-
-    #[derive(Debug, Clone, Serialize, Deserialize)]
-    pub struct RootsCapability {
-        #[serde(rename = "listChanged")]
-        pub list_changed: bool,
-    }
-
-    #[derive(Debug, Clone, Serialize, Deserialize)]
-    pub struct ClientInfo {
-        pub name: String,
-        pub version: String,
-    }
-
-    /// MCP initialize response result.
-    #[derive(Debug, Clone, Serialize, Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    pub struct InitializeResult {
-        pub protocol_version: String,
-        pub capabilities: ServerCapabilities,
-        pub server_info: ServerInfo,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub instructions: Option<String>,
-    }
 
     #[derive(Debug, Clone, Serialize, Deserialize, Default)]
     pub struct ServerCapabilities {
@@ -394,6 +354,18 @@ pub mod types {
 
 pub mod transport {
     use super::*;
+    use reqwest::header::{CONTENT_TYPE, HeaderValue};
+    #[cfg(test)]
+    use tokio::sync::mpsc;
+
+    pub const LEGACY_PROTOCOL_VERSION: &str = "2024-11-05";
+    pub const STREAMABLE_HTTP_PROTOCOL_VERSION: &str = "2025-11-25";
+    pub const STREAMABLE_HTTP_PROTOCOL_VERSIONS: &[&str] = &[
+        STREAMABLE_HTTP_PROTOCOL_VERSION,
+        "2025-06-18",
+        "2025-03-26",
+        LEGACY_PROTOCOL_VERSION,
+    ];
 
     /// A transport can send requests and receive responses.
     #[async_trait]
@@ -416,148 +388,155 @@ pub mod transport {
         fn subscribe_to_notifications(
             &self,
         ) -> BoxStream<'static, anyhow::Result<serde_json::Value>>;
+
+        fn protocol_version(&self) -> &'static str {
+            LEGACY_PROTOCOL_VERSION
+        }
     }
 
-    /// Stdio transport: spawns a subprocess and communicates via stdin/stdout.
-    pub struct StdioTransport {
-        child: Arc<Mutex<Child>>,
-        stdin: Arc<Mutex<ChildStdin>>,
-        stdout_rx: Arc<Mutex<mpsc::UnboundedReceiver<String>>>,
+    pub(crate) fn bearer_header_value(token: &str) -> anyhow::Result<HeaderValue> {
+        HeaderValue::from_str(&format!("Bearer {}", token))
+            .map_err(|e| anyhow::anyhow!("invalid bearer token header: {}", e))
     }
 
-    impl StdioTransport {
-        pub async fn spawn(config: &McpServerConfig) -> anyhow::Result<Self> {
-            let command = config
-                .command
-                .as_deref()
-                .ok_or_else(|| anyhow::anyhow!("MCP server '{}' has no command configured", config.name))?;
+    pub(crate) fn is_event_stream_response(response: &reqwest::Response) -> bool {
+        response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .map(|value| value.contains("text/event-stream"))
+            .unwrap_or(false)
+    }
 
-            let mut cmd = Command::new(command);
-            cmd.args(&config.args)
-                .envs(&config.env)
-                .stdin(std::process::Stdio::piped())
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::piped());
+    pub(crate) fn resolve_legacy_endpoint(base_url: &str, endpoint: &str) -> anyhow::Result<String> {
+        let endpoint = endpoint.trim();
+        if endpoint.is_empty() {
+            anyhow::bail!("legacy SSE endpoint event did not include a POST endpoint");
+        }
+        if let Ok(url) = url::Url::parse(endpoint) {
+            return Ok(url.to_string());
+        }
+        let base = url::Url::parse(base_url)
+            .map_err(|e| anyhow::anyhow!("invalid legacy SSE base URL '{}': {}", base_url, e))?;
+        base.join(endpoint)
+            .map(|url| url.to_string())
+            .map_err(|e| anyhow::anyhow!("failed to resolve legacy SSE endpoint '{}': {}", endpoint, e))
+    }
 
-            let mut child = cmd.spawn().map_err(|e| {
+    #[cfg(test)]
+    pub(super) fn route_incoming_value(
+        server_name: &str,
+        value: serde_json::Value,
+        response_tx: &mpsc::UnboundedSender<JsonRpcResponse>,
+        notification_tx: &mpsc::UnboundedSender<serde_json::Value>,
+    ) -> anyhow::Result<()> {
+        let is_response = value.get("id").map(|id| !id.is_null()).unwrap_or(false)
+            || value.get("result").is_some()
+            || value.get("error").is_some();
+
+        if is_response {
+            let response: JsonRpcResponse = serde_json::from_value(value).map_err(|e| {
                 anyhow::anyhow!(
-                    "MCP server '{}': failed to spawn '{}': {}",
-                    config.name,
-                    command,
+                    "MCP server '{}': failed to parse JSON-RPC response from HTTP transport: {}",
+                    server_name,
                     e
                 )
             })?;
+            let _ = response_tx.send(response);
+            return Ok(());
+        }
 
-            let stdin = child
-                .stdin
-                .take()
-                .ok_or_else(|| anyhow::anyhow!("MCP server '{}': could not capture stdin", config.name))?;
-            let stdout = child
-                .stdout
-                .take()
-                .ok_or_else(|| anyhow::anyhow!("MCP server '{}': could not capture stdout", config.name))?;
+        if value.get("method").is_some() {
+            let _ = notification_tx.send(value);
+        }
 
-            let (tx, rx) = mpsc::unbounded_channel::<String>();
+        Ok(())
+    }
 
-            // Background reader task — forwards stdout lines to the channel.
-            tokio::spawn(async move {
-                let reader = BufReader::new(stdout);
-                let mut lines = reader.lines();
-                while let Ok(Some(line)) = lines.next_line().await {
-                    if tx.send(line).is_err() {
-                        break;
-                    }
-                }
-            });
+    fn dispatch_sse_event<F>(
+        event_name: &mut Option<String>,
+        data_lines: &mut Vec<String>,
+        on_event: &mut F,
+    ) -> anyhow::Result<()>
+    where
+        F: FnMut(Option<&str>, &str) -> anyhow::Result<()>,
+    {
+        if event_name.is_none() && data_lines.is_empty() {
+            return Ok(());
+        }
+        let data = data_lines.join("\n");
+        on_event(event_name.as_deref(), &data)?;
+        *event_name = None;
+        data_lines.clear();
+        Ok(())
+    }
 
-            Ok(Self {
-                child: Arc::new(Mutex::new(child)),
-                stdin: Arc::new(Mutex::new(stdin)),
-                stdout_rx: Arc::new(Mutex::new(rx)),
-            })
+    pub(super) fn process_sse_line(
+        line: &str,
+        event_name: &mut Option<String>,
+        data_lines: &mut Vec<String>,
+    ) {
+        if line.starts_with(':') {
+            return;
+        }
+        let (field, value) = match line.split_once(':') {
+            Some((field, value)) => (field, value.strip_prefix(' ').unwrap_or(value)),
+            None => (line, ""),
+        };
+        match field {
+            "event" => *event_name = Some(value.to_string()),
+            "data" => data_lines.push(value.to_string()),
+            _ => {}
         }
     }
 
-    #[async_trait]
-    impl McpTransport for StdioTransport {
-        async fn send(&self, message: &JsonRpcRequest) -> anyhow::Result<()> {
-            let json = serde_json::to_string(message)? + "\n";
-            let mut stdin = self.stdin.lock().await;
-            stdin.write_all(json.as_bytes()).await?;
-            stdin.flush().await?;
-            Ok(())
-        }
+    pub(crate) async fn process_sse_response<F>(
+        response: reqwest::Response,
+        mut on_event: F,
+    ) -> anyhow::Result<()>
+    where
+        F: FnMut(Option<&str>, &str) -> anyhow::Result<()>,
+    {
+        let mut stream = response.bytes_stream();
+        let mut buffer = String::new();
+        let mut event_name: Option<String> = None;
+        let mut data_lines: Vec<String> = Vec::new();
 
-        async fn recv(&self) -> anyhow::Result<Option<JsonRpcResponse>> {
-            let mut rx = self.stdout_rx.lock().await;
-            let line = rx.recv().await;
-            match line {
-                Some(s) => {
-                    let resp: JsonRpcResponse = serde_json::from_str(&s)
-                        .map_err(|e| anyhow::anyhow!("MCP response parse error: {} (raw: {})", e, s))?;
-                    Ok(Some(resp))
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|e| anyhow::anyhow!("failed reading SSE stream: {}", e))?;
+            buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+            while let Some(pos) = buffer.find('\n') {
+                let mut line: String = buffer.drain(..=pos).collect();
+                if line.ends_with('\n') {
+                    line.pop();
                 }
-                None => Ok(None),
+                if line.ends_with('\r') {
+                    line.pop();
+                }
+                if line.is_empty() {
+                    dispatch_sse_event(&mut event_name, &mut data_lines, &mut on_event)?;
+                } else {
+                    process_sse_line(&line, &mut event_name, &mut data_lines);
+                }
             }
         }
 
-        async fn close(&self) -> anyhow::Result<()> {
-            let mut child = self.child.lock().await;
-            let _ = child.kill().await;
-            Ok(())
-        }
-
-        async fn try_receive_raw(&self) -> anyhow::Result<Option<serde_json::Value>> {
-            let mut rx = self.stdout_rx.lock().await;
-            match rx.try_recv() {
-                Ok(line) => {
-                    let val: serde_json::Value = serde_json::from_str(&line)
-                        .map_err(|e| anyhow::anyhow!("MCP raw parse error: {} (raw: {})", e, line))?;
-                    Ok(Some(val))
-                }
-                Err(mpsc::error::TryRecvError::Empty) => Ok(None),
-                Err(mpsc::error::TryRecvError::Disconnected) => Ok(None),
+        if !buffer.is_empty() {
+            if buffer.ends_with('\r') {
+                buffer.pop();
+            }
+            if buffer.is_empty() {
+                dispatch_sse_event(&mut event_name, &mut data_lines, &mut on_event)?;
+            } else {
+                process_sse_line(&buffer, &mut event_name, &mut data_lines);
             }
         }
 
-        fn subscribe_to_notifications(
-            &self,
-        ) -> BoxStream<'static, anyhow::Result<serde_json::Value>> {
-            let stdout_rx = Arc::clone(&self.stdout_rx);
-
-            // Create a channel to bridge from the exclusive receiver to the stream
-            let (tx, rx) = mpsc::channel::<anyhow::Result<serde_json::Value>>(100);
-
-            // Spawn a background task that polls the stdout_rx and forwards to tx
-            tokio::spawn(async move {
-                loop {
-                    let line = {
-                        let mut out_rx = stdout_rx.lock().await;
-                        out_rx.recv().await
-                    };
-
-                    match line {
-                        Some(s) => {
-                            let val: anyhow::Result<serde_json::Value> =
-                                serde_json::from_str(&s)
-                                    .map_err(|e| anyhow::anyhow!("MCP raw parse error: {} (raw: {})", e, s));
-
-                            if tx.send(val).await.is_err() {
-                                // Receiver dropped; exit the polling task
-                                break;
-                            }
-                        }
-                        None => {
-                            // stdout_rx closed
-                            break;
-                        }
-                    }
-                }
-            });
-
-            Box::pin(ReceiverStream::new(rx))
-        }
+        dispatch_sse_event(&mut event_name, &mut data_lines, &mut on_event)?;
+        Ok(())
     }
+
 }
 
 // ---------------------------------------------------------------------------
@@ -566,7 +545,6 @@ pub mod transport {
 
 pub mod client {
     use super::*;
-    use std::sync::atomic::{AtomicU64, Ordering};
 
     /// A fully initialized MCP client connected to a single server.
     pub struct McpClient {
@@ -577,93 +555,123 @@ pub mod client {
         pub resources: Vec<McpResource>,
         pub prompts: Vec<McpPrompt>,
         pub instructions: Option<String>,
-        transport: Arc<dyn transport::McpTransport>,
-        next_id: AtomicU64,
-        #[allow(dead_code)]
-        pending: Arc<Mutex<HashMap<u64, oneshot::Sender<JsonRpcResponse>>>>,
+        backend: Option<Arc<dyn backend::McpClientBackend>>,
     }
 
     impl McpClient {
-        /// Connect to an MCP server using stdio transport and complete the
-        /// initialize handshake.  The `config` should already have env vars
-        /// expanded via `expand_server_config`.
-        pub async fn connect_stdio(config: &McpServerConfig) -> anyhow::Result<Self> {
-            let transport = transport::StdioTransport::spawn(config).await?;
-            let client = Self {
-                server_name: config.name.clone(),
-                server_info: None,
-                capabilities: ServerCapabilities::default(),
-                tools: vec![],
-                resources: vec![],
-                prompts: vec![],
-                instructions: None,
-                transport: Arc::new(transport),
-                next_id: AtomicU64::new(1),
-                pending: Arc::new(Mutex::new(HashMap::new())),
-            };
-
-            client.initialize().await
+        fn from_snapshot(snapshot: backend::McpClientSnapshot) -> Self {
+            Self {
+                server_name: snapshot.server_name,
+                server_info: snapshot.server_info,
+                capabilities: snapshot.capabilities,
+                tools: snapshot.tools,
+                resources: snapshot.resources,
+                prompts: snapshot.prompts,
+                instructions: snapshot.instructions,
+                backend: None,
+            }
         }
 
-        /// Send the MCP initialize handshake and discover capabilities.
-        async fn initialize(mut self) -> anyhow::Result<Self> {
-            let params = InitializeParams {
-                protocol_version: "2024-11-05".to_string(),
-                capabilities: ClientCapabilities {
-                    roots: Some(RootsCapability { list_changed: false }),
-                    sampling: None,
-                },
-                client_info: ClientInfo {
-                    name: claurst_core::constants::APP_NAME.to_string(),
-                    version: claurst_core::constants::APP_VERSION.to_string(),
-                },
-            };
+        fn from_backend(backend: Arc<dyn backend::McpClientBackend>) -> Self {
+            let snapshot = backend.snapshot();
+            let mut client = Self::from_snapshot(snapshot);
+            client.backend = Some(backend);
+            client
+        }
 
-            let result: InitializeResult = self
-                .call("initialize", Some(serde_json::to_value(&params)?))
-                .await
-                .map_err(|e| anyhow::anyhow!("MCP server '{}' initialize failed: {}", self.server_name, e))?;
+        fn backend(&self) -> anyhow::Result<&Arc<dyn backend::McpClientBackend>> {
+            self.backend
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("MCP client backend missing"))
+        }
 
-            self.server_info = Some(result.server_info);
-            self.instructions = result.instructions;
-            self.capabilities = result.capabilities.clone();
-
-            // Send initialized notification
-            let notif = JsonRpcRequest::notification("notifications/initialized", None);
-            self.transport.send(&notif).await?;
-
-            // Discover tools if supported
-            if result.capabilities.tools.is_some() {
-                match self.list_tools().await {
-                    Ok(tools) => self.tools = tools,
-                    Err(e) => warn!(server = %self.server_name, error = %e, "Failed to list tools"),
+        pub async fn connect(config: &McpServerConfig, auth_token: Option<String>) -> anyhow::Result<Self> {
+            match config.server_type.as_str() {
+                "stdio" => Self::connect_stdio(config).await,
+                "sse" => {
+                    let backend = crate::rmcp_backend::RmcpClientBackend::connect_legacy_sse(
+                        config,
+                        auth_token,
+                    )
+                    .await?;
+                    Ok(Self::from_backend(Arc::new(backend)))
                 }
-            }
-
-            // Discover resources if supported
-            if result.capabilities.resources.is_some() {
-                match self.list_resources().await {
-                    Ok(resources) => self.resources = resources,
-                    Err(e) => warn!(server = %self.server_name, error = %e, "Failed to list resources"),
+                "http" => {
+                    let mut last_error = None;
+                    for &protocol_version in transport::STREAMABLE_HTTP_PROTOCOL_VERSIONS {
+                        let protocol_version = serde_json::from_value::<rmcp::model::ProtocolVersion>(
+                            Value::String(protocol_version.to_string()),
+                        )
+                        .map_err(|e| {
+                            anyhow::anyhow!(
+                                "MCP server '{}': invalid streamable HTTP protocol version '{}': {}",
+                                config.name,
+                                protocol_version,
+                                e
+                            )
+                        })?;
+                        let protocol_version_label = protocol_version.as_str().to_string();
+                        match crate::rmcp_backend::RmcpClientBackend::connect_http(
+                            config,
+                            auth_token.clone(),
+                            protocol_version,
+                        )
+                        .await
+                        {
+                            Ok(backend) => return Ok(Self::from_backend(Arc::new(backend))),
+                            Err(e) => {
+                                let message = e.to_string();
+                                if Self::is_unsupported_protocol_error(&message) {
+                                    debug!(
+                                        server = %config.name,
+                                        protocol_version = %protocol_version_label,
+                                        error = %message,
+                                        "Streamable HTTP protocol version unsupported; trying fallback"
+                                    );
+                                    last_error = Some(e);
+                                    continue;
+                                }
+                                return Err(e);
+                            }
+                        }
+                    }
+                    Err(last_error.unwrap_or_else(|| {
+                        anyhow::anyhow!(
+                            "MCP server '{}': no supported streamable HTTP protocol version found",
+                            config.name
+                        )
+                    }))
                 }
+                other => Err(anyhow::anyhow!(
+                    "MCP server '{}': unsupported transport type '{}'",
+                    config.name,
+                    other
+                )),
             }
+        }
 
-            // Discover prompts if supported
-            if result.capabilities.prompts.is_some() {
-                match self.list_prompts().await {
-                    Ok(prompts) => self.prompts = prompts,
-                    Err(e) => warn!(server = %self.server_name, error = %e, "Failed to list prompts"),
-                }
-            }
+        pub(crate) fn is_unsupported_protocol_error(message: &str) -> bool {
+            // rmcp, servers, and gateways do not emit a single stable
+            // protocol-negotiation error string, so match the known variants
+            // conservatively to keep downgrade fallback working.
+            let lower = message.to_ascii_lowercase();
+            lower.contains("unsupported protocol version")
+                || lower.contains("unsupported mcp-protocol-version")
+                || (lower.contains("protocol version") && lower.contains("unsupported"))
+                || (lower.contains("mcp-protocol-version") && lower.contains("bad request"))
+        }
 
-            Ok(self)
+        /// Connect to an MCP server using stdio transport. The `config` should
+        /// already have env vars expanded via `expand_server_config`.
+        pub async fn connect_stdio(config: &McpServerConfig) -> anyhow::Result<Self> {
+            let backend = crate::rmcp_backend::RmcpClientBackend::connect_stdio(config).await?;
+            Ok(Self::from_backend(Arc::new(backend)))
         }
 
         // ---- High-level API -----------------------------------------------
 
         pub async fn list_tools(&self) -> anyhow::Result<Vec<McpTool>> {
-            let result: ListToolsResult = self.call("tools/list", None).await?;
-            Ok(result.tools)
+            self.backend()?.list_tools().await
         }
 
         pub async fn call_tool(
@@ -671,70 +679,28 @@ pub mod client {
             name: &str,
             arguments: Option<Value>,
         ) -> anyhow::Result<CallToolResult> {
-            let params = CallToolParams {
-                name: name.to_string(),
-                arguments,
-            };
-            self.call("tools/call", Some(serde_json::to_value(&params)?))
-                .await
-                .map_err(|e| {
-                    anyhow::anyhow!(
-                        "MCP server '{}': tool '{}' call failed: {}",
-                        self.server_name,
-                        name,
-                        e
-                    )
-                })
+            self.backend()?.call_tool(name, arguments).await.map_err(|e| {
+                anyhow::anyhow!(
+                    "MCP server '{}': tool '{}' call failed: {}",
+                    self.server_name,
+                    name,
+                    e
+                )
+            })
         }
 
         pub async fn list_resources(&self) -> anyhow::Result<Vec<McpResource>> {
-            let result: ListResourcesResult = self.call("resources/list", None).await?;
-            let mut resources = result.resources;
-
-            // Apply template rendering for resources with prompt annotations
-            for resource in &mut resources {
-                if let Some(annotations) = &resource.annotations {
-                    if let Some(prompt_template) = annotations.get("prompt") {
-                        if let Some(template_str) = prompt_template.as_str() {
-                            // Build context from resource fields
-                            let context = serde_json::json!({
-                                "uri": resource.uri,
-                                "name": resource.name,
-                                "description": resource.description,
-                                "mimeType": resource.mime_type,
-                            });
-
-                            // Render the template and replace description
-                            let rendered = TemplateRenderer::render(template_str, &context);
-                            resource.description = Some(rendered);
-                        }
-                    }
-                }
-            }
-
+            let mut resources = self.backend()?.list_resources().await?;
+            apply_resource_templates(&mut resources);
             Ok(resources)
         }
 
         pub async fn read_resource(&self, uri: &str) -> anyhow::Result<ResourceContents> {
-            let params = serde_json::json!({ "uri": uri });
-            let result: Value = self.call("resources/read", Some(params)).await?;
-            let contents = result
-                .get("contents")
-                .and_then(|c| c.as_array())
-                .and_then(|arr| arr.first())
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "MCP server '{}': no contents in resources/read response for '{}'",
-                        self.server_name,
-                        uri
-                    )
-                })?;
-            Ok(serde_json::from_value(contents.clone())?)
+            self.backend()?.read_resource(uri).await
         }
 
         pub async fn list_prompts(&self) -> anyhow::Result<Vec<McpPrompt>> {
-            let result: ListPromptsResult = self.call("prompts/list", None).await?;
-            Ok(result.prompts)
+            self.backend()?.list_prompts().await
         }
 
         /// Invoke `prompts/get` with the given name and optional arguments map.
@@ -746,12 +712,15 @@ pub mod client {
             name: &str,
             arguments: Option<std::collections::HashMap<String, String>>,
         ) -> anyhow::Result<GetPromptResult> {
-            let mut params = serde_json::json!({ "name": name });
-            if let Some(args) = arguments {
-                params["arguments"] = serde_json::to_value(args)?;
-            }
-            let result: GetPromptResult = self.call("prompts/get", Some(params)).await?;
-            Ok(result)
+            self.backend()?.get_prompt(name, arguments).await
+        }
+
+        pub async fn subscribe_resource(&self, uri: &str) -> anyhow::Result<()> {
+            self.backend()?.subscribe_resource(uri).await
+        }
+
+        pub async fn unsubscribe_resource(&self, uri: &str) -> anyhow::Result<()> {
+            self.backend()?.unsubscribe_resource(uri).await
         }
 
         /// Get all tools as `ToolDefinition` objects suitable for the API.
@@ -759,102 +728,14 @@ pub mod client {
             self.tools.iter().map(|t| t.into()).collect()
         }
 
-        /// Access the transport for subscribing to notifications.
-        pub fn transport(&self) -> Arc<dyn transport::McpTransport> {
-            Arc::clone(&self.transport)
+        /// Subscribe to raw JSON notifications from the active backend.
+        pub fn subscribe_to_notifications(&self) -> BoxStream<'static, anyhow::Result<serde_json::Value>> {
+            self.backend()
+                .expect("MCP client backend missing")
+                .subscribe_to_notifications()
         }
 
         // ---- Notification dispatch ----------------------------------------
-
-        /// Drain any pending server-initiated notifications from the transport
-        /// and route them to the appropriate subscribers in `resource_subscriptions`.
-        ///
-        /// Only messages that have a `"method"` field but no non-null `"id"` field
-        /// are treated as notifications; everything else is skipped (this method
-        /// does NOT consume RPC response messages).
-        ///
-        /// Handled notification methods:
-        /// - `notifications/resources/updated` — delivers a [`ResourceChangedEvent`]
-        ///   to the matching sender in `resource_subscriptions`.
-        /// - `notifications/tools/list_changed` — logged at info level.
-        /// - anything else — logged at debug level.
-        /// Drain any pending server-initiated notifications from the transport
-        /// and route them to the appropriate subscribers in `resource_subscriptions`.
-        /// This method is kept for backward compatibility and fallback use.
-        #[allow(dead_code)]
-        pub(crate) async fn poll_notifications(
-            &self,
-            resource_subscriptions: &dashmap::DashMap<
-                (String, String),
-                tokio::sync::mpsc::Sender<ResourceChangedEvent>,
-            >,
-        ) {
-            loop {
-                let raw = match self.transport.try_receive_raw().await {
-                    Ok(Some(v)) => v,
-                    Ok(None) => break,
-                    Err(e) => {
-                        debug!(
-                            server = %self.server_name,
-                            error = %e,
-                            "poll_notifications: transport error"
-                        );
-                        break;
-                    }
-                };
-
-                // Only process server-initiated notifications (have "method", no non-null "id")
-                let has_method = raw.get("method").is_some();
-                let has_id = raw.get("id").map(|v| !v.is_null()).unwrap_or(false);
-                if !has_method || has_id {
-                    // This is an RPC response, not a notification — skip it.
-                    // (In practice this should not occur because call() drains
-                    //  responses synchronously before poll_notifications runs.)
-                    debug!(
-                        server = %self.server_name,
-                        "poll_notifications: skipping non-notification message"
-                    );
-                    continue;
-                }
-
-                let method = raw["method"].as_str().unwrap_or("");
-                match method {
-                    "notifications/resources/updated" => {
-                        let uri = raw["params"]["uri"].as_str().unwrap_or("").to_string();
-                        let key = (self.server_name.clone(), uri.clone());
-                        if let Some(tx) = resource_subscriptions.get(&key) {
-                            let event = ResourceChangedEvent {
-                                server_name: self.server_name.clone(),
-                                uri,
-                            };
-                            if let Err(e) = tx.send(event).await {
-                                debug!(
-                                    server = %self.server_name,
-                                    error = %e,
-                                    "poll_notifications: resource subscription receiver dropped"
-                                );
-                            }
-                        } else {
-                            debug!(
-                                server = %self.server_name,
-                                uri = %raw["params"]["uri"],
-                                "poll_notifications: no subscriber for resource update"
-                            );
-                        }
-                    }
-                    "notifications/tools/list_changed" => {
-                        info!(server = %self.server_name, "MCP tools list changed");
-                    }
-                    other => {
-                        debug!(
-                            server = %self.server_name,
-                            method = %other,
-                            "Unhandled MCP notification"
-                        );
-                    }
-                }
-            }
-        }
 
         /// Process a single notification message from the transport stream.
         /// Routes resource updates to subscribers and logs other notifications.
@@ -916,59 +797,8 @@ pub mod client {
             }
         }
 
-        // ---- Internal RPC machinery ---------------------------------------
-
-        /// Send a request and wait for the response, deserializing into T.
-        pub(crate) async fn call<T: for<'de> Deserialize<'de>>(
-            &self,
-            method: &str,
-            params: Option<Value>,
-        ) -> anyhow::Result<T> {
-            let id = self.next_id.fetch_add(1, Ordering::SeqCst);
-            let req = JsonRpcRequest::new(id, method, params);
-
-            // We use a simple request/response loop here (no concurrent requests).
-            // For production use, proper demultiplexing by id would be needed.
-            self.transport.send(&req).await?;
-
-            loop {
-                let resp = self
-                    .transport
-                    .recv()
-                    .await?
-                    .ok_or_else(|| anyhow::anyhow!("MCP transport closed while waiting for response to '{}'", method))?;
-
-                // Check if this response matches our request id
-                let resp_id = resp.id.as_ref().and_then(|v| v.as_u64()).unwrap_or(0);
-                if resp_id != id {
-                    // Might be a server-initiated notification; skip
-                    debug!(got_id = resp_id, want_id = id, "Skipping non-matching response");
-                    continue;
-                }
-
-                if let Some(err) = resp.error {
-                    return Err(anyhow::anyhow!(
-                        "MCP error {} from '{}': {}",
-                        err.code,
-                        method,
-                        err.message
-                    ));
-                }
-
-                let result = resp
-                    .result
-                    .ok_or_else(|| anyhow::anyhow!("No result in MCP response for '{}'", method))?;
-                return Ok(serde_json::from_value(result)?);
-            }
-        }
-
-        /// Test-only constructor: build an `McpClient` backed by an arbitrary
-        /// transport without going through the real MCP handshake.
         #[cfg(test)]
-        pub fn new_for_test(
-            server_name: impl Into<String>,
-            transport: Arc<dyn transport::McpTransport>,
-        ) -> Self {
+        pub fn new_for_test(server_name: impl Into<String>) -> Self {
             Self {
                 server_name: server_name.into(),
                 server_info: None,
@@ -977,9 +807,26 @@ pub mod client {
                 resources: vec![],
                 prompts: vec![],
                 instructions: None,
-                transport,
-                next_id: AtomicU64::new(1),
-                pending: Arc::new(Mutex::new(HashMap::new())),
+                backend: None,
+            }
+        }
+    }
+
+    fn apply_resource_templates(resources: &mut [McpResource]) {
+        for resource in resources {
+            if let Some(annotations) = &resource.annotations {
+                if let Some(prompt_template) = annotations.get("prompt") {
+                    if let Some(template_str) = prompt_template.as_str() {
+                        let context = serde_json::json!({
+                            "uri": resource.uri,
+                            "name": resource.name,
+                            "description": resource.description,
+                            "mimeType": resource.mime_type,
+                        });
+                        let rendered = TemplateRenderer::render(template_str, &context);
+                        resource.description = Some(rendered);
+                    }
+                }
             }
         }
     }
@@ -1051,16 +898,17 @@ impl McpManager {
             let expanded = expand_server_config(config);
 
             match expanded.server_type.as_str() {
-                "stdio" => {
-                    debug!(
-                        server = %expanded.name,
-                        command = ?expanded.command,
-                        "Connecting to MCP server via stdio"
-                    );
-                    match McpClient::connect_stdio(&expanded).await {
+                "stdio" | "sse" | "http" => {
+                    let auth_token = if matches!(expanded.server_type.as_str(), "sse" | "http") {
+                        manager.load_token(&expanded.name).await
+                    } else {
+                        None
+                    };
+                    match client::McpClient::connect(&expanded, auth_token).await {
                         Ok(client) => {
                             info!(
                                 server = %expanded.name,
+                                transport = %expanded.server_type,
                                 tools = client.tools.len(),
                                 resources = client.resources.len(),
                                 "MCP server connected"
@@ -1070,6 +918,7 @@ impl McpManager {
                         Err(e) => {
                             error!(
                                 server = %expanded.name,
+                                transport = %expanded.server_type,
                                 error = %e,
                                 "Failed to connect to MCP server"
                             );
@@ -1318,50 +1167,52 @@ impl McpManager {
     /// Return the current authentication state for a server.
     ///
     /// - Returns `Authenticated` if a valid (non-expired) token exists on disk.
-    /// - Returns `NotRequired` for stdio servers (they don't use OAuth).
-    /// - Returns `Required` for HTTP servers that lack a valid token.
+    /// - Returns `NotRequired` for stdio servers.
+    /// - Returns `Required` for remote `http` / `sse` servers that lack a valid token.
     pub fn auth_state(&self, server_name: &str) -> McpAuthState {
-        // Check whether a token is already stored
-        if let Some(token) = oauth::get_mcp_token(server_name) {
-            if !token.is_expired(60) {
-                let token_expiry = token.expires_at.map(|ts| {
-                    chrono::DateTime::<chrono::Utc>::from(
-                        std::time::UNIX_EPOCH + std::time::Duration::from_secs(ts),
-                    )
-                });
-                return McpAuthState::Authenticated { token_expiry };
-            }
-        }
-
-        // Determine server type from stored configs
         let config = match self.server_configs.get(server_name) {
             Some(c) => c,
             None => return McpAuthState::NotRequired,
         };
 
-        match config.server_type.as_str() {
-            "http" | "sse" => McpAuthState::Required {
-                auth_url: config
-                    .url
-                    .clone()
-                    .unwrap_or_else(|| "(unknown URL)".to_string()),
-            },
-            _ => McpAuthState::NotRequired,
+        if !matches!(config.server_type.as_str(), "http" | "sse") {
+            return McpAuthState::NotRequired;
+        }
+
+        if let Some(token) = oauth::get_mcp_token(server_name) {
+            if !token.is_expired(60) {
+                return McpAuthState::Authenticated {
+                    token_expiry: token.expiry_datetime(),
+                };
+            }
+
+            if token.refresh_token.is_some() {
+                return McpAuthState::Required {
+                    auth_url: format!(
+                        "{} (refreshable token detected; connection will try to refresh automatically)",
+                        config.url
+                            .clone()
+                            .unwrap_or_else(|| "(unknown URL)".to_string())
+                    ),
+                };
+            }
+        }
+
+        McpAuthState::Required {
+            auth_url: config
+                .url
+                .clone()
+                .unwrap_or_else(|| "(unknown URL)".to_string()),
         }
     }
 
     /// Initiate OAuth 2.0 + PKCE for an HTTP MCP server.
-    ///
-    /// 1. GETs `<server_url>/.well-known/oauth-authorization-server`
-    /// 2. Parses `authorization_endpoint`
-    /// 3. Generates PKCE challenge
-    /// 4. Returns the full auth URL (browser opening done at the command layer)
-    ///
-    /// The PKCE verifier is *not* persisted here; it is embedded in the URL
-    /// so the command layer can display it.  A full end-to-end exchange would
-    /// store the verifier and wait for the callback — that is handled by
-    /// `oauth::exchange_code` once the code is received.
     pub async fn initiate_auth(&self, server_name: &str) -> anyhow::Result<String> {
+        Ok(self.begin_auth(server_name).await?.auth_url)
+    }
+
+    /// Build a full OAuth authorization session for an HTTP/SSE MCP server.
+    pub async fn begin_auth(&self, server_name: &str) -> anyhow::Result<oauth::McpAuthSession> {
         let config = self
             .server_configs
             .get(server_name)
@@ -1375,67 +1226,29 @@ impl McpManager {
                     "MCP server '{}' has no URL configured (required for OAuth)",
                     server_name
                 )
-            })?
-            .trim_end_matches('/');
+            })?;
 
-        // 1. Fetch OAuth Authorization Server Metadata (RFC 8414)
-        let metadata_url = format!("{}/.well-known/oauth-authorization-server", base_url);
-        let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(10))
-            .build()
-            .map_err(|e| anyhow::anyhow!("Failed to build HTTP client: {}", e))?;
+        oauth::begin_mcp_auth(server_name, base_url).await
+    }
 
-        let authorization_endpoint = match client.get(&metadata_url).send().await {
-            Ok(resp) if resp.status().is_success() => {
-                let meta: serde_json::Value = resp
-                    .json()
-                    .await
-                    .map_err(|e| anyhow::anyhow!("OAuth metadata parse error: {}", e))?;
-                meta.get("authorization_endpoint")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string())
-                    .ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "OAuth metadata for '{}' missing 'authorization_endpoint'",
-                            server_name
-                        )
-                    })?
-            }
-            Ok(resp) => {
-                // Metadata endpoint not found — fall back to <base_url>/oauth/authorize
-                let status = resp.status();
-                debug!(
-                    server = %server_name,
-                    status = %status,
-                    "OAuth metadata endpoint returned non-success; using fallback"
-                );
-                format!("{}/oauth/authorize", base_url)
-            }
-            Err(e) => {
-                // Network error — fall back
-                debug!(server = %server_name, error = %e, "Failed to fetch OAuth metadata; using fallback");
-                format!("{}/oauth/authorize", base_url)
-            }
-        };
+    /// Run the browser-based OAuth flow and persist the resulting token.
+    pub async fn authenticate(&self, server_name: &str) -> anyhow::Result<oauth::McpAuthResult> {
+        let config = self
+            .server_configs
+            .get(server_name)
+            .ok_or_else(|| anyhow::anyhow!("Unknown MCP server: {}", server_name))?;
 
-        // 2. Allocate a redirect port
-        let redirect_port = oauth::oauth_port_alloc()
-            .map_err(|e| anyhow::anyhow!("Failed to allocate OAuth redirect port: {}", e))?;
-        let redirect_uri = format!("http://127.0.0.1:{}/callback", redirect_port);
+        let base_url = config
+            .url
+            .as_deref()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "MCP server '{}' has no URL configured (required for OAuth)",
+                    server_name
+                )
+            })?;
 
-        // 3. Generate PKCE
-        let verifier = oauth::pkce_verifier();
-        let challenge = oauth::pkce_challenge(&verifier);
-
-        // 4. Build auth URL
-        let auth_url = format!(
-            "{}?client_id=claurst&redirect_uri={}&response_type=code&code_challenge={}&code_challenge_method=S256",
-            authorization_endpoint,
-            urlencoding::encode(&redirect_uri),
-            challenge,
-        );
-
-        Ok(auth_url)
+        oauth::run_mcp_auth_flow(server_name, base_url).await
     }
 
     /// Store an OAuth access token for an MCP server.
@@ -1467,14 +1280,14 @@ impl McpManager {
 
     /// Load the stored OAuth access token for an MCP server, if any.
     ///
-    /// Returns `None` if no token is stored or the token is expired.
-    pub fn load_token(&self, server_name: &str) -> Option<String> {
-        let token = oauth::get_mcp_token(server_name)?;
-        if token.is_expired(60) {
-            None
-        } else {
-            Some(token.access_token)
-        }
+    /// Returns `None` if no token is stored or the token cannot be refreshed.
+    pub async fn load_token(&self, server_name: &str) -> Option<String> {
+        let config = self.server_configs.get(server_name)?;
+        let server_url = config.url.as_deref()?;
+        oauth::get_valid_mcp_access_token(server_name, server_url)
+            .await
+            .ok()
+            .flatten()
     }
 
     // -----------------------------------------------------------------------
@@ -1501,7 +1314,7 @@ impl McpManager {
 
             tokio::spawn(async move {
                 // Subscribe to the transport's notification stream
-                let mut notification_stream = client_clone.transport().subscribe_to_notifications();
+                let mut notification_stream = client_clone.subscribe_to_notifications();
 
                 // Process notifications from the stream
                 while let Some(result) = notification_stream.next().await {
@@ -1661,6 +1474,16 @@ mod tests {
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("\"jsonrpc\":\"2.0\""));
         assert!(json.contains("\"method\":\"tools/list\""));
+        assert!(json.contains("\"id\":1"));
+    }
+
+    #[test]
+    fn test_json_rpc_notification_omits_id() {
+        let req = JsonRpcRequest::notification("notifications/initialized", None);
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("\"jsonrpc\":\"2.0\""));
+        assert!(json.contains("\"method\":\"notifications/initialized\""));
+        assert!(!json.contains("\"id\""));
     }
 
     // ---- McpTool → ToolDefinition ------------------------------------------
@@ -1779,6 +1602,45 @@ mod tests {
         let mgr = McpManager::new();
         assert!(mgr.failed_servers().is_empty());
     }
+
+    #[test]
+    fn test_auth_state_uses_token_expiry_datetime() {
+        let mut mgr = McpManager::new();
+        mgr.server_configs.insert(
+            "remote".to_string(),
+            McpServerConfig {
+                name: "remote".to_string(),
+                command: None,
+                args: vec![],
+                env: HashMap::new(),
+                url: Some("https://example.com/mcp".to_string()),
+                server_type: "http".to_string(),
+            },
+        );
+
+        let expires_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+            + 3600;
+        let token = oauth::McpToken {
+            access_token: "tok".to_string(),
+            refresh_token: None,
+            expires_at: Some(expires_at),
+            scope: None,
+            server_name: "remote".to_string(),
+        };
+        oauth::store_mcp_token(&token).expect("store token");
+
+        match mgr.auth_state("remote") {
+            McpAuthState::Authenticated { token_expiry } => {
+                assert_eq!(token_expiry, token.expiry_datetime());
+            }
+            other => panic!("expected authenticated, got {:?}", other),
+        }
+
+        oauth::remove_mcp_token("remote").ok();
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1828,8 +1690,7 @@ pub async fn subscribe_resource(
         }
     };
 
-    let params = serde_json::json!({ "uri": uri });
-    if let Err(e) = client.call::<serde_json::Value>("resources/subscribe", Some(params)).await {
+    if let Err(e) = client.subscribe_resource(uri).await {
         tracing::warn!(server_name, uri, error = %e, "subscribe_resource RPC failed");
         return make_dead();
     }
@@ -1857,12 +1718,83 @@ pub async fn unsubscribe_resource(
         .get(server_name)
         .ok_or_else(|| format!("unsubscribe_resource: server '{}' not connected", server_name))?;
 
-    let params = serde_json::json!({ "uri": uri });
     client
-        .call_tool("resources/unsubscribe", Some(params))
+        .unsubscribe_resource(uri)
         .await
         .map_err(|e| format!("unsubscribe_resource failed: {e}"))
         .map(|_| ())
+}
+
+// ---------------------------------------------------------------------------
+// Transport tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod transport_tests {
+    use super::transport::*;
+    use tokio::sync::mpsc as tokio_mpsc;
+
+    #[tokio::test]
+    async fn test_route_incoming_value_sends_response_to_response_queue() {
+        let (response_tx, mut response_rx) = tokio_mpsc::unbounded_channel();
+        let (notification_tx, mut notification_rx) = tokio_mpsc::unbounded_channel();
+        let value = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 7,
+            "result": {"ok": true}
+        });
+
+        route_incoming_value("srv", value, &response_tx, &notification_tx).unwrap();
+
+        let response = response_rx.recv().await.expect("expected response");
+        assert_eq!(response.id, Some(serde_json::json!(7)));
+        assert!(notification_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn test_route_incoming_value_sends_notification_to_notification_queue() {
+        let (response_tx, mut response_rx) = tokio_mpsc::unbounded_channel();
+        let (notification_tx, mut notification_rx) = tokio_mpsc::unbounded_channel();
+        let value = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///foo.txt"}
+        });
+
+        route_incoming_value("srv", value.clone(), &response_tx, &notification_tx).unwrap();
+
+        let notification = notification_rx.recv().await.expect("expected notification");
+        assert_eq!(notification, value);
+        assert!(response_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn test_resolve_legacy_endpoint_supports_relative_path() {
+        let endpoint = resolve_legacy_endpoint("https://example.com/mcp", "/messages").unwrap();
+        assert_eq!(endpoint, "https://example.com/messages");
+    }
+
+    #[test]
+    fn test_process_sse_line_collects_event_and_data() {
+        let mut event_name = None;
+        let mut data_lines = Vec::new();
+        process_sse_line("event: endpoint", &mut event_name, &mut data_lines);
+        process_sse_line("data: /messages", &mut event_name, &mut data_lines);
+        assert_eq!(event_name.as_deref(), Some("endpoint"));
+        assert_eq!(data_lines, vec!["/messages".to_string()]);
+    }
+
+    #[test]
+    fn test_is_unsupported_protocol_error_matches_rmcp_variants() {
+        assert!(crate::McpClient::is_unsupported_protocol_error(
+            "unsupported protocol version: 2025-11-25"
+        ));
+        assert!(crate::McpClient::is_unsupported_protocol_error(
+            "Bad Request: Unsupported MCP-Protocol-Version: 2025-11-25"
+        ));
+        assert!(!crate::McpClient::is_unsupported_protocol_error("connection reset by peer"));
+    }
+
 }
 
 // ---------------------------------------------------------------------------
@@ -1873,110 +1805,24 @@ pub async fn unsubscribe_resource(
 mod notification_tests {
     use super::*;
 
-    /// A mock transport that returns pre-queued raw JSON lines and discards sends.
-    struct MockTransport {
-        queue: tokio::sync::Mutex<std::collections::VecDeque<String>>,
-    }
-
-    impl MockTransport {
-        fn with_lines(lines: &[&str]) -> Arc<Self> {
-            Arc::new(Self {
-                queue: tokio::sync::Mutex::new(
-                    lines.iter().map(|s| s.to_string()).collect(),
-                ),
-            })
-        }
-    }
-
-    #[async_trait::async_trait]
-    impl transport::McpTransport for MockTransport {
-        async fn send(&self, _msg: &JsonRpcRequest) -> anyhow::Result<()> {
-            Ok(())
-        }
-
-        async fn recv(&self) -> anyhow::Result<Option<JsonRpcResponse>> {
-            Ok(None)
-        }
-
-        async fn close(&self) -> anyhow::Result<()> {
-            Ok(())
-        }
-
-        async fn try_receive_raw(&self) -> anyhow::Result<Option<serde_json::Value>> {
-            let mut q = self.queue.lock().await;
-            match q.pop_front() {
-                Some(line) => {
-                    let v: serde_json::Value = serde_json::from_str(&line)?;
-                    Ok(Some(v))
-                }
-                None => Ok(None),
-            }
-        }
-
-        fn subscribe_to_notifications(
-            &self,
-        ) -> BoxStream<'static, anyhow::Result<serde_json::Value>> {
-            let queue = Arc::new(tokio::sync::Mutex::new(
-                self.queue
-                    .blocking_lock()
-                    .iter()
-                    .map(|s| s.clone())
-                    .collect::<std::collections::VecDeque<_>>(),
-            ));
-
-            let (tx, rx) = tokio::sync::mpsc::channel::<anyhow::Result<serde_json::Value>>(100);
-
-            // Spawn a background task that yields queued notifications
-            tokio::spawn(async move {
-                loop {
-                    let line = {
-                        let mut q = queue.lock().await;
-                        q.pop_front()
-                    };
-
-                    match line {
-                        Some(s) => {
-                            let val: anyhow::Result<serde_json::Value> = serde_json::from_str(&s)
-                                .map_err(|e| anyhow::anyhow!("Mock parse error: {} (raw: {})", e, s));
-
-                            if tx.send(val).await.is_err() {
-                                break;
-                            }
-                        }
-                        None => {
-                            // Queue exhausted
-                            break;
-                        }
-                    }
-                }
-            });
-
-            Box::pin(ReceiverStream::new(rx))
-        }
-    }
-
     #[tokio::test]
-    async fn test_poll_notifications_routes_resource_updated() {
+    async fn test_process_notification_routes_resource_updated() {
         let notification = serde_json::json!({
             "jsonrpc": "2.0",
             "method": "notifications/resources/updated",
             "params": { "uri": "file:///foo.txt" }
-        })
-        .to_string();
+        });
 
-        let client = client::McpClient::new_for_test(
-            "myserver",
-            MockTransport::with_lines(&[&notification]),
-        );
+        let client = client::McpClient::new_for_test("myserver");
 
         let subscriptions: DashMap<
             (String, String),
             tokio::sync::mpsc::Sender<ResourceChangedEvent>,
         > = DashMap::new();
-        let (tx, mut rx) = tokio_mpsc::channel::<ResourceChangedEvent>(4);
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<ResourceChangedEvent>(4);
         subscriptions.insert(("myserver".to_string(), "file:///foo.txt".to_string()), tx);
 
-        client.poll_notifications(&subscriptions).await;
+        client.process_notification(notification, &subscriptions).await;
 
         let event = rx.try_recv().expect("expected a ResourceChangedEvent");
         assert_eq!(event.server_name, "myserver");
@@ -1985,90 +1831,63 @@ mod notification_tests {
     }
 
     #[tokio::test]
-    async fn test_poll_notifications_no_subscriber_does_not_panic() {
+    async fn test_process_notification_no_subscriber_does_not_panic() {
         let notification = serde_json::json!({
             "jsonrpc": "2.0",
             "method": "notifications/resources/updated",
             "params": { "uri": "file:///unsubscribed.txt" }
-        })
-        .to_string();
+        });
 
-        let client = client::McpClient::new_for_test(
-            "myserver",
-            MockTransport::with_lines(&[&notification]),
-        );
+        let client = client::McpClient::new_for_test("myserver");
         let subscriptions: DashMap<
             (String, String),
             tokio::sync::mpsc::Sender<ResourceChangedEvent>,
         > = DashMap::new();
-        // No subscriber registered — should silently skip without panicking.
-        client.poll_notifications(&subscriptions).await;
+        client.process_notification(notification, &subscriptions).await;
     }
 
     #[tokio::test]
-    async fn test_poll_notifications_tools_list_changed() {
+    async fn test_process_notification_tools_list_changed() {
         let notification = serde_json::json!({
             "jsonrpc": "2.0",
             "method": "notifications/tools/list_changed",
             "params": {}
-        })
-        .to_string();
+        });
 
-        let client = client::McpClient::new_for_test(
-            "myserver",
-            MockTransport::with_lines(&[&notification]),
-        );
+        let client = client::McpClient::new_for_test("myserver");
         let subscriptions: DashMap<
             (String, String),
             tokio::sync::mpsc::Sender<ResourceChangedEvent>,
         > = DashMap::new();
-        client.poll_notifications(&subscriptions).await; // must not panic
+        client.process_notification(notification, &subscriptions).await;
     }
 
     #[tokio::test]
-    async fn test_poll_notifications_empty_queue_is_noop() {
-        let client = client::McpClient::new_for_test(
-            "myserver",
-            MockTransport::with_lines(&[]),
-        );
-        let subscriptions: DashMap<
-            (String, String),
-            tokio::sync::mpsc::Sender<ResourceChangedEvent>,
-        > = DashMap::new();
-        // Must return immediately without blocking or panicking.
-        client.poll_notifications(&subscriptions).await;
-    }
-
-    #[tokio::test]
-    async fn test_poll_notifications_multiple_events() {
+    async fn test_process_notification_multiple_events() {
         let n1 = serde_json::json!({
             "jsonrpc": "2.0",
             "method": "notifications/resources/updated",
             "params": { "uri": "file:///a.txt" }
-        })
-        .to_string();
+        });
         let n2 = serde_json::json!({
             "jsonrpc": "2.0",
             "method": "notifications/resources/updated",
             "params": { "uri": "file:///b.txt" }
-        })
-        .to_string();
+        });
 
-        let client = client::McpClient::new_for_test(
-            "s1",
-            MockTransport::with_lines(&[&n1, &n2]),
-        );
+        let client = client::McpClient::new_for_test("s1");
 
         let subscriptions: DashMap<
             (String, String),
             tokio::sync::mpsc::Sender<ResourceChangedEvent>,
         > = DashMap::new();
-        let (tx_a, mut rx_a) = tokio_mpsc::channel::<ResourceChangedEvent>(4);
-        let (tx_b, mut rx_b) = tokio_mpsc::channel::<ResourceChangedEvent>(4);
+        let (tx_a, mut rx_a) = tokio::sync::mpsc::channel::<ResourceChangedEvent>(4);
+        let (tx_b, mut rx_b) = tokio::sync::mpsc::channel::<ResourceChangedEvent>(4);
         subscriptions.insert(("s1".to_string(), "file:///a.txt".to_string()), tx_a);
         subscriptions.insert(("s1".to_string(), "file:///b.txt".to_string()), tx_b);
 
-        client.poll_notifications(&subscriptions).await;
+        client.process_notification(n1, &subscriptions).await;
+        client.process_notification(n2, &subscriptions).await;
 
         let ev_a = rx_a.try_recv().expect("expected event for a.txt");
         assert_eq!(ev_a.uri, "file:///a.txt");
@@ -2078,32 +1897,25 @@ mod notification_tests {
     }
 
     #[tokio::test]
-    async fn test_poll_notifications_skips_rpc_responses() {
-        // A message with a non-null "id" field is an RPC response — must not
-        // be dispatched as a notification even if it has a "method" field.
+    async fn test_process_notification_skips_rpc_responses() {
         let response = serde_json::json!({
             "jsonrpc": "2.0",
             "id": 42,
             "method": "notifications/resources/updated",
             "params": { "uri": "file:///foo.txt" }
-        })
-        .to_string();
+        });
 
-        let client = client::McpClient::new_for_test(
-            "myserver",
-            MockTransport::with_lines(&[&response]),
-        );
+        let client = client::McpClient::new_for_test("myserver");
 
         let subscriptions: DashMap<
             (String, String),
             tokio::sync::mpsc::Sender<ResourceChangedEvent>,
         > = DashMap::new();
-        let (tx, mut rx) = tokio_mpsc::channel::<ResourceChangedEvent>(4);
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<ResourceChangedEvent>(4);
         subscriptions.insert(("myserver".to_string(), "file:///foo.txt".to_string()), tx);
 
-        client.poll_notifications(&subscriptions).await;
+        client.process_notification(response, &subscriptions).await;
 
-        // The event must NOT have been delivered because the message has an id.
         assert!(
             rx.try_recv().is_err(),
             "RPC response must not be dispatched as a notification"

--- a/src-rust/crates/mcp/src/oauth.rs
+++ b/src-rust/crates/mcp/src/oauth.rs
@@ -3,6 +3,9 @@
 
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpListener;
 
 // ---------------------------------------------------------------------------
 // Token storage
@@ -28,6 +31,10 @@ impl McpToken {
             .unwrap_or_default()
             .as_secs();
         now + grace_secs >= exp
+    }
+
+    pub fn expiry_datetime(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        token_expiry_datetime(self.expires_at)
     }
 }
 
@@ -60,7 +67,287 @@ pub fn get_mcp_token(server_name: &str) -> Option<McpToken> {
 /// Delete the stored token for a server (effectively logs out).
 pub fn remove_mcp_token(server_name: &str) -> std::io::Result<()> {
     let path = token_path(server_name);
-    if path.exists() { std::fs::remove_file(&path) } else { Ok(()) }
+    if path.exists() {
+        std::fs::remove_file(&path)
+    } else {
+        Ok(())
+    }
+}
+
+pub fn token_expiry_datetime(
+    expires_at: Option<u64>,
+) -> Option<chrono::DateTime<chrono::Utc>> {
+    expires_at.map(|timestamp| {
+        chrono::DateTime::<chrono::Utc>::from(
+            std::time::UNIX_EPOCH + std::time::Duration::from_secs(timestamp),
+        )
+    })
+}
+
+// ---------------------------------------------------------------------------
+// OAuth metadata / auth flow helpers
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpOAuthMetadata {
+    pub authorization_endpoint: String,
+    pub token_endpoint: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct McpAuthSession {
+    pub server_name: String,
+    pub auth_url: String,
+    pub redirect_uri: String,
+    pub verifier: String,
+    pub metadata: McpOAuthMetadata,
+}
+
+#[derive(Debug, Clone)]
+pub struct McpAuthResult {
+    pub server_name: String,
+    pub auth_url: String,
+    pub redirect_uri: String,
+    pub token_path: PathBuf,
+}
+
+fn normalized_server_url(server_url: &str) -> &str {
+    server_url.trim_end_matches('/')
+}
+
+fn fallback_oauth_metadata(server_url: &str) -> McpOAuthMetadata {
+    let base_url = normalized_server_url(server_url);
+    McpOAuthMetadata {
+        authorization_endpoint: format!("{}/oauth/authorize", base_url),
+        token_endpoint: format!("{}/oauth/token", base_url),
+    }
+}
+
+fn build_mcp_auth_url(
+    authorization_endpoint: &str,
+    redirect_uri: &str,
+    verifier: &str,
+) -> String {
+    let challenge = pkce_challenge(verifier);
+    format!(
+        "{}?client_id=claurst&redirect_uri={}&response_type=code&code_challenge={}&code_challenge_method=S256",
+        authorization_endpoint,
+        urlencoding::encode(redirect_uri),
+        challenge,
+    )
+}
+
+pub async fn fetch_oauth_metadata(server_url: &str) -> anyhow::Result<McpOAuthMetadata> {
+    let base_url = normalized_server_url(server_url);
+    let fallback = fallback_oauth_metadata(base_url);
+    let metadata_url = format!("{}/.well-known/oauth-authorization-server", base_url);
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|e| anyhow::anyhow!("Failed to build HTTP client: {}", e))?;
+
+    match client.get(&metadata_url).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            let meta: serde_json::Value = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("OAuth metadata parse error: {}", e))?;
+            Ok(McpOAuthMetadata {
+                authorization_endpoint: meta
+                    .get("authorization_endpoint")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or(fallback.authorization_endpoint.as_str())
+                    .to_string(),
+                token_endpoint: meta
+                    .get("token_endpoint")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or(fallback.token_endpoint.as_str())
+                    .to_string(),
+            })
+        }
+        Ok(_) | Err(_) => Ok(fallback),
+    }
+}
+
+pub async fn begin_mcp_auth(
+    server_name: &str,
+    server_url: &str,
+) -> anyhow::Result<McpAuthSession> {
+    let metadata = fetch_oauth_metadata(server_url).await?;
+    let redirect_port = oauth_port_alloc()
+        .map_err(|e| anyhow::anyhow!("Failed to allocate OAuth redirect port: {}", e))?;
+    let redirect_uri = format!("http://127.0.0.1:{}/callback", redirect_port);
+    let verifier = pkce_verifier();
+    let auth_url = build_mcp_auth_url(
+        &metadata.authorization_endpoint,
+        &redirect_uri,
+        &verifier,
+    );
+
+    Ok(McpAuthSession {
+        server_name: server_name.to_string(),
+        auth_url,
+        redirect_uri,
+        verifier,
+        metadata,
+    })
+}
+
+async fn bind_callback_listener(
+    redirect_uri: &str,
+) -> anyhow::Result<(TcpListener, String, String)> {
+    let redirect_url = url::Url::parse(redirect_uri)
+        .map_err(|e| anyhow::anyhow!("Failed to parse redirect URI '{}': {}", redirect_uri, e))?;
+    let host = redirect_url
+        .host_str()
+        .ok_or_else(|| anyhow::anyhow!("Redirect URI '{}' is missing host", redirect_uri))?
+        .to_string();
+    let port = redirect_url
+        .port_or_known_default()
+        .ok_or_else(|| anyhow::anyhow!("Redirect URI '{}' is missing port", redirect_uri))?;
+    let callback_path = if redirect_url.path().is_empty() {
+        "/callback".to_string()
+    } else {
+        redirect_url.path().to_string()
+    };
+    let listener = TcpListener::bind((host.as_str(), port))
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to bind OAuth callback listener on {}:{}: {}", host, port, e))?;
+
+    Ok((listener, host, callback_path))
+}
+
+async fn wait_for_authorization_code(
+    listener: TcpListener,
+    host: &str,
+    callback_path: &str,
+    expected_state: Option<&str>,
+) -> anyhow::Result<String> {
+    let (mut socket, _) = tokio::time::timeout(Duration::from_secs(180), listener.accept())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout waiting for OAuth callback"))?
+        .map_err(|e| anyhow::anyhow!("Failed to accept OAuth callback connection: {}", e))?;
+
+    let (reader, mut writer) = socket.split();
+    let mut reader = BufReader::new(reader);
+    let mut request_line = String::new();
+    reader
+        .read_line(&mut request_line)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to read OAuth callback request: {}", e))?;
+    loop {
+        let mut header = String::new();
+        reader
+            .read_line(&mut header)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to read OAuth callback headers: {}", e))?;
+        if header.trim().is_empty() {
+            break;
+        }
+    }
+
+    let path = request_line.split_whitespace().nth(1).unwrap_or("");
+    let parsed_url = url::Url::parse(&format!("http://{}{}", host, path))
+        .map_err(|e| anyhow::anyhow!("Failed to parse OAuth callback URL '{}': {}", path, e))?;
+
+    let response = "HTTP/1.1 200 OK\r\nContent-Type: text/plain; charset=utf-8\r\nConnection: close\r\n\r\nMCP OAuth authentication finished. You can close this tab.\r\n";
+    writer
+        .write_all(response.as_bytes())
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to write OAuth callback response: {}", e))?;
+
+    if parsed_url.path() != callback_path {
+        anyhow::bail!(
+            "OAuth callback path mismatch: expected '{}', got '{}'",
+            callback_path,
+            parsed_url.path()
+        );
+    }
+
+    if let Some(expected_state) = expected_state {
+        let received_state = parsed_url
+            .query_pairs()
+            .find(|(key, _)| key == "state")
+            .map(|(_, value)| value.to_string());
+        if received_state.as_deref() != Some(expected_state) {
+            anyhow::bail!("OAuth state mismatch — possible CSRF attack");
+        }
+    }
+
+    parsed_url
+        .query_pairs()
+        .find(|(key, _)| key == "code")
+        .map(|(_, value)| value.to_string())
+        .ok_or_else(|| anyhow::anyhow!("OAuth callback did not contain an authorization code"))
+}
+
+pub async fn run_mcp_auth_session(session: McpAuthSession) -> anyhow::Result<McpAuthResult> {
+    let (listener, host, callback_path) = bind_callback_listener(&session.redirect_uri).await?;
+    open::that(&session.auth_url)
+        .map_err(|e| anyhow::anyhow!("Failed to open browser for OAuth: {}", e))?;
+
+    let code = wait_for_authorization_code(listener, &host, &callback_path, None).await?;
+    let mut token = exchange_code(
+        &session.metadata.token_endpoint,
+        &code,
+        &session.verifier,
+        &session.redirect_uri,
+    )
+    .await?;
+    token.server_name = session.server_name.clone();
+    store_mcp_token(&token).map_err(|e| {
+        anyhow::anyhow!(
+            "Failed to store MCP token for '{}': {}",
+            session.server_name,
+            e
+        )
+    })?;
+
+    Ok(McpAuthResult {
+        server_name: session.server_name,
+        auth_url: session.auth_url,
+        redirect_uri: session.redirect_uri,
+        token_path: token_path(&token.server_name),
+    })
+}
+
+pub async fn run_mcp_auth_flow(
+    server_name: &str,
+    server_url: &str,
+) -> anyhow::Result<McpAuthResult> {
+    let session = begin_mcp_auth(server_name, server_url).await?;
+    run_mcp_auth_session(session).await
+}
+
+pub async fn get_valid_mcp_token(
+    server_name: &str,
+    server_url: &str,
+) -> anyhow::Result<Option<McpToken>> {
+    let Some(token) = get_mcp_token(server_name) else {
+        return Ok(None);
+    };
+
+    if !token.is_expired(60) {
+        return Ok(Some(token));
+    }
+
+    if token.refresh_token.is_none() {
+        return Ok(None);
+    }
+
+    let metadata = fetch_oauth_metadata(server_url).await?;
+    refresh_mcp_token(server_name, &metadata.token_endpoint)
+        .await
+        .map(Some)
+}
+
+pub async fn get_valid_mcp_access_token(
+    server_name: &str,
+    server_url: &str,
+) -> anyhow::Result<Option<String>> {
+    Ok(get_valid_mcp_token(server_name, server_url)
+        .await?
+        .map(|token| token.access_token))
 }
 
 // ---------------------------------------------------------------------------
@@ -290,5 +577,43 @@ mod tests {
             server_name: "test".to_string(),
         };
         assert!(t.is_expired(0));
+    }
+
+    #[test]
+    fn fallback_metadata_uses_default_oauth_paths() {
+        let metadata = fallback_oauth_metadata("https://example.com/mcp/");
+        assert_eq!(
+            metadata.authorization_endpoint,
+            "https://example.com/mcp/oauth/authorize"
+        );
+        assert_eq!(metadata.token_endpoint, "https://example.com/mcp/oauth/token");
+    }
+
+    #[test]
+    fn build_auth_url_contains_required_params() {
+        let verifier = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG";
+        let redirect_uri = "http://127.0.0.1:9999/callback";
+        let url = build_mcp_auth_url(
+            "https://example.com/oauth/authorize",
+            redirect_uri,
+            verifier,
+        );
+        assert!(url.contains("client_id=claurst"));
+        assert!(url.contains("response_type=code"));
+        assert!(url.contains("code_challenge_method=S256"));
+        assert!(url.contains("redirect_uri=http%3A%2F%2F127.0.0.1%3A9999%2Fcallback"));
+    }
+
+    #[tokio::test]
+    async fn bind_callback_listener_reuses_redirect_port() {
+        let (listener, host, callback_path) =
+            bind_callback_listener("http://127.0.0.1:14555/callback")
+                .await
+                .expect("listener should bind");
+        let port = listener.local_addr().expect("listener addr").port();
+        assert_eq!(host, "127.0.0.1");
+        assert_eq!(callback_path, "/callback");
+        assert_eq!(port, 14555);
+        drop(listener);
     }
 }

--- a/src-rust/crates/mcp/src/rmcp_backend.rs
+++ b/src-rust/crates/mcp/src/rmcp_backend.rs
@@ -1,0 +1,1007 @@
+use crate::backend::{McpBackendKind, McpClientBackend, McpClientSnapshot};
+use crate::transport;
+use crate::types::{
+    CallToolResult, GetPromptResult, McpContent, McpPrompt, McpPromptArgument,
+    McpResource, McpTool, PromptMessage, PromptMessageContent, PromptsCapability,
+    ResourceContents, ResourcesCapability, ServerCapabilities, ServerInfo, ToolsCapability,
+};
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+use rmcp::model as rmcp_model;
+use rmcp::service::RunningService;
+use rmcp::transport::{
+    ConfigureCommandExt, StreamableHttpClientTransport, TokioChildProcess,
+    streamable_http_client::StreamableHttpClientTransportConfig,
+};
+use rmcp::{ClientHandler, RoleClient, ServiceExt};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex as StdMutex};
+use tokio::process::Command;
+use tokio::sync::{mpsc, oneshot, Mutex};
+use tokio::task::JoinHandle;
+use tokio_stream::wrappers::ReceiverStream;
+
+pub struct RmcpNotificationClient {
+    notifications_tx: mpsc::UnboundedSender<Value>,
+    client_info: rmcp_model::ClientInfo,
+}
+
+impl RmcpNotificationClient {
+    pub fn new(
+        notifications_tx: mpsc::UnboundedSender<Value>,
+        client_info: rmcp_model::ClientInfo,
+    ) -> Self {
+        Self {
+            notifications_tx,
+            client_info,
+        }
+    }
+
+    fn send_notification(&self, method: &str, params: Option<Value>) {
+        let payload = match params {
+            Some(params) => json!({
+                "jsonrpc": "2.0",
+                "method": method,
+                "params": params,
+            }),
+            None => json!({
+                "jsonrpc": "2.0",
+                "method": method,
+            }),
+        };
+        let _ = self.notifications_tx.send(payload);
+    }
+}
+
+impl ClientHandler for RmcpNotificationClient {
+    async fn on_resource_updated(
+        &self,
+        params: rmcp_model::ResourceUpdatedNotificationParam,
+        _context: rmcp::service::NotificationContext<RoleClient>,
+    ) {
+        self.send_notification(
+            "notifications/resources/updated",
+            Some(json!({ "uri": params.uri })),
+        );
+    }
+
+    async fn on_resource_list_changed(
+        &self,
+        _context: rmcp::service::NotificationContext<RoleClient>,
+    ) {
+        self.send_notification("notifications/resources/list_changed", Some(json!({})));
+    }
+
+    async fn on_tool_list_changed(
+        &self,
+        _context: rmcp::service::NotificationContext<RoleClient>,
+    ) {
+        self.send_notification("notifications/tools/list_changed", Some(json!({})));
+    }
+
+    async fn on_prompt_list_changed(
+        &self,
+        _context: rmcp::service::NotificationContext<RoleClient>,
+    ) {
+        self.send_notification("notifications/prompts/list_changed", Some(json!({})));
+    }
+
+    fn get_info(&self) -> rmcp_model::ClientInfo {
+        self.client_info.clone()
+    }
+}
+
+pub struct RmcpClientBackend {
+    snapshot: McpClientSnapshot,
+    peer: rmcp::Peer<RoleClient>,
+    #[allow(dead_code)]
+    running: Mutex<RunningService<RoleClient, RmcpNotificationClient>>,
+    notifications_rx: Arc<Mutex<mpsc::UnboundedReceiver<Value>>>,
+}
+
+impl RmcpClientBackend {
+    pub async fn connect_stdio(
+        config: &claurst_core::config::McpServerConfig,
+    ) -> anyhow::Result<Self> {
+        let command = config
+            .command
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("MCP server '{}' has no command configured", config.name))?;
+
+        let transport = TokioChildProcess::new(Command::new(&command).configure(|cmd| {
+            cmd.args(&config.args);
+            cmd.envs(&config.env);
+        }))
+        .map_err(|e| anyhow::anyhow!("failed to spawn rmcp stdio child for '{}': {}", config.name, e))?;
+
+        let client_info = build_client_info(rmcp_model::ProtocolVersion::default());
+        Self::connect_with_transport(config, transport, client_info, "stdio").await
+    }
+
+    pub async fn connect_http(
+        config: &claurst_core::config::McpServerConfig,
+        auth_token: Option<String>,
+        protocol_version: rmcp_model::ProtocolVersion,
+    ) -> anyhow::Result<Self> {
+        let endpoint = config
+            .url
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("MCP server '{}' has no URL configured", config.name))?;
+
+        let mut transport_config = StreamableHttpClientTransportConfig::with_uri(endpoint);
+        if let Some(token) = auth_token {
+            transport_config = transport_config.auth_header(token);
+        }
+
+        let transport = StreamableHttpClientTransport::from_config(transport_config);
+        let client_info = build_client_info(protocol_version);
+        Self::connect_with_transport(config, transport, client_info, "http").await
+    }
+
+    pub async fn connect_legacy_sse(
+        config: &claurst_core::config::McpServerConfig,
+        auth_token: Option<String>,
+    ) -> anyhow::Result<Self> {
+        // Legacy SSE servers still expose the real POST endpoint via
+        // `event: endpoint`; keep a thin compatibility shim here and hand the
+        // session and capability flow back to rmcp once connected.
+        let transport = LegacySseRmcpTransport::connect(config, auth_token).await?;
+        let client_info = build_client_info(rmcp_model::ProtocolVersion::V_2024_11_05);
+        Self::connect_with_transport(config, transport, client_info, "sse").await
+    }
+
+    async fn connect_with_transport<T, E, A>(
+        config: &claurst_core::config::McpServerConfig,
+        transport: T,
+        client_info: rmcp_model::ClientInfo,
+        transport_label: &str,
+    ) -> anyhow::Result<Self>
+    where
+        T: rmcp::transport::IntoTransport<RoleClient, E, A>,
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        let (notifications_tx, notifications_rx) = mpsc::unbounded_channel();
+        let handler = RmcpNotificationClient::new(notifications_tx, client_info);
+        let running = handler.serve(transport).await.map_err(|e| {
+            anyhow::anyhow!(
+                "rmcp {} client '{}' failed to initialize: {}",
+                transport_label,
+                config.name,
+                e
+            )
+        })?;
+
+        let peer = running.peer().clone();
+        let snapshot = build_snapshot(config, &peer).await?;
+
+        Ok(Self {
+            snapshot,
+            peer,
+            running: Mutex::new(running),
+            notifications_rx: Arc::new(Mutex::new(notifications_rx)),
+        })
+    }
+}
+
+fn build_client_info(protocol_version: rmcp_model::ProtocolVersion) -> rmcp_model::ClientInfo {
+    let mut client_info = rmcp_model::ClientInfo::default();
+    client_info.protocol_version = protocol_version;
+    client_info.capabilities.roots = Some(rmcp_model::RootsCapabilities {
+        list_changed: Some(false),
+    });
+    client_info.client_info = rmcp_model::Implementation::new(
+        claurst_core::constants::APP_NAME,
+        claurst_core::constants::APP_VERSION,
+    );
+    client_info
+}
+
+#[derive(Debug, thiserror::Error)]
+enum LegacySseTransportError {
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+struct LegacySseRmcpTransport {
+    server_name: String,
+    sse_url: String,
+    client: reqwest::Client,
+    auth_token: Option<String>,
+    post_endpoint: Arc<StdMutex<Option<String>>>,
+    incoming_tx: mpsc::UnboundedSender<rmcp::service::RxJsonRpcMessage<RoleClient>>,
+    incoming_rx: Arc<Mutex<mpsc::UnboundedReceiver<rmcp::service::RxJsonRpcMessage<RoleClient>>>>,
+    background_tasks: Arc<StdMutex<Vec<JoinHandle<()>>>>,
+}
+
+impl LegacySseRmcpTransport {
+    async fn connect(
+        config: &claurst_core::config::McpServerConfig,
+        auth_token: Option<String>,
+    ) -> anyhow::Result<Self> {
+        let sse_url = config
+            .url
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("MCP server '{}' has no URL configured", config.name))?;
+        let client = reqwest::Client::new();
+        let (incoming_tx, incoming_rx) = mpsc::unbounded_channel();
+        let transport = Self {
+            server_name: config.name.clone(),
+            sse_url,
+            client,
+            auth_token,
+            post_endpoint: Arc::new(StdMutex::new(None)),
+            incoming_tx,
+            incoming_rx: Arc::new(Mutex::new(incoming_rx)),
+            background_tasks: Arc::new(StdMutex::new(Vec::new())),
+        };
+        transport.start_sse_listener().await?;
+        Ok(transport)
+    }
+
+    async fn start_sse_listener(&self) -> anyhow::Result<()> {
+        let (endpoint_tx, endpoint_rx) = oneshot::channel::<anyhow::Result<String>>();
+        let endpoint_tx = Arc::new(StdMutex::new(Some(endpoint_tx)));
+
+        let mut request = self
+            .client
+            .get(&self.sse_url)
+            .header(reqwest::header::ACCEPT, "text/event-stream");
+        if let Some(token) = &self.auth_token {
+            request = request.header(
+                reqwest::header::AUTHORIZATION,
+                transport::bearer_header_value(token)?,
+            );
+        }
+        let response = request.send().await.map_err(|e| {
+            anyhow::anyhow!(
+                "MCP server '{}': failed to open legacy SSE stream '{}': {}",
+                self.server_name,
+                self.sse_url,
+                e
+            )
+        })?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "MCP server '{}': legacy SSE stream returned HTTP {}: {}",
+                self.server_name,
+                status,
+                body
+            );
+        }
+
+        let server_name = self.server_name.clone();
+        let sse_url = self.sse_url.clone();
+        let post_endpoint = Arc::clone(&self.post_endpoint);
+        let incoming_tx = self.incoming_tx.clone();
+        let endpoint_tx_for_task = Arc::clone(&endpoint_tx);
+        let task = tokio::spawn(async move {
+            let result = transport::process_sse_response(response, |event, data| {
+                if matches!(event, Some("endpoint")) {
+                    let endpoint = transport::resolve_legacy_endpoint(&sse_url, data)?;
+                    *post_endpoint.lock().expect("endpoint mutex poisoned") = Some(endpoint.clone());
+                    if let Some(tx) = endpoint_tx_for_task
+                        .lock()
+                        .expect("endpoint sender mutex poisoned")
+                        .take()
+                    {
+                        let _ = tx.send(Ok(endpoint));
+                    }
+                    return Ok(());
+                }
+
+                if data.trim().is_empty() {
+                    return Ok(());
+                }
+
+                let message = parse_server_message(&server_name, data)?;
+                let _ = incoming_tx.send(message);
+                Ok(())
+            })
+            .await;
+
+            if let Err(e) = result {
+                tracing::warn!(server = %server_name, error = %e, "Legacy SSE stream closed with error");
+                if let Some(tx) = endpoint_tx_for_task
+                    .lock()
+                    .expect("endpoint sender mutex poisoned")
+                    .take()
+                {
+                    let _ = tx.send(Err(anyhow::anyhow!(e.to_string())));
+                }
+            } else if let Some(tx) = endpoint_tx_for_task
+                .lock()
+                .expect("endpoint sender mutex poisoned")
+                .take()
+            {
+                let _ = tx.send(Err(anyhow::anyhow!(
+                    "legacy SSE stream closed before announcing endpoint"
+                )));
+            }
+        });
+        self.background_tasks.lock().expect("task mutex poisoned").push(task);
+
+        let endpoint = tokio::time::timeout(std::time::Duration::from_secs(10), endpoint_rx)
+            .await
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "MCP server '{}': timed out waiting for legacy SSE endpoint event",
+                    self.server_name
+                )
+            })?
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "MCP server '{}': legacy SSE stream ended before endpoint discovery",
+                    self.server_name
+                )
+            })??;
+        *self.post_endpoint.lock().expect("endpoint mutex poisoned") = Some(endpoint);
+        Ok(())
+    }
+}
+
+impl Drop for LegacySseRmcpTransport {
+    fn drop(&mut self) {
+        // Some upper-layer paths drop the backend instead of calling close()
+        // explicitly. Abort the listener tasks again here so legacy SSE does
+        // not outlive the connection teardown.
+        let mut tasks = self.background_tasks.lock().expect("task mutex poisoned");
+        for handle in tasks.drain(..) {
+            handle.abort();
+        }
+    }
+}
+
+impl rmcp::transport::Transport<RoleClient> for LegacySseRmcpTransport {
+    type Error = LegacySseTransportError;
+
+    fn send(
+        &mut self,
+        item: rmcp::service::TxJsonRpcMessage<RoleClient>,
+    ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send + 'static {
+        let endpoint = self
+            .post_endpoint
+            .lock()
+            .expect("endpoint mutex poisoned")
+            .clone();
+        let client = self.client.clone();
+        let auth_token = self.auth_token.clone();
+        let server_name = self.server_name.clone();
+        let incoming_tx = self.incoming_tx.clone();
+        let background_tasks = Arc::clone(&self.background_tasks);
+        async move {
+            let endpoint = endpoint.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "MCP server '{}': legacy SSE POST endpoint has not been discovered",
+                    server_name
+                )
+            })?;
+
+            let mut request = client
+                .post(endpoint)
+                .header(reqwest::header::CONTENT_TYPE, "application/json")
+                .json(&item);
+            if let Some(token) = &auth_token {
+                request = request.header(
+                    reqwest::header::AUTHORIZATION,
+                    transport::bearer_header_value(token)?,
+                );
+            }
+
+            let response = request.send().await.map_err(|e| {
+                anyhow::anyhow!(
+                    "MCP server '{}': legacy SSE POST request failed: {}",
+                    server_name,
+                    e
+                )
+            })?;
+
+            handle_legacy_sse_http_response(server_name, response, incoming_tx, background_tasks)
+                .await
+                .map_err(Into::into)
+        }
+    }
+
+    fn receive(
+        &mut self,
+    ) -> impl std::future::Future<Output = Option<rmcp::service::RxJsonRpcMessage<RoleClient>>> + Send {
+        let incoming_rx = Arc::clone(&self.incoming_rx);
+        async move {
+            let mut rx = incoming_rx.lock().await;
+            rx.recv().await
+        }
+    }
+
+    fn close(&mut self) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send {
+        let background_tasks = Arc::clone(&self.background_tasks);
+        async move {
+            let mut tasks = background_tasks.lock().expect("task mutex poisoned");
+            for handle in tasks.drain(..) {
+                handle.abort();
+            }
+            Ok(())
+        }
+    }
+}
+
+fn parse_server_message(
+    server_name: &str,
+    data: &str,
+) -> anyhow::Result<rmcp::service::RxJsonRpcMessage<RoleClient>> {
+    serde_json::from_str(data).map_err(|e| {
+        anyhow::anyhow!(
+            "MCP server '{}': failed to parse legacy SSE JSON payload: {}",
+            server_name,
+            e
+        )
+    })
+}
+
+async fn handle_legacy_sse_http_response(
+    server_name: String,
+    response: reqwest::Response,
+    incoming_tx: mpsc::UnboundedSender<rmcp::service::RxJsonRpcMessage<RoleClient>>,
+    background_tasks: Arc<StdMutex<Vec<JoinHandle<()>>>>,
+) -> anyhow::Result<()> {
+    let status = response.status();
+    if !status.is_success() && status != reqwest::StatusCode::ACCEPTED {
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!(
+            "MCP server '{}': HTTP {} from legacy SSE transport: {}",
+            server_name,
+            status,
+            body
+        );
+    }
+
+    if status == reqwest::StatusCode::ACCEPTED {
+        return Ok(());
+    }
+
+    if transport::is_event_stream_response(&response) {
+        let server_name_for_task = server_name.clone();
+        let task = tokio::spawn(async move {
+            if let Err(e) = transport::process_sse_response(response, |_, data| {
+                if data.trim().is_empty() {
+                    return Ok(());
+                }
+                let message = parse_server_message(&server_name_for_task, data)?;
+                let _ = incoming_tx.send(message);
+                Ok(())
+            })
+            .await
+            {
+                tracing::warn!(server = %server_name_for_task, error = %e, "legacy SSE POST stream closed with error");
+            }
+        });
+        background_tasks.lock().expect("task mutex poisoned").push(task);
+        return Ok(());
+    }
+
+    let text = response.text().await.map_err(|e| {
+        anyhow::anyhow!(
+            "MCP server '{}': failed to read legacy SSE HTTP response body: {}",
+            server_name,
+            e
+        )
+    })?;
+    if text.trim().is_empty() {
+        return Ok(());
+    }
+
+    let message = parse_server_message(&server_name, &text)?;
+    let _ = incoming_tx.send(message);
+    Ok(())
+}
+
+#[async_trait]
+impl McpClientBackend for RmcpClientBackend {
+    fn kind(&self) -> McpBackendKind {
+        McpBackendKind::Rmcp
+    }
+
+    fn snapshot(&self) -> McpClientSnapshot {
+        self.snapshot.clone()
+    }
+
+    async fn list_tools(&self) -> anyhow::Result<Vec<McpTool>> {
+        let tools = self
+            .peer
+            .list_all_tools()
+            .await
+            .map_err(|e| anyhow::anyhow!("rmcp list_tools failed: {}", e))?;
+        Ok(tools.into_iter().map(convert_tool).collect())
+    }
+
+    async fn call_tool(
+        &self,
+        name: &str,
+        arguments: Option<Value>,
+    ) -> anyhow::Result<CallToolResult> {
+        let mut params = rmcp_model::CallToolRequestParams::new(name.to_string());
+        if let Some(arguments) = arguments {
+            params = params.with_arguments(json_value_to_object(arguments)?);
+        }
+        let result = self
+            .peer
+            .call_tool(params)
+            .await
+            .map_err(|e| anyhow::anyhow!("rmcp call_tool '{}' failed: {}", name, e))?;
+        Ok(convert_call_tool_result(result))
+    }
+
+    async fn list_resources(&self) -> anyhow::Result<Vec<McpResource>> {
+        let resources = self
+            .peer
+            .list_all_resources()
+            .await
+            .map_err(|e| anyhow::anyhow!("rmcp list_resources failed: {}", e))?;
+        Ok(resources.into_iter().map(convert_resource).collect())
+    }
+
+    async fn read_resource(&self, uri: &str) -> anyhow::Result<ResourceContents> {
+        let result = self
+            .peer
+            .read_resource(rmcp_model::ReadResourceRequestParams::new(uri.to_string()))
+            .await
+            .map_err(|e| anyhow::anyhow!("rmcp read_resource '{}' failed: {}", uri, e))?;
+        let first = result
+            .contents
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("rmcp read_resource '{}' returned no contents", uri))?;
+        Ok(convert_resource_contents(first))
+    }
+
+    async fn list_prompts(&self) -> anyhow::Result<Vec<McpPrompt>> {
+        let prompts = self
+            .peer
+            .list_all_prompts()
+            .await
+            .map_err(|e| anyhow::anyhow!("rmcp list_prompts failed: {}", e))?;
+        Ok(prompts.into_iter().map(convert_prompt).collect())
+    }
+
+    async fn get_prompt(
+        &self,
+        name: &str,
+        arguments: Option<HashMap<String, String>>,
+    ) -> anyhow::Result<GetPromptResult> {
+        let mut params = rmcp_model::GetPromptRequestParams::new(name.to_string());
+        if let Some(arguments) = arguments {
+            let args = arguments
+                .into_iter()
+                .map(|(key, value)| (key, Value::String(value)))
+                .collect();
+            params = params.with_arguments(args);
+        }
+        let result = self
+            .peer
+            .get_prompt(params)
+            .await
+            .map_err(|e| anyhow::anyhow!("rmcp get_prompt '{}' failed: {}", name, e))?;
+        Ok(convert_get_prompt_result(result))
+    }
+
+    async fn subscribe_resource(&self, uri: &str) -> anyhow::Result<()> {
+        self.peer
+            .subscribe(rmcp_model::SubscribeRequestParams::new(uri.to_string()))
+            .await
+            .map_err(|e| anyhow::anyhow!("rmcp subscribe '{}' failed: {}", uri, e))
+    }
+
+    async fn unsubscribe_resource(&self, uri: &str) -> anyhow::Result<()> {
+        self.peer
+            .unsubscribe(rmcp_model::UnsubscribeRequestParams::new(uri.to_string()))
+            .await
+            .map_err(|e| anyhow::anyhow!("rmcp unsubscribe '{}' failed: {}", uri, e))
+    }
+
+    fn subscribe_to_notifications(&self) -> BoxStream<'static, anyhow::Result<Value>> {
+        let notifications_rx = Arc::clone(&self.notifications_rx);
+        let (tx, rx) = mpsc::channel::<anyhow::Result<Value>>(100);
+        tokio::spawn(async move {
+            loop {
+                let next = {
+                    let mut receiver = notifications_rx.lock().await;
+                    receiver.recv().await
+                };
+                match next {
+                    Some(value) => {
+                        if tx.send(Ok(value)).await.is_err() {
+                            break;
+                        }
+                    }
+                    None => break,
+                }
+            }
+        });
+        Box::pin(ReceiverStream::new(rx))
+    }
+}
+
+async fn build_snapshot(
+    config: &claurst_core::config::McpServerConfig,
+    peer: &rmcp::Peer<RoleClient>,
+) -> anyhow::Result<McpClientSnapshot> {
+    let server_info = peer.peer_info().cloned();
+
+    let (server_info_value, capabilities, instructions) = match server_info {
+        Some(info) => (
+            Some(ServerInfo {
+                name: info.server_info.name,
+                version: info.server_info.version,
+            }),
+            convert_server_capabilities(info.capabilities),
+            info.instructions,
+        ),
+        None => (None, ServerCapabilities::default(), None),
+    };
+
+    let tools = if capabilities.tools.is_some() {
+        peer.list_all_tools()
+            .await
+            .map_err(|e| anyhow::anyhow!("rmcp list_all_tools failed: {}", e))?
+            .into_iter()
+            .map(convert_tool)
+            .collect()
+    } else {
+        vec![]
+    };
+
+    let resources = if capabilities.resources.is_some() {
+        peer.list_all_resources()
+            .await
+            .map_err(|e| anyhow::anyhow!("rmcp list_all_resources failed: {}", e))?
+            .into_iter()
+            .map(convert_resource)
+            .collect()
+    } else {
+        vec![]
+    };
+
+    let prompts = if capabilities.prompts.is_some() {
+        peer.list_all_prompts()
+            .await
+            .map_err(|e| anyhow::anyhow!("rmcp list_all_prompts failed: {}", e))?
+            .into_iter()
+            .map(convert_prompt)
+            .collect()
+    } else {
+        vec![]
+    };
+
+    Ok(McpClientSnapshot {
+        server_name: config.name.clone(),
+        server_info: server_info_value,
+        capabilities,
+        tools,
+        resources,
+        prompts,
+        instructions,
+    })
+}
+
+fn convert_server_capabilities(capabilities: rmcp_model::ServerCapabilities) -> ServerCapabilities {
+    ServerCapabilities {
+        tools: capabilities.tools.map(|tools| ToolsCapability {
+            list_changed: tools.list_changed.unwrap_or(false),
+        }),
+        resources: capabilities.resources.map(|resources| ResourcesCapability {
+            subscribe: resources.subscribe.unwrap_or(false),
+            list_changed: resources.list_changed.unwrap_or(false),
+        }),
+        prompts: capabilities.prompts.map(|prompts| PromptsCapability {
+            list_changed: prompts.list_changed.unwrap_or(false),
+        }),
+        logging: capabilities.logging.map(Value::Object),
+    }
+}
+
+fn convert_tool(tool: rmcp_model::Tool) -> McpTool {
+    McpTool {
+        name: tool.name.into_owned(),
+        description: tool.description.map(|description| description.into_owned()),
+        input_schema: Value::Object((*tool.input_schema).clone()),
+    }
+}
+
+fn convert_resource(resource: rmcp_model::Resource) -> McpResource {
+    McpResource {
+        uri: resource.uri.clone(),
+        name: resource.name.clone(),
+        description: resource.description.clone(),
+        mime_type: resource.mime_type.clone(),
+        annotations: resource
+            .annotations
+            .as_ref()
+            .and_then(|annotations| serde_json::to_value(annotations).ok()),
+    }
+}
+
+fn convert_prompt(prompt: rmcp_model::Prompt) -> McpPrompt {
+    McpPrompt {
+        name: prompt.name,
+        description: prompt.description,
+        arguments: prompt
+            .arguments
+            .unwrap_or_default()
+            .into_iter()
+            .map(|argument| McpPromptArgument {
+                name: argument.name,
+                description: argument.description,
+                required: argument.required.unwrap_or(false),
+            })
+            .collect(),
+    }
+}
+
+fn convert_resource_contents(resource: rmcp_model::ResourceContents) -> ResourceContents {
+    match resource {
+        rmcp_model::ResourceContents::TextResourceContents {
+            uri,
+            mime_type,
+            text,
+            ..
+        } => ResourceContents {
+            uri,
+            mime_type,
+            text: Some(text),
+            blob: None,
+        },
+        rmcp_model::ResourceContents::BlobResourceContents {
+            uri,
+            mime_type,
+            blob,
+            ..
+        } => ResourceContents {
+            uri,
+            mime_type,
+            text: None,
+            blob: Some(blob),
+        },
+    }
+}
+
+fn convert_prompt_message(message: rmcp_model::PromptMessage) -> PromptMessage {
+    PromptMessage {
+        role: match message.role {
+            rmcp_model::PromptMessageRole::User => "user".to_string(),
+            rmcp_model::PromptMessageRole::Assistant => "assistant".to_string(),
+        },
+        content: match message.content {
+            rmcp_model::PromptMessageContent::Text { text } => PromptMessageContent::Text { text },
+            rmcp_model::PromptMessageContent::Image { image } => PromptMessageContent::Image {
+                data: image.data.clone(),
+                mime_type: image.mime_type.clone(),
+            },
+            rmcp_model::PromptMessageContent::Resource { resource } => {
+                PromptMessageContent::Resource {
+                    resource: serde_json::to_value(resource).unwrap_or(Value::Null),
+                }
+            }
+            rmcp_model::PromptMessageContent::ResourceLink { link } => {
+                PromptMessageContent::Resource {
+                    resource: serde_json::to_value(link).unwrap_or(Value::Null),
+                }
+            }
+        },
+    }
+}
+
+fn convert_get_prompt_result(result: rmcp_model::GetPromptResult) -> GetPromptResult {
+    GetPromptResult {
+        description: result.description,
+        messages: result
+            .messages
+            .into_iter()
+            .map(convert_prompt_message)
+            .collect(),
+    }
+}
+
+fn convert_call_tool_result(result: rmcp_model::CallToolResult) -> CallToolResult {
+    CallToolResult {
+        content: result.content.into_iter().map(convert_content).collect(),
+        is_error: result.is_error.unwrap_or(false),
+    }
+}
+
+fn convert_content(content: rmcp_model::Content) -> McpContent {
+    match content.raw {
+        rmcp_model::RawContent::Text(text) => McpContent::Text { text: text.text },
+        rmcp_model::RawContent::Image(image) => McpContent::Image {
+            data: image.data.clone(),
+            mime_type: image.mime_type.clone(),
+        },
+        rmcp_model::RawContent::Resource(resource) => McpContent::Resource {
+            resource: convert_resource_contents(resource.resource),
+        },
+        rmcp_model::RawContent::ResourceLink(link) => McpContent::Resource {
+            resource: ResourceContents {
+                uri: link.uri,
+                mime_type: link.mime_type,
+                text: None,
+                blob: None,
+            },
+        },
+        rmcp_model::RawContent::Audio(audio) => McpContent::Text {
+            text: format!("[Audio: {} | base64 bytes omitted]", audio.mime_type),
+        },
+    }
+}
+
+
+fn json_value_to_object(value: Value) -> anyhow::Result<rmcp_model::JsonObject> {
+    match value {
+        Value::Object(map) => Ok(map),
+        other => Err(anyhow::anyhow!(
+            "rmcp tool arguments must be a JSON object, got {}",
+            other
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use claurst_core::config::McpServerConfig;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio::time::{Duration, timeout};
+
+    fn test_sse_config(url: String) -> McpServerConfig {
+        McpServerConfig {
+            name: "test-sse".to_string(),
+            command: None,
+            args: vec![],
+            env: HashMap::new(),
+            url: Some(url),
+            server_type: "sse".to_string(),
+        }
+    }
+
+    async fn serve_single_response(
+        status_line: &str,
+        content_type: &str,
+        body: &str,
+    ) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test listener");
+        let addr = listener.local_addr().expect("listener addr");
+        let response = format!(
+            "HTTP/1.1 {status_line}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept test connection");
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf).await;
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("write test response");
+            let _ = stream.shutdown().await;
+        });
+        format!("http://{addr}")
+    }
+
+    async fn fetch_response(status_line: &str, content_type: &str, body: &str) -> reqwest::Response {
+        let url = serve_single_response(status_line, content_type, body).await;
+        reqwest::Client::new()
+            .get(url)
+            .send()
+            .await
+            .expect("fetch test response")
+    }
+
+    #[test]
+    fn build_client_info_sets_expected_protocol_and_identity() {
+        let info = build_client_info(rmcp_model::ProtocolVersion::V_2024_11_05);
+        assert_eq!(info.protocol_version, rmcp_model::ProtocolVersion::V_2024_11_05);
+        assert_eq!(info.client_info.name, claurst_core::constants::APP_NAME);
+        assert_eq!(info.client_info.version, claurst_core::constants::APP_VERSION);
+        assert_eq!(
+            info.capabilities
+                .roots
+                .as_ref()
+                .and_then(|roots| roots.list_changed),
+            Some(false)
+        );
+    }
+
+    #[tokio::test]
+    async fn legacy_sse_transport_connect_discovers_endpoint_event() {
+        let body = "event: endpoint\ndata: /messages\n\n";
+        let url = serve_single_response("200 OK", "text/event-stream", body).await;
+        let config = test_sse_config(url.clone());
+
+        let transport = LegacySseRmcpTransport::connect(&config, None)
+            .await
+            .expect("connect legacy sse transport");
+
+        let endpoint = transport
+            .post_endpoint
+            .lock()
+            .expect("endpoint mutex poisoned")
+            .clone();
+        let expected = format!("{url}/messages");
+        assert_eq!(endpoint.as_deref(), Some(expected.as_str()));
+    }
+
+    #[tokio::test]
+    async fn handle_legacy_sse_http_response_queues_json_message() {
+        let response = fetch_response(
+            "200 OK",
+            "application/json",
+            r#"{"jsonrpc":"2.0","id":1,"result":{}}"#,
+        )
+        .await;
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let tasks = Arc::new(StdMutex::new(Vec::new()));
+
+        handle_legacy_sse_http_response("test".to_string(), response, tx, Arc::clone(&tasks))
+            .await
+            .expect("handle json response");
+
+        let message = timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("json response timeout")
+            .expect("json response message");
+        assert!(matches!(message, rmcp::service::RxJsonRpcMessage::<RoleClient>::Response(_)));
+    }
+
+    #[tokio::test]
+    async fn handle_legacy_sse_http_response_queues_sse_message() {
+        let response = fetch_response(
+            "200 OK",
+            "text/event-stream",
+            "data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n\n",
+        )
+        .await;
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let tasks = Arc::new(StdMutex::new(Vec::new()));
+
+        handle_legacy_sse_http_response("test".to_string(), response, tx, Arc::clone(&tasks))
+            .await
+            .expect("handle sse response");
+
+        let message = timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("sse response timeout")
+            .expect("sse response message");
+        assert!(matches!(message, rmcp::service::RxJsonRpcMessage::<RoleClient>::Response(_)));
+    }
+
+    #[tokio::test]
+    async fn legacy_sse_transport_drop_aborts_background_tasks() {
+        let task = tokio::spawn(async move {
+            loop {
+                tokio::task::yield_now().await;
+            }
+        });
+
+        let transport = LegacySseRmcpTransport {
+            server_name: "test".to_string(),
+            sse_url: "http://localhost/sse".to_string(),
+            client: reqwest::Client::new(),
+            auth_token: None,
+            post_endpoint: Arc::new(StdMutex::new(None)),
+            incoming_tx: mpsc::unbounded_channel().0,
+            incoming_rx: Arc::new(Mutex::new(mpsc::unbounded_channel().1)),
+            background_tasks: Arc::new(StdMutex::new(vec![task])),
+        };
+
+        let background_tasks = Arc::clone(&transport.background_tasks);
+        drop(transport);
+
+        let is_empty = background_tasks
+            .lock()
+            .expect("task mutex poisoned")
+            .is_empty();
+        assert!(is_empty);
+    }
+}

--- a/src-rust/crates/tools/src/mcp_auth_tool.rs
+++ b/src-rust/crates/tools/src/mcp_auth_tool.rs
@@ -3,12 +3,10 @@
 // Tool name: "mcp__auth"
 //
 // When called by the LLM (or user) with a `server_name`, this tool:
-//  1. Checks whether the server is already connected (no auth needed).
-//  2. If the server is an HTTP/SSE server, calls `McpManager::initiate_auth()`
-//     to fetch `/.well-known/oauth-authorization-server` metadata, build the
-//     PKCE authorization URL, and return it so the user can open it.
-//  3. Attempts to open the URL in the system browser (best-effort).
-//  4. For stdio servers, explains env-var based authentication.
+//  1. Checks whether the server is already connected (or currently connecting).
+//  2. If the server is a remote MCP server (`http` / `sse`), runs the browser-
+//     based OAuth flow and stores the resulting token locally.
+//  3. For stdio servers, explains env-var based authentication.
 //
 // This mirrors the TypeScript `mcp__<name>__authenticate` dynamic tool.
 
@@ -32,8 +30,8 @@ impl Tool for McpAuthTool {
 
     fn description(&self) -> &str {
         "Start the OAuth 2.0 + PKCE authorization flow for an MCP server that \
-         requires authentication. Returns the authorization URL that the user \
-         should open in their browser. For stdio servers that use environment \
+         requires authentication. Completes the browser flow and stores the \
+         resulting token locally. For stdio servers that use environment \
          variables for auth, returns setup instructions instead."
     }
 
@@ -74,11 +72,12 @@ impl Tool for McpAuthTool {
         // 1. Check current connection status.
         match manager.server_status(&params.server_name) {
             McpServerStatus::Connected { tool_count } => {
-                return ToolResult::success(format!(
-                    "MCP server \"{}\" is already connected ({} tool(s) available). \
-                     No authentication needed.",
-                    params.server_name, tool_count
-                ));
+                // Fall through to allow re-authentication even when already connected.
+                tracing::debug!(
+                    server = %params.server_name,
+                    tool_count,
+                    "McpAuthTool: server already connected; continuing with re-authentication"
+                );
             }
             McpServerStatus::Connecting => {
                 return ToolResult::success(format!(
@@ -91,7 +90,7 @@ impl Tool for McpAuthTool {
                 tracing::debug!(
                     server = %params.server_name,
                     error = %error,
-                    "McpAuthTool: server failed; attempting to initiate auth"
+                    "McpAuthTool: server failed; attempting to authenticate"
                 );
             }
             McpServerStatus::Disconnected { .. } => {
@@ -99,31 +98,30 @@ impl Tool for McpAuthTool {
             }
         }
 
-        // 2. Use McpManager::initiate_auth() to build the PKCE auth URL.
-        match manager.initiate_auth(&params.server_name).await {
-            Ok(auth_url) => {
-                // 3. Best-effort browser open.
-                let _ = open::that(&auth_url);
-
-                ToolResult::success(
-                    json!({
-                        "status": "auth_required",
-                        "auth_url": auth_url,
-                        "message": format!(
-                            "Opening browser for OAuth authentication of \"{}\".\n\
-                             If the browser did not open, visit:\n\n  {}\n\n\
-                             After authorizing, run /mcp connect {} to reconnect.",
-                            params.server_name, auth_url, params.server_name
-                        )
-                    })
-                    .to_string(),
-                )
-            }
+        // 2. Run the full OAuth flow and persist the resulting token.
+        match manager.authenticate(&params.server_name).await {
+            Ok(result) => ToolResult::success(
+                json!({
+                    "status": "authenticated",
+                    "server_name": result.server_name,
+                    "auth_url": result.auth_url,
+                    "redirect_uri": result.redirect_uri,
+                    "token_path": result.token_path,
+                    "message": format!(
+                        "Completed OAuth authentication for \"{}\" and saved the token.\n\
+                         Token path: {}\n\
+                         You can now run /mcp connect {} or press r in the MCP panel to reconnect.",
+                        result.server_name,
+                        result.token_path.display(),
+                        result.server_name
+                    )
+                })
+                .to_string(),
+            ),
             Err(e) => {
-                // initiate_auth() failed (e.g. no URL configured, network error).
                 // Return a descriptive error so the LLM can guide the user.
                 ToolResult::error(format!(
-                    "Could not initiate OAuth for \"{}\": {}\n\n\
+                    "Could not complete OAuth for \"{}\": {}\n\n\
                      This may mean the server is a stdio server (uses env-var auth) \
                      or its URL is not configured. Run /mcp auth {} in the Claude \
                      interface for detailed instructions.",

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -729,6 +729,8 @@ pub struct App {
     pub mcp_manager: Option<Arc<claurst_mcp::McpManager>>,
     /// Queued request for a real MCP reconnect from the interactive loop.
     pub pending_mcp_reconnect: bool,
+    /// Pending MCP panel-auth request for the interactive loop.
+    pub pending_mcp_panel_auth: Option<String>,
     /// Shared file-history service used for turn diff reconstruction.
     pub file_history: Option<Arc<parking_lot::Mutex<FileHistory>>>,
     /// Shared query-loop turn counter for turn-local diff reconstruction.
@@ -1174,6 +1176,7 @@ impl App {
             remote_session_url: None,
             mcp_manager: None,
             pending_mcp_reconnect: false,
+            pending_mcp_panel_auth: None,
             file_history: None,
             current_turn: None,
             plan_mode: false,
@@ -1742,6 +1745,7 @@ impl App {
         self.custom_provider_dialog = crate::custom_provider_dialog::CustomProviderDialogState::new();
         self.device_auth_dialog = crate::device_auth_dialog::DeviceAuthDialogState::new();
         self.device_auth_pending = None;
+        self.pending_mcp_panel_auth = None;
         self.model_picker_fetch_pending = false;
         self.has_credentials = has_credentials;
         self.fast_mode = false;
@@ -1753,6 +1757,13 @@ impl App {
 
     /// Handle slash commands that should open UI screens rather than execute
     /// as normal commands. Returns `true` if the command was intercepted.
+    pub fn intercept_slash_command_with_args(&mut self, cmd: &str, args: &str) -> bool {
+        if cmd == "mcp" && !args.trim().is_empty() {
+            return false;
+        }
+        self.intercept_slash_command(cmd)
+    }
+
     pub fn intercept_slash_command(&mut self, cmd: &str) -> bool {
         self.close_secondary_views();
         match cmd {
@@ -2474,6 +2485,10 @@ impl App {
         self.mcp_view.open(servers);
     }
 
+    pub fn take_pending_mcp_panel_auth(&mut self) -> Option<String> {
+        self.pending_mcp_panel_auth.take()
+    }
+
     pub fn take_pending_mcp_reconnect(&mut self) -> bool {
         let pending = self.pending_mcp_reconnect;
         self.pending_mcp_reconnect = false;
@@ -3111,8 +3126,7 @@ impl App {
         }
 
         if self.mcp_view.open {
-            self.handle_mcp_view_key(key);
-            return false;
+            return self.handle_mcp_view_key(key);
         }
 
         if self.stats_dialog.open {
@@ -3762,7 +3776,7 @@ impl App {
         }
     }
 
-    fn handle_mcp_view_key(&mut self, key: KeyEvent) {
+    fn handle_mcp_view_key(&mut self, key: KeyEvent) -> bool {
         match key.code {
             KeyCode::Esc | KeyCode::Char('q') => self.mcp_view.close(),
             KeyCode::Tab | KeyCode::Left | KeyCode::Right => self.mcp_view.switch_pane(),
@@ -3770,6 +3784,20 @@ impl App {
             KeyCode::Down => self.mcp_view.select_next(),
             KeyCode::Backspace => self.mcp_view.pop_search_char(),
             KeyCode::Char('e') => self.mcp_view.toggle_error_detail(),
+            KeyCode::Char('a')
+                if self.mcp_view.active_pane == crate::mcp_view::McpViewPane::ServerList =>
+            {
+                let selected_server = self
+                    .mcp_view
+                    .servers
+                    .get(self.mcp_view.selected_server)
+                    .map(|server| server.name.clone());
+                if let Some(server_name) = selected_server {
+                    self.pending_mcp_panel_auth = Some(server_name);
+                    self.mcp_view.close();
+                    self.status_message = Some("Starting MCP auth...".to_string());
+                }
+            }
             KeyCode::Char('r') => {
                 self.pending_mcp_reconnect = true;
                 self.status_message = Some("Reconnecting MCP runtime...".to_string());
@@ -3781,6 +3809,7 @@ impl App {
             }
             _ => {}
         }
+        false
     }
 
     fn handle_agents_menu_key(&mut self, key: KeyEvent) {
@@ -5276,12 +5305,10 @@ impl App {
                         if should_submit {
                             // Check if this is a slash command that should open a UI screen
                             if crate::input::is_slash_command(&self.prompt_input.text) {
-                                let cmd = {
-                                    let (c, _) =
-                                        crate::input::parse_slash_command(&self.prompt_input.text);
-                                    c.to_string()
-                                };
-                                if self.intercept_slash_command(&cmd) {
+                                let slash_input = self.prompt_input.text.clone();
+                                let (cmd, args) =
+                                        crate::input::parse_slash_command(&slash_input);
+                                if self.intercept_slash_command_with_args(cmd, args) {
                                     self.clear_prompt();
                                     continue;
                                 }
@@ -5387,6 +5414,13 @@ mod tests {
             kind: KeyEventKind::Press,
             state: KeyEventState::NONE,
         }
+    }
+
+    #[test]
+    fn test_mcp_subcommand_is_not_intercepted() {
+        let mut app = make_app();
+        assert!(!app.intercept_slash_command_with_args("mcp", "auth mcphub"));
+        assert!(!app.mcp_view.open);
     }
 
     #[test]

--- a/src-rust/crates/tui/src/lib.rs
+++ b/src-rust/crates/tui/src/lib.rs
@@ -908,6 +908,85 @@ mod tests {
     }
 
     #[test]
+    fn test_mcp_view_auth_key_queues_selected_server_panel_auth() {
+        let mut app = make_app();
+        app.mcp_view.open(vec![McpServerView {
+            name: "mcphub".to_string(),
+            transport: "http".to_string(),
+            status: McpViewStatus::Connected,
+            tool_count: 1,
+            resource_count: 0,
+            prompt_count: 0,
+            resources: vec![],
+            prompts: vec![],
+            error_message: None,
+            tools: vec![McpToolView {
+                name: "read_file".to_string(),
+                server: "mcphub".to_string(),
+                description: "Read a file".to_string(),
+                input_schema: None,
+            }],
+        }]);
+
+        let submit = app.handle_key_event(key(KeyCode::Char('a')));
+        assert!(!submit);
+        assert_eq!(app.prompt_input.text, "");
+        assert_eq!(app.take_pending_mcp_panel_auth().as_deref(), Some("mcphub"));
+        assert!(!app.mcp_view.open);
+        assert_eq!(app.mcp_view.tool_search, "");
+    }
+
+    #[test]
+    fn test_mcp_view_auth_key_with_no_servers_is_safe_noop() {
+        let mut app = make_app();
+        app.mcp_view.open(vec![]);
+
+        let submit = app.handle_key_event(key(KeyCode::Char('a')));
+        assert!(!submit);
+        assert!(app.mcp_view.open);
+        assert_eq!(app.prompt_input.text, "");
+        assert!(app.take_pending_mcp_panel_auth().is_none());
+    }
+
+    #[test]
+    fn test_mcp_view_auth_key_only_works_in_servers_pane() {
+        let mut app = make_app();
+        app.mcp_view.open(vec![McpServerView {
+            name: "mcphub".to_string(),
+            transport: "http".to_string(),
+            status: McpViewStatus::Connected,
+            tool_count: 1,
+            resource_count: 0,
+            prompt_count: 0,
+            resources: vec![],
+            prompts: vec![],
+            error_message: None,
+            tools: vec![McpToolView {
+                name: "read_file".to_string(),
+                server: "mcphub".to_string(),
+                description: "Read a file".to_string(),
+                input_schema: None,
+            }],
+        }]);
+        app.mcp_view.switch_pane();
+
+        let submit = app.handle_key_event(key(KeyCode::Char('a')));
+        assert!(!submit);
+        assert!(app.mcp_view.open);
+        assert_eq!(app.mcp_view.tool_search, "a");
+        assert!(app.take_pending_mcp_panel_auth().is_none());
+    }
+
+    #[test]
+    fn test_take_pending_mcp_panel_auth_clears_after_read() {
+        let mut app = make_app();
+        app.pending_mcp_panel_auth = Some("mcphub".to_string());
+
+        assert_eq!(app.take_pending_mcp_panel_auth().as_deref(), Some("mcphub"));
+        assert!(app.take_pending_mcp_panel_auth().is_none());
+    }
+
+    #[test]
     fn test_message_renderer_includes_tool_use_and_thinking_blocks() {
         let msg = claurst_core::types::Message::assistant_blocks(vec![
             ContentBlock::Thinking {

--- a/src-rust/crates/tui/src/mcp_view.rs
+++ b/src-rust/crates/tui/src/mcp_view.rs
@@ -283,6 +283,8 @@ pub fn render_mcp_view(state: &McpViewState, area: Rect, buf: &mut Buffer) {
         Span::raw("filter tools  "),
         Span::styled(" e ", Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)),
         Span::raw("error detail  "),
+        Span::styled(" a ", Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)),
+        Span::raw("auth  "),
         Span::styled(" r ", Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)),
         Span::raw("reconnect"),
     ]);
@@ -645,6 +647,19 @@ mod tests {
         let buf = terminal.backend().buffer().clone();
         let content: String = buf.content().iter().map(|c| c.symbol().chars().next().unwrap_or(' ')).collect();
         assert!(content.contains("timeout") || content.contains("Error Detail"));
+    }
+
+    #[test]
+    fn mcp_view_footer_renders_auth_hotkey() {
+        let mut terminal = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        let mut state = McpViewState::new();
+        state.open(vec![make_server("fs-server", McpViewStatus::Connected, None)]);
+        terminal.draw(|frame| {
+            render_mcp_view(&state, frame.area(), frame.buffer_mut());
+        }).unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let content: String = buf.content().iter().map(|c| c.symbol().chars().next().unwrap_or(' ')).collect();
+        assert!(content.contains("auth") || content.contains(" a "));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

  - Add rmcp-backed MCP support for stdio, http, and sse
  - Add OAuth initiation for MCP servers
  - Keep legacy SSE compatibility through endpoint discovery before handing session flow to rmcp
  - Upgrade workspace reqwest to 0.13 and remove the parallel reqwest version from the dependency tree
  - Add focused MCP transport tests for protocol fallback, legacy SSE endpoint discovery, JSON/SSE response handling, and teardown behavior
  - Fix /mcp subcommand flows across all subcommands (including auth, logs, etc.)

## Why

  Before this change, MCP support was effectively limited to stdio.

  That meant remote MCP servers using http or sse could not be supported through the same backend path, and OAuth-based MCP server initiation was  not part of the flow.

  This change expands MCP transport support to rmcp-backed stdio, http, and sse, adds OAuth initiation for MCP servers, and aligns the workspace  HTTP stack on reqwest 0.13 so the transport layer matches the backend we now standardize on.

## Notes

  - Legacy SSE servers are still supported through a thin compatibility shim that consumes event: endpoint before handing session and capability flow back to rmcp
  - HTTP protocol downgrade fallback is preserved for known MCP protocol version errors
  - Workspace reqwest is now unified on 0.13.2

## Test plan

  - cargo test -p claurst-mcp --lib --tests
  - cargo test -p claurst-core --lib --tests
  - cargo check -p claurst-mcp -p claurst -p claurst-commands -p claurst-tools -p claurst-tui -p claurst-plugins -p claurst-bridge
  - cargo tree -i reqwest

## Issue
#101