### PR TITLE
feat(tui): auto-copy selection to clipboard on mouse release

### DIFF
--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -1072,9 +1072,11 @@ pub mod config {
         /// Managed agent (manager-executor) configuration.
         #[serde(default)]
         pub managed_agents: Option<ManagedAgentConfig>,
-        /// When true, releasing a drag selection automatically copies it to the
-        /// system clipboard.
-        #[serde(default = "default_true", rename = "autoCopyOnHighlight")]
+        /// When true, releasing a drag selection automatically copies it to
+        /// the system clipboard. Defaults to `false` — users opt in by
+        /// setting `"autoCopyOnHighlight": true` in
+        /// `~/.claurst/settings.json`.
+        #[serde(default, rename = "autoCopyOnHighlight")]
         pub auto_copy_on_highlight: bool,
     }
 

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -1072,6 +1072,10 @@ pub mod config {
         /// Managed agent (manager-executor) configuration.
         #[serde(default)]
         pub managed_agents: Option<ManagedAgentConfig>,
+        /// When true, releasing a drag selection automatically copies it to the
+        /// system clipboard.
+        #[serde(default = "default_true", rename = "autoCopyOnHighlight")]
+        pub auto_copy_on_highlight: bool,
     }
 
     /// A user-defined slash command template.
@@ -1601,6 +1605,7 @@ pub mod config {
                     SkillsConfig { paths, urls }
                 },
                 managed_agents: over.managed_agents.or(base.managed_agents),
+                auto_copy_on_highlight: over.auto_copy_on_highlight || base.auto_copy_on_highlight,
             }
         }
     }

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -1162,7 +1162,7 @@ impl App {
         let user_keybindings = UserKeybindings::load(&Settings::config_dir());
         let auto_copy_on_highlight = Settings::load_sync()
             .map(|s| s.auto_copy_on_highlight)
-            .unwrap_or(true);
+            .unwrap_or(false);
         Self {
             config,
             cost_tracker,

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -962,6 +962,8 @@ pub struct App {
     pub selection_focus: Option<(u16, u16)>,
     /// Text extracted from the current selection (updated each render frame).
     pub selection_text: RefCell<String>,
+    /// When true, releasing a drag selection automatically copies it to clipboard.
+    pub auto_copy_selection: bool,
 
     // ---- Advanced mouse interaction state --------------------------------
     /// Timestamp of the last left mouse click (for double/triple-click detection).
@@ -1158,6 +1160,9 @@ impl App {
         let config = config;
         let model_name = config.effective_model().to_string();
         let user_keybindings = UserKeybindings::load(&Settings::config_dir());
+        let auto_copy_on_highlight = Settings::load_sync()
+            .map(|s| s.auto_copy_on_highlight)
+            .unwrap_or(true);
         Self {
             config,
             cost_tracker,
@@ -1358,6 +1363,7 @@ impl App {
             selection_anchor: None,
             selection_focus: None,
             selection_text: RefCell::new(String::new()),
+            auto_copy_selection: auto_copy_on_highlight,
             last_click_time: None,
             last_click_position: None,
             click_count: 0,
@@ -5411,6 +5417,19 @@ impl App {
                 // Clear if no actual drag (single click = no selection)
                 if self.selection_anchor == self.selection_focus {
                     self.clear_selection();
+                } else if self.auto_copy_selection {
+                    // Auto-copy finalized selection to clipboard.
+                    let sel_text = self.selection_text.borrow().clone();
+                    if !sel_text.is_empty() {
+                        let copied = crate::image_paste::write_clipboard_text(&sel_text);
+                        if copied {
+                            self.notifications.push(
+                                NotificationKind::Info,
+                                "Copied to clipboard".to_string(),
+                                Some(1),
+                            );
+                        }
+                    }
                 }
             }
             _ => {}


### PR DESCRIPTION
When `auto_copy_selection` is enabled (default true), releasing a drag selection automatically copies the extracted text to the system clipboard and shows a brief notification. This removes the need for a manual `Ctrl+C`/`CMD+C` after highlighting text.