### PR TITLE
feat: wire PermissionManager into the interactive permission flow

### DIFF
--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -1256,13 +1256,20 @@ fn permission_request_from_core(
     let tool_use_id = pending.tool_use_id.clone();
 
     match (tool_name.as_str(), pending.request.path.clone()) {
-        ("Bash", Some(command)) => claurst_tui::dialogs::PermissionRequest::bash(
-            tool_use_id,
-            tool_name,
-            reason,
-            command,
-            None,
-        ),
+        ("Bash", Some(command)) => {
+            let suggested_prefix = command
+                .split_whitespace()
+                .next()
+                .filter(|prefix| !prefix.is_empty())
+                .map(|prefix| format!("{} ", prefix));
+            claurst_tui::dialogs::PermissionRequest::bash(
+                tool_use_id,
+                tool_name,
+                reason,
+                command,
+                suggested_prefix,
+            )
+        },
         ("PowerShell", Some(command)) => claurst_tui::dialogs::PermissionRequest::powershell(
             tool_use_id,
             tool_name,
@@ -2270,19 +2277,31 @@ async fn run_interactive(
                     break;
                 };
 
-                let reevaluated = tool_ctx
-                    .permission_manager
-                    .as_ref()
-                    .and_then(|manager| manager.lock().ok())
-                    .map(|manager| {
-                        manager.evaluate(
-                            &pending.request.tool_name,
-                            &pending.request.description,
-                            pending.request.path.as_deref(),
-                            pending.request.working_dir.as_deref(),
-                            &pending.request.allowed_roots,
-                        )
-                    });
+                let prefix_allowed = pending.request.tool_name == "Bash"
+                    && pending
+                        .request
+                        .path
+                        .as_deref()
+                        .map(|command| app.bash_command_allowed_by_prefix(command))
+                        .unwrap_or(false);
+
+                let reevaluated = if prefix_allowed {
+                    Some(claurst_core::permissions::PermissionDecision::Allow)
+                } else {
+                    tool_ctx
+                        .permission_manager
+                        .as_ref()
+                        .and_then(|manager| manager.lock().ok())
+                        .map(|manager| {
+                            manager.evaluate(
+                                &pending.request.tool_name,
+                                &pending.request.description,
+                                pending.request.path.as_deref(),
+                                pending.request.working_dir.as_deref(),
+                                &pending.request.allowed_roots,
+                            )
+                        })
+                };
 
                 match reevaluated {
                     Some(claurst_core::permissions::PermissionDecision::Ask { .. }) | None => {

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -1259,7 +1259,6 @@ fn permission_request_from_core(
         ("Bash", Some(command)) => claurst_tui::dialogs::PermissionRequest::bash(
             tool_use_id,
             tool_name,
-            pending.request.description.clone(),
             reason,
             command,
             None,
@@ -1267,7 +1266,6 @@ fn permission_request_from_core(
         ("PowerShell", Some(command)) => claurst_tui::dialogs::PermissionRequest::powershell(
             tool_use_id,
             tool_name,
-            pending.request.description.clone(),
             reason,
             command,
         ),

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -36,7 +36,7 @@ use claurst_core::{
     constants::APP_VERSION,
     context::ContextBuilder,
     cost::CostTracker,
-    permissions::{AutoPermissionHandler, InteractivePermissionHandler},
+    permissions::{AutoPermissionHandler, InteractivePermissionHandler, PermissionManager},
 };
 use async_trait::async_trait;
 use claurst_core::types::ToolDefinition;
@@ -76,7 +76,12 @@ impl Tool for McpToolWrapper {
         self.tool_def.input_schema.clone()
     }
 
-    async fn execute(&self, input: serde_json::Value, _ctx: &ToolContext) -> ToolResult {
+    async fn execute(&self, input: serde_json::Value, ctx: &ToolContext) -> ToolResult {
+        let desc = format!("Run MCP tool {}", self.tool_def.name);
+        if let Err(e) = ctx.check_permission(self.name(), &desc, false) {
+            return ToolResult::error(e.to_string());
+        }
+
         // Strip the server-name prefix to get the bare tool name.
         let prefix = format!("{}_", self.server_name);
         let bare_name = self
@@ -586,18 +591,15 @@ async fn main() -> anyhow::Result<()> {
         );
     }
 
-    // Build tools
-    // Interactive mode uses InteractivePermissionHandler which allows writes in Default mode
-    // (the user is watching the TUI so they can intervene). Headless/print mode uses
-    // AutoPermissionHandler which denies writes in Default mode for safety.
+    let permission_manager = Arc::new(std::sync::Mutex::new(PermissionManager::new(
+        config.permission_mode.clone(),
+        &settings,
+    )));
+
     let permission_handler: Arc<dyn claurst_core::PermissionHandler> = if is_headless {
-        Arc::new(AutoPermissionHandler {
-            mode: config.permission_mode.clone(),
-        })
+        Arc::new(AutoPermissionHandler::with_manager(permission_manager.clone()))
     } else {
-        Arc::new(InteractivePermissionHandler {
-            mode: config.permission_mode.clone(),
-        })
+        Arc::new(InteractivePermissionHandler::with_manager(permission_manager.clone()))
     };
     let cost_tracker = CostTracker::new();
     // Use --session-id if provided, otherwise generate a fresh UUID.
@@ -613,6 +615,8 @@ async fn main() -> anyhow::Result<()> {
     // Initialize MCP servers first (needed for ToolContext.mcp_manager).
     let mcp_manager_arc = connect_mcp_manager_arc(&config).await;
 
+    let pending_permissions = Arc::new(ParkingMutex::new(claurst_tools::PendingPermissionStore::default()));
+
     let tool_ctx = ToolContext {
         working_dir: cwd.clone(),
         permission_mode: config.permission_mode.clone(),
@@ -626,6 +630,8 @@ async fn main() -> anyhow::Result<()> {
         config: config.clone(),
         managed_agent_config: config.managed_agents.clone(),
         completion_notifier: None,
+        pending_permissions: Some(pending_permissions.clone()),
+        permission_manager: Some(permission_manager.clone()),
     };
 
     // Register the cc-query-backed agent runner so TeamCreateTool can spawn real
@@ -1242,6 +1248,48 @@ async fn run_headless(
 // Interactive REPL mode
 // ---------------------------------------------------------------------------
 
+fn permission_request_from_core(
+    pending: &claurst_tools::PendingPermissionRequest,
+) -> claurst_tui::dialogs::PermissionRequest {
+    let reason = pending.reason.clone();
+    let tool_name = pending.request.tool_name.clone();
+    let tool_use_id = pending.tool_use_id.clone();
+
+    match (tool_name.as_str(), pending.request.path.clone()) {
+        ("Bash", Some(command)) => claurst_tui::dialogs::PermissionRequest::bash(
+            tool_use_id,
+            tool_name,
+            pending.request.description.clone(),
+            reason,
+            command,
+            None,
+        ),
+        ("PowerShell", Some(command)) => claurst_tui::dialogs::PermissionRequest::powershell(
+            tool_use_id,
+            tool_name,
+            pending.request.description.clone(),
+            reason,
+            command,
+        ),
+        ("Read", Some(path)) => claurst_tui::dialogs::PermissionRequest::file_read(
+            tool_use_id,
+            tool_name,
+            reason,
+            path,
+        ),
+        (_, Some(path)) if matches!(tool_name.as_str(), "Write" | "Edit" | "NotebookEdit") => {
+            claurst_tui::dialogs::PermissionRequest::file_write(tool_use_id, tool_name, reason, path)
+        }
+        _ => claurst_tui::dialogs::PermissionRequest::from_reason(
+            tool_use_id,
+            tool_name,
+            reason,
+            pending.request.path.clone(),
+        ),
+    }
+}
+
+
 async fn run_interactive(
     config: Config,
     settings: claurst_core::config::Settings,
@@ -1310,7 +1358,11 @@ async fn run_interactive(
     if !session.model.is_empty() {
         live_config.model = Some(session.model.clone());
     }
-    tool_ctx.config = live_config.clone();
+    let pending_permissions = tool_ctx
+        .pending_permissions
+        .clone()
+        .unwrap_or_else(|| Arc::new(ParkingMutex::new(claurst_tools::PendingPermissionStore::default())));
+
 
     // Set up terminal
     let mut terminal = setup_terminal()?;
@@ -2096,10 +2148,84 @@ async fn run_interactive(
                         current_query = Some((handle, msgs_arc));
                         continue;
                     }
+                    if let Some(pr) = app.permission_request.as_mut() {
+                        if claurst_tui::dialogs::handle_permission_key(pr, key) {
+                            let tool_use_id = pr.tool_use_id.clone();
+                            let selected_option = pr.selected_option;
+                            let selected_key = pr.options.get(selected_option).map(|o| o.key);
+                            let should_record_bash_prefix = selected_key == Some('P');
+                            let selected_path = pending_permissions
+                                .lock()
+                                .waiting
+                                .get(&tool_use_id)
+                                .and_then(|p| p.request.path.clone());
+                            let bash_prefix = if should_record_bash_prefix {
+                                match &pr.kind {
+                                    claurst_tui::dialogs::PermissionDialogKind::Bash { command, .. } => {
+                                        let first_word = command.split_whitespace().next().unwrap_or("").to_string();
+                                        if first_word.is_empty() { None } else { Some(first_word) }
+                                    }
+                                    _ => None,
+                                }
+                            } else {
+                                None
+                            };
+                            app.permission_request = None;
+
+                            if let Some(prefix) = bash_prefix {
+                                app.bash_prefix_allowlist.insert(prefix);
+                            }
+
+                            if let Some(mut pending) = pending_permissions.lock().waiting.remove(&tool_use_id) {
+                                let decision = match selected_key {
+                                    Some('n') => claurst_core::permissions::PermissionDecision::Deny,
+                                    _ => claurst_core::permissions::PermissionDecision::Allow,
+                                };
+
+                                if let Some(manager) = tool_ctx.permission_manager.as_ref() {
+                                    if let Ok(mut manager) = manager.lock() {
+                                        match selected_key {
+                                            Some('Y') => {
+                                                if let Some(path) = selected_path.as_deref() {
+                                                    manager.add_session_allow_path(&pending.request.tool_name, path);
+                                                } else {
+                                                    manager.add_session_allow(&pending.request.tool_name);
+                                                }
+                                            }
+                                            Some('p') => {
+                                                let mut settings = match claurst_core::config::Settings::load_sync() {
+                                                    Ok(s) => s,
+                                                    Err(_) => claurst_core::config::Settings::default(),
+                                                };
+                                                if let Some(path) = selected_path.as_deref() {
+                                                    let pattern = format!("{}*", path);
+                                                    let _ = manager.add_persistent_allow_path(&pending.request.tool_name, &pattern, &mut settings);
+                                                } else {
+                                                    let _ = manager.add_persistent_allow(&pending.request.tool_name, &mut settings);
+                                                }
+                                            }
+                                            _ => {}
+                                        }
+                                    }
+                                }
+
+                                if let Some(tx) = pending.decision_tx.take() {
+                                    let _ = tx.send(decision);
+                                }
+                            }
+                            continue;
+                        }
+                        continue;
+                    }
 
                     app.handle_key_event(key);
                     cmd_ctx.config = app.config.clone();
                     tool_ctx.config = app.config.clone();
+                    if let Some(manager) = tool_ctx.permission_manager.as_ref() {
+                        if let Ok(mut manager) = manager.lock() {
+                            manager.mode = tool_ctx.config.permission_mode.clone();
+                        }
+                    }
                     if !app.model_name.is_empty() {
                         session.model = app.model_name.clone();
                     }
@@ -2136,6 +2262,43 @@ async fn run_interactive(
                     // Terminal resize - will be handled on next draw
                 }
                 _ => {}
+            }
+        }
+
+        if app.permission_request.is_none() {
+            loop {
+                let next_pending = pending_permissions.lock().queue.pop_front();
+                let Some(mut pending) = next_pending else {
+                    break;
+                };
+
+                let reevaluated = tool_ctx
+                    .permission_manager
+                    .as_ref()
+                    .and_then(|manager| manager.lock().ok())
+                    .map(|manager| {
+                        manager.evaluate(
+                            &pending.request.tool_name,
+                            &pending.request.description,
+                            pending.request.path.as_deref(),
+                            pending.request.working_dir.as_deref(),
+                            &pending.request.allowed_roots,
+                        )
+                    });
+
+                match reevaluated {
+                    Some(claurst_core::permissions::PermissionDecision::Ask { .. }) | None => {
+                        let tool_use_id = pending.tool_use_id.clone();
+                        app.permission_request = Some(permission_request_from_core(&pending));
+                        pending_permissions.lock().waiting.insert(tool_use_id, pending);
+                        break;
+                    }
+                    Some(decision) => {
+                        if let Some(tx) = pending.decision_tx.take() {
+                            let _ = tx.send(decision);
+                        }
+                    }
+                }
             }
         }
 

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -2085,6 +2085,28 @@ pub mod permissions {
     // PermissionManager
     // -----------------------------------------------------------------------
 
+    /// Returns true when `path` falls under the active workspace roots.
+    fn is_path_within_allowed_roots(
+        path: &str,
+        working_dir: Option<&std::path::Path>,
+        allowed_roots: &[std::path::PathBuf],
+    ) -> bool {
+        let canonical_path = std::fs::canonicalize(path)
+            .unwrap_or_else(|_| std::path::PathBuf::from(path));
+
+        let mut roots: Vec<std::path::PathBuf> = Vec::new();
+        if let Some(root) = working_dir {
+            roots.push(std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf()));
+        }
+        roots.extend(
+            allowed_roots
+                .iter()
+                .map(|root| std::fs::canonicalize(root).unwrap_or_else(|_| root.clone())),
+        );
+
+        roots.iter().any(|root| canonical_path.starts_with(root))
+    }
+
     /// Pending permission request waiting for resolution (e.g. from a bridge
     /// remote peer or the interactive TUI dialog).
     pub struct PendingPermission {
@@ -2145,6 +2167,8 @@ pub mod permissions {
             tool_name: &str,
             description: &str,
             path: Option<&str>,
+            working_dir: Option<&std::path::Path>,
+            allowed_roots: &[std::path::PathBuf],
         ) -> PermissionDecision {
             use crate::config::PermissionMode;
 
@@ -2185,25 +2209,41 @@ pub mod permissions {
                 return PermissionDecision::Allow;
             }
 
-            // Step 4 — AcceptEdits auto-allows everything
-            if self.mode == PermissionMode::AcceptEdits {
+            let level = match PermissionLevel::for_tool(tool_name) {
+                PermissionLevel::Read
+                    if !matches!(
+                        tool_name,
+                        "Read" | "Glob" | "Grep" | "ListMcpResources" | "ReadMcpResource" | "LSP" | "Skill"
+                    ) => PermissionLevel::Execute,
+                other => other,
+            };
+            let read_in_workspace = path.is_some_and(|target| {
+                is_path_within_allowed_roots(target, working_dir, allowed_roots)
+            });
+            let should_ask_read = match tool_name {
+                "ListMcpResources" | "ReadMcpResource" => true,
+                _ if matches!(level, PermissionLevel::Read) && path.is_some() => !read_in_workspace,
+                _ => false,
+            };
+
+            // Step 4 — AcceptEdits: only auto-allow Edit; everything else keeps normal checks.
+            if self.mode == PermissionMode::AcceptEdits && tool_name == "Edit" {
                 return PermissionDecision::Allow;
             }
 
             // Step 5 — Plan mode: reads only
             if self.mode == PermissionMode::Plan {
-                let level = PermissionLevel::for_tool(tool_name);
                 return match level {
                     PermissionLevel::Read => PermissionDecision::Allow,
                     _ => PermissionDecision::Deny,
                 };
             }
 
-            // Step 6 — Default: derive from tool danger level
-            let level = PermissionLevel::for_tool(tool_name);
+            // Step 6 — Default / remaining AcceptEdits behavior.
             match level {
-                PermissionLevel::Read => PermissionDecision::Allow,
-                PermissionLevel::Write
+                PermissionLevel::Read if !should_ask_read => PermissionDecision::Allow,
+                PermissionLevel::Read
+                | PermissionLevel::Write
                 | PermissionLevel::Execute
                 | PermissionLevel::Network => {
                     let reason =
@@ -2254,6 +2294,28 @@ pub mod permissions {
             let rule = PermissionRule {
                 tool_name: Some(tool_name.to_string()),
                 path_pattern: None,
+                action: PermissionAction::Allow,
+                scope: PermissionScope::Persistent,
+            };
+            let serialized = SerializedPermissionRule::from(&rule);
+            settings.permission_rules.push(serialized);
+            settings
+                .save_sync()
+                .map_err(|e| crate::error::ClaudeError::Config(e.to_string()))?;
+            self.persistent_rules.push(rule);
+            Ok(())
+        }
+
+        /// Allow `tool_name` persistently on `path` and save settings.
+        pub fn add_persistent_allow_path(
+            &mut self,
+            tool_name: &str,
+            path: &str,
+            settings: &mut crate::config::Settings,
+        ) -> crate::error::Result<()> {
+            let rule = PermissionRule {
+                tool_name: Some(tool_name.to_string()),
+                path_pattern: Some(path.to_string()),
                 action: PermissionAction::Allow,
                 scope: PermissionScope::Persistent,
             };
@@ -2331,6 +2393,12 @@ pub mod permissions {
         pub description: String,
         pub details: Option<String>,
         pub is_read_only: bool,
+        /// Canonical or resolved target path when the permission decision is path-sensitive.
+        pub path: Option<String>,
+        /// Current workspace root used for path-boundary checks.
+        pub working_dir: Option<std::path::PathBuf>,
+        /// Additional workspace roots considered in-bounds for file access.
+        pub allowed_roots: Vec<std::path::PathBuf>,
         /// Context-aware description showing user WHY the tool needs permission.
         /// E.g. "bash: execute `ls -la /home`", "write file: /path/to/.bashrc", "fetch: https://example.com"
         pub context_description: Option<String>,
@@ -2359,7 +2427,15 @@ pub mod permissions {
             use crate::config::PermissionMode;
             match self.mode {
                 PermissionMode::BypassPermissions => PermissionDecision::Allow,
-                PermissionMode::AcceptEdits => PermissionDecision::Allow,
+                    PermissionMode::AcceptEdits => {
+                        if request.tool_name == "Edit" {
+                            PermissionDecision::Allow
+                        } else if request.is_read_only {
+                            PermissionDecision::Allow
+                        } else {
+                            PermissionDecision::Deny
+                        }
+                    }
                 PermissionMode::Plan => {
                     if request.is_read_only {
                         PermissionDecision::Allow
@@ -2434,7 +2510,9 @@ pub mod permissions {
                 let decision = m.evaluate(
                     &request.tool_name,
                     &request.description,
-                    request.details.as_deref(),
+                    request.path.as_deref(),
+                    request.working_dir.as_deref(),
+                    &request.allowed_roots,
                 );
                 return match decision {
                     PermissionDecision::Ask { .. } => PermissionDecision::Deny,
@@ -2469,7 +2547,9 @@ pub mod permissions {
                 return m.evaluate(
                     &request.tool_name,
                     &request.description,
-                    request.details.as_deref(),
+                    request.path.as_deref(),
+                    request.working_dir.as_deref(),
+                    &request.allowed_roots,
                 );
             }
             // If the lock is poisoned fall back to allow (user is watching)
@@ -2516,14 +2596,57 @@ pub mod permissions {
         #[test]
         fn bypass_always_allows() {
             let m = mgr(PermissionMode::BypassPermissions);
-            assert_eq!(m.evaluate("Bash", "rm -rf /", None), PermissionDecision::Allow);
+            assert_eq!(
+                m.evaluate("Bash", "rm -rf /", None, None, &[]),
+                PermissionDecision::Allow
+            );
         }
 
         #[test]
-        fn default_read_allows() {
+        fn default_read_allows_workspace_paths() {
             let m = mgr(PermissionMode::Default);
+            let cwd = std::path::Path::new("/workspace");
             assert_eq!(
-                m.evaluate("Read", "read file", None),
+                m.evaluate(
+                    "Read",
+                    "read file",
+                    Some("/workspace/src/lib.rs"),
+                    Some(cwd),
+                    &[],
+                ),
+                PermissionDecision::Allow
+            );
+        }
+
+        #[test]
+        fn default_read_asks_outside_workspace() {
+            let m = mgr(PermissionMode::Default);
+            let cwd = std::path::Path::new("/workspace");
+            match m.evaluate(
+                "Read",
+                "read file",
+                Some("/tmp/outside.txt"),
+                Some(cwd),
+                &[],
+            ) {
+                PermissionDecision::Ask { .. } => {}
+                other => panic!("Expected Ask, got {:?}", other),
+            }
+        }
+
+        #[test]
+        fn default_read_allows_additional_workspace_roots() {
+            let m = mgr(PermissionMode::Default);
+            let cwd = std::path::Path::new("/workspace");
+            let extra = vec![std::path::PathBuf::from("/external")];
+            assert_eq!(
+                m.evaluate(
+                    "Read",
+                    "read file",
+                    Some("/external/notes.txt"),
+                    Some(cwd),
+                    &extra,
+                ),
                 PermissionDecision::Allow
             );
         }
@@ -2531,7 +2654,7 @@ pub mod permissions {
         #[test]
         fn default_bash_asks() {
             let m = mgr(PermissionMode::Default);
-            match m.evaluate("Bash", "echo hello", None) {
+            match m.evaluate("Bash", "echo hello", None, None, &[]) {
                 PermissionDecision::Ask { .. } => {}
                 other => panic!("Expected Ask, got {:?}", other),
             }
@@ -2542,7 +2665,7 @@ pub mod permissions {
             let mut m = mgr(PermissionMode::Default);
             m.add_session_allow("Bash");
             assert_eq!(
-                m.evaluate("Bash", "echo hi", None),
+                m.evaluate("Bash", "echo hi", None, None, &[]),
                 PermissionDecision::Allow
             );
         }
@@ -2557,14 +2680,14 @@ pub mod permissions {
                 action: PermissionAction::Deny,
                 scope: PermissionScope::Session,
             });
-            assert_eq!(m.evaluate("Bash", "echo hi", None), PermissionDecision::Deny);
+            assert_eq!(m.evaluate("Bash", "echo hi", None, None, &[]), PermissionDecision::Deny);
         }
 
         #[test]
         fn plan_denies_writes() {
             let m = mgr(PermissionMode::Plan);
             assert_eq!(
-                m.evaluate("Write", "write file", Some("/tmp/foo")),
+                m.evaluate("Write", "write file", Some("/tmp/foo"), None, &[]),
                 PermissionDecision::Deny
             );
         }
@@ -2573,18 +2696,22 @@ pub mod permissions {
         fn plan_allows_reads() {
             let m = mgr(PermissionMode::Plan);
             assert_eq!(
-                m.evaluate("Read", "read file", Some("/tmp/foo")),
+                m.evaluate("Read", "read file", Some("/tmp/foo"), None, &[]),
                 PermissionDecision::Allow
             );
         }
 
         #[test]
-        fn accept_edits_allows_all() {
+        fn accept_edits_only_allows_edit() {
             let m = mgr(PermissionMode::AcceptEdits);
             assert_eq!(
-                m.evaluate("Bash", "rm -rf /tmp", None),
+                m.evaluate("Edit", "edit file", Some("/workspace/src/lib.rs"), None, &[]),
                 PermissionDecision::Allow
             );
+            match m.evaluate("Bash", "rm -rf /tmp", None, None, &[]) {
+                PermissionDecision::Ask { .. } => {}
+                other => panic!("Expected Ask, got {:?}", other),
+            }
         }
 
         #[test]
@@ -2597,7 +2724,7 @@ pub mod permissions {
                 scope: PermissionScope::Session,
             });
             assert_eq!(
-                m.evaluate("Write", "write", Some("/tmp/foo/bar.txt")),
+                m.evaluate("Write", "write", Some("/tmp/foo/bar.txt"), None, &[]),
                 PermissionDecision::Allow
             );
         }
@@ -2611,7 +2738,7 @@ pub mod permissions {
                 action: PermissionAction::Allow,
                 scope: PermissionScope::Session,
             });
-            match m.evaluate("Write", "write", Some("/etc/hosts")) {
+            match m.evaluate("Write", "write", Some("/etc/hosts"), None, &[]) {
                 PermissionDecision::Ask { .. } => {}
                 other => panic!("Expected Ask, got {:?}", other),
             }
@@ -3928,6 +4055,9 @@ mod tests {
             description: format!("{} operation", tool_name),
             details: None,
             is_read_only,
+            path: None,
+            working_dir: None,
+            allowed_roots: Vec::new(),
             context_description: None,
         }
     }
@@ -3966,35 +4096,23 @@ mod tests {
     }
 
     #[test]
-    fn test_auto_handler_accept_edits_allows_writes() {
+    fn test_auto_handler_accept_edits_only_allows_edit() {
         let handler = crate::permissions::AutoPermissionHandler {
             mode: crate::config::PermissionMode::AcceptEdits,
         };
         assert_eq!(
+            handler.check_permission(&make_req("Edit", false)),
+            crate::permissions::PermissionDecision::Allow
+        );
+        assert_eq!(
             handler.check_permission(&make_req("FileWrite", false)),
-            crate::permissions::PermissionDecision::Allow
-        );
-    }
-
-    #[test]
-    fn test_auto_handler_plan_denies_writes() {
-        let handler = crate::permissions::AutoPermissionHandler {
-            mode: crate::config::PermissionMode::Plan,
-        };
-        assert_eq!(
-            handler.check_permission(&make_req("Bash", false)),
             crate::permissions::PermissionDecision::Deny
-        );
-        assert_eq!(
-            handler.check_permission(&make_req("FileRead", true)),
-            crate::permissions::PermissionDecision::Allow
         );
     }
 
     #[test]
     fn test_interactive_handler_default_allows_writes() {
-        // InteractivePermissionHandler allows writes in Default mode
-        // (user is watching the TUI)
+        // Legacy InteractivePermissionHandler still allows everything outside Plan.
         let handler = crate::permissions::InteractivePermissionHandler {
             mode: crate::config::PermissionMode::Default,
         };
@@ -4005,17 +4123,35 @@ mod tests {
     }
 
     #[test]
-    fn test_interactive_handler_plan_allows_reads_denies_writes() {
-        let handler = crate::permissions::InteractivePermissionHandler {
-            mode: crate::config::PermissionMode::Plan,
-        };
+    fn test_managed_interactive_default_asks_for_write() {
+        let manager = std::sync::Arc::new(std::sync::Mutex::new(
+            crate::permissions::PermissionManager::new(
+                crate::config::PermissionMode::Default,
+                &crate::config::Settings::default(),
+            ),
+        ));
+        let handler = crate::permissions::InteractivePermissionHandler::with_manager(manager);
+        match handler.check_permission(&make_req("FileWrite", false)) {
+            crate::permissions::PermissionDecision::Ask { .. } => {}
+            other => panic!("Expected Ask, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_managed_interactive_default_allows_workspace_read() {
+        let manager = std::sync::Arc::new(std::sync::Mutex::new(
+            crate::permissions::PermissionManager::new(
+                crate::config::PermissionMode::Default,
+                &crate::config::Settings::default(),
+            ),
+        ));
+        let handler = crate::permissions::InteractivePermissionHandler::with_manager(manager);
+        let mut req = make_req("Read", true);
+        req.path = Some("/workspace/src/lib.rs".to_string());
+        req.working_dir = Some(std::path::PathBuf::from("/workspace"));
         assert_eq!(
-            handler.check_permission(&make_req("FileRead", true)),
+            handler.check_permission(&req),
             crate::permissions::PermissionDecision::Allow
-        );
-        assert_eq!(
-            handler.check_permission(&make_req("FileWrite", false)),
-            crate::permissions::PermissionDecision::Deny
         );
     }
 

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -2045,13 +2045,7 @@ pub mod permissions {
         level: PermissionLevel,
     ) -> String {
         match level {
-            PermissionLevel::Execute => {
-                let cmd = path.unwrap_or(description);
-                format!(
-                    "Bash wants to run: `{}`\nThis will execute a shell command.",
-                    cmd
-                )
-            }
+            PermissionLevel::Execute => description.to_string(),
             PermissionLevel::Write => {
                 let target = path.unwrap_or(description);
                 let extra = if target.contains("/etc/") || target.contains("\\etc\\") {
@@ -2747,9 +2741,19 @@ pub mod permissions {
         #[test]
         fn format_reason_bash() {
             let s =
-                format_permission_reason("Bash", "ls -la", None, PermissionLevel::Execute);
-            assert!(s.contains("Bash wants to run"));
-            assert!(s.contains("ls -la"));
+                format_permission_reason("Bash", "This will execute a shell command.", None, PermissionLevel::Execute);
+            assert_eq!(s, "This will execute a shell command.");
+        }
+
+        #[test]
+        fn format_reason_powershell() {
+            let s = format_permission_reason(
+                "PowerShell",
+                "[High risk] This may modify system-wide security policy.",
+                None,
+                PermissionLevel::Execute,
+            );
+            assert_eq!(s, "[High risk] This may modify system-wide security policy.");
         }
 
         #[test]

--- a/src-rust/crates/tools/src/bash.rs
+++ b/src-rust/crates/tools/src/bash.rs
@@ -367,7 +367,12 @@ impl Tool for BashTool {
 
         // Permission check
         let desc = params.description.as_deref().unwrap_or(&params.command);
-        if let Err(e) = ctx.check_permission(self.name(), desc, false) {
+        if let Err(e) = ctx.check_permission_for_path(
+            self.name(),
+            desc,
+            std::path::PathBuf::from(&params.command),
+            false,
+        ) {
             return ToolResult::error(e.to_string());
         }
 

--- a/src-rust/crates/tools/src/bash.rs
+++ b/src-rust/crates/tools/src/bash.rs
@@ -366,10 +366,17 @@ impl Tool for BashTool {
         };
 
         // Permission check
-        let desc = params.description.as_deref().unwrap_or(&params.command);
+        let reason = params
+            .description
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("This will execute a shell command.")
+            .to_string();
+
         if let Err(e) = ctx.check_permission_for_path(
             self.name(),
-            desc,
+            &reason,
             std::path::PathBuf::from(&params.command),
             false,
         ) {

--- a/src-rust/crates/tools/src/file_read.rs
+++ b/src-rust/crates/tools/src/file_read.rs
@@ -64,6 +64,16 @@ impl Tool for FileReadTool {
         let path = ctx.resolve_path(&params.file_path);
         debug!(path = %path.display(), "Reading file");
 
+        // Permission check
+        if let Err(e) = ctx.check_permission_for_path(
+            self.name(),
+            &format!("Read {}", path.display()),
+            path.clone(),
+            true,
+        ) {
+            return ToolResult::error(e.to_string());
+        }
+
         // Check if file exists
         if !path.exists() {
             return ToolResult::error(format!("File not found: {}", path.display()));

--- a/src-rust/crates/tools/src/glob_tool.rs
+++ b/src-rust/crates/tools/src/glob_tool.rs
@@ -62,6 +62,15 @@ impl Tool for GlobTool {
             .map(|p| ctx.resolve_path(p))
             .unwrap_or_else(|| ctx.working_dir.clone());
 
+        if let Err(e) = ctx.check_permission_for_path(
+            self.name(),
+            &format!("Glob {} in {}", params.pattern, base_dir.display()),
+            base_dir.clone(),
+            true,
+        ) {
+            return ToolResult::error(e.to_string());
+        }
+
         debug!(pattern = %params.pattern, dir = %base_dir.display(), "Running glob");
 
         if !base_dir.exists() || !base_dir.is_dir() {
@@ -79,7 +88,23 @@ impl Tool for GlobTool {
         let pattern_str = pattern_str.replace('\\', "/");
 
         let entries: Vec<PathBuf> = match glob::glob(&pattern_str) {
-            Ok(paths) => paths.filter_map(|p| p.ok()).collect(),
+            Ok(paths) => {
+                let mut out = Vec::new();
+                for path in paths.filter_map(|p| p.ok()) {
+                    if !ctx.path_is_within_workspace(&path) {
+                        if let Err(e) = ctx.check_permission_for_path(
+                            self.name(),
+                            &format!("Glob result {}", path.display()),
+                            path.clone(),
+                            true,
+                        ) {
+                            return ToolResult::error(e.to_string());
+                        }
+                    }
+                    out.push(path);
+                }
+                out
+            }
             Err(e) => {
                 return ToolResult::error(format!("Invalid glob pattern: {}", e));
             }

--- a/src-rust/crates/tools/src/grep_tool.rs
+++ b/src-rust/crates/tools/src/grep_tool.rs
@@ -144,6 +144,15 @@ impl Tool for GrepTool {
             .map(|p| ctx.resolve_path(p))
             .unwrap_or_else(|| ctx.working_dir.clone());
 
+        if let Err(e) = ctx.check_permission_for_path(
+            self.name(),
+            &format!("Grep {} in {}", params.pattern, search_path.display()),
+            search_path.clone(),
+            true,
+        ) {
+            return ToolResult::error(e.to_string());
+        }
+
         debug!(pattern = %params.pattern, path = %search_path.display(), "Running grep");
 
         // Compile regex
@@ -209,6 +218,17 @@ impl Tool for GrepTool {
             }
 
             let path = entry.path();
+
+            if !ctx.path_is_within_workspace(path) {
+                if let Err(e) = ctx.check_permission_for_path(
+                    self.name(),
+                    &format!("Grep result {}", path.display()),
+                    path.to_path_buf(),
+                    true,
+                ) {
+                    return ToolResult::error(e.to_string());
+                }
+            }
 
             // Type filter
             if !type_exts.is_empty() {

--- a/src-rust/crates/tools/src/lib.rs
+++ b/src-rust/crates/tools/src/lib.rs
@@ -9,7 +9,7 @@ use claurst_core::cost::CostTracker;
 use claurst_core::permissions::{PermissionDecision, PermissionHandler, PermissionRequest};
 use claurst_core::types::ToolDefinition;
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -148,6 +148,20 @@ pub enum PermissionLevel {
     Forbidden,
 }
 
+#[derive(Debug)]
+pub struct PendingPermissionRequest {
+    pub tool_use_id: String,
+    pub request: claurst_core::permissions::PermissionRequest,
+    pub reason: String,
+    pub decision_tx: Option<tokio::sync::oneshot::Sender<PermissionDecision>>,
+}
+
+#[derive(Default)]
+pub struct PendingPermissionStore {
+    pub queue: VecDeque<PendingPermissionRequest>,
+    pub waiting: HashMap<String, PendingPermissionRequest>,
+}
+
 /// Persistent shell state shared across Bash tool invocations within one session.
 ///
 /// The `BashTool` reads and writes this state on every call so that `cd` and
@@ -241,6 +255,10 @@ pub struct ToolContext {
     /// Optional notifier for injecting completion messages into the next agent turn.
     /// Set when the query loop has a command queue wired up.
     pub completion_notifier: Option<CompletionNotifier>,
+    /// Queue used by interactive mode to surface permission dialogs to the TUI.
+    pub pending_permissions: Option<Arc<parking_lot::Mutex<PendingPermissionStore>>>,
+    /// Shared permission manager so the interactive loop can record session/persistent approvals.
+    pub permission_manager: Option<Arc<std::sync::Mutex<claurst_core::permissions::PermissionManager>>>,
 }
 
 impl ToolContext {
@@ -254,6 +272,81 @@ impl ToolContext {
         }
     }
 
+    fn permission_allowed_roots(&self) -> Vec<PathBuf> {
+        let mut roots = self.config.workspace_paths.clone();
+        roots.extend(self.config.additional_dirs.clone());
+        roots
+    }
+
+    fn build_permission_request(
+        &self,
+        tool_name: &str,
+        description: &str,
+        details: Option<String>,
+        is_read_only: bool,
+        path: Option<PathBuf>,
+    ) -> PermissionRequest {
+        PermissionRequest {
+            tool_name: tool_name.to_string(),
+            description: description.to_string(),
+            details,
+            is_read_only,
+            path: path.map(|p| p.display().to_string()),
+            working_dir: Some(self.working_dir.clone()),
+            allowed_roots: self.permission_allowed_roots(),
+            context_description: None,
+        }
+    }
+
+    fn request_permission_inner(
+        &self,
+        request: PermissionRequest,
+    ) -> Result<(), claurst_core::error::ClaudeError> {
+        let decision = self.permission_handler.request_permission(&request);
+        match decision {
+            PermissionDecision::Allow | PermissionDecision::AllowPermanently => Ok(()),
+            PermissionDecision::Ask { reason } if self.non_interactive => Err(
+                claurst_core::error::ClaudeError::PermissionDenied(format!(
+                    "Permission denied for tool '{}': {}",
+                    request.tool_name,
+                    reason
+                )),
+            ),
+            PermissionDecision::Ask { reason } => {
+                let Some(queue) = &self.pending_permissions else {
+                    return Err(claurst_core::error::ClaudeError::PermissionDenied(format!(
+                        "Permission denied for tool '{}'",
+                        request.tool_name
+                    )));
+                };
+
+                let (tx, rx) = tokio::sync::oneshot::channel();
+                queue.lock().queue.push_back(PendingPermissionRequest {
+                    tool_use_id: format!(
+                        "perm-{}-{}",
+                        self.session_id,
+                        self.current_turn.fetch_add(1, Ordering::Relaxed)
+                    ),
+                    request,
+                    reason,
+                    decision_tx: Some(tx),
+                });
+
+                let decision = tokio::task::block_in_place(|| rx.blocking_recv());
+                match decision {
+                    Ok(PermissionDecision::Allow | PermissionDecision::AllowPermanently) => Ok(()),
+                    _ => Err(claurst_core::error::ClaudeError::PermissionDenied(
+                        "Permission denied by user".to_string(),
+                    )),
+                }
+            }
+            _ => Err(claurst_core::error::ClaudeError::PermissionDenied(format!(
+                "Permission denied for tool '{}'",
+                request.tool_name
+            ))),
+        }
+    }
+
     /// Check permissions for a tool invocation.
     pub fn check_permission(
         &self,
@@ -261,28 +354,23 @@ impl ToolContext {
         description: &str,
         is_read_only: bool,
     ) -> Result<(), claurst_core::error::ClaudeError> {
-        let request = PermissionRequest {
-            tool_name: tool_name.to_string(),
-            description: description.to_string(),
-            details: None,
-            is_read_only,
-            context_description: None,
-        };
-        let decision = self.permission_handler.request_permission(&request);
-        match decision {
-            PermissionDecision::Allow | PermissionDecision::AllowPermanently => Ok(()),
-            _ => Err(claurst_core::error::ClaudeError::PermissionDenied(format!(
-                "Permission denied for tool '{}'",
-                tool_name
-            ))),
-        }
+        let request = self.build_permission_request(tool_name, description, None, is_read_only, None);
+        self.request_permission_inner(request)
+    }
+
+    pub fn check_permission_for_path(
+        &self,
+        tool_name: &str,
+        description: &str,
+        path: PathBuf,
+        is_read_only: bool,
+    ) -> Result<(), claurst_core::error::ClaudeError> {
+        let request = self.build_permission_request(tool_name, description, None, is_read_only, Some(path));
+        self.request_permission_inner(request)
     }
 
     /// Like `check_permission` but also passes structured `details` text
     /// (e.g. a risk explanation) that the TUI permission dialog can display.
-    ///
-    /// Used by PowerShellTool (and any future tool) when it needs to show
-    /// the user *why* a command is considered risky before they approve it.
     pub fn check_permission_with_details(
         &self,
         tool_name: &str,
@@ -290,21 +378,55 @@ impl ToolContext {
         details: &str,
         is_read_only: bool,
     ) -> Result<(), claurst_core::error::ClaudeError> {
-        let request = PermissionRequest {
-            tool_name: tool_name.to_string(),
-            description: description.to_string(),
-            details: Some(details.to_string()),
+        let request = self.build_permission_request(
+            tool_name,
+            description,
+            Some(details.to_string()),
             is_read_only,
-            context_description: None,
-        };
-        let decision = self.permission_handler.request_permission(&request);
-        match decision {
-            PermissionDecision::Allow | PermissionDecision::AllowPermanently => Ok(()),
-            _ => Err(claurst_core::error::ClaudeError::PermissionDenied(format!(
+            None,
+        );
+        self.request_permission_inner(request).map_err(|_| {
+            claurst_core::error::ClaudeError::PermissionDenied(format!(
                 "Permission denied for tool '{}': {}",
                 tool_name, details
-            ))),
-        }
+            ))
+        })
+    }
+
+    pub fn path_is_within_workspace(&self, path: &std::path::Path) -> bool {
+        let resolved = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+        let mut roots = vec![
+            std::fs::canonicalize(&self.working_dir).unwrap_or_else(|_| self.working_dir.clone()),
+        ];
+        roots.extend(
+            self.permission_allowed_roots()
+                .into_iter()
+                .map(|root| std::fs::canonicalize(&root).unwrap_or(root)),
+        );
+        roots.iter().any(|root| resolved.starts_with(root))
+    }
+
+    pub fn check_permission_with_details_and_path(
+        &self,
+        tool_name: &str,
+        description: &str,
+        details: &str,
+        path: PathBuf,
+        is_read_only: bool,
+    ) -> Result<(), claurst_core::error::ClaudeError> {
+        let request = self.build_permission_request(
+            tool_name,
+            description,
+            Some(details.to_string()),
+            is_read_only,
+            Some(path),
+        );
+        self.request_permission_inner(request).map_err(|_| {
+            claurst_core::error::ClaudeError::PermissionDenied(format!(
+                "Permission denied for tool '{}': {}",
+                tool_name, details
+            ))
+        })
     }
 
     pub fn current_turn_index(&self) -> usize {
@@ -556,6 +678,8 @@ mod tests {
             config: Config::default(),
             managed_agent_config: None,
             completion_notifier: None,
+            pending_permissions: None,
+            permission_manager: None,
         };
 
         // Absolute paths pass through unchanged
@@ -586,6 +710,8 @@ mod tests {
             config: Config::default(),
             managed_agent_config: None,
             completion_notifier: None,
+            pending_permissions: None,
+            permission_manager: None,
         };
 
         // Relative paths get joined with working_dir

--- a/src-rust/crates/tools/src/lib.rs
+++ b/src-rust/crates/tools/src/lib.rs
@@ -302,6 +302,7 @@ impl ToolContext {
         &self,
         request: PermissionRequest,
     ) -> Result<(), claurst_core::error::ClaudeError> {
+        let interactive_reason = request.details.clone();
         let decision = self.permission_handler.request_permission(&request);
         match decision {
             PermissionDecision::Allow | PermissionDecision::AllowPermanently => Ok(()),
@@ -309,7 +310,7 @@ impl ToolContext {
                 claurst_core::error::ClaudeError::PermissionDenied(format!(
                     "Permission denied for tool '{}': {}",
                     request.tool_name,
-                    reason
+                    interactive_reason.unwrap_or(reason)
                 )),
             ),
             PermissionDecision::Ask { reason } => {
@@ -328,7 +329,7 @@ impl ToolContext {
                         self.current_turn.fetch_add(1, Ordering::Relaxed)
                     ),
                     request,
-                    reason,
+                    reason: interactive_reason.unwrap_or(reason),
                     decision_tx: Some(tx),
                 });
 
@@ -543,6 +544,53 @@ pub fn find_tool(name: &str) -> Option<Box<dyn Tool>> {
 mod tests {
     use super::*;
 
+    struct AskPermissionHandler {
+        reason: String,
+    }
+
+    impl claurst_core::permissions::PermissionHandler for AskPermissionHandler {
+        fn check_permission(
+            &self,
+            _request: &claurst_core::permissions::PermissionRequest,
+        ) -> claurst_core::permissions::PermissionDecision {
+            claurst_core::permissions::PermissionDecision::Ask {
+                reason: self.reason.clone(),
+            }
+        }
+
+        fn request_permission(
+            &self,
+            request: &claurst_core::permissions::PermissionRequest,
+        ) -> claurst_core::permissions::PermissionDecision {
+            self.check_permission(request)
+        }
+    }
+
+    fn test_tool_context(
+        handler: Arc<dyn claurst_core::permissions::PermissionHandler>,
+    ) -> ToolContext {
+        use claurst_core::config::Config;
+
+        ToolContext {
+            working_dir: PathBuf::from("/workspace"),
+            permission_mode: claurst_core::config::PermissionMode::Default,
+            permission_handler: handler,
+            cost_tracker: claurst_core::cost::CostTracker::new(),
+            session_id: "test".to_string(),
+            file_history: Arc::new(parking_lot::Mutex::new(
+                claurst_core::file_history::FileHistory::new(),
+            )),
+            current_turn: Arc::new(AtomicUsize::new(0)),
+            non_interactive: true,
+            mcp_manager: None,
+            config: Config::default(),
+            managed_agent_config: None,
+            completion_notifier: None,
+            pending_permissions: None,
+            permission_manager: None,
+        }
+    }
+
     // ---- Tool registry tests ------------------------------------------------
 
     #[test]
@@ -657,30 +705,12 @@ mod tests {
 
     #[test]
     fn test_resolve_path_absolute() {
-        use claurst_core::config::Config;
         use claurst_core::permissions::AutoPermissionHandler;
 
         let handler = Arc::new(AutoPermissionHandler {
             mode: claurst_core::config::PermissionMode::Default,
         });
-        let ctx = ToolContext {
-            working_dir: PathBuf::from("/workspace"),
-            permission_mode: claurst_core::config::PermissionMode::Default,
-            permission_handler: handler,
-            cost_tracker: claurst_core::cost::CostTracker::new(),
-            session_id: "test".to_string(),
-            file_history: Arc::new(parking_lot::Mutex::new(
-                claurst_core::file_history::FileHistory::new(),
-            )),
-            current_turn: Arc::new(AtomicUsize::new(0)),
-            non_interactive: true,
-            mcp_manager: None,
-            config: Config::default(),
-            managed_agent_config: None,
-            completion_notifier: None,
-            pending_permissions: None,
-            permission_manager: None,
-        };
+        let ctx = test_tool_context(handler);
 
         // Absolute paths pass through unchanged
         let resolved = ctx.resolve_path("/absolute/path/file.rs");
@@ -689,34 +719,51 @@ mod tests {
 
     #[test]
     fn test_resolve_path_relative() {
-        use claurst_core::config::Config;
         use claurst_core::permissions::AutoPermissionHandler;
 
         let handler = Arc::new(AutoPermissionHandler {
             mode: claurst_core::config::PermissionMode::Default,
         });
-        let ctx = ToolContext {
-            working_dir: PathBuf::from("/workspace"),
-            permission_mode: claurst_core::config::PermissionMode::Default,
-            permission_handler: handler,
-            cost_tracker: claurst_core::cost::CostTracker::new(),
-            session_id: "test".to_string(),
-            file_history: Arc::new(parking_lot::Mutex::new(
-                claurst_core::file_history::FileHistory::new(),
-            )),
-            current_turn: Arc::new(AtomicUsize::new(0)),
-            non_interactive: true,
-            mcp_manager: None,
-            config: Config::default(),
-            managed_agent_config: None,
-            completion_notifier: None,
-            pending_permissions: None,
-            permission_manager: None,
-        };
+        let ctx = test_tool_context(handler);
 
         // Relative paths get joined with working_dir
         let resolved = ctx.resolve_path("src/main.rs");
         assert_eq!(resolved, PathBuf::from("/workspace/src/main.rs"));
+    }
+
+    #[test]
+    fn test_request_permission_uses_details_for_non_interactive_errors() {
+        let ctx = test_tool_context(Arc::new(AskPermissionHandler {
+            reason: "generic reason".to_string(),
+        }));
+        let request = ctx.build_permission_request(
+            "PowerShell",
+            "[High risk] set execution policy",
+            Some("[High risk] This may modify system-wide security policy.".to_string()),
+            false,
+            Some(PathBuf::from("Set-ExecutionPolicy RemoteSigned")),
+        );
+
+        let error = ctx.request_permission_inner(request).unwrap_err().to_string();
+        assert!(error.contains("[High risk] This may modify system-wide security policy."));
+        assert!(!error.contains("generic reason"));
+    }
+
+    #[test]
+    fn test_request_permission_falls_back_to_handler_reason_without_details() {
+        let ctx = test_tool_context(Arc::new(AskPermissionHandler {
+            reason: "generic reason".to_string(),
+        }));
+        let request = ctx.build_permission_request(
+            "Bash",
+            "run ls",
+            None,
+            false,
+            Some(PathBuf::from("ls -la")),
+        );
+
+        let error = ctx.request_permission_inner(request).unwrap_err().to_string();
+        assert!(error.contains("generic reason"));
     }
 
     // ---- PermissionLevel tests ---------------------------------------------

--- a/src-rust/crates/tools/src/lsp_tool.rs
+++ b/src-rust/crates/tools/src/lsp_tool.rs
@@ -73,6 +73,15 @@ impl Tool for LspTool {
                 .into_owned()
         };
 
+        if let Err(e) = ctx.check_permission_for_path(
+            self.name(),
+            &format!("LSP {} {}", action, file_path),
+            std::path::PathBuf::from(&file_path),
+            true,
+        ) {
+            return ToolResult::error(e.to_string());
+        }
+
         // line/column only required for position-based actions
         let line = input
             .get("line")

--- a/src-rust/crates/tools/src/mcp_auth_tool.rs
+++ b/src-rust/crates/tools/src/mcp_auth_tool.rs
@@ -60,6 +60,14 @@ impl Tool for McpAuthTool {
             Err(e) => return ToolResult::error(format!("Invalid input: {}", e)),
         };
 
+        if let Err(e) = ctx.check_permission(
+            self.name(),
+            &format!("Authenticate MCP server {}", params.server_name),
+            false,
+        ) {
+            return ToolResult::error(e.to_string());
+        }
+
         let manager = match &ctx.mcp_manager {
             Some(m) => m,
             None => {

--- a/src-rust/crates/tools/src/mcp_resources.rs
+++ b/src-rust/crates/tools/src/mcp_resources.rs
@@ -53,6 +53,21 @@ impl Tool for ListMcpResourcesTool {
             Err(e) => return ToolResult::error(format!("Invalid input: {}", e)),
         };
 
+        if let Err(e) = ctx.check_permission(
+            self.name(),
+            &format!(
+                "List MCP resources{}",
+                params
+                    .server
+                    .as_deref()
+                    .map(|s| format!(" for {}", s))
+                    .unwrap_or_default()
+            ),
+            true,
+        ) {
+            return ToolResult::error(e.to_string());
+        }
+
         let manager = match &ctx.mcp_manager {
             Some(m) => m,
             None => {
@@ -122,6 +137,14 @@ impl Tool for ReadMcpResourceTool {
             Ok(p) => p,
             Err(e) => return ToolResult::error(format!("Invalid input: {}", e)),
         };
+
+        if let Err(e) = ctx.check_permission(
+            self.name(),
+            &format!("Read MCP resource {}:{}", params.server, params.uri),
+            true,
+        ) {
+            return ToolResult::error(e.to_string());
+        }
 
         let manager = match &ctx.mcp_manager {
             Some(m) => m,

--- a/src-rust/crates/tools/src/monitor_tool.rs
+++ b/src-rust/crates/tools/src/monitor_tool.rs
@@ -268,6 +268,8 @@ mod tests {
             config: Config::default(),
             managed_agent_config: None,
             completion_notifier: None,
+            pending_permissions: None,
+            permission_manager: None,
         }
     }
 }

--- a/src-rust/crates/tools/src/powershell.rs
+++ b/src-rust/crates/tools/src/powershell.rs
@@ -142,7 +142,13 @@ impl Tool for PowerShellTool {
                     params.description.as_deref().unwrap_or(&params.command)
                 );
                 let details = risk_explanation(PsRiskLevel::High, &params.command);
-                if let Err(e) = ctx.check_permission_with_details(self.name(), &desc, &details, false) {
+                if let Err(e) = ctx.check_permission_with_details_and_path(
+                    self.name(),
+                    &desc,
+                    &details,
+                    std::path::PathBuf::from(&params.command),
+                    false,
+                ) {
                     return ToolResult::error(e.to_string());
                 }
             }
@@ -164,7 +170,13 @@ impl Tool for PowerShellTool {
                         params.description.as_deref().unwrap_or(&params.command)
                     );
                     let details = risk_explanation(PsRiskLevel::Medium, &params.command);
-                    if let Err(e) = ctx.check_permission_with_details(self.name(), &desc, &details, false) {
+                    if let Err(e) = ctx.check_permission_with_details_and_path(
+                        self.name(),
+                        &desc,
+                        &details,
+                        std::path::PathBuf::from(&params.command),
+                        false,
+                    ) {
                         return ToolResult::error(e.to_string());
                     }
                 }
@@ -174,7 +186,12 @@ impl Tool for PowerShellTool {
                 // Standard (non-risk-gated) permission check — honours bypass
                 // and plan-mode rules, but does not show a dialog.
                 let desc = params.description.as_deref().unwrap_or(&params.command);
-                if let Err(e) = ctx.check_permission(self.name(), desc, false) {
+                if let Err(e) = ctx.check_permission_for_path(
+                    self.name(),
+                    desc,
+                    std::path::PathBuf::from(&params.command),
+                    false,
+                ) {
                     return ToolResult::error(e.to_string());
                 }
             }

--- a/src-rust/crates/tools/src/powershell.rs
+++ b/src-rust/crates/tools/src/powershell.rs
@@ -61,17 +61,12 @@ fn risk_explanation(level: PsRiskLevel, command: &str) -> String {
              Command: {}",
             command
         ),
-        PsRiskLevel::High => format!(
-            "PowerShell wants to run a HIGH-risk command:\n  {}\n\n\
-             This may modify system-wide security policy, the registry (HKLM), \
-             user accounts, or firewall rules.",
-            command
-        ),
-        PsRiskLevel::Medium => format!(
-            "PowerShell wants to run a MEDIUM-risk command:\n  {}\n\n\
-             This may delete files, control services, or make network requests.",
-            command
-        ),
+        PsRiskLevel::High => {
+            "[High risk] This may modify system-wide security policy, the registry (HKLM), user accounts, or firewall rules.".to_string()
+        }
+        PsRiskLevel::Medium => {
+            "[Medium risk] This may delete files, control services, or make network requests.".to_string()
+        }
         PsRiskLevel::Low => String::new(), // never shown
     }
 }
@@ -185,10 +180,17 @@ impl Tool for PowerShellTool {
             PsRiskLevel::Low => {
                 // Standard (non-risk-gated) permission check — honours bypass
                 // and plan-mode rules, but does not show a dialog.
-                let desc = params.description.as_deref().unwrap_or(&params.command);
+                let reason = params
+                    .description
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or("This will execute a PowerShell command.")
+                    .to_string();
+
                 if let Err(e) = ctx.check_permission_for_path(
                     self.name(),
-                    desc,
+                    &reason,
                     std::path::PathBuf::from(&params.command),
                     false,
                 ) {

--- a/src-rust/crates/tools/src/pty_bash.rs
+++ b/src-rust/crates/tools/src/pty_bash.rs
@@ -530,7 +530,12 @@ impl Tool for PtyBashTool {
 
         // Permission check
         let desc = params.description.as_deref().unwrap_or(&params.command);
-        if let Err(e) = ctx.check_permission(self.name(), desc, false) {
+        if let Err(e) = ctx.check_permission_for_path(
+            self.name(),
+            desc,
+            std::path::PathBuf::from(&params.command),
+            false,
+        ) {
             return ToolResult::error(e.to_string());
         }
 

--- a/src-rust/crates/tools/src/pty_bash.rs
+++ b/src-rust/crates/tools/src/pty_bash.rs
@@ -529,10 +529,17 @@ impl Tool for PtyBashTool {
         };
 
         // Permission check
-        let desc = params.description.as_deref().unwrap_or(&params.command);
+        let reason = params
+            .description
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("This will execute a shell command.")
+            .to_string();
+
         if let Err(e) = ctx.check_permission_for_path(
             self.name(),
-            desc,
+            &reason,
             std::path::PathBuf::from(&params.command),
             false,
         ) {

--- a/src-rust/crates/tools/src/skill_tool.rs
+++ b/src-rust/crates/tools/src/skill_tool.rs
@@ -65,11 +65,9 @@ impl Tool for SkillTool {
         };
 
         let dirs = skill_search_dirs(ctx);
-
         if params.skill == "list" {
             return list_skills(&dirs).await;
         }
-
         let skill_name = params.skill.trim_end_matches(".md");
         debug!(skill = skill_name, "Loading skill");
 
@@ -87,8 +85,8 @@ impl Tool for SkillTool {
             return ToolResult::success(prompt);
         }
 
-        let raw = match find_and_read_skill(skill_name, &dirs).await {
-            Some(c) => c,
+        let (skill_path, raw) = match find_and_read_skill(skill_name, &dirs).await {
+            Some(found) => found,
             None => {
                 return ToolResult::error(format!(
                     "Skill '{}' not found. Use skill=\"list\" to see available skills.",
@@ -96,6 +94,15 @@ impl Tool for SkillTool {
                 ));
             }
         };
+
+        if let Err(e) = ctx.check_permission_for_path(
+            self.name(),
+            &format!("Load skill {}", params.skill),
+            skill_path,
+            true,
+        ) {
+            return ToolResult::error(e.to_string());
+        }
 
         // Strip YAML frontmatter if present (--- ... ---)
         let content = strip_frontmatter(&raw);
@@ -186,11 +193,11 @@ async fn list_skills(dirs: &[PathBuf]) -> ToolResult {
     ))
 }
 
-async fn find_and_read_skill(name: &str, dirs: &[PathBuf]) -> Option<String> {
+async fn find_and_read_skill(name: &str, dirs: &[PathBuf]) -> Option<(PathBuf, String)> {
     for dir in dirs {
         let path = dir.join(format!("{}.md", name));
         if let Ok(content) = tokio::fs::read_to_string(&path).await {
-            return Some(content);
+            return Some((path, content));
         }
     }
     None

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -5599,6 +5599,7 @@ mod tests {
             "tu-1".to_string(),
             "Bash".to_string(),
             "wants to run".to_string(),
+            "wants to run".to_string(),
             "git status".to_string(),
             Some("git".to_string()),
         );
@@ -5631,6 +5632,7 @@ mod tests {
             "tu-2".to_string(),
             "Bash".to_string(),
             "wants to run".to_string(),
+            "wants to run".to_string(),
             "cargo build".to_string(),
             Some("cargo".to_string()),
         );
@@ -5661,6 +5663,7 @@ mod tests {
         let pr = PermissionRequest::bash(
             "tu-3".to_string(),
             "Bash".to_string(),
+            "wants to run".to_string(),
             "wants to run".to_string(),
             "npm install".to_string(),
             Some("npm".to_string()),

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -5598,8 +5598,7 @@ mod tests {
         let pr = PermissionRequest::bash(
             "tu-1".to_string(),
             "Bash".to_string(),
-            "wants to run".to_string(),
-            "wants to run".to_string(),
+            "This will execute a shell command.".to_string(),
             "git status".to_string(),
             Some("git".to_string()),
         );
@@ -5631,8 +5630,7 @@ mod tests {
         let mut pr = PermissionRequest::bash(
             "tu-2".to_string(),
             "Bash".to_string(),
-            "wants to run".to_string(),
-            "wants to run".to_string(),
+            "This will execute a shell command.".to_string(),
             "cargo build".to_string(),
             Some("cargo".to_string()),
         );
@@ -5663,8 +5661,7 @@ mod tests {
         let pr = PermissionRequest::bash(
             "tu-3".to_string(),
             "Bash".to_string(),
-            "wants to run".to_string(),
-            "wants to run".to_string(),
+            "This will execute a shell command.".to_string(),
             "npm install".to_string(),
             Some("npm".to_string()),
         );

--- a/src-rust/crates/tui/src/dialogs.rs
+++ b/src-rust/crates/tui/src/dialogs.rs
@@ -24,6 +24,8 @@ pub enum PermissionDialogKind {
         command: String,
         suggested_prefix: Option<String>,
     },
+    /// PowerShell command execution — rendered like Bash without prefix rules.
+    PowerShell { command: String },
     /// File read — three options: once / session / deny.
     FileRead { path: String },
     /// File write — four options: once / session / project / deny.
@@ -56,7 +58,7 @@ pub struct PermissionOption {
 pub struct PermissionRequest {
     pub tool_use_id: String,
     pub tool_name: String,
-    /// Short verb phrase, e.g. "wants to run: `rm -rf /tmp/foo`"
+    /// Short summary line shown when present.
     pub description: String,
     /// One-sentence danger explanation shown in yellow.
     pub danger_explanation: String,
@@ -99,11 +101,7 @@ impl PermissionRequest {
         reason: String,
         input_preview: Option<String>,
     ) -> Self {
-        let (description, danger_explanation) = if let Some(nl) = reason.find('\n') {
-            (reason[..nl].to_string(), reason[nl + 1..].to_string())
-        } else {
-            (reason, String::new())
-        };
+        let (description, danger_explanation) = split_reason(reason);
 
         Self {
             tool_use_id,
@@ -122,17 +120,10 @@ impl PermissionRequest {
     pub fn bash(
         tool_use_id: String,
         tool_name: String,
-        description: String,
         reason: String,
         command: String,
         suggested_prefix: Option<String>,
     ) -> Self {
-        let danger_explanation = if let Some(nl) = reason.find('\n') {
-            reason[nl + 1..].to_string()
-        } else {
-            String::new()
-        };
-
         let options = Self::bash_options(suggested_prefix.as_deref());
         let kind = PermissionDialogKind::Bash {
             command: command.clone(),
@@ -142,8 +133,8 @@ impl PermissionRequest {
         Self {
             tool_use_id,
             tool_name,
-            description,
-            danger_explanation,
+            description: String::new(),
+            danger_explanation: command_reason_body(reason, &command),
             input_preview: Some(command),
             kind,
             selected_option: 0,
@@ -154,23 +145,16 @@ impl PermissionRequest {
     pub fn powershell(
         tool_use_id: String,
         tool_name: String,
-        description: String,
         reason: String,
         command: String,
     ) -> Self {
-        let danger_explanation = if let Some(nl) = reason.find('\n') {
-            reason[nl + 1..].to_string()
-        } else {
-            String::new()
-        };
-
         Self {
             tool_use_id,
             tool_name,
-            description,
-            danger_explanation,
-            input_preview: Some(command),
-            kind: PermissionDialogKind::Generic,
+            description: String::new(),
+            danger_explanation: command_reason_body(reason, &command),
+            input_preview: Some(command.clone()),
+            kind: PermissionDialogKind::PowerShell { command },
             selected_option: 0,
             options: Self::default_options(),
         }
@@ -281,6 +265,31 @@ impl PermissionRequest {
     }
 }
 
+fn split_reason(reason: String) -> (String, String) {
+    if let Some(nl) = reason.find('\n') {
+        (reason[..nl].to_string(), reason[nl + 1..].to_string())
+    } else {
+        (reason, String::new())
+    }
+}
+
+fn command_reason_body(reason: String, command: &str) -> String {
+    let (_, danger_explanation) = split_reason(reason.clone());
+    let candidate = if danger_explanation.is_empty() {
+        reason
+    } else {
+        danger_explanation
+    };
+    let mut lines: Vec<&str> = candidate.lines().collect();
+    if lines.first().is_some_and(|line| line.trim() == command) {
+        lines.remove(0);
+        while lines.first().is_some_and(|line| line.trim().is_empty()) {
+            lines.remove(0);
+        }
+    }
+    lines.join("\n").trim().to_string()
+}
+
 // ---------------------------------------------------------------------------
 // Rendering helpers
 // ---------------------------------------------------------------------------
@@ -342,8 +351,8 @@ fn word_wrap(text: &str, width: usize) -> Vec<String> {
 ///   │                                                │
 ///   │  > rm -rf /tmp/foo                             │
 ///   │                                                │
-///   │  Bash wants to run: `rm -rf /tmp/foo`          │
-///   │  This will delete files permanently.           │
+///   │  This will execute a shell command.             │
+///   │  This may modify system-wide security policy.   │
 ///   │                                                │
 ///   │  [1] Yes, allow once                           │
 ///   │  [2] Yes, allow this session                   │
@@ -361,9 +370,10 @@ pub fn render_permission_dialog(frame: &mut Frame, pr: &PermissionRequest, area:
     let dialog_width = inner_width.min(area.width.saturating_sub(4));
     let text_width = (dialog_width as usize).saturating_sub(4); // 2 border + 2 padding
 
-    // Build a command block for Bash dialogs to prominently display the command.
+    // Build a command block for Bash / PowerShell dialogs to prominently display the command.
     let bash_command_lines: Option<Vec<Line>> = match &pr.kind {
-        PermissionDialogKind::Bash { command, .. } => {
+        PermissionDialogKind::Bash { command, .. }
+        | PermissionDialogKind::PowerShell { command } => {
             let wrapped = word_wrap(command, text_width.saturating_sub(4));
             Some(
                 wrapped
@@ -391,7 +401,11 @@ pub fn render_permission_dialog(frame: &mut Frame, pr: &PermissionRequest, area:
     };
 
     // Count how many lines we need
-    let desc_lines = word_wrap(&pr.description, text_width);
+    let desc_lines = if pr.description.trim().is_empty() {
+        vec![]
+    } else {
+        word_wrap(&pr.description, text_width)
+    };
     let expl_lines = if pr.danger_explanation.is_empty() {
         vec![]
     } else {
@@ -400,7 +414,7 @@ pub fn render_permission_dialog(frame: &mut Frame, pr: &PermissionRequest, area:
 
     // preview line count (used for non-Bash kinds; Bash uses its own block above)
     let preview_line_count: u16 = match &pr.kind {
-        PermissionDialogKind::Bash { .. } => 0, // rendered separately as bash_command_lines
+        PermissionDialogKind::Bash { .. } | PermissionDialogKind::PowerShell { .. } => 0,
         _ => {
             if pr.input_preview.is_some() { 3 } else { 0 }
         }
@@ -450,7 +464,10 @@ pub fn render_permission_dialog(frame: &mut Frame, pr: &PermissionRequest, area:
     }
 
     // ---- Input preview for non-Bash kinds -----------------------------------
-    if !matches!(pr.kind, PermissionDialogKind::Bash { .. }) {
+    if !matches!(
+        pr.kind,
+        PermissionDialogKind::Bash { .. } | PermissionDialogKind::PowerShell { .. }
+    ) {
         if let Some(ref preview) = pr.input_preview {
             lines.push(Line::from(vec![
                 Span::styled(
@@ -516,7 +533,9 @@ pub fn render_permission_dialog(frame: &mut Frame, pr: &PermissionRequest, area:
     }
 
     let (border_color, title_text) = match &pr.kind {
-        PermissionDialogKind::Bash { .. } => (Color::Yellow, " Permission Required "),
+        PermissionDialogKind::Bash { .. } | PermissionDialogKind::PowerShell { .. } => {
+            (Color::Yellow, " Permission Required ")
+        }
         PermissionDialogKind::FileRead { .. } => (Color::Cyan, " File Read Permission "),
         PermissionDialogKind::FileWrite { .. } => (Color::Yellow, " File Write Permission "),
         PermissionDialogKind::Generic => (Color::Yellow, " Permission Required "),
@@ -1225,12 +1244,57 @@ mod tests {
         let pr = PermissionRequest::from_reason(
             "id2".to_string(),
             "Bash".to_string(),
-            "Bash wants to run: `rm -rf /tmp`\nThis will delete files permanently.".to_string(),
+            "Custom summary\nThis will delete files permanently.".to_string(),
             Some("rm -rf /tmp".to_string()),
         );
-        assert_eq!(pr.description, "Bash wants to run: `rm -rf /tmp`");
+        assert_eq!(pr.description, "Custom summary");
         assert_eq!(pr.danger_explanation, "This will delete files permanently.");
         assert_eq!(pr.input_preview.as_deref(), Some("rm -rf /tmp"));
+    }
+
+    #[test]
+    fn powershell_reason_uses_reason_body_only() {
+        let pr = PermissionRequest::powershell(
+            "id-ps".to_string(),
+            "PowerShell".to_string(),
+            "[High risk] This may modify system-wide security policy.".to_string(),
+            "Set-ExecutionPolicy RemoteSigned".to_string(),
+        );
+        assert!(pr.description.is_empty());
+        assert_eq!(
+            pr.danger_explanation,
+            "[High risk] This may modify system-wide security policy."
+        );
+        assert_eq!(
+            pr.kind,
+            PermissionDialogKind::PowerShell {
+                command: "Set-ExecutionPolicy RemoteSigned".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn powershell_reason_drops_duplicate_command_line() {
+        let pr = PermissionRequest::powershell(
+            "id-ps-2".to_string(),
+            "PowerShell".to_string(),
+            "This may modify system-wide security policy.".to_string(),
+            "Set-ExecutionPolicy RemoteSigned".to_string(),
+        );
+        assert!(pr.description.is_empty());
+        assert_eq!(pr.danger_explanation, "This may modify system-wide security policy.");
+    }
+
+    #[test]
+    fn powershell_reason_without_duplicate_line_keeps_explanation() {
+        let pr = PermissionRequest::powershell(
+            "id-ps-3".to_string(),
+            "PowerShell".to_string(),
+            "This will execute a shell command.".to_string(),
+            "Get-ChildItem".to_string(),
+        );
+        assert!(pr.description.is_empty());
+        assert_eq!(pr.danger_explanation, "This will execute a shell command.");
     }
 
     #[test]
@@ -1273,7 +1337,6 @@ mod tests {
             "id-bash-1".to_string(),
             "Bash".to_string(),
             "Wants to run a command".to_string(),
-            "Wants to run a command".to_string(),
             "ls -la".to_string(),
             None,
         );
@@ -1291,7 +1354,6 @@ mod tests {
         let pr = PermissionRequest::bash(
             "id-bash-2".to_string(),
             "Bash".to_string(),
-            "Wants to run git command".to_string(),
             "Wants to run git command".to_string(),
             "git status".to_string(),
             Some("git ".to_string()),
@@ -1368,7 +1430,6 @@ mod tests {
         let mut pr = PermissionRequest::bash(
             "id".to_string(),
             "Bash".to_string(),
-            "desc".to_string(),
             "desc".to_string(),
             "git push".to_string(),
             Some("git ".to_string()),

--- a/src-rust/crates/tui/src/dialogs.rs
+++ b/src-rust/crates/tui/src/dialogs.rs
@@ -122,14 +122,15 @@ impl PermissionRequest {
     pub fn bash(
         tool_use_id: String,
         tool_name: String,
+        description: String,
         reason: String,
         command: String,
         suggested_prefix: Option<String>,
     ) -> Self {
-        let (description, danger_explanation) = if let Some(nl) = reason.find('\n') {
-            (reason[..nl].to_string(), reason[nl + 1..].to_string())
+        let danger_explanation = if let Some(nl) = reason.find('\n') {
+            reason[nl + 1..].to_string()
         } else {
-            (reason, String::new())
+            String::new()
         };
 
         let options = Self::bash_options(suggested_prefix.as_deref());
@@ -147,6 +148,31 @@ impl PermissionRequest {
             kind,
             selected_option: 0,
             options,
+        }
+    }
+
+    pub fn powershell(
+        tool_use_id: String,
+        tool_name: String,
+        description: String,
+        reason: String,
+        command: String,
+    ) -> Self {
+        let danger_explanation = if let Some(nl) = reason.find('\n') {
+            reason[nl + 1..].to_string()
+        } else {
+            String::new()
+        };
+
+        Self {
+            tool_use_id,
+            tool_name,
+            description,
+            danger_explanation,
+            input_preview: Some(command),
+            kind: PermissionDialogKind::Generic,
+            selected_option: 0,
+            options: Self::default_options(),
         }
     }
 
@@ -1247,6 +1273,7 @@ mod tests {
             "id-bash-1".to_string(),
             "Bash".to_string(),
             "Wants to run a command".to_string(),
+            "Wants to run a command".to_string(),
             "ls -la".to_string(),
             None,
         );
@@ -1264,6 +1291,7 @@ mod tests {
         let pr = PermissionRequest::bash(
             "id-bash-2".to_string(),
             "Bash".to_string(),
+            "Wants to run git command".to_string(),
             "Wants to run git command".to_string(),
             "git status".to_string(),
             Some("git ".to_string()),
@@ -1340,6 +1368,7 @@ mod tests {
         let mut pr = PermissionRequest::bash(
             "id".to_string(),
             "Bash".to_string(),
+            "desc".to_string(),
             "desc".to_string(),
             "git push".to_string(),
             Some("git ".to_string()),


### PR DESCRIPTION
  ## Summary
  - route TUI and tool permission checks through `PermissionManager`
  - add queued interactive permission handling in the TUI for pending approvals
  - enforce workspace-aware read boundaries and MCP/file-related permission checks in default mode

  ## Test plan
  - [x] cargo build --package claurst
  - [x] cargo test --workspace
  - [x] manually verify interactive permission prompts in TUI

  ## Image
<img width="2873" height="1625" alt="PixPin_2026-04-21_11-34-44" src="https://github.com/user-attachments/assets/dcdc1c66-150f-42e8-ba22-f8e62b1cec3f" />
