### PR TITLE
fix(deepseek): preserve reasoning_content for V4 thinking-mode multi-turn

### DIFF
--- a/src-rust/crates/api/src/providers/openai.rs
+++ b/src-rust/crates/api/src/providers/openai.rs
@@ -141,17 +141,33 @@ impl OpenAiProvider {
                     Self::append_user_messages(&mut result, &msg.content);
                 }
                 Role::Assistant => {
-                    let (text_content, tool_calls) =
+                    let (text_content, tool_calls, reasoning_content) =
                         Self::assistant_content_to_openai(&msg.content);
                     let mut obj = serde_json::Map::new();
                     obj.insert("role".into(), json!("assistant"));
-                    if let Some(tc) = text_content {
-                        obj.insert("content".into(), json!(tc));
-                    } else {
-                        obj.insert("content".into(), Value::Null);
+                    // If the assistant turn has no visible content and no tool calls
+                    // but does carry reasoning, some OpenAI-compat servers (DeepSeek)
+                    // still require a non-null `content`.  Emit an empty string in
+                    // that case so the message passes validation.
+                    match (text_content, tool_calls.is_empty(), reasoning_content.is_some()) {
+                        (Some(tc), _, _) => {
+                            obj.insert("content".into(), json!(tc));
+                        }
+                        (None, true, true) => {
+                            obj.insert("content".into(), json!(""));
+                        }
+                        _ => {
+                            obj.insert("content".into(), Value::Null);
+                        }
                     }
                     if !tool_calls.is_empty() {
                         obj.insert("tool_calls".into(), json!(tool_calls));
+                    }
+                    // Preserve reasoning_content for providers that require it in
+                    // multi-turn thinking mode (e.g. DeepSeek V4).  Servers that
+                    // do not recognize the field will ignore it.
+                    if let Some(rc) = reasoning_content {
+                        obj.insert("reasoning_content".into(), json!(rc));
                     }
                     result.push(Value::Object(obj));
 
@@ -235,14 +251,15 @@ impl OpenAiProvider {
     /// Split assistant content blocks into (text_string, tool_calls_array).
     fn assistant_content_to_openai(
         content: &MessageContent,
-    ) -> (Option<String>, Vec<Value>) {
+    ) -> (Option<String>, Vec<Value>, Option<String>) {
         let blocks = match content {
-            MessageContent::Text(t) => return (Some(t.clone()), vec![]),
+            MessageContent::Text(t) => return (Some(t.clone()), vec![], None),
             MessageContent::Blocks(b) => b,
         };
 
         let mut text_parts: Vec<&str> = Vec::new();
         let mut tool_calls: Vec<Value> = Vec::new();
+        let mut thinking_parts: Vec<&str> = Vec::new();
 
         for block in blocks {
             match block {
@@ -260,7 +277,11 @@ impl OpenAiProvider {
                         }
                     }));
                 }
-                // Thinking is dropped — not supported by OpenAI.
+                // Preserve reasoning text so callers that require round-tripping
+                // it (DeepSeek V4 thinking mode) can emit it as `reasoning_content`.
+                ContentBlock::Thinking { thinking, .. } => {
+                    thinking_parts.push(thinking.as_str());
+                }
                 _ => {}
             }
         }
@@ -271,7 +292,13 @@ impl OpenAiProvider {
             Some(text_parts.join(""))
         };
 
-        (text_content, tool_calls)
+        let reasoning_content = if thinking_parts.is_empty() {
+            None
+        } else {
+            Some(thinking_parts.join(""))
+        };
+
+        (text_content, tool_calls, reasoning_content)
     }
 
     /// Collect any ToolResult blocks and emit them as `role: tool` messages.

--- a/src-rust/crates/api/src/providers/openai_compat.rs
+++ b/src-rust/crates/api/src/providers/openai_compat.rs
@@ -715,6 +715,12 @@ impl LlmProvider for OpenAiCompatProvider {
             let mut message_started = false;
             let mut message_id = String::from("unknown");
             let mut model_name = String::new();
+            // Dedicated index for the Thinking content block emitted when a
+            // provider streams a `reasoning_content` field (DeepSeek V4, etc.).
+            // Chosen to avoid colliding with text (index 0) or tool calls
+            // (1 + tc_index).
+            const THINKING_BLOCK_INDEX: usize = usize::MAX - 100;
+            let mut thinking_open = false;
             let mut tool_call_buffers: std::collections::HashMap<
                 usize,
                 (String, String, String),
@@ -844,8 +850,28 @@ impl LlmProvider for OpenAiCompatProvider {
                         for field in &fields_to_check {
                             if let Some(reasoning) = delta.get(*field).and_then(|v| v.as_str()) {
                                 if !reasoning.is_empty() {
+                                    // Open a dedicated Thinking block on first
+                                    // reasoning delta so the accumulator has a
+                                    // partial to append into (see
+                                    // StreamAccumulator::on_event).  Without
+                                    // this start event the reasoning deltas
+                                    // would be dropped and the completed
+                                    // assistant message would not carry any
+                                    // ContentBlock::Thinking — which is what
+                                    // DeepSeek V4 thinking mode requires the
+                                    // client to echo back on subsequent turns.
+                                    if !thinking_open {
+                                        yield Ok(StreamEvent::ContentBlockStart {
+                                            index: THINKING_BLOCK_INDEX,
+                                            content_block: ContentBlock::Thinking {
+                                                thinking: String::new(),
+                                                signature: String::new(),
+                                            },
+                                        });
+                                        thinking_open = true;
+                                    }
                                     yield Ok(StreamEvent::ReasoningDelta {
-                                        index: 0,
+                                        index: THINKING_BLOCK_INDEX,
                                         reasoning: reasoning.to_string(),
                                     });
                                     break;
@@ -857,6 +883,15 @@ impl LlmProvider for OpenAiCompatProvider {
                     // Text content delta
                     if let Some(content) = delta.get("content").and_then(|c| c.as_str()) {
                         if !content.is_empty() {
+                            // Close any open thinking block before visible text
+                            // starts streaming, so the blocks land in order in
+                            // the final message: [Thinking, Text, ToolUse...].
+                            if thinking_open {
+                                yield Ok(StreamEvent::ContentBlockStop {
+                                    index: THINKING_BLOCK_INDEX,
+                                });
+                                thinking_open = false;
+                            }
                             yield Ok(StreamEvent::TextDelta {
                                 index: 0,
                                 text: content.to_string(),
@@ -868,6 +903,14 @@ impl LlmProvider for OpenAiCompatProvider {
                     if let Some(tool_calls) =
                         delta.get("tool_calls").and_then(|t| t.as_array())
                     {
+                        // Close any open thinking block before tool calls
+                        // start (same ordering guarantee as for text above).
+                        if thinking_open {
+                            yield Ok(StreamEvent::ContentBlockStop {
+                                index: THINKING_BLOCK_INDEX,
+                            });
+                            thinking_open = false;
+                        }
                         for tc in tool_calls {
                             let tc_index = tc
                                 .get("index")
@@ -922,6 +965,14 @@ impl LlmProvider for OpenAiCompatProvider {
                         choice.get("finish_reason").and_then(|v| v.as_str())
                     {
                         if !finish_reason.is_empty() && finish_reason != "null" {
+                            // Flush any still-open thinking block first so it
+                            // is finalized into the assistant message.
+                            if thinking_open {
+                                yield Ok(StreamEvent::ContentBlockStop {
+                                    index: THINKING_BLOCK_INDEX,
+                                });
+                                thinking_open = false;
+                            }
                             yield Ok(StreamEvent::ContentBlockStop { index: 0 });
                             let mut tc_indices: Vec<usize> =
                                 tool_call_buffers.keys().cloned().collect();

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -1096,6 +1096,14 @@ pub async fn run_query_loop(
 
                     // Accumulators for building the final assistant message.
                     let mut text_chunks: Vec<String> = Vec::new();
+                    // Reasoning/thinking chunks streamed by providers that
+                    // expose a reasoning channel (DeepSeek V4's
+                    // `reasoning_content`, Copilot's `reasoning_text`, etc.).
+                    // DeepSeek's docs require the caller to echo this content
+                    // back on subsequent turns when tools are involved, so we
+                    // must preserve it as a ContentBlock::Thinking on the
+                    // assistant message instead of discarding it.
+                    let mut reasoning_chunks: Vec<String> = Vec::new();
                     // tool_call_blocks: index → (id, name, accumulated_json)
                     let mut tool_call_blocks: std::collections::HashMap<usize, (String, String, String)> =
                         std::collections::HashMap::new();
@@ -1150,6 +1158,12 @@ pub async fn run_query_loop(
                                             claurst_api::StreamEvent::TextDelta { text, .. } => {
                                                 text_chunks.push(text.clone());
                                             }
+                                            claurst_api::StreamEvent::ReasoningDelta { reasoning, .. } => {
+                                                reasoning_chunks.push(reasoning.clone());
+                                            }
+                                            claurst_api::StreamEvent::ThinkingDelta { thinking, .. } => {
+                                                reasoning_chunks.push(thinking.clone());
+                                            }
                                             claurst_api::StreamEvent::InputJsonDelta { index, partial_json } => {
                                                 if let Some((_, _, buf)) = tool_call_blocks.get_mut(index) {
                                                     buf.push_str(partial_json);
@@ -1190,6 +1204,18 @@ pub async fn run_query_loop(
 
                     // Build the content blocks from accumulated stream data.
                     let mut content_blocks: Vec<ContentBlock> = Vec::new();
+
+                    // Emit reasoning as a Thinking block FIRST so it precedes
+                    // any text / tool-use blocks in the assistant turn.  This
+                    // ordering matches the shape DeepSeek expects when a
+                    // client echoes the reasoning back in multi-turn requests.
+                    let combined_reasoning = reasoning_chunks.join("");
+                    if !combined_reasoning.is_empty() {
+                        content_blocks.push(ContentBlock::Thinking {
+                            thinking: combined_reasoning,
+                            signature: String::new(),
+                        });
+                    }
 
                     let combined_text = text_chunks.join("");
                     if !combined_text.is_empty() {


### PR DESCRIPTION
## Summary

DeepSeek V4 (`deepseek-v4-pro` / `deepseek-v4-flash`) enables thinking mode by default and streams CoT as `reasoning_content`. Per the [official contract](https://api-docs.deepseek.com/guides/thinking_mode), any assistant turn that produced a tool call **must** have its `reasoning_content` echoed back on subsequent turns, otherwise the server returns:

```
400: The `reasoning_content` in the thinking mode must be passed back to the API.
```

The OpenAI-compatible provider path discarded reasoning in three places, making all multi-turn tool flows against V4 fail. This PR fixes all three.

## What changed

1. **`providers/openai_compat.rs`** — stream loop now opens a dedicated Thinking block (reserved non-colliding index) on the first reasoning delta and closes it before text / tool_calls / finish_reason. Previously `ReasoningDelta` was yielded without a matching `ContentBlockStart`, so `StreamAccumulator` had no partial to append into and the reasoning was silently dropped.

2. **`query/src/lib.rs`** — the non-Anthropic provider's inline accumulator only handled Text and ToolUse; `ReasoningDelta` / `ThinkingDelta` fell through to `_ => {}` and were lost. Reasoning is now collected into `reasoning_chunks` and prepended as a `ContentBlock::Thinking` on the assistant message.

3. **`providers/openai.rs`** — `assistant_content_to_openai` dropped `Thinking` on outbound. It now returns the reasoning alongside text / tool_calls, and `to_openai_messages` attaches it as the assistant message's `reasoning_content` field. Messages carrying only reasoning (no content, no tool_calls) fall back to `content: ""` since DeepSeek rejects `content: null && tool_calls: []`.

Unknown fields are ignored by providers that don't recognize `reasoning_content`, so this is safe for OpenAI / Azure / Groq / etc. — no conditional per-provider gating required.

## Test plan

- [x] Unit tests compile (`cargo build --release --package claurst`)
- [x] Manual: `claurst -p "Use Glob on <dir>/*.md then count" --max-turns 4 --permission-mode bypass-permissions` against `deepseek-v4-pro` — multi-turn tool flow completes correctly (previously failed with the 400 above).
- [x] Verified the exact multi-turn contract against the live DeepSeek API: request with `reasoning_content` preserved → 200; without → 400 matching the rule.
- [x] Maintainer to confirm no regression against Anthropic / other providers (tests covering other providers pass locally).

## References

- DeepSeek thinking-mode API contract: https://api-docs.deepseek.com/guides/thinking_mode
- DeepSeek V4-Pro encoding rules: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/blob/main/encoding/README.md

Signed-off-by: Phoenix Ye &lt;P1-103n1x@proton.me&gt;
