### PR TITLE
fix(ollama): replace null content with empty string to prevent crash after tool use

### DIFF
--- a/src-rust/crates/api/src/providers/openai_compat.rs
+++ b/src-rust/crates/api/src/providers/openai_compat.rs
@@ -251,8 +251,11 @@ impl OpenAiCompatProvider {
                 &request.messages,
                 field,
             );
-            // DeepSeek rejects `content: null` on assistant messages — it
-            // requires either a non-null content (even "") or tool_calls.
+        }
+
+        // Some providers (DeepSeek, Ollama) reject `content: null` on
+        // assistant messages — replace with an empty string.
+        if self.quirks.reasoning_field.is_some() || self.quirks.no_api_key_required {
             Self::ensure_content_not_null(&mut messages);
         }
 


### PR DESCRIPTION
## Problem

When using Ollama with models that use tool calls (e.g. qwen3.5, devstral), 
Claurst crashes after the first tool use with:

  ERROR Provider stream failed provider=ollama 
  error=[ollama] Invalid request: invalid message content type: <nil>

This happens because when an assistant message contains only tool_calls 
(no text), the content field is set to `null`. The OpenAI spec allows this, 
but Ollama rejects it.

## Fix

In `build_messages()`, replace `content: null` with `content: ""` for 
assistant messages when the provider does not require an API key (Ollama, 
LM Studio, llama.cpp).

## Testing

Reproduced and verified on:
- macOS Apple M5, 32GB RAM
- Ollama 0.13+
- Models: qwen3.5:9b, qwen3.5:27b, devstral-small-2:24b

Before fix: crash after any tool use in the same session
After fix: conversation continues normally after tool use ✅
