### PR TITLE
fix(tui): bypass-permissions dialog only shows once per session

### DIFF
--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -1708,10 +1708,13 @@ async fn run_interactive(
 
     // Mirror TS BypassPermissionsModeDialog.tsx startup gate
     // Shown as the highest-priority startup dialog (blocks all other UI).
+    // Only show once per session — subsequent sessions in the same directory
+    // will show the dialog again (not persisted across sessions).
     use claurst_core::config::PermissionMode;
-    if live_config.permission_mode == PermissionMode::BypassPermissions {
+    if live_config.permission_mode == PermissionMode::BypassPermissions && !app.bypass_permissions_dialog_shown {
         app.bypass_permissions_dialog.show();
-    } else {
+        app.bypass_permissions_dialog_shown = true;
+    } else if live_config.permission_mode != PermissionMode::BypassPermissions {
         // Show onboarding only if NOT in bypass-permissions mode.
         // Bypass dialog is a mandatory security gate and takes absolute priority.
         if !has_credentials {

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -831,6 +831,8 @@ pub struct App {
     /// Shown at startup when --dangerously-skip-permissions was passed.
     /// User must explicitly accept or the session exits.
     pub bypass_permissions_dialog: crate::bypass_permissions_dialog::BypassPermissionsDialogState,
+    /// Whether the bypass-permissions dialog has been shown this session.
+    pub bypass_permissions_dialog_shown: bool,
     /// First-launch onboarding welcome dialog.
     pub onboarding_dialog: crate::onboarding_dialog::OnboardingDialogState,
     /// API key input dialog (opened from /connect for key-based providers).
@@ -1266,6 +1268,7 @@ impl App {
             mcp_approval: McpApprovalDialogState::new(),
             go_to_line_dialog: GoToLineDialog::new(),
             bypass_permissions_dialog: crate::bypass_permissions_dialog::BypassPermissionsDialogState::new(),
+            bypass_permissions_dialog_shown: false,
             onboarding_dialog: crate::onboarding_dialog::OnboardingDialogState::new(),
             key_input_dialog: crate::key_input_dialog::KeyInputDialogState::new(),
             custom_provider_dialog: crate::custom_provider_dialog::CustomProviderDialogState::new(),


### PR DESCRIPTION
Fixes Kuberwastaken/claurst#142

The bypass-permissions dialog now only shows once when claurst starts with `--yolo` (bypass mode), instead of showing every time. Users still see it in each new session, which is the intended security gate behavior. Added a session-level tracking flag to prevent repeated prompts within the same session.