### PR TITLE
fix(api): match OVERFLOW_PATTERNS as real regexes via RegexSet

### DIFF
--- a/src-rust/Cargo.lock
+++ b/src-rust/Cargo.lock
@@ -644,6 +644,7 @@ dependencies = [
  "hmac",
  "once_cell",
  "parking_lot",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/src-rust/crates/api/Cargo.toml
+++ b/src-rust/crates/api/Cargo.toml
@@ -18,6 +18,7 @@ bytes = { workspace = true }
 async-trait = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
+regex = { workspace = true }
 xxhash-rust = { version = "0.8", features = ["xxh64"] }
 async-stream = { workspace = true }
 chrono = { workspace = true }

--- a/src-rust/crates/api/src/error_handling.rs
+++ b/src-rust/crates/api/src/error_handling.rs
@@ -12,6 +12,8 @@
 use std::time::Duration;
 
 use claurst_core::provider_id::ProviderId;
+use once_cell::sync::Lazy;
+use regex::RegexSet;
 
 use crate::provider_error::ProviderError;
 
@@ -19,7 +21,12 @@ use crate::provider_error::ProviderError;
 // Overflow pattern table
 // ---------------------------------------------------------------------------
 
-/// 29+ context-overflow patterns that appear across all major providers.
+/// Context-overflow patterns that appear across all major providers.
+///
+/// Patterns are real regexes (compiled once into a [`RegexSet`] for batched
+/// matching). Plain phrases match as literal substrings; entries containing
+/// `.*` / `.+` exercise the regex engine. Matching is case-insensitive via the
+/// `(?i)` prefix applied to every pattern.
 static OVERFLOW_PATTERNS: &[&str] = &[
     "prompt is too long",
     "input is too long for requested model",
@@ -52,20 +59,33 @@ static OVERFLOW_PATTERNS: &[&str] = &[
     "input.*too.*long",
 ];
 
+/// Compiled regex set used by [`is_context_overflow`].
+///
+/// Built once on first use. `(?i)` makes each pattern case-insensitive so the
+/// caller no longer needs to lowercase the input. `RegexSet` evaluates all
+/// patterns in a single pass over the input — typically faster than the prior
+/// per-pattern `.contains()` loop once the set is warmed.
+static OVERFLOW_REGEX: Lazy<RegexSet> = Lazy::new(|| {
+    let with_flags: Vec<String> = OVERFLOW_PATTERNS
+        .iter()
+        .map(|p| format!("(?i){}", p))
+        .collect();
+    RegexSet::new(&with_flags).expect("OVERFLOW_PATTERNS must compile")
+});
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
 /// Returns `true` if `message` matches any known context-overflow pattern.
 ///
-/// The comparison is case-insensitive.  Patterns are matched as substrings
-/// (not full regexes) for performance — the pattern table is designed so that
-/// simple substring matching is sufficient.
+/// Matching is case-insensitive (each pattern is prefixed with `(?i)` at
+/// compile time). Patterns are real regexes evaluated as a single
+/// [`RegexSet`] pass — entries containing `.*` / `.+` participate as the
+/// author intended (under the previous substring-only matcher they were
+/// silently dead).
 pub fn is_context_overflow(message: &str) -> bool {
-    let lower = message.to_lowercase();
-    OVERFLOW_PATTERNS
-        .iter()
-        .any(|pattern| lower.contains(&pattern.to_lowercase()))
+    OVERFLOW_REGEX.is_match(message)
 }
 
 /// Convert an HTTP error response into the appropriate [`ProviderError`].
@@ -262,8 +282,7 @@ impl RetryConfig {
     /// Applies exponential back-off with ±10 % jitter derived from the
     /// current system time (no external `rand` dependency required).
     pub fn delay_for_attempt(&self, attempt: u32) -> Duration {
-        let base = self.initial_delay.as_secs_f64()
-            * self.backoff_multiplier.powi(attempt as i32);
+        let base = self.initial_delay.as_secs_f64() * self.backoff_multiplier.powi(attempt as i32);
         let jitter = base * 0.1 * time_jitter_f64();
         Duration::from_secs_f64((base + jitter).min(self.max_delay.as_secs_f64()))
     }
@@ -293,6 +312,86 @@ mod tests {
         assert!(is_context_overflow("This exceeds the context window"));
         assert!(is_context_overflow("Maximum context length exceeded"));
         assert!(!is_context_overflow("something else went wrong"));
+    }
+
+    /// Regression: every entry in `OVERFLOW_PATTERNS` containing `.*` was
+    /// silently dead under the previous substring-only matcher because real
+    /// error messages don't contain a literal `.*`. The samples below are
+    /// representative of the messages each pattern was *meant* to capture.
+    #[test]
+    fn test_is_context_overflow_regex_patterns_fire() {
+        // "input token count.*exceeds the maximum" — Anthropic-style.
+        assert!(is_context_overflow(
+            "input token count of 250000 exceeds the maximum allowed"
+        ));
+        // "maximum context length is.*tokens" — generic.
+        assert!(is_context_overflow("maximum context length is 8192 tokens"));
+        // "too large for model with.*maximum context length" — vLLM.
+        assert!(is_context_overflow(
+            "This model's prompt is too large for model with maximum context length 32768"
+        ));
+        // "context length is only.*tokens" — provider-specific.
+        assert!(is_context_overflow(
+            "context length is only 4096 tokens, requested 9000"
+        ));
+        // "input length.*exceeds.*context length" — gemini-compat / OpenAI relay.
+        assert!(is_context_overflow(
+            "input length of 9000 exceeds the context length of 8000"
+        ));
+        // "context.*length.*exceeded" — Together AI.
+        assert!(is_context_overflow(
+            "request rejected: context length has been exceeded"
+        ));
+        // "token.*limit.*exceeded" — generic provider-overflow phrasing.
+        assert!(is_context_overflow(
+            "your request token limit has been exceeded for this model"
+        ));
+        // "prompt.*too.*long" — variant phrasing the literal "prompt too long" misses.
+        assert!(is_context_overflow(
+            "this prompt is way too long, please shorten"
+        ));
+        // "exceeds.*context.*size" — fallback formatter.
+        assert!(is_context_overflow(
+            "request exceeds the context size limit"
+        ));
+        // "context.*window.*exceeded" — bedrock-style.
+        assert!(is_context_overflow("the context window has been exceeded"));
+        // "max.*tokens.*exceeded" — short summary phrasing.
+        assert!(is_context_overflow("max input tokens exceeded"));
+        // "input.*too.*long" — variant phrasing.
+        assert!(is_context_overflow(
+            "the input was too long for the configured limit"
+        ));
+    }
+
+    #[test]
+    fn test_is_context_overflow_case_insensitive() {
+        assert!(is_context_overflow("PROMPT IS TOO LONG"));
+        assert!(is_context_overflow("Maximum Context Length"));
+        assert!(is_context_overflow(
+            "INPUT TOKEN COUNT 9999 EXCEEDS THE MAXIMUM"
+        ));
+    }
+
+    #[test]
+    fn test_is_context_overflow_no_false_positives_on_unrelated_errors() {
+        assert!(!is_context_overflow("invalid api key"));
+        assert!(!is_context_overflow(
+            "rate limit exceeded for requests per minute"
+        ));
+        assert!(!is_context_overflow("model not found"));
+        assert!(!is_context_overflow("billing not active"));
+    }
+
+    #[test]
+    fn test_overflow_regex_compiles() {
+        // Forces lazy initialisation; panics here surface as test failures
+        // rather than runtime crashes inside `parse_error_response`.
+        assert_eq!(
+            OVERFLOW_REGEX.patterns().len(),
+            OVERFLOW_PATTERNS.len(),
+            "RegexSet must contain exactly one entry per OVERFLOW_PATTERNS line"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Bug

`crates/api/src/error_handling.rs::OVERFLOW_PATTERNS` lists 29 entries used by `is_context_overflow` to classify provider responses as `ProviderError::ContextOverflow`. **12 of those entries contain `.*` meta-characters** (e.g. `\"input token count.*exceeds the maximum\"`, `\"too large for model with.*maximum context length\"`, `\"context.*length.*exceeded\"`).

The matcher uses substring comparison:

```rust
OVERFLOW_PATTERNS
    .iter()
    .any(|pattern| lower.contains(&pattern.to_lowercase()))
```

`String::contains` is literal — there is no regex engine — so any pattern with `.*` only matches an error message that contains a literal `.*`, which provider servers never emit. Those 12 entries are dead code and the classifier silently under-detects overflow on real error bodies it was meant to catch.

The doc comment claimed \"the pattern table is designed so that simple substring matching is sufficient,\" but the table itself disagrees with that claim.

## Fix

Compile all 29 entries once into a `regex::RegexSet` (lazy via `once_cell::sync::Lazy`). Each pattern is prefixed with `(?i)` so case-insensitivity no longer requires an upfront `to_lowercase` allocation on the input. `is_context_overflow` becomes a single `OVERFLOW_REGEX.is_match(message)` call.

Pattern strings are unchanged — each is now interpreted as the author originally intended. `RegexSet` evaluates all patterns in a single pass over the input, so the hot-path cost stays comparable to (and in many cases below) the prior 29-iteration `lower.contains(...)` loop after the lazy initialiser warms up.

## Tests

Added a regression test (`test_is_context_overflow_regex_patterns_fire`) with one realistic error-message sample per previously-dead pattern:

| Pattern | Sample message |
| --- | --- |
| `input token count.*exceeds the maximum` | `input token count of 250000 exceeds the maximum allowed` |
| `maximum context length is.*tokens` | `maximum context length is 8192 tokens` |
| `too large for model with.*maximum context length` | `... too large for model with maximum context length 32768` |
| `context length is only.*tokens` | `context length is only 4096 tokens, requested 9000` |
| `input length.*exceeds.*context length` | `input length of 9000 exceeds the context length of 8000` |
| `context.*length.*exceeded` | `request rejected: context length has been exceeded` |
| `token.*limit.*exceeded` | `your request token limit has been exceeded for this model` |
| `prompt.*too.*long` | `this prompt is way too long, please shorten` |
| `exceeds.*context.*size` | `request exceeds the context size limit` |
| `context.*window.*exceeded` | `the context window has been exceeded` |
| `max.*tokens.*exceeded` | `max input tokens exceeded` |
| `input.*too.*long` | `the input was too long for the configured limit` |

Plus:

- `test_is_context_overflow_case_insensitive` — pins the `(?i)` semantics.
- `test_is_context_overflow_no_false_positives_on_unrelated_errors` — guards \"invalid api key\" / \"rate limit exceeded for requests per minute\" / \"model not found\" / \"billing not active\" against accidental overflow classification.
- `test_overflow_regex_compiles` — asserts `RegexSet.patterns().len() == OVERFLOW_PATTERNS.len()` so future edits to the array can't silently fail compilation.

### Pre-fix verification

Running the new regression test against the **prior** matcher body (substring `.contains`):

```
test error_handling::tests::test_is_context_overflow_regex_patterns_fire ... FAILED
assertion failed: is_context_overflow(\"input token count of 250000 exceeds the maximum allowed\")
```

After the fix: 10/10 `error_handling` tests pass.

## Local gates

- `cargo test -p claurst-api` → **31 passed / 1 failed / 0 ignored**
  - The single failure (`codex_adapter::tests::test_anthropic_to_openai_request_basic`) reproduces on `main` without my changes — it's a pre-existing float-precision flake (`0.699999988079071 != 0.7`) in unrelated code. Net new failures: **0**.
- `cargo clippy -p claurst-api --tests --no-deps` → no new warnings on touched files.
- `rustfmt --check crates/api/src/error_handling.rs` → clean.
- `cargo check -p claurst-api --tests` → clean.

## Diff shape

3 files, +111 / -10:

- `crates/api/Cargo.toml` — `regex = { workspace = true }` (already a workspace dep, no version churn).
- `crates/api/src/error_handling.rs` — `OVERFLOW_REGEX: Lazy<RegexSet>`, `is_context_overflow` body collapsed to one line, doc comment refreshed, +12 regression assertions.
- `Cargo.lock` — auto-update for the new transitive in `claurst-api`.

The `OVERFLOW_PATTERNS` array itself is unchanged so anyone adding a new pattern keeps editing the same place.

## Out of scope

- The `extract_token_limit` heuristic (lines 209-229) only inspects words *before* the integer; many real error messages put the token-limit number at the end (`...8192 tokens`) and won't match. Different surface — happy to file a follow-up if useful.
- The default `ClientConfig.beta_features` includes Anthropic-only tags (`interleaved-thinking-2025-05-14`, etc.) that get sent to OpenAI-compatible providers via `MinimaxProvider`. Off-topic for this PR.

---

🔹 AI-assisted (Claude Opus 4.7); reviewed end-to-end before submit.