### PR TITLE
fix: MCP stdio startup and environment propagation

### DIFF
--- a/src-rust/Cargo.lock
+++ b/src-rust/Cargo.lock
@@ -800,6 +800,7 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
+ "which",
 ]
 
 [[package]]

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -604,6 +604,37 @@ async fn main() -> anyhow::Result<()> {
         Arc::new(InteractivePermissionHandler::with_manager(permission_manager.clone()))
     };
     let cost_tracker = CostTracker::new();
+
+    // Load plugins and register any plugin-provided MCP servers into the
+    // in-memory config (does not modify the settings file on disk).
+    let plugin_registry = claurst_plugins::load_plugins(&cwd, &[]).await;
+    {
+        let plugin_cmd_count = plugin_registry.all_command_defs().len();
+        let plugin_hook_count = plugin_registry
+            .build_hook_registry()
+            .values()
+            .map(|v| v.len())
+            .sum::<usize>();
+        info!(
+            plugins = plugin_registry.enabled_count(),
+            commands = plugin_cmd_count,
+            hooks = plugin_hook_count,
+            "Plugins loaded"
+        );
+
+        // Register plugin MCP servers before constructing the MCP manager so they connect at startup.
+        let existing_names: std::collections::HashSet<String> = config
+            .mcp_servers
+            .iter()
+            .map(|s| s.name.clone())
+            .collect();
+        for mcp_server in plugin_registry.all_mcp_servers() {
+            if !existing_names.contains(&mcp_server.name) {
+                config.mcp_servers.push(mcp_server);
+            }
+        }
+    }
+
     // Use --session-id if provided, otherwise generate a fresh UUID.
     let session_id = cli
         .session_id_flag
@@ -649,37 +680,6 @@ async fn main() -> anyhow::Result<()> {
     // (AgentTool lives in cc-query to avoid a circular cc-tools ↔ cc-query dependency).
     // Wrap in Arc so the list can be shared by the main loop AND the cron scheduler.
     let tools = build_tools_with_mcp(mcp_manager_arc.clone());
-
-    // Load plugins and register any plugin-provided MCP servers into the
-    // in-memory config (does not modify the settings file on disk).
-    let plugin_registry = claurst_plugins::load_plugins(&cwd, &[]).await;
-    {
-        let plugin_cmd_count = plugin_registry.all_command_defs().len();
-        let plugin_hook_count = plugin_registry
-            .build_hook_registry()
-            .values()
-            .map(|v| v.len())
-            .sum::<usize>();
-        info!(
-            plugins = plugin_registry.enabled_count(),
-            commands = plugin_cmd_count,
-            hooks = plugin_hook_count,
-            "Plugins loaded"
-        );
-
-        // Register plugin MCP servers into the in-memory config so they are
-        // picked up by any subsequent MCP manager construction.
-        let existing_names: std::collections::HashSet<String> = config
-            .mcp_servers
-            .iter()
-            .map(|s| s.name.clone())
-            .collect();
-        for mcp_server in plugin_registry.all_mcp_servers() {
-            if !existing_names.contains(&mcp_server.name) {
-                config.mcp_servers.push(mcp_server);
-            }
-        }
-    }
 
     // Build model registry for dynamic model/provider resolution.
     // The registry is pre-populated with a hardcoded snapshot and enriched

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -888,6 +888,7 @@ pub mod config {
 
     /// Top-level configuration values, merged from CLI args + settings file + env.
     #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+    #[serde(default)]
     pub struct Config {
         pub api_key: Option<String>,
         pub model: Option<String>,
@@ -3786,6 +3787,31 @@ mod tests {
     }
 
     // ---- Config tests -------------------------------------------------------
+
+    #[test]
+    fn test_settings_config_mcp_server_env_deserializes_with_defaults() {
+        let settings: crate::config::Settings = serde_json::from_str(
+            r#"{
+                "config": {
+                    "mcp_servers": [
+                        {
+                            "name": "mcp-router",
+                            "command": "pnpx",
+                            "args": ["@mcp_router/cli@latest", "connect"],
+                            "env": { "MCPR_TOKEN": "test-token" },
+                            "type": "stdio"
+                        }
+                    ]
+                }
+            }"#,
+        )
+        .expect("parse minimal mcp server config");
+
+        let config = settings.effective_config();
+        let server = config.mcp_servers.first().expect("mcp server loaded");
+        assert_eq!(server.name, "mcp-router");
+        assert_eq!(server.env.get("MCPR_TOKEN").map(String::as_str), Some("test-token"));
+    }
 
     #[test]
     fn test_config_effective_model_default() {

--- a/src-rust/crates/mcp/Cargo.toml
+++ b/src-rust/crates/mcp/Cargo.toml
@@ -28,4 +28,5 @@ dirs = { workspace = true }
 chrono = { workspace = true }
 open = { workspace = true }
 urlencoding = { workspace = true }
+which = { workspace = true }
 rmcp = { version = "1.4.0", default-features = false, features = ["client", "auth", "transport-child-process", "transport-streamable-http-client-reqwest", "reqwest-native-tls"] }

--- a/src-rust/crates/mcp/src/rmcp_backend.rs
+++ b/src-rust/crates/mcp/src/rmcp_backend.rs
@@ -92,6 +92,14 @@ impl ClientHandler for RmcpNotificationClient {
     }
 }
 
+fn build_stdio_command(command: &str, config: &claurst_core::config::McpServerConfig) -> Command {
+    let program = which::which(command).unwrap_or_else(|_| command.into());
+    Command::new(program).configure(|cmd| {
+        cmd.args(&config.args);
+        cmd.envs(&config.env);
+    })
+}
+
 pub struct RmcpClientBackend {
     snapshot: McpClientSnapshot,
     peer: rmcp::Peer<RoleClient>,
@@ -109,10 +117,7 @@ impl RmcpClientBackend {
             .clone()
             .ok_or_else(|| anyhow::anyhow!("MCP server '{}' has no command configured", config.name))?;
 
-        let transport = TokioChildProcess::new(Command::new(&command).configure(|cmd| {
-            cmd.args(&config.args);
-            cmd.envs(&config.env);
-        }))
+        let transport = TokioChildProcess::new(build_stdio_command(&command, config))
         .map_err(|e| anyhow::anyhow!("failed to spawn rmcp stdio child for '{}': {}", config.name, e))?;
 
         let client_info = build_client_info(rmcp_model::ProtocolVersion::default());
@@ -896,6 +901,29 @@ mod tests {
             .send()
             .await
             .expect("fetch test response")
+    }
+
+    #[test]
+    fn build_stdio_command_includes_configured_env() {
+        let config = McpServerConfig {
+            name: "mcp-router".to_string(),
+            command: Some("pnpx".to_string()),
+            args: vec!["@mcp_router/cli@latest".to_string(), "connect".to_string()],
+            env: HashMap::from([("MCPR_TOKEN".to_string(), "test-token".to_string())]),
+            url: None,
+            server_type: "stdio".to_string(),
+        };
+
+        let command = build_stdio_command("definitely-missing-mcp-command", &config);
+        let envs = command.as_std().get_envs().collect::<Vec<_>>();
+
+        assert_eq!(command.as_std().get_program().to_string_lossy(), "definitely-missing-mcp-command");
+        assert!(envs.iter().any(|(key, value)| {
+            key.to_string_lossy() == "MCPR_TOKEN"
+                && value
+                    .as_ref()
+                    .is_some_and(|value| value.to_string_lossy() == "test-token")
+        }));
     }
 
     #[test]


### PR DESCRIPTION
Register plugin-provided MCP servers before the MCP manager is constructed so stdio servers are connected during startup.Preserve configured environment variables when launching MCP stdio child processes.
Resolve stdio commands through which' when available, while keeping the original command as a fallback.Add regression tests for MCP server env deserialization and stdio command env propagation.