### PR TITLE
Add option to prevent cursor from blinking

### DIFF
--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -962,6 +962,9 @@ pub mod config {
         /// Set via `--auto-commits` flag or `"autoCommits": true` in settings.json.
         #[serde(default, rename = "autoCommits", skip_serializing_if = "Option::is_none")]
         pub auto_commits: Option<bool>,
+        /// Enable cursor blinking in the chat prompt. Defaults to false (disabled).
+        #[serde(default, rename = "cursorBlinkEnabled", skip_serializing_if = "is_false")]
+        pub cursor_blink_enabled: bool,
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -1155,6 +1158,10 @@ pub mod config {
             color: Some("green".to_string()),
         });
         m
+    }
+
+    fn is_false(b: &bool) -> bool {
+        !b
     }
 
     impl Config {
@@ -1583,6 +1590,7 @@ pub mod config {
                 },
                 managed_agents: over.config.managed_agents.or(base.config.managed_agents),
                 auto_commits: over.config.auto_commits.or(base.config.auto_commits),
+                cursor_blink_enabled: over.config.cursor_blink_enabled || base.config.cursor_blink_enabled,
             };
             Self {
                 config: merged_config,

--- a/src-rust/crates/query/src/context_analyzer.rs
+++ b/src-rust/crates/query/src/context_analyzer.rs
@@ -268,6 +268,7 @@ mod tests {
             content: MessageContent::Text(text.to_string()),
             uuid: None,
             cost: None,
+            snapshot_patch: None,
         }
     }
 

--- a/src-rust/crates/tui/src/prompt_input.rs
+++ b/src-rust/crates/tui/src/prompt_input.rs
@@ -2599,6 +2599,7 @@ pub fn render_prompt_input(
     focused: bool,
     mode: InputMode,
     accent_override: Color,
+    cursor_blink_enabled: bool,
 ) {
     if area.width == 0 || area.height == 0 {
         return;
@@ -2643,16 +2644,18 @@ pub fn render_prompt_input(
         .width
         .saturating_sub(prefix_width)
         .saturating_sub(right_pad) as usize;
-    let cursor_blink_on = {
+    let cursor_visible = if cursor_blink_enabled {
         let ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis();
         (ms / 530) % 2 == 0
+    } else {
+        true
     };
     // Render cursor as an overlay so its blink state never shifts the
     // underlying text (issue #149: cursor blink shifted the prompt).
-    let show_cursor = focused && cursor_blink_on;
+    let show_cursor = focused && cursor_visible;
 
     // Use the raw text — no inline cursor character — so layout is stable.
     let display_text: String = if state.text.is_empty() {

--- a/src-rust/crates/tui/src/render.rs
+++ b/src-rust/crates/tui/src/render.rs
@@ -1832,6 +1832,7 @@ fn render_input(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
             InputMode::Default
         },
         app.accent_color,
+        app.settings_screen.cursor_blink_enabled,
     );
 }
 

--- a/src-rust/crates/tui/src/settings_screen.rs
+++ b/src-rust/crates/tui/src/settings_screen.rs
@@ -59,6 +59,7 @@ pub struct SettingsScreen {
     pub reduce_motion: bool,
     pub terminal_progress_bar: bool,
     pub verbose: bool,
+    pub cursor_blink_enabled: bool,
 }
 
 impl SettingsScreen {
@@ -80,6 +81,7 @@ impl SettingsScreen {
             reduce_motion: false,
             terminal_progress_bar: true,
             verbose: false,
+            cursor_blink_enabled: false,
         }
     }
 
@@ -101,6 +103,7 @@ impl SettingsScreen {
         self.reduce_motion = read_setting_bool(&self.settings_snapshot, "reduceMotion", false);
         self.terminal_progress_bar = read_setting_bool(&self.settings_snapshot, "terminalProgressBar", true);
         self.verbose = self.settings_snapshot.config.verbose;
+        self.cursor_blink_enabled = read_setting_bool(&self.settings_snapshot, "cursorBlinkEnabled", false);
     }
 
     pub fn close(&mut self) {
@@ -303,6 +306,13 @@ fn all_entries(screen: &SettingsScreen) -> Vec<SettingsEntry> {
             description: "Log additional debug information. Takes effect on next session.",
             kind: SettingKind::Bool,
             value: if screen.verbose { "true" } else { "false" }.to_string(),
+        },
+        SettingsEntry {
+            key: "cursor_blink_enabled",
+            label: "Cursor blinking",
+            description: "Enable cursor blinking in the chat prompt.",
+            kind: SettingKind::Bool,
+            value: if screen.cursor_blink_enabled { "true" } else { "false" }.to_string(),
         },
     ]
 }
@@ -615,6 +625,10 @@ fn toggle_or_cycle_current(screen: &mut SettingsScreen) {
                         screen.settings_snapshot.config.verbose = new_value;
                         let _ = screen.settings_snapshot.save_sync();
                     }
+                    "cursor_blink_enabled" => {
+                        screen.cursor_blink_enabled = new_value;
+                        save_setting_bool("cursorBlinkEnabled", new_value);
+                    }
                     _ => {}
                 }
             }
@@ -657,10 +671,10 @@ mod tests {
     }
 
     #[test]
-    fn all_entries_returns_eight_settings() {
+    fn all_entries_returns_nine_settings() {
         let screen = SettingsScreen::new();
         let entries = all_entries(&screen);
-        assert_eq!(entries.len(), 8, "Should have 8 editable settings");
+        assert_eq!(entries.len(), 9, "Should have 9 editable settings");
     }
 
     #[test]


### PR DESCRIPTION
This adds an option to prevent the cursor from blinking (and just be solid).

@Kuberwastaken - this is now ready for review.