### PR TITLE
fix(tui): enable Cmd+V/Ctrl+V paste support

### DIFF
--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -2599,6 +2599,24 @@ async fn run_interactive(
                         session.updated_at = chrono::Utc::now();
                     }
                 }
+                Event::Paste(data) => {
+                    // Cmd+V paste on macOS / Ctrl+Shift+V on Linux (via bracketed paste)
+                    if !app.is_streaming
+                        && app.permission_request.is_none()
+                        && !app.history_search_overlay.visible
+                        && app.history_search.is_none()
+                    {
+                        if app.key_input_dialog.visible {
+                            // Paste into API key input dialog
+                            for ch in data.chars() {
+                                app.key_input_dialog.insert_char(ch);
+                            }
+                        } else {
+                            // Paste into main prompt input
+                            app.prompt_input.paste(&data);
+                        }
+                    }
+                }
                 Event::Mouse(mouse) => {
                     app.handle_mouse_event(mouse);
                 }

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -2923,6 +2923,19 @@ impl App {
                 KeyCode::Backspace => {
                     self.key_input_dialog.backspace();
                 }
+                KeyCode::Char('v') if key.modifiers.contains(KeyModifiers::CONTROL) || key.modifiers.contains(KeyModifiers::SUPER) => {
+                    if let Some(text) = crate::image_paste::read_clipboard_text() {
+                        if text.is_empty() {
+                            self.notifications.push(NotificationKind::Warning, "Clipboard is empty".to_string(), Some(2));
+                        } else {
+                            for ch in text.chars() {
+                                self.key_input_dialog.insert_char(ch);
+                            }
+                        }
+                    } else {
+                        self.notifications.push(NotificationKind::Warning, "Could not read clipboard".to_string(), Some(2));
+                    }
+                }
                 KeyCode::Char(c) => {
                     self.key_input_dialog.insert_char(c);
                 }


### PR DESCRIPTION
## Summary

Fixed CMD+V paste not working on Ghostty and other terminals. The main event loop was silently discarding `Event::Paste` events, preventing clipboard paste via bracketed paste mode.

Also added Ctrl+V/Cmd+V clipboard paste support in the API key input dialog with proper error notifications.

Fixes #76.