### PR TITLE
Redesigned `/config` dialog

### DIFF
--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -2173,9 +2173,12 @@ impl App {
                 false
             }
             "keybindings" => {
-                // Open settings on KeyBindings tab
-                self.settings_screen.open();
-                self.settings_screen.active_tab = crate::settings_screen::SettingsTab::KeyBindings;
+                // Open the keybindings.json file in the external editor
+                let keybindings_path = claurst_core::config::Settings::config_dir().join("keybindings.json");
+
+                if let Err(e) = open_file_externally(&keybindings_path) {
+                    eprintln!("Failed to open keybindings file: {}", e);
+                }
                 true
             }
             "help" => {
@@ -6074,6 +6077,50 @@ impl App {
         }
 
         self.status_message = Some("No previous errors found.".to_string());
+    }
+}
+
+// Helper function to open a file in the user's external editor
+fn open_file_externally(path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
+    // Try to open with the system's default application
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open")
+            .arg(path)
+            .spawn()?;
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        std::process::Command::new("xdg-open")
+            .arg(path)
+            .spawn()?;
+        Ok(())
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        std::process::Command::new("cmd")
+            .args(&["/C", "start", ""])
+            .arg(path)
+            .spawn()?;
+        Ok(())
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        // Fallback for other systems: try common editors in order
+        for editor in &["nano", "vi", "vim", "emacs"] {
+            match std::process::Command::new(editor)
+                .arg(path)
+                .spawn()
+            {
+                Ok(_) => return Ok(()),
+                Err(_) => continue,
+            }
+        }
+        Err("No suitable editor found".into())
     }
 }
 

--- a/src-rust/crates/tui/src/settings_screen.rs
+++ b/src-rust/crates/tui/src/settings_screen.rs
@@ -1,116 +1,85 @@
-// settings_screen.rs — Full-screen tabbed settings interface.
+// settings_screen.rs — Flat searchable settings interface.
 //
-// Opened by /config or /settings commands. Provides a tabbed UI for
-// viewing and editing General, Display, Privacy, Advanced, and KeyBindings
-// settings. Changes are persisted via Settings::save_sync().
+// Opened by /config or /settings commands. Shows all editable settings
+// in a single scrollable list with live search filtering.
+// Changes are persisted via Settings::save_sync() or settings.json writes.
 
 use claurst_core::config::{Config, Settings};
-use claurst_core::keybindings::default_bindings;
-use claurst_core::output_styles::builtin_styles;
+use claurst_core::output_styles::{builtin_styles, find_style};
 use crate::overlays::{
-    centered_rect, render_dark_overlay, render_dialog_bg, CLAURST_ACCENT, CLAURST_MUTED,
-    CLAURST_PANEL_BG, CLAURST_TEXT,
+    centered_rect, modal_search_line, render_dark_overlay, render_dialog_bg, CLAURST_ACCENT,
+    CLAURST_MUTED, CLAURST_PANEL_BG,
 };
 use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Paragraph, Tabs, Wrap};
+use ratatui::widgets::{Block, Paragraph};
 use ratatui::Frame;
+use std::collections::HashMap;
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SettingsTab {
-    General,
-    Display,
-    Privacy,
-    Advanced,
-    KeyBindings,
+#[derive(Debug, Clone)]
+pub enum SettingKind {
+    Bool,
+    Enum { options: Vec<&'static str> },
+    Number,
 }
 
-impl SettingsTab {
-    pub fn all() -> &'static [SettingsTab] {
-        &[
-            SettingsTab::General,
-            SettingsTab::Display,
-            SettingsTab::Privacy,
-            SettingsTab::Advanced,
-            SettingsTab::KeyBindings,
-        ]
-    }
-
-    pub fn label(&self) -> &'static str {
-        match self {
-            SettingsTab::General => "General",
-            SettingsTab::Display => "Display",
-            SettingsTab::Privacy => "Privacy",
-            SettingsTab::Advanced => "Advanced",
-            SettingsTab::KeyBindings => "KeyBindings",
-        }
-    }
-
-    pub fn index(&self) -> usize {
-        Self::all().iter().position(|t| t == self).unwrap_or(0)
-    }
+#[derive(Debug, Clone)]
+pub struct SettingsEntry {
+    pub key: &'static str,
+    pub label: &'static str,
+    pub description: &'static str,
+    pub kind: SettingKind,
+    pub value: String,
 }
 
 pub struct SettingsScreen {
     pub visible: bool,
-    pub active_tab: SettingsTab,
-    pub scroll_offset: u16,
+    pub search_query: String,
+    pub selected_idx: usize,
+    pub scroll_offset: usize,
     /// Which field is being edited (field name as key).
     pub edit_field: Option<String>,
     /// Current buffer content while editing a field.
     pub edit_value: String,
-    /// Snapshot of settings at open time for display.
+    /// Snapshot of settings at open time.
     pub settings_snapshot: Settings,
     /// Pending changes (field_name → new_value string).
-    pub pending_changes: std::collections::HashMap<String, String>,
+    pub pending_changes: HashMap<String, String>,
 
     // ---- Real settings fields ----
-
-    /// Whether auto-compact is enabled.
-    pub auto_compact_enabled: bool,
-    /// Auto-compact threshold (0-100%).
-    pub auto_compact_threshold: u8,
-    /// Whether desktop notifications are enabled.
-    pub notifications_enabled: bool,
-    /// Whether to reduce UI motion (animations).
-    pub reduce_motion: bool,
-    /// Whether to show turn duration in status bar.
+    pub auto_compact: bool,
+    pub notifications: bool,
     pub show_turn_duration: bool,
-    /// Whether the terminal progress bar is enabled.
+    pub output_style: String,
+    pub reduce_motion: bool,
     pub terminal_progress_bar: bool,
-
-    /// Index of the currently-selected interactive field within the active tab.
-    pub selected_field: usize,
+    pub verbose: bool,
 }
 
 impl SettingsScreen {
     pub fn new() -> Self {
         let settings_snapshot = Settings::load_sync().unwrap_or_default();
-        let auto_compact_enabled = settings_snapshot.config.auto_compact;
-        let auto_compact_threshold = {
-            let t = settings_snapshot.config.compact_threshold;
-            if t > 0.0 { (t * 100.0).round() as u8 } else { 95 }
-        };
         Self {
             visible: false,
-            active_tab: SettingsTab::General,
+            search_query: String::new(),
+            selected_idx: 0,
             scroll_offset: 0,
             edit_field: None,
             edit_value: String::new(),
             settings_snapshot,
-            pending_changes: std::collections::HashMap::new(),
-            auto_compact_enabled,
-            auto_compact_threshold,
-            notifications_enabled: true,
-            reduce_motion: false,
+            pending_changes: HashMap::new(),
+            auto_compact: false,
+            notifications: true,
             show_turn_duration: false,
+            output_style: "default".to_string(),
+            reduce_motion: false,
             terminal_progress_bar: true,
-            selected_field: 0,
+            verbose: false,
         }
     }
 
@@ -119,45 +88,19 @@ impl SettingsScreen {
         self.pending_changes.clear();
         self.edit_field = None;
         self.edit_value.clear();
+        self.search_query.clear();
+        self.selected_idx = 0;
         self.scroll_offset = 0;
-        self.active_tab = SettingsTab::General;
-        self.selected_field = 0;
         self.visible = true;
 
-        // Wire real boolean settings from the settings snapshot.
-        self.auto_compact_enabled = read_setting_bool(
-            &self.settings_snapshot,
-            "autoCompact",
-            self.settings_snapshot.config.auto_compact,
-        );
-        self.auto_compact_threshold = read_setting_u8(
-            &self.settings_snapshot,
-            "autoCompactThreshold",
-            {
-                let t = self.settings_snapshot.config.compact_threshold;
-                if t > 0.0 { (t * 100.0).round() as u8 } else { 95 }
-            },
-        );
-        self.notifications_enabled = read_setting_bool(
-            &self.settings_snapshot,
-            "notifications",
-            true,
-        );
-        self.reduce_motion = read_setting_bool(
-            &self.settings_snapshot,
-            "reduceMotion",
-            false,
-        );
-        self.show_turn_duration = read_setting_bool(
-            &self.settings_snapshot,
-            "showTurnDuration",
-            false,
-        );
-        self.terminal_progress_bar = read_setting_bool(
-            &self.settings_snapshot,
-            "terminalProgressBar",
-            true,
-        );
+        // Wire real settings from snapshot
+        self.auto_compact = read_setting_bool(&self.settings_snapshot, "autoCompact", false);
+        self.notifications = read_setting_bool(&self.settings_snapshot, "notifications", true);
+        self.show_turn_duration = read_setting_bool(&self.settings_snapshot, "showTurnDuration", false);
+        self.output_style = read_setting_string(&self.settings_snapshot, "outputStyle", "default");
+        self.reduce_motion = read_setting_bool(&self.settings_snapshot, "reduceMotion", false);
+        self.terminal_progress_bar = read_setting_bool(&self.settings_snapshot, "terminalProgressBar", true);
+        self.verbose = self.settings_snapshot.config.verbose;
     }
 
     pub fn close(&mut self) {
@@ -166,51 +109,25 @@ impl SettingsScreen {
         self.edit_value.clear();
     }
 
-    pub fn next_tab(&mut self) {
-        let idx = self.active_tab.index();
-        let next = (idx + 1) % SettingsTab::all().len();
-        self.active_tab = SettingsTab::all()[next].clone();
-        self.scroll_offset = 0;
-        self.selected_field = 0;
-        self.edit_field = None;
-        self.edit_value.clear();
+    pub fn push_search_char(&mut self, c: char) {
+        self.search_query.push(c);
+        self.selected_idx = 0;
     }
 
-    pub fn prev_tab(&mut self) {
-        let idx = self.active_tab.index();
-        let prev = if idx == 0 {
-            SettingsTab::all().len() - 1
-        } else {
-            idx - 1
-        };
-        self.active_tab = SettingsTab::all()[prev].clone();
-        self.scroll_offset = 0;
-        self.selected_field = 0;
-        self.edit_field = None;
-        self.edit_value.clear();
+    pub fn pop_search_char(&mut self) {
+        self.search_query.pop();
+        self.selected_idx = 0;
     }
 
-    pub fn scroll_up(&mut self) {
-        if self.selected_field > 0 {
-            self.selected_field -= 1;
+    pub fn select_prev(&mut self) {
+        if self.selected_idx > 0 {
+            self.selected_idx -= 1;
         }
-        self.scroll_offset = self.scroll_offset.saturating_sub(1);
     }
 
-    pub fn scroll_down(&mut self) {
-        let max_fields = self.max_fields_for_tab();
-        if self.selected_field + 1 < max_fields {
-            self.selected_field += 1;
-        }
-        self.scroll_offset = self.scroll_offset.saturating_add(1);
-    }
-
-    /// Returns the number of interactive (togglable) fields in the current tab.
-    fn max_fields_for_tab(&self) -> usize {
-        match &self.active_tab {
-            SettingsTab::General => 3, // auto-compact, notifications, show-turn-duration
-            SettingsTab::Display => 2, // reduce-motion, terminal-progress-bar
-            _ => 0,
+    pub fn select_next(&mut self, total_visible: usize) {
+        if total_visible > 0 && self.selected_idx + 1 < total_visible {
+            self.selected_idx += 1;
         }
     }
 
@@ -238,13 +155,6 @@ impl SettingsScreen {
     pub fn apply_and_save(&mut self, config: &mut Config) {
         for (field, value) in &self.pending_changes {
             match field.as_str() {
-                "model" => {
-                    config.model = if value.is_empty() {
-                        None
-                    } else {
-                        Some(value.clone())
-                    };
-                }
                 "max_tokens" => {
                     if let Ok(n) = value.parse::<u32>() {
                         config.max_tokens = Some(n);
@@ -260,7 +170,6 @@ impl SettingsScreen {
                 _ => {}
             }
         }
-        // Update snapshot and persist
         self.settings_snapshot.config = config.clone();
         let _ = self.settings_snapshot.save_sync();
         self.pending_changes.clear();
@@ -277,8 +186,6 @@ impl Default for SettingsScreen {
 // Settings I/O helpers
 // ---------------------------------------------------------------------------
 
-/// Read a boolean value from `settings.json` by camelCase key, falling back to
-/// `default` when the file is absent or the key is missing.
 fn read_setting_bool(_settings: &Settings, key: &str, default: bool) -> bool {
     let path = claurst_core::config::Settings::config_dir().join("settings.json");
     if let Ok(content) = std::fs::read_to_string(&path) {
@@ -291,22 +198,18 @@ fn read_setting_bool(_settings: &Settings, key: &str, default: bool) -> bool {
     default
 }
 
-/// Read a u8 value from `settings.json` by camelCase key, falling back to
-/// `default` when the file is absent or the key is missing.
-fn read_setting_u8(_settings: &Settings, key: &str, default: u8) -> u8 {
+fn read_setting_string(_settings: &Settings, key: &str, default: &str) -> String {
     let path = claurst_core::config::Settings::config_dir().join("settings.json");
     if let Ok(content) = std::fs::read_to_string(&path) {
         if let Ok(val) = serde_json::from_str::<serde_json::Value>(&content) {
-            if let Some(n) = val.get(key).and_then(|v| v.as_u64()) {
-                return n as u8;
+            if let Some(s) = val.get(key).and_then(|v| v.as_str()) {
+                return s.to_string();
             }
         }
     }
-    default
+    default.to_string()
 }
 
-/// Write a single boolean key-value pair to `settings.json`, preserving other
-/// fields already present in the file.
 fn save_setting_bool(key: &str, value: bool) {
     let path = claurst_core::config::Settings::config_dir().join("settings.json");
     let mut val: serde_json::Value = std::fs::read_to_string(&path)
@@ -321,47 +224,93 @@ fn save_setting_bool(key: &str, value: bool) {
     }
 }
 
-/// Toggle the boolean field currently selected in `screen` and persist the
-/// change. The mapping is: General tab fields 0,1,2 → auto_compact_enabled,
-/// notifications_enabled, show_turn_duration; Display tab fields 0,1 →
-/// reduce_motion, terminal_progress_bar.
-pub fn toggle_current_field(screen: &mut SettingsScreen, _config: &mut Config) {
-    match &screen.active_tab {
-        SettingsTab::General => match screen.selected_field {
-            0 => {
-                screen.auto_compact_enabled = !screen.auto_compact_enabled;
-                save_setting_bool("autoCompact", screen.auto_compact_enabled);
-            }
-            1 => {
-                screen.notifications_enabled = !screen.notifications_enabled;
-                save_setting_bool("notifications", screen.notifications_enabled);
-            }
-            2 => {
-                screen.show_turn_duration = !screen.show_turn_duration;
-                save_setting_bool("showTurnDuration", screen.show_turn_duration);
-            }
-            _ => {}
-        },
-        SettingsTab::Display => match screen.selected_field {
-            0 => {
-                screen.reduce_motion = !screen.reduce_motion;
-                save_setting_bool("reduceMotion", screen.reduce_motion);
-            }
-            1 => {
-                screen.terminal_progress_bar = !screen.terminal_progress_bar;
-                save_setting_bool("terminalProgressBar", screen.terminal_progress_bar);
-            }
-            _ => {}
-        },
-        _ => {}
+fn save_setting_string(key: &str, value: &str) {
+    let path = claurst_core::config::Settings::config_dir().join("settings.json");
+    let mut val: serde_json::Value = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_else(|| serde_json::Value::Object(Default::default()));
+    if let Some(obj) = val.as_object_mut() {
+        obj.insert(key.to_string(), serde_json::Value::String(value.to_string()));
     }
+    if let Ok(json) = serde_json::to_string_pretty(&val) {
+        let _ = std::fs::write(&path, json);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Settings entries definition
+// ---------------------------------------------------------------------------
+
+fn all_entries(screen: &SettingsScreen) -> Vec<SettingsEntry> {
+    vec![
+        SettingsEntry {
+            key: "max_tokens",
+            label: "Max Tokens",
+            description: "Maximum tokens per response.",
+            kind: SettingKind::Number,
+            value: screen.settings_snapshot.config.max_tokens
+                .map(|n| n.to_string())
+                .unwrap_or_else(|| claurst_core::constants::DEFAULT_MAX_TOKENS.to_string()),
+        },
+        SettingsEntry {
+            key: "auto_compact",
+            label: "Auto-compact",
+            description: "Automatically compact turns at threshold.",
+            kind: SettingKind::Bool,
+            value: if screen.auto_compact { "true" } else { "false" }.to_string(),
+        },
+        SettingsEntry {
+            key: "notifications",
+            label: "Desktop notifications",
+            description: "Notify when a turn completes.",
+            kind: SettingKind::Bool,
+            value: if screen.notifications { "true" } else { "false" }.to_string(),
+        },
+        SettingsEntry {
+            key: "show_turn_duration",
+            label: "Show turn duration",
+            description: "Display elapsed time per turn in status bar.",
+            kind: SettingKind::Bool,
+            value: if screen.show_turn_duration { "true" } else { "false" }.to_string(),
+        },
+        SettingsEntry {
+            key: "output_style",
+            label: "Output Style",
+            description: "Controls the verbosity and format of responses.",
+            kind: SettingKind::Enum {
+                options: vec!["default", "concise", "explanatory", "learning"],
+            },
+            value: screen.output_style.clone(),
+        },
+        SettingsEntry {
+            key: "reduce_motion",
+            label: "Reduce motion",
+            description: "Disable UI animations.",
+            kind: SettingKind::Bool,
+            value: if screen.reduce_motion { "true" } else { "false" }.to_string(),
+        },
+        SettingsEntry {
+            key: "terminal_progress_bar",
+            label: "Terminal progress bar",
+            description: "Show progress during tool use.",
+            kind: SettingKind::Bool,
+            value: if screen.terminal_progress_bar { "true" } else { "false" }.to_string(),
+        },
+        SettingsEntry {
+            key: "verbose",
+            label: "Verbose logging",
+            description: "Log additional debug information. Takes effect on next session.",
+            kind: SettingKind::Bool,
+            value: if screen.verbose { "true" } else { "false" }.to_string(),
+        },
+    ]
 }
 
 // ---------------------------------------------------------------------------
 // Rendering
 // ---------------------------------------------------------------------------
 
-/// Render the settings screen (full-screen popup) into `frame`.
 pub fn render_settings_screen(frame: &mut Frame, screen: &SettingsScreen, area: Rect) {
     if !screen.visible {
         return;
@@ -387,17 +336,26 @@ pub fn render_settings_screen(frame: &mut Frame, screen: &SettingsScreen, area: 
         return;
     }
 
-    // Split into header + tabs + content + footer
+    // Split into header + search + spacer + content + description + footer
     let layout = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Length(1), Constraint::Length(2), Constraint::Min(1), Constraint::Length(1)])
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Min(1),
+            Constraint::Percentage(50),
+            Constraint::Length(1),
+        ])
         .split(inner);
 
     let header_area = layout[0];
-    let tabs_area = layout[1];
-    let content_area = layout[2];
-    let footer_area = layout[3];
+    let search_area = layout[1];
+    let content_area = layout[3];
+    let description_area = layout[4];
+    let footer_area = layout[5];
 
+    // Header
     let title = Line::from(vec![
         Span::styled(" Settings", Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)),
         Span::styled(" — Claurst", Style::default().fg(CLAURST_MUTED)),
@@ -408,34 +366,47 @@ pub fn render_settings_screen(frame: &mut Frame, screen: &SettingsScreen, area: 
     ]);
     frame.render_widget(Paragraph::new(title).style(Style::default().bg(CLAURST_PANEL_BG)), header_area);
 
-    // Tabs bar
-    let tab_labels: Vec<Line> = SettingsTab::all()
-        .iter()
-        .map(|t| {
-            if *t == screen.active_tab {
-                Line::from(vec![Span::styled(
-                    format!(" {} ", t.label()),
-                    Style::default()
-                        .fg(Color::Black)
-                        .bg(CLAURST_ACCENT)
-                        .add_modifier(Modifier::BOLD),
-                )])
-            } else {
-                Line::from(vec![Span::styled(
-                    format!(" {} ", t.label()),
-                    Style::default().fg(CLAURST_MUTED),
-                )])
-            }
-        })
+    // Search
+    let search_line = modal_search_line(&screen.search_query, "Type to search settings...", Color::DarkGray, CLAURST_ACCENT);
+    frame.render_widget(Paragraph::new(search_line).style(Style::default().bg(CLAURST_PANEL_BG)), search_area);
+
+    // Content
+    render_settings_list(frame, screen, content_area);
+
+    // Description of selected entry
+    let all = all_entries(screen);
+    let filtered: Vec<_> = all.iter()
+        .filter(|e| e.label.to_lowercase().contains(&screen.search_query.to_lowercase()))
         .collect();
 
-    let tabs = Tabs::new(tab_labels)
-        .divider(Span::styled("  ", Style::default().fg(CLAURST_MUTED)))
-        .style(Style::default().fg(CLAURST_MUTED).bg(CLAURST_PANEL_BG));
-    frame.render_widget(tabs, tabs_area);
+    let desc_text = if let Some(entry) = filtered.get(screen.selected_idx) {
+        // For Output Style, show current selection and all available options with descriptions
+        if entry.key == "output_style" {
+            let mut lines = vec![entry.description.to_string(), String::new()];
 
-    // Tab content
-    render_tab_content(frame, screen, content_area);
+            let all_styles = builtin_styles();
+            let current_style_name = if screen.output_style.is_empty() { "default" } else { &screen.output_style };
+            if let Some(current_style) = find_style(&all_styles, current_style_name) {
+                lines.push(format!("Current: {} — {}", current_style.label, current_style.description));
+                lines.push(String::new());
+            }
+
+            lines.push("Available:".to_string());
+            for style in builtin_styles() {
+                lines.push(format!("  {} — {}", style.name, style.description));
+            }
+            lines.join("\n")
+        } else {
+            entry.description.to_string()
+        }
+    } else {
+        String::new()
+    };
+    let desc_para = Paragraph::new(desc_text)
+        .style(Style::default().fg(Color::DarkGray))
+        .alignment(Alignment::Left)
+        .block(Block::default().padding(ratatui::widgets::Padding::new(1, 0, 1, 0)));
+    frame.render_widget(desc_para, description_area);
 
     // Footer
     let footer = if screen.edit_field.is_some() {
@@ -447,12 +418,10 @@ pub fn render_settings_screen(frame: &mut Frame, screen: &SettingsScreen, area: 
         ])
     } else {
         Line::from(vec![
-            Span::styled(" Tab ", Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)),
-            Span::raw("next tab  "),
             Span::styled(" ↑↓ ", Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)),
-            Span::raw("select  "),
-            Span::styled(" Space/Enter ", Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)),
-            Span::raw("toggle  "),
+            Span::raw("navigate  "),
+            Span::styled(" Enter ", Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)),
+            Span::raw("toggle/edit  "),
             Span::styled(" Esc ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
             Span::raw("close"),
         ])
@@ -463,668 +432,80 @@ pub fn render_settings_screen(frame: &mut Frame, screen: &SettingsScreen, area: 
     frame.render_widget(footer_para, footer_area);
 }
 
-fn render_tab_content(frame: &mut Frame, screen: &SettingsScreen, area: Rect) {
-    let lines = match &screen.active_tab {
-        SettingsTab::General => build_general_lines(screen),
-        SettingsTab::Display => build_display_lines(screen),
-        SettingsTab::Privacy => build_privacy_lines(screen),
-        SettingsTab::Advanced => build_advanced_lines(screen),
-        SettingsTab::KeyBindings => build_keybindings_lines(screen),
-    };
+fn render_settings_list(frame: &mut Frame, screen: &SettingsScreen, area: Rect) {
+    let all = all_entries(screen);
 
-    let total = lines.len() as u16;
-    let visible = area.height;
-    let max_scroll = total.saturating_sub(visible);
-    let scroll = screen.scroll_offset.min(max_scroll);
+    // Filter entries by search query
+    let filtered: Vec<_> = all
+        .iter()
+        .filter(|e| e.label.to_lowercase().contains(&screen.search_query.to_lowercase()))
+        .collect();
 
-    let para = Paragraph::new(lines)
-        .wrap(Wrap { trim: false })
-        .scroll((scroll, 0));
+    if filtered.is_empty() {
+        let para = Paragraph::new("No settings match your search.").style(Style::default().fg(Color::DarkGray));
+        frame.render_widget(para, area);
+        return;
+    }
+
+    // Build lines
+    let mut lines: Vec<Line> = Vec::new();
+    let visible_rows = area.height as usize;
+
+    for (i, entry) in filtered.iter().enumerate() {
+        let is_selected = i == screen.selected_idx;
+        let marker = if is_selected { "►" } else { " " };
+
+        let label_len = 40usize;
+
+        // Show edit value if currently editing this field, otherwise show the entry value
+        let value_str = if screen.edit_field.as_deref() == Some(entry.key) && is_selected {
+            format!("{}_ ", screen.edit_value)  // Add cursor indicator
+        } else {
+            entry.value.clone()
+        };
+
+        let row_style = if is_selected {
+            Style::default()
+                .fg(Color::Black)
+                .bg(CLAURST_ACCENT)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+        };
+
+        let line = Line::from(vec![
+            Span::styled(
+                format!("   {} {:<label_len$}", marker, entry.label),
+                row_style,
+            ),
+            Span::styled(value_str, row_style),
+        ]);
+        lines.push(line);
+    }
+
+    // Scroll tracking is handled in update_scroll_offset_for_selection()
+
+    // Apply manual scrolling
+    let visible_lines: Vec<Line> = lines
+        .into_iter()
+        .skip(screen.scroll_offset)
+        .take(visible_rows.max(1))
+        .collect();
+
+    let para = Paragraph::new(visible_lines);
     frame.render_widget(para, area);
 }
 
 // ---------------------------------------------------------------------------
-// General tab
+// Key handling
 // ---------------------------------------------------------------------------
 
-fn build_general_lines(screen: &SettingsScreen) -> Vec<Line<'static>> {
-    let cfg = &screen.settings_snapshot.config;
-    let mut lines: Vec<Line<'static>> = Vec::new();
-
-    lines.push(section_header("General Settings"));
-    lines.push(Line::from(""));
-
-    // Model
-    let model_val = cfg.model.clone().unwrap_or_else(|| {
-        claurst_core::constants::DEFAULT_MODEL.to_string()
-    });
-    lines.extend(field_lines(
-        "model",
-        "Model",
-        &model_val,
-        "AI model used for responses.",
-        screen,
-    ));
-    // Show available models hint
-    lines.push(indent_line(
-        "  Available: claude-opus-4-6, claude-sonnet-4-6, claude-haiku-4-5-20251001",
-        Color::DarkGray,
-    ));
-    lines.push(Line::from(""));
-
-    // Max tokens
-    let max_tokens_val = cfg
-        .max_tokens
-        .map(|n| n.to_string())
-        .unwrap_or_else(|| claurst_core::constants::DEFAULT_MAX_TOKENS.to_string());
-    lines.extend(field_lines(
-        "max_tokens",
-        "Max Tokens",
-        &max_tokens_val,
-        "Maximum tokens per response.",
-        screen,
-    ));
-    lines.push(Line::from(""));
-
-    // Output style
-    let style_names: Vec<String> = builtin_styles().into_iter().map(|s| s.name).collect();
-    let output_style_val = cfg
-        .output_style
-        .clone()
-        .unwrap_or_else(|| "default".to_string());
-    lines.extend(field_lines(
-        "output_style",
-        "Output Style",
-        &output_style_val,
-        "Controls the verbosity and format of responses.",
-        screen,
-    ));
-    lines.push(indent_line(
-        &format!("  Available: {}", style_names.join(", ")),
-        Color::DarkGray,
-    ));
-    lines.push(Line::from(""));
-
-    // Working directory
-    let wd = cfg
-        .project_dir
-        .as_ref()
-        .map(|p| p.display().to_string())
-        .unwrap_or_else(|| std::env::current_dir()
-            .map(|p| p.display().to_string())
-            .unwrap_or_else(|_| "(unknown)".to_string()));
-    lines.push(label_value_line("Working Directory", &wd));
-    lines.push(indent_line("  (Set via --project-dir flag)", Color::DarkGray));
-    lines.push(Line::from(""));
-
-    // --- Toggleable fields ---
-
-    lines.push(section_header("Behaviour"));
-    lines.push(Line::from(""));
-
-    // Field 0: Auto-compact
-    lines.extend(toggle_field_lines(
-        screen.auto_compact_enabled,
-        "Auto-compact",
-        &format!("Automatically compact at {}%", screen.auto_compact_threshold),
-        screen.selected_field == 0,
-    ));
-
-    // Field 1: Notifications
-    lines.extend(toggle_field_lines(
-        screen.notifications_enabled,
-        "Desktop notifications",
-        "Notify when turn completes",
-        screen.selected_field == 1,
-    ));
-
-    // Field 2: Show turn duration
-    lines.extend(toggle_field_lines(
-        screen.show_turn_duration,
-        "Show turn duration",
-        "Display elapsed time per turn",
-        screen.selected_field == 2,
-    ));
-
-    lines
-}
-
-// ---------------------------------------------------------------------------
-// Display tab
-// ---------------------------------------------------------------------------
-
-fn build_display_lines(screen: &SettingsScreen) -> Vec<Line<'static>> {
-    let cfg = &screen.settings_snapshot.config;
-    let mut lines: Vec<Line<'static>> = Vec::new();
-
-    lines.push(section_header("Display Settings"));
-    lines.push(Line::from(""));
-
-    // Theme
-    let theme_name = match &cfg.theme {
-        claurst_core::config::Theme::Default => "default",
-        claurst_core::config::Theme::Dark => "dark",
-        claurst_core::config::Theme::Light => "light",
-        claurst_core::config::Theme::Deuteranopia => "deuteranopia",
-        claurst_core::config::Theme::Custom(s) => s.as_str(),
-    };
-    lines.push(label_value_line("Theme", theme_name));
-    lines.push(indent_line("  Options: default, dark, light, deuteranopia  (use /theme to change)", Color::DarkGray));
-    lines.push(Line::from(""));
-
-    // Output format
-    let fmt = match &cfg.output_format {
-        claurst_core::config::OutputFormat::Text => "text",
-        claurst_core::config::OutputFormat::Json => "json",
-        claurst_core::config::OutputFormat::StreamJson => "stream-json",
-    };
-    lines.push(label_value_line("Output Format", fmt));
-    lines.push(indent_line("  Options: text, json, stream-json", Color::DarkGray));
-    lines.push(Line::from(""));
-
-    // Verbose
-    let verbose = if cfg.verbose { "yes" } else { "no" };
-    lines.push(label_value_line("Verbose Mode", verbose));
-    lines.push(indent_line("  Shows additional debug information during queries.", Color::DarkGray));
-    lines.push(Line::from(""));
-
-    // --- Toggleable fields ---
-
-    lines.push(section_header("UI Options"));
-    lines.push(Line::from(""));
-
-    // Field 0: Reduce motion
-    lines.extend(toggle_field_lines(
-        screen.reduce_motion,
-        "Reduce motion",
-        "Disable UI animations",
-        screen.selected_field == 0,
-    ));
-
-    // Field 1: Terminal progress bar
-    lines.extend(toggle_field_lines(
-        screen.terminal_progress_bar,
-        "Terminal progress bar",
-        "Show progress during tool use",
-        screen.selected_field == 1,
-    ));
-
-    // Output styles section
-    lines.push(section_header("Available Output Styles"));
-    lines.push(Line::from(""));
-    for style in builtin_styles() {
-        let active = cfg.output_style.as_deref() == Some(&style.name)
-            || (cfg.output_style.is_none() && style.name == "default");
-        let marker = if active { " *" } else { "  " };
-        lines.push(Line::from(vec![
-            Span::styled(
-                format!("{}  {:<15}", marker, style.name),
-                Style::default()
-                    .fg(if active { CLAURST_ACCENT } else { CLAURST_TEXT })
-                    .add_modifier(if active { Modifier::BOLD } else { Modifier::empty() }),
-            ),
-            Span::styled(style.description.clone(), Style::default().fg(Color::DarkGray)),
-        ]));
-    }
-    lines.push(Line::from(""));
-
-    let _ = cfg; // suppress unused warning
-    lines
-}
-
-// ---------------------------------------------------------------------------
-// Privacy tab
-// ---------------------------------------------------------------------------
-
-fn build_privacy_lines(screen: &SettingsScreen) -> Vec<Line<'static>> {
-    let mut lines: Vec<Line<'static>> = Vec::new();
-
-    lines.push(section_header("Privacy Settings"));
-    lines.push(Line::from(""));
-
-    lines.push(Line::from(vec![Span::styled(
-        "  Claurst does not collect telemetry or usage data.",
-        Style::default().fg(Color::DarkGray),
-    )]));
-    lines.push(Line::from(""));
-
-    // Verbose (local debug logging)
-    privacy_toggle_lines(
-        &mut lines,
-        "Verbose Logging",
-        screen.settings_snapshot.config.verbose,
-        "Logs additional debug information locally (--verbose flag).",
-    );
-
-    lines
-}
-
-fn privacy_toggle_lines(lines: &mut Vec<Line<'static>>, name: &str, enabled: bool, desc: &str) {
-    let (toggle_text, toggle_color) = if enabled {
-        (" ON  ", Color::Green)
-    } else {
-        (" OFF ", Color::Red)
-    };
-    lines.push(Line::from(vec![
-        Span::styled(
-            format!("  {:<25}", name),
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
-        ),
-        Span::styled(
-            format!("[{}]", toggle_text),
-            Style::default()
-                .fg(toggle_color)
-                .add_modifier(Modifier::BOLD),
-        ),
-    ]));
-    lines.push(indent_line(&format!("  {}", desc), Color::DarkGray));
-    lines.push(Line::from(""));
-}
-
-// ---------------------------------------------------------------------------
-// Advanced tab
-// ---------------------------------------------------------------------------
-
-fn build_advanced_lines(screen: &SettingsScreen) -> Vec<Line<'static>> {
-    let cfg = &screen.settings_snapshot.config;
-    let mut lines: Vec<Line<'static>> = Vec::new();
-
-    lines.push(section_header("Advanced Settings"));
-    lines.push(Line::from(""));
-
-    // API key source
-    let active_provider = cfg.selected_provider_id();
-    let env_source = claurst_core::config::api_key_env_vars_for_provider(active_provider)
-        .iter()
-        .find_map(|env_var| {
-            std::env::var(env_var)
-                .ok()
-                .filter(|value| !value.is_empty())
-                .map(|_| *env_var)
-        });
-    let stored_key = {
-        let auth_store = claurst_core::AuthStore::load();
-        let lookup_keys: Vec<&str> = match active_provider {
-            "togetherai" | "together-ai" => vec!["togetherai", "together-ai"],
-            "lmstudio" | "lm-studio" => vec!["lmstudio", "lm-studio"],
-            "llamacpp" | "llama-cpp" | "llama-server" => {
-                vec!["llamacpp", "llama-cpp", "llama-server"]
-            }
-            "moonshot" | "moonshotai" => vec!["moonshot", "moonshotai"],
-            "zhipu" | "zhipuai" => vec!["zhipu", "zhipuai"],
-            "vultr" | "vultr-ai" => vec!["vultr", "vultr-ai"],
-            "google" | "google-vertex" => vec!["google", "google-vertex"],
-            _ => vec![active_provider],
-        };
-        lookup_keys.iter().any(|provider_id| match auth_store.get(provider_id) {
-            Some(claurst_core::StoredCredential::ApiKey { key }) => !key.is_empty(),
-            Some(claurst_core::StoredCredential::OAuthToken {
-                access, refresh, ..
-            }) if active_provider == "github-copilot" => {
-                !access.is_empty() || !refresh.is_empty()
-            }
-            _ => false,
-        })
-    };
-    let key_source = if cfg.api_key.as_ref().is_some_and(|key| !key.is_empty()) {
-        "settings.api_key (masked)".to_string()
-    } else if cfg
-        .provider_configs
-        .get(active_provider)
-        .and_then(|provider| provider.api_key.as_ref())
-        .is_some_and(|key| !key.is_empty())
-    {
-        format!("settings.provider_configs.{active_provider}.api_key (masked)")
-    } else if let Some(env_var) = env_source {
-        format!("environment variable ({env_var})")
-    } else if stored_key {
-        "stored credential".to_string()
-    } else {
-        "not set".to_string()
-    };
-    lines.push(label_value_line("API Key Source", &key_source));
-    if cfg.api_key.is_some()
-        || cfg
-            .provider_configs
-            .get(active_provider)
-            .and_then(|provider| provider.api_key.as_ref())
-            .is_some()
-    {
-        lines.push(indent_line("  ***...***", Color::DarkGray));
-    }
-    lines.push(Line::from(""));
-
-    // MCP Servers
-    lines.push(section_header("MCP Servers"));
-    lines.push(Line::from(""));
-    if cfg.mcp_servers.is_empty() {
-        lines.push(indent_line("  (none configured)", Color::DarkGray));
-    } else {
-        for srv in &cfg.mcp_servers {
-            let kind = if srv.url.is_some() { "http" } else { &srv.server_type };
-            lines.push(Line::from(vec![
-                Span::styled(
-                    format!("  {:<20}", srv.name),
-                    Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(format!("[{}]", kind), Style::default().fg(Color::DarkGray)),
-            ]));
-            if let Some(cmd) = &srv.command {
-                lines.push(indent_line(&format!("  cmd: {}", cmd), Color::DarkGray));
-            }
-            if let Some(url) = &srv.url {
-                lines.push(indent_line(&format!("  url: {}", url), Color::DarkGray));
-            }
-        }
-    }
-    lines.push(Line::from(""));
-
-    // Hooks
-    lines.push(section_header("Configured Hooks"));
-    lines.push(Line::from(""));
-    if cfg.hooks.is_empty() {
-        lines.push(indent_line("  (none configured)", Color::DarkGray));
-    } else {
-        for (event, entries) in &cfg.hooks {
-            for entry in entries {
-                let event_name = format!("{:?}", event);
-                let filter = entry
-                    .tool_filter
-                    .as_deref()
-                    .map(|f| format!("[{}]", f))
-                    .unwrap_or_default();
-                let blocking = if entry.blocking { " (blocking)" } else { "" };
-                lines.push(Line::from(vec![
-                    Span::styled(
-                        format!("  {:<20}", event_name),
-                        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
-                    ),
-                    Span::styled(filter, Style::default().fg(CLAURST_ACCENT)),
-                    Span::styled(blocking.to_string(), Style::default().fg(Color::Red)),
-                ]));
-                lines.push(indent_line(&format!("    cmd: {}", entry.command), Color::DarkGray));
-            }
-        }
-    }
-    lines.push(Line::from(""));
-
-    // Environment variables
-    lines.push(section_header("Environment Variables"));
-    lines.push(Line::from(""));
-    if cfg.env.is_empty() {
-        lines.push(indent_line("  (none configured)", Color::DarkGray));
-    } else {
-        for (key, _val) in &cfg.env {
-            lines.push(Line::from(vec![
-                Span::styled(
-                    format!("  {:<25}", key),
-                    Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
-                ),
-                Span::styled("= ***".to_string(), Style::default().fg(Color::DarkGray)),
-            ]));
-        }
-    }
-    lines.push(Line::from(""));
-
-    lines
-}
-
-// ---------------------------------------------------------------------------
-// KeyBindings tab
-// ---------------------------------------------------------------------------
-
-fn build_keybindings_lines(_screen: &SettingsScreen) -> Vec<Line<'static>> {
-    let mut lines: Vec<Line<'static>> = Vec::new();
-
-    lines.push(section_header("Key Bindings"));
-    lines.push(Line::from(""));
-    lines.push(Line::from(vec![Span::styled(
-        "  Edit ~/.claurst/keybindings.json to customise bindings.",
-        Style::default().fg(Color::Yellow).add_modifier(Modifier::ITALIC),
-    )]));
-    lines.push(Line::from(""));
-
-    // Group bindings by context
-    let mut by_context: std::collections::HashMap<String, Vec<(String, String)>> =
-        std::collections::HashMap::new();
-
-    for binding in default_bindings() {
-        if let Some(action) = &binding.action {
-            let ctx_name = format!("{:?}", binding.context);
-            let chord_str = binding
-                .chord
-                .iter()
-                .map(|ks| {
-                    let mut parts = Vec::new();
-                    if ks.ctrl { parts.push("Ctrl"); }
-                    if ks.alt { parts.push("Alt"); }
-                    if ks.shift { parts.push("Shift"); }
-                    parts.push(ks.key.as_str());
-                    parts.join("+")
-                })
-                .collect::<Vec<_>>()
-                .join(" ");
-            by_context
-                .entry(ctx_name)
-                .or_default()
-                .push((chord_str, action.clone()));
-        }
-    }
-
-    // Render in sorted context order
-    let mut contexts: Vec<String> = by_context.keys().cloned().collect();
-    contexts.sort();
-
-    // Ensure Global and Chat come first
-    contexts.retain(|c| c != "Global" && c != "Chat");
-    let mut ordered = vec!["Global".to_string(), "Chat".to_string()];
-    ordered.extend(contexts);
-
-    for ctx in &ordered {
-        if let Some(entries) = by_context.get(ctx) {
-            lines.push(Line::from(vec![Span::styled(
-                format!("  {} Context", ctx),
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
-            )]));
-            lines.push(Line::from(""));
-            for (chord, action) in entries {
-                lines.push(Line::from(vec![
-                    Span::raw("    "),
-                    Span::styled(
-                        format!("{:<25}", chord),
-                        Style::default()
-                            .fg(CLAURST_ACCENT)
-                            .add_modifier(Modifier::BOLD),
-                    ),
-                    Span::styled(action.clone(), Style::default().fg(Color::White)),
-                ]));
-            }
-            lines.push(Line::from(""));
-        }
-    }
-
-    lines
-}
-
-// ---------------------------------------------------------------------------
-// Shared helpers
-// ---------------------------------------------------------------------------
-
-fn section_header(title: &str) -> Line<'static> {
-    Line::from(vec![Span::styled(
-        format!("  {}", title),
-        Style::default()
-            .fg(CLAURST_ACCENT)
-            .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
-    )])
-}
-
-fn label_value_line(label: &str, value: &str) -> Line<'static> {
-    Line::from(vec![
-        Span::styled(
-            format!("  {:<25}", label),
-            Style::default().fg(CLAURST_TEXT).add_modifier(Modifier::BOLD),
-        ),
-        Span::styled(value.to_string(), Style::default().fg(CLAURST_ACCENT)),
-    ])
-}
-
-fn indent_line(text: &str, color: Color) -> Line<'static> {
-    Line::from(vec![Span::styled(
-        text.to_string(),
-        Style::default().fg(color),
-    )])
-}
-
-/// Build a pair of display lines for a boolean toggle field.
-///
-/// Format:
-///   `[✓] Label    Description`  (selected → highlighted row)
-///   `[○] Label    Description`  (unchecked)
-fn toggle_field_lines(
-    enabled: bool,
-    label: &str,
-    description: &str,
-    selected: bool,
-) -> Vec<Line<'static>> {
-    let (check_char, check_color) = if enabled {
-        ("✓", Color::Green)
-    } else {
-        ("○", Color::DarkGray)
-    };
-
-    let row_style = if selected {
-        Style::default()
-            .fg(Color::Black)
-            .bg(CLAURST_ACCENT)
-            .add_modifier(Modifier::BOLD)
-    } else {
-        Style::default()
-    };
-
-    let line = Line::from(vec![
-        Span::styled(
-            format!("  [{}] {:<26}", check_char, label),
-            if selected {
-                row_style.fg(Color::Black).bg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)
-            } else {
-                Style::default()
-                    .fg(if enabled { CLAURST_TEXT } else { Color::DarkGray })
-                    .add_modifier(if enabled { Modifier::BOLD } else { Modifier::empty() })
-            },
-        ),
-        Span::styled(
-            check_char.to_string(),
-            Style::default().fg(check_color),
-        ),
-        // Overwrite the duplicated check_char — we embedded it above; use the
-        // description as the right-hand column instead.
-        Span::styled(
-            format!("  {}", description),
-            if selected {
-                Style::default().fg(Color::Black).bg(CLAURST_ACCENT)
-            } else {
-                Style::default().fg(Color::DarkGray)
-            },
-        ),
-    ]);
-
-    // Build it cleanly without the accidental duplicate span
-    let clean_line = Line::from(vec![
-        Span::styled(
-            format!("  [{}] {:<26}", check_char, label),
-            if selected {
-                Style::default()
-                    .fg(Color::Black)
-                    .bg(CLAURST_ACCENT)
-                    .add_modifier(Modifier::BOLD)
-            } else {
-                Style::default()
-                    .fg(if enabled { CLAURST_TEXT } else { Color::DarkGray })
-                    .add_modifier(if enabled { Modifier::BOLD } else { Modifier::empty() })
-            },
-        ),
-        Span::styled(
-            format!("  {}", description),
-            if selected {
-                Style::default().fg(Color::Black).bg(CLAURST_ACCENT)
-            } else {
-                Style::default().fg(Color::DarkGray)
-            },
-        ),
-    ]);
-
-    let _ = line; // discard the draft with the duplicate
-    vec![clean_line, Line::from("")]
-}
-
-/// Build display lines for an editable field.
-fn field_lines(
-    field_key: &str,
-    label: &str,
-    current_value: &str,
-    description: &str,
-    screen: &SettingsScreen,
-) -> Vec<Line<'static>> {
-    let is_editing = screen.edit_field.as_deref() == Some(field_key);
-    let has_pending = screen.pending_changes.contains_key(field_key);
-
-    let display_value = if is_editing {
-        format!("{}_", screen.edit_value)
-    } else if let Some(pending) = screen.pending_changes.get(field_key) {
-        format!("{} (unsaved)", pending)
-    } else {
-        current_value.to_string()
-    };
-
-    let value_color = if is_editing {
-        Color::Yellow
-    } else if has_pending {
-        Color::Magenta
-    } else {
-        CLAURST_ACCENT
-    };
-
-    let edit_hint = if is_editing {
-        " [editing]"
-    } else {
-        " [Enter to edit]"
-    };
-
-    vec![
-        Line::from(vec![
-            Span::styled(
-                format!("  {:<25}", label),
-                Style::default().fg(CLAURST_TEXT).add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(display_value, Style::default().fg(value_color)),
-            Span::styled(
-                edit_hint.to_string(),
-                Style::default()
-                    .fg(Color::DarkGray)
-                    .add_modifier(Modifier::ITALIC),
-            ),
-        ]),
-        Line::from(vec![Span::styled(
-            format!("    {}", description),
-            Style::default().fg(Color::DarkGray),
-        )]),
-    ]
-}
-
-// ---------------------------------------------------------------------------
-// Key handling helpers (called from app.rs)
-// ---------------------------------------------------------------------------
-
-/// Returns `true` if the key event was consumed by the settings screen.
 pub fn handle_settings_key(
     screen: &mut SettingsScreen,
     config: &mut Config,
     key: crossterm::event::KeyEvent,
 ) -> bool {
-    use crossterm::event::{KeyCode, KeyModifiers};
+    use crossterm::event::KeyCode;
 
     if !screen.visible {
         return false;
@@ -1143,7 +524,7 @@ pub fn handle_settings_key(
             KeyCode::Backspace => {
                 screen.edit_value.pop();
             }
-            KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+            KeyCode::Char(c) => {
                 screen.edit_value.push(c);
             }
             _ => {}
@@ -1153,71 +534,108 @@ pub fn handle_settings_key(
 
     // Navigation mode
     match key.code {
+        KeyCode::Enter => {
+            toggle_or_cycle_current(screen);
+        }
         KeyCode::Esc => {
-            screen.close();
+            if !screen.search_query.is_empty() {
+                screen.search_query.clear();
+                screen.selected_idx = 0;
+            } else {
+                screen.close();
+            }
         }
-        KeyCode::Tab => {
-            screen.next_tab();
-        }
-        KeyCode::BackTab => {
-            screen.prev_tab();
-        }
-        // Left/Right also switch tabs so users can navigate sections
-        // (General/Display/Privacy/Advanced/KeyBindings) without Tab.
-        KeyCode::Left => {
-            screen.prev_tab();
-        }
-        KeyCode::Right => {
-            screen.next_tab();
+        KeyCode::Backspace => {
+            screen.pop_search_char();
         }
         KeyCode::Up => {
-            screen.scroll_up();
+            screen.select_prev();
+            update_scroll_offset_for_selection(screen);
         }
         KeyCode::Down => {
-            screen.scroll_down();
+            let all = all_entries(screen);
+            let filtered: Vec<_> = all
+                .iter()
+                .filter(|e| e.label.to_lowercase().contains(&screen.search_query.to_lowercase()))
+                .collect();
+            screen.select_next(filtered.len());
+            update_scroll_offset_for_selection(screen);
         }
-        KeyCode::PageUp => {
-            for _ in 0..10 {
-                screen.scroll_up();
-            }
-        }
-        KeyCode::PageDown => {
-            for _ in 0..10 {
-                screen.scroll_down();
-            }
-        }
-        // Space toggles the currently-selected boolean field
-        KeyCode::Char(' ') => {
-            toggle_current_field(screen, config);
-        }
-        KeyCode::Enter => {
-            // For tabs with interactive boolean fields, Enter toggles.
-            // For General tab with no field selected (selected_field beyond
-            // boolean range), fall through to text editing.
-            let has_toggle = matches!(
-                &screen.active_tab,
-                SettingsTab::General | SettingsTab::Display
-            ) && screen.selected_field < screen.max_fields_for_tab();
-
-            if has_toggle {
-                toggle_current_field(screen, config);
-            } else {
-                // Start editing the first editable text field
-                match &screen.active_tab {
-                    SettingsTab::General => {
-                        let cfg = &screen.settings_snapshot.config;
-                        let model_val = cfg.model.clone().unwrap_or_else(|| {
-                            claurst_core::constants::DEFAULT_MODEL.to_string()
-                        });
-                        screen.start_edit("model", &model_val);
-                    }
-                    _ => {}
-                }
-            }
+        KeyCode::Char(c) => {
+            screen.push_search_char(c);
         }
         _ => {}
     }
     true
+}
+
+fn update_scroll_offset_for_selection(screen: &mut SettingsScreen) {
+    let visible_rows = 10; // Rough estimate, will be actual in real usage
+    if screen.selected_idx < screen.scroll_offset {
+        screen.scroll_offset = screen.selected_idx;
+    } else if screen.selected_idx >= screen.scroll_offset + visible_rows {
+        screen.scroll_offset = screen.selected_idx.saturating_sub(visible_rows - 1);
+    }
+}
+
+fn toggle_or_cycle_current(screen: &mut SettingsScreen) {
+    let all = all_entries(screen);
+    let filtered: Vec<_> = all
+        .iter()
+        .filter(|e| e.label.to_lowercase().contains(&screen.search_query.to_lowercase()))
+        .collect();
+
+    if let Some(entry) = filtered.get(screen.selected_idx) {
+        match entry.kind {
+            SettingKind::Bool => {
+                let new_value = entry.value != "true";
+                match entry.key {
+                    "auto_compact" => {
+                        screen.auto_compact = new_value;
+                        save_setting_bool("autoCompact", new_value);
+                    }
+                    "notifications" => {
+                        screen.notifications = new_value;
+                        save_setting_bool("notifications", new_value);
+                    }
+                    "show_turn_duration" => {
+                        screen.show_turn_duration = new_value;
+                        save_setting_bool("showTurnDuration", new_value);
+                    }
+                    "reduce_motion" => {
+                        screen.reduce_motion = new_value;
+                        save_setting_bool("reduceMotion", new_value);
+                    }
+                    "terminal_progress_bar" => {
+                        screen.terminal_progress_bar = new_value;
+                        save_setting_bool("terminalProgressBar", new_value);
+                    }
+                    "verbose" => {
+                        screen.verbose = new_value;
+                        screen.settings_snapshot.config.verbose = new_value;
+                        let _ = screen.settings_snapshot.save_sync();
+                    }
+                    _ => {}
+                }
+            }
+            SettingKind::Enum { ref options } => {
+                let current_idx = options.iter().position(|&o| o == entry.value).unwrap_or(0);
+                let next_idx = (current_idx + 1) % options.len();
+                let new_value = options[next_idx];
+
+                match entry.key {
+                    "output_style" => {
+                        screen.output_style = new_value.to_string();
+                        save_setting_string("outputStyle", new_value);
+                    }
+                    _ => {}
+                }
+            }
+            SettingKind::Number => {
+                screen.start_edit(entry.key, &entry.value);
+            }
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1227,221 +645,71 @@ pub fn handle_settings_key(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
-    use tempfile::NamedTempFile;
-
-    // Helper: create a temporary settings.json with a given JSON body.
-    #[allow(dead_code)]
-    fn write_temp_settings(json: &str) -> NamedTempFile {
-        let mut f = NamedTempFile::new().expect("tempfile");
-        f.write_all(json.as_bytes()).expect("write");
-        f
-    }
-
-    // ---------------------------------------------------------------------------
-    // read_setting_bool tests
-    // ---------------------------------------------------------------------------
-
-    #[test]
-    fn read_setting_bool_returns_default_when_file_missing() {
-        // Point config_dir at a non-existent path by using a temp dir that has
-        // no settings.json. Because read_setting_bool internally calls
-        // Settings::config_dir() we can't easily redirect it in a unit test
-        // without modifying the helper signature; instead, we exercise the
-        // fallback branch directly by using a fabricated Settings and relying on
-        // the fact that a random temp dir won't have settings.json.
-        //
-        // This test simply asserts the default is honoured when parsing fails.
-        let settings = Settings::default();
-        // Call with a key that definitely doesn't exist in the (absent) file.
-        let result = read_setting_bool(&settings, "thisKeyDoesNotExist_xyzzy", true);
-        // We can't guarantee the file doesn't exist on the test machine, but we
-        // can guarantee that a missing key returns the default.
-        // If the file exists but lacks the key: returns true.
-        // If the file is absent: returns true.
-        assert!(result, "default should be returned for missing key");
-    }
-
-    #[test]
-    fn read_setting_bool_false_default_when_key_absent() {
-        let settings = Settings::default();
-        let result = read_setting_bool(&settings, "anotherMissingKey_abc123", false);
-        assert!(!result);
-    }
-
-    // ---------------------------------------------------------------------------
-    // SettingsScreen::new() defaults
-    // ---------------------------------------------------------------------------
 
     #[test]
     fn settings_screen_new_has_sensible_defaults() {
         let screen = SettingsScreen::new();
-        assert!(!screen.visible, "should not be visible on creation");
-        assert_eq!(screen.active_tab, SettingsTab::General);
-        assert_eq!(screen.scroll_offset, 0);
-        assert_eq!(screen.selected_field, 0);
+        assert!(!screen.visible);
+        assert!(screen.search_query.is_empty());
+        assert_eq!(screen.selected_idx, 0);
         assert!(screen.edit_field.is_none());
         assert!(screen.edit_value.is_empty());
-        assert!(screen.pending_changes.is_empty());
-        // Boolean defaults
-        assert!(screen.notifications_enabled, "notifications default on");
-        assert!(!screen.reduce_motion, "reduce_motion default off");
-        assert!(!screen.show_turn_duration, "show_turn_duration default off");
-        assert!(screen.terminal_progress_bar, "terminal_progress_bar default on");
     }
 
     #[test]
-    fn settings_screen_new_auto_compact_threshold_sensible() {
+    fn all_entries_returns_eight_settings() {
         let screen = SettingsScreen::new();
-        // Threshold must be in 0-100 range
-        assert!(
-            screen.auto_compact_threshold <= 100,
-            "threshold {} out of range",
-            screen.auto_compact_threshold
-        );
-    }
-
-    // ---------------------------------------------------------------------------
-    // toggle_current_field tests
-    // ---------------------------------------------------------------------------
-
-    #[test]
-    fn toggle_current_field_general_field0_flips_auto_compact() {
-        let mut screen = SettingsScreen::new();
-        let mut config = Config::default();
-        screen.active_tab = SettingsTab::General;
-        screen.selected_field = 0;
-
-        let before = screen.auto_compact_enabled;
-        toggle_current_field(&mut screen, &mut config);
-        assert_eq!(
-            screen.auto_compact_enabled,
-            !before,
-            "auto_compact_enabled should have flipped"
-        );
-        // Toggle back
-        toggle_current_field(&mut screen, &mut config);
-        assert_eq!(screen.auto_compact_enabled, before);
+        let entries = all_entries(&screen);
+        assert_eq!(entries.len(), 8, "Should have 8 editable settings");
     }
 
     #[test]
-    fn toggle_current_field_general_field1_flips_notifications() {
+    fn search_filters_entries_correctly() {
         let mut screen = SettingsScreen::new();
-        let mut config = Config::default();
-        screen.active_tab = SettingsTab::General;
-        screen.selected_field = 1;
-
-        let before = screen.notifications_enabled;
-        toggle_current_field(&mut screen, &mut config);
-        assert_eq!(screen.notifications_enabled, !before);
-    }
-
-    #[test]
-    fn toggle_current_field_display_field0_flips_reduce_motion() {
-        let mut screen = SettingsScreen::new();
-        let mut config = Config::default();
-        screen.active_tab = SettingsTab::Display;
-        screen.selected_field = 0;
-
-        let before = screen.reduce_motion;
-        toggle_current_field(&mut screen, &mut config);
-        assert_eq!(screen.reduce_motion, !before);
-    }
-
-    #[test]
-    fn toggle_current_field_display_field1_flips_terminal_progress_bar() {
-        let mut screen = SettingsScreen::new();
-        let mut config = Config::default();
-        screen.active_tab = SettingsTab::Display;
-        screen.selected_field = 1;
-
-        let before = screen.terminal_progress_bar;
-        toggle_current_field(&mut screen, &mut config);
-        assert_eq!(screen.terminal_progress_bar, !before);
-    }
-
-    // ---------------------------------------------------------------------------
-    // General tab render includes auto-compact row
-    // ---------------------------------------------------------------------------
-
-    #[test]
-    fn general_tab_contains_auto_compact_row() {
-        let mut screen = SettingsScreen::new();
-        screen.auto_compact_enabled = true;
-        screen.auto_compact_threshold = 95;
-
-        let lines = build_general_lines(&screen);
-
-        // Flatten all spans to a single string for easy assertion
-        let text: String = lines
+        let all = all_entries(&screen);
+        let filtered: Vec<_> = all
             .iter()
-            .flat_map(|l| l.spans.iter())
-            .map(|s| s.content.as_ref())
+            .filter(|e| e.label.to_lowercase().contains("token"))
             .collect();
-
-        assert!(
-            text.contains("Auto-compact"),
-            "General tab should render an Auto-compact row; got: {}",
-            &text[..text.len().min(300)]
-        );
-        assert!(
-            text.contains("95%"),
-            "General tab should show threshold percentage"
-        );
+        assert_eq!(filtered.len(), 1, "Should find exactly 1 entry matching 'token'");
+        assert_eq!(filtered[0].label, "Max Tokens");
     }
 
     #[test]
-    fn general_tab_contains_notifications_row() {
-        let screen = SettingsScreen::new();
-        let lines = build_general_lines(&screen);
-        let text: String = lines
-            .iter()
-            .flat_map(|l| l.spans.iter())
-            .map(|s| s.content.as_ref())
-            .collect();
-        assert!(
-            text.contains("Desktop notifications"),
-            "General tab should render a Notifications row"
-        );
-    }
-
-    #[test]
-    fn display_tab_contains_reduce_motion_and_progress_bar_rows() {
-        let screen = SettingsScreen::new();
-        let lines = build_display_lines(&screen);
-        let text: String = lines
-            .iter()
-            .flat_map(|l| l.spans.iter())
-            .map(|s| s.content.as_ref())
-            .collect();
-        assert!(text.contains("Reduce motion"), "Display tab should have Reduce motion row");
-        assert!(
-            text.contains("Terminal progress bar"),
-            "Display tab should have Terminal progress bar row"
-        );
-    }
-
-    // ---------------------------------------------------------------------------
-    // max_fields_for_tab sanity
-    // ---------------------------------------------------------------------------
-
-    #[test]
-    fn max_fields_for_tab_returns_correct_counts() {
+    fn toggle_bool_entry_flips_value() {
         let mut screen = SettingsScreen::new();
+        screen.notifications = true;
+        screen.open();
 
-        screen.active_tab = SettingsTab::General;
-        assert_eq!(screen.max_fields_for_tab(), 3);
+        let initial = screen.notifications;
+        let all = all_entries(&screen);
+        let entry = &all[2]; // notifications is at index 2
+        assert_eq!(entry.label, "Desktop notifications");
 
-        screen.active_tab = SettingsTab::Display;
-        assert_eq!(screen.max_fields_for_tab(), 2);
+        // Simulate toggle (manually, since toggle_or_cycle_current modifies internal state)
+        screen.notifications = !screen.notifications;
+        assert_ne!(screen.notifications, initial);
+    }
 
-        screen.active_tab = SettingsTab::Privacy;
-        assert_eq!(screen.max_fields_for_tab(), 0);
+    #[test]
+    fn cycle_enum_entry_wraps_around() {
+        let mut screen = SettingsScreen::new();
+        screen.output_style = "default".to_string();
 
-        screen.active_tab = SettingsTab::Advanced;
-        assert_eq!(screen.max_fields_for_tab(), 0);
+        // Simulate cycling through all options
+        let options = vec!["default", "concise", "explanatory", "learning"];
+        let mut idx = options.iter().position(|&o| o == "default").unwrap();
 
-        screen.active_tab = SettingsTab::KeyBindings;
-        assert_eq!(screen.max_fields_for_tab(), 0);
+        idx = (idx + 1) % options.len();
+        assert_eq!(options[idx], "concise");
+
+        idx = (idx + 1) % options.len();
+        assert_eq!(options[idx], "explanatory");
+
+        idx = (idx + 1) % options.len();
+        assert_eq!(options[idx], "learning");
+
+        idx = (idx + 1) % options.len();
+        assert_eq!(options[idx], "default"); // Wraps around
     }
 }


### PR DESCRIPTION
Based on top of #153. Once that is merged, I will mark this draft "Ready for review". 

- Redesigned `/config` dialog to show **only** editable settings

<img width="1078" height="554" alt="image" src="https://github.com/user-attachments/assets/63262add-b76e-4433-b233-cd186ad64cfe" />

- Added `/keybindings` to open keybindings file in external editor