### PR TITLE
feat: add OpenCode Go as a provider option in /connect

### DIFF
--- a/src-rust/crates/api/src/providers/openai_compat_providers.rs
+++ b/src-rust/crates/api/src/providers/openai_compat_providers.rs
@@ -44,6 +44,7 @@ pub fn provider_for_id(provider_id: &str) -> Option<OpenAiCompatProvider> {
         "upstage" => Some(upstage()),
         "stepfun" => Some(stepfun()),
         "fireworks" => Some(fireworks()),
+        "opencode-go" | "opencode_go" => Some(opencode_go()),
         _ => None,
     }
 }
@@ -475,4 +476,21 @@ pub fn fireworks() -> OpenAiCompatProvider {
         "https://api.fireworks.ai/inference/v1",
     )
     .with_api_key(key)
+}
+
+/// OpenCode Go — flat-rate subscription endpoint hosted by opencode.ai.
+/// OpenAI-compatible chat completions surface; same key works for the Zen
+/// metered tier, hence the shared `OPENCODE_API_KEY` env var.
+pub fn opencode_go() -> OpenAiCompatProvider {
+    let key = std::env::var("OPENCODE_API_KEY").unwrap_or_default();
+    OpenAiCompatProvider::new(
+        ProviderId::OPENCODE_GO,
+        "OpenCode Go",
+        "https://opencode.ai/zen/go/v1",
+    )
+    .with_api_key(key)
+    .with_quirks(ProviderQuirks {
+        include_usage_in_stream: true,
+        ..Default::default()
+    })
 }

--- a/src-rust/crates/api/src/registry.rs
+++ b/src-rust/crates/api/src/registry.rs
@@ -566,6 +566,9 @@ impl ProviderRegistry {
         if std::env::var("FIREWORKS_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
             self.register(Arc::new(p::fireworks()));
         }
+        if std::env::var("OPENCODE_API_KEY").map(|v| !v.is_empty()).unwrap_or(false) {
+            self.register(Arc::new(p::opencode_go()));
+        }
         self
     }
 }

--- a/src-rust/crates/core/src/provider_id.rs
+++ b/src-rust/crates/core/src/provider_id.rs
@@ -72,6 +72,7 @@ impl ProviderId {
     pub const NOVITA: &'static str = "novita";
     pub const MINIMAX: &'static str = "minimax";
     pub const CODEX: &'static str = "codex";
+    pub const OPENCODE_GO: &'static str = "opencode-go";
 }
 
 impl fmt::Display for ProviderId {

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -249,6 +249,7 @@ fn provider_picker_items() -> Vec<SelectItem> {
         SelectItem { id: "groq".into(), title: "Groq".into(), description: "Fast hosted inference".into(), category: "Popular".into(), badge: Some("FREE".into()) },
         SelectItem { id: "ollama".into(), title: "Ollama".into(), description: "Run models locally".into(), category: "Popular".into(), badge: Some("LOCAL".into()) },
         SelectItem { id: "zai".into(), title: "Z.AI".into(), description: "GLM-5.1 / GLM-5 / GLM-4.7 Coding Plan".into(), category: "Popular".into(), badge: None },
+        SelectItem { id: "opencode-go".into(), title: "OpenCode Go".into(), description: "$10/mo flat-rate · Kimi · DeepSeek · GLM · MiniMax".into(), category: "Popular".into(), badge: None },
         SelectItem { id: "cerebras".into(), title: "Cerebras".into(), description: "Fast hosted inference".into(), category: "Other".into(), badge: Some("FREE".into()) },
         SelectItem { id: "sambanova".into(), title: "SambaNova".into(), description: "Fast hosted inference".into(), category: "Other".into(), badge: Some("FREE".into()) },
         SelectItem { id: "lmstudio".into(), title: "LM Studio".into(), description: "Local model server".into(), category: "Other".into(), badge: Some("LOCAL".into()) },


### PR DESCRIPTION
OpenCode Go is a flat-rate subscription endpoint at opencode.ai that exposes an OpenAI-compatible /v1/chat/completions surface, fronting Kimi, DeepSeek, GLM, MiniMax, and Qwen models. Wire it up as a stock OpenAiCompat provider so users can pick it from the /connect picker and paste their OPENCODE_API_KEY.