### PR TITLE
Enable Cmd+C / Cmd+V on macOS; enable kitty keyboard protocol

### DIFF
--- a/src-rust/crates/core/src/keybindings.rs
+++ b/src-rust/crates/core/src/keybindings.rs
@@ -154,6 +154,16 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         ("pagedown", "scrollDown", KeyContext::Chat),
         ("tab", "indent", KeyContext::Chat),
         ("shift+enter", "newline", KeyContext::Chat),
+        // Fallback for terminals that do not support the kitty keyboard protocol
+        // (e.g. Terminal.app, older iTerm2, Windows Terminal, or SSH sessions).
+        // Without the protocol, Shift+Enter is sent as a raw newline byte (0x0A,
+        // LF); crossterm reports that as KeyCode::Char('j') with CONTROL because
+        // Ctrl+J == 0x0A in ASCII. When the protocol is enabled (see
+        // PushKeyboardEnhancementFlags in tui/src/lib.rs), terminals like Ghostty
+        // send a proper CSI-u sequence with the Shift modifier instead, so this
+        // fallback is not needed there. Keep it as a compatibility belt-and-braces
+        // for terminals that do not support the protocol.
+        ("ctrl+j", "newline", KeyContext::Chat),
         ("home", "goLineStart", KeyContext::Chat),
         ("end", "goLineEnd", KeyContext::Chat),
 
@@ -636,6 +646,19 @@ mod tests {
         assert_eq!(user.bindings[0].action.as_deref(), Some("chat:externalEditor"));
         assert_eq!(user.bindings[1].chord, "space");
         assert_eq!(user.bindings[1].action, None);
+    }
+
+    #[test]
+    fn test_ctrl_j_maps_to_newline() {
+        let bindings = default_bindings();
+        let ctrl_j = bindings.iter().find(|b| {
+            b.chord.len() == 1
+                && b.chord[0].ctrl
+                && b.chord[0].key == "j"
+                && b.context == KeyContext::Chat
+        });
+        assert!(ctrl_j.is_some(), "ctrl+j binding not found");
+        assert_eq!(ctrl_j.unwrap().action.as_deref(), Some("newline"));
     }
 
     #[test]

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -3699,11 +3699,12 @@ impl App {
             return false;
         }
 
-        // ---- Ctrl+V — clipboard paste (image first, then text fallback) ----
+        // ---- Ctrl+V / Cmd+V — clipboard paste (image first, then text fallback) ----
         // Only fires when NOT in vim Normal/Visual/VisualBlock mode (where \x16 is
         // already consumed by the vim handler above to enter VisualBlock mode).
         if key.code == KeyCode::Char('v')
-            && key.modifiers.contains(KeyModifiers::CONTROL)
+            && (key.modifiers.contains(KeyModifiers::CONTROL)
+                || key.modifiers.contains(KeyModifiers::SUPER))
             && !matches!(
                 self.prompt_input.vim_mode,
                 crate::prompt_input::VimMode::Normal
@@ -3843,6 +3844,19 @@ impl App {
                 self.show_help = !self.show_help;
                 self.help_overlay.toggle();
             }
+            // With the kitty keyboard protocol, Shift+/ is reported as Char('/') with
+            // SHIFT rather than Char('?'), so also accept that form for the help toggle.
+            KeyCode::Char('/')
+                if key.modifiers.contains(KeyModifiers::SHIFT)
+                    && !self.is_streaming
+                    && self.prompt_input.is_empty()
+                    && !key.modifiers.contains(KeyModifiers::CONTROL)
+                    && !key.modifiers.contains(KeyModifiers::ALT)
+                    && !key.modifiers.contains(KeyModifiers::SUPER) =>
+            {
+                self.show_help = !self.show_help;
+                self.help_overlay.toggle();
+            }
 
             KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) && !self.is_streaming => {
                 self.prompt_input.kill_line_backward();
@@ -3885,6 +3899,14 @@ impl App {
 
             // ---- Text entry (blocked while streaming) ------------------
             KeyCode::Char(c) if !self.is_streaming => {
+                // With the kitty keyboard protocol, Shift+letter is reported as the base
+                // (lowercase) key with the SHIFT modifier.  Apply uppercase so the
+                // correct character is inserted.
+                let c = if key.modifiers.contains(KeyModifiers::SHIFT) && c.is_ascii_alphabetic() {
+                    c.to_ascii_uppercase()
+                } else {
+                    c
+                };
                 if self.prompt_input.vim_enabled && self.prompt_input.vim_mode != VimMode::Insert {
                     self.prompt_input.vim_command(&c.to_string());
                 } else {

--- a/src-rust/crates/tui/src/lib.rs
+++ b/src-rust/crates/tui/src/lib.rs
@@ -16,13 +16,11 @@ use crossterm::event::{
     DisableMouseCapture, EnableMouseCapture, KeyboardEnhancementFlags,
     PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
-// EnableBracketedPaste is intentionally NOT used. On Windows, `EnableBracketedPaste` causes
-// Windows Terminal to wrap Ctrl+V content in VT escape sequences that crossterm's Windows
-// Console API backend doesn't decode as `Event::Paste` — the bytes land as raw key events,
-// turning every `\n` into a prompt submit and triggering PTT on any `v` in the text.
-// Paste is handled cleanly via the Ctrl+V clipboard-reader instead (PowerShell / pbpaste /
-// xclip), which works on all platforms without needing bracketed paste mode.
-#[allow(unused_imports)]
+// EnableBracketedPaste is enabled on macOS and Linux only. On Windows, it causes
+// Windows Terminal to wrap Ctrl+V content in VT escape sequences that crossterm's
+// Windows Console API backend doesn't decode as `Event::Paste` — the bytes land as
+// raw key events, turning every `\n` into a prompt submit. Unix terminals (macOS/Linux)
+// handle bracketed paste correctly, allowing multi-line pastes to preserve newlines.
 use crossterm::event::{DisableBracketedPaste, EnableBracketedPaste};
 use crossterm::execute;
 use crossterm::terminal::{
@@ -174,6 +172,29 @@ pub use device_auth_dialog::{DeviceAuthDialogState, DeviceAuthStatus, DeviceAuth
 // Terminal initialization / teardown helpers (public API)
 // ---------------------------------------------------------------------------
 
+/// Restore terminal capabilities (alternate screen, mouse capture, bracketed paste, keyboard enhancement).
+/// Used by both restore_terminal and the panic hook.
+fn restore_terminal_cleanup() -> io::Result<()> {
+    #[cfg(not(target_os = "windows"))]
+    execute!(
+        io::stdout(),
+        LeaveAlternateScreen,
+        DisableMouseCapture,
+        DisableBracketedPaste,
+        PopKeyboardEnhancementFlags,
+    )?;
+
+    #[cfg(target_os = "windows")]
+    execute!(
+        io::stdout(),
+        LeaveAlternateScreen,
+        DisableMouseCapture,
+        PopKeyboardEnhancementFlags,
+    )?;
+
+    Ok(())
+}
+
 /// Set up the terminal for TUI mode (raw mode + alternate screen + mouse capture).
 ///
 /// Also installs a panic hook that restores the terminal before printing the
@@ -193,19 +214,28 @@ pub fn setup_terminal() -> io::Result<Terminal<CrosstermBackend<Stdout>>> {
         if std::thread::current().id() == main_thread_id {
             // Best-effort restore — ignore errors, we're already unwinding.
             let _ = disable_raw_mode();
-            let _ = execute!(
-                io::stdout(),
-                LeaveAlternateScreen,
-                DisableMouseCapture,
-                PopKeyboardEnhancementFlags,
-                crossterm::cursor::Show,
-            );
+            let _ = restore_terminal_cleanup();
+            let _ = execute!(io::stdout(), crossterm::cursor::Show);
         }
         original_hook(panic_info);
     }));
 
     enable_raw_mode()?;
     let mut stdout = io::stdout();
+
+    #[cfg(not(target_os = "windows"))]
+    execute!(
+        stdout,
+        EnterAlternateScreen,
+        EnableMouseCapture,
+        EnableBracketedPaste,
+        PushKeyboardEnhancementFlags(
+            KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                | KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES,
+        ),
+    )?;
+
+    #[cfg(target_os = "windows")]
     execute!(
         stdout,
         EnterAlternateScreen,
@@ -215,6 +245,7 @@ pub fn setup_terminal() -> io::Result<Terminal<CrosstermBackend<Stdout>>> {
                 | KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES,
         ),
     )?;
+
     set_terminal_title("\u{1f980} Claurst");
     let backend = CrosstermBackend::new(stdout);
     let terminal = Terminal::new(backend)?;
@@ -229,12 +260,7 @@ pub fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> io
         terminal.backend_mut(),
         crossterm::terminal::SetTitle(""),
     );
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture,
-        PopKeyboardEnhancementFlags,
-    )?;
+    restore_terminal_cleanup()?;
     terminal.show_cursor()?;
     Ok(())
 }

--- a/src-rust/crates/tui/src/lib.rs
+++ b/src-rust/crates/tui/src/lib.rs
@@ -12,7 +12,10 @@
 // - Bridge connection status badge
 // - Plugin hint banners
 
-use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
+use crossterm::event::{
+    DisableMouseCapture, EnableMouseCapture, KeyboardEnhancementFlags,
+    PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+};
 // EnableBracketedPaste is intentionally NOT used. On Windows, `EnableBracketedPaste` causes
 // Windows Terminal to wrap Ctrl+V content in VT escape sequences that crossterm's Windows
 // Console API backend doesn't decode as `Event::Paste` — the bytes land as raw key events,
@@ -194,6 +197,7 @@ pub fn setup_terminal() -> io::Result<Terminal<CrosstermBackend<Stdout>>> {
                 io::stdout(),
                 LeaveAlternateScreen,
                 DisableMouseCapture,
+                PopKeyboardEnhancementFlags,
                 crossterm::cursor::Show,
             );
         }
@@ -202,7 +206,15 @@ pub fn setup_terminal() -> io::Result<Terminal<CrosstermBackend<Stdout>>> {
 
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    execute!(
+        stdout,
+        EnterAlternateScreen,
+        EnableMouseCapture,
+        PushKeyboardEnhancementFlags(
+            KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                | KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES,
+        ),
+    )?;
     set_terminal_title("\u{1f980} Claurst");
     let backend = CrosstermBackend::new(stdout);
     let terminal = Terminal::new(backend)?;
@@ -217,7 +229,12 @@ pub fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> io
         terminal.backend_mut(),
         crossterm::terminal::SetTitle(""),
     );
-    execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture)?;
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture,
+        PopKeyboardEnhancementFlags,
+    )?;
     terminal.show_cursor()?;
     Ok(())
 }


### PR DESCRIPTION
This fixes `Cmd+C` copy, `Cmd+V` paste, and makes `Shift+Enter` reporting more reliable on terminals that support the protocol.