### PR TITLE
Add more config options to `/config`

### DIFF
--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -1081,6 +1081,12 @@ pub mod config {
         /// `~/.claurst/settings.json`.
         #[serde(default, rename = "autoCopyOnHighlight")]
         pub auto_copy_on_highlight: bool,
+        /// Whether to show current working directory in footer. Defaults to true.
+        #[serde(default = "default_true", rename = "showCwd")]
+        pub show_cwd: bool,
+        /// Whether to show git branch in footer. Defaults to true.
+        #[serde(default = "default_true", rename = "showGitBranch")]
+        pub show_git_branch: bool,
     }
 
     /// A user-defined slash command template.

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -1087,6 +1087,21 @@ pub mod config {
         /// Whether to show git branch in footer. Defaults to true.
         #[serde(default = "default_true", rename = "showGitBranch")]
         pub show_git_branch: bool,
+        /// Whether to enable desktop notifications. Defaults to true.
+        #[serde(default = "default_true", rename = "notifications")]
+        pub notifications: bool,
+        /// Whether to show turn duration in output. Defaults to false.
+        #[serde(default, rename = "showTurnDuration")]
+        pub show_turn_duration: bool,
+        /// Whether to reduce motion in UI. Defaults to false.
+        #[serde(default, rename = "reduceMotion")]
+        pub reduce_motion: bool,
+        /// Whether to show terminal progress bars. Defaults to true.
+        #[serde(default = "default_true", rename = "terminalProgressBar")]
+        pub terminal_progress_bar: bool,
+        /// Whether to enable auto-compact. Defaults to true.
+        #[serde(default = "default_true", rename = "autoCompact")]
+        pub auto_compact: bool,
     }
 
     /// A user-defined slash command template.
@@ -1622,6 +1637,13 @@ pub mod config {
                 },
                 managed_agents: over.managed_agents.or(base.managed_agents),
                 auto_copy_on_highlight: over.auto_copy_on_highlight || base.auto_copy_on_highlight,
+                notifications: over.notifications || base.notifications,
+                show_turn_duration: over.show_turn_duration || base.show_turn_duration,
+                reduce_motion: over.reduce_motion || base.reduce_motion,
+                terminal_progress_bar: over.terminal_progress_bar || base.terminal_progress_bar,
+                show_cwd: over.show_cwd || base.show_cwd,
+                show_git_branch: over.show_git_branch || base.show_git_branch,
+                auto_compact: over.auto_compact || base.auto_compact,
             }
         }
     }

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -982,8 +982,6 @@ pub struct App {
     /// each frame. Used by double/triple-click word and paragraph detection
     /// (issue #149 follow-up: prior word-boundary detection was a placeholder).
     pub last_row_text: RefCell<std::collections::HashMap<u16, String>>,
-    /// When true, releasing a drag selection automatically copies it to clipboard.
-    pub auto_copy_selection: bool,
 
     // ---- Advanced mouse interaction state --------------------------------
     /// Timestamp of the last left mouse click (for double/triple-click detection).
@@ -1180,9 +1178,6 @@ impl App {
         let config = config;
         let model_name = config.effective_model().to_string();
         let user_keybindings = UserKeybindings::load(&Settings::config_dir());
-        let auto_copy_on_highlight = Settings::load_sync()
-            .map(|s| s.auto_copy_on_highlight)
-            .unwrap_or(false);
         Self {
             config,
             cost_tracker,
@@ -1388,7 +1383,6 @@ impl App {
             selection_focus: None,
             selection_text: RefCell::new(String::new()),
             last_row_text: RefCell::new(std::collections::HashMap::new()),
-            auto_copy_selection: auto_copy_on_highlight,
             last_click_time: None,
             last_click_position: None,
             click_count: 0,
@@ -5584,7 +5578,7 @@ impl App {
                 // Clear if no actual drag (single click = no selection)
                 if self.selection_anchor == self.selection_focus {
                     self.clear_selection();
-                } else if self.auto_copy_selection {
+                } else if self.settings_screen.auto_copy_enabled {
                     // Auto-copy finalized selection to clipboard.
                     let sel_text = self.selection_text.borrow().clone();
                     if !sel_text.is_empty() {

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -894,6 +894,10 @@ pub struct App {
     pub pr_url: Option<String>,
     /// PR review state: "approved", "changes_requested", "review_required", etc.
     pub pr_state: Option<String>,
+    /// Current working directory path.
+    pub current_dir: Option<String>,
+    /// Current git branch name.
+    pub git_branch: Option<String>,
     /// Count of in-progress background tasks (drives the footer pill).
     pub background_task_count: usize,
     /// Background task status text shown in footer pill.
@@ -1324,6 +1328,12 @@ impl App {
             pr_number: None,
             pr_url: None,
             pr_state: None,
+            current_dir: std::env::current_dir().ok().and_then(|p| {
+                p.to_str().map(|s| s.to_string())
+            }),
+            git_branch: claurst_core::git_utils::get_repo_root(
+                std::env::current_dir().as_deref().unwrap_or_else(|_| std::path::Path::new("."))
+            ).map(|repo_root| claurst_core::git_utils::get_current_branch(&repo_root)),
             background_task_count: 0,
             background_task_status: None,
             status_line_override: None,

--- a/src-rust/crates/tui/src/render.rs
+++ b/src-rust/crates/tui/src/render.rs
@@ -2260,6 +2260,36 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
             ));
         }
 
+        // Git branch (if settings enabled)
+        if app.settings_screen.show_git_branch {
+            if let Some(ref branch) = app.git_branch {
+                if !parts.is_empty() {
+                    parts.push(Span::raw("  "));
+                }
+                parts.push(Span::styled(
+                    format!("⎇ {}", branch),
+                    Style::default().fg(Color::Cyan),
+                ));
+            }
+        }
+
+        // Current directory (if settings enabled)
+        if app.settings_screen.show_cwd {
+            if let Some(ref dir) = app.current_dir {
+                if !parts.is_empty() {
+                    parts.push(Span::raw("  "));
+                }
+                let display_dir = if dir.starts_with(std::env::var("HOME").as_deref().unwrap_or("")) {
+                    dir.replace(std::env::var("HOME").as_deref().unwrap_or(""), "~")
+                } else {
+                    dir.clone()
+                };
+                parts.push(Span::styled(
+                    display_dir,
+                    Style::default().fg(Color::DarkGray),
+                ));
+            }
+        }
 
         // Output style indicator (only when non-default)
         if app.output_style != "auto" {

--- a/src-rust/crates/tui/src/settings_screen.rs
+++ b/src-rust/crates/tui/src/settings_screen.rs
@@ -60,6 +60,7 @@ pub struct SettingsScreen {
     pub terminal_progress_bar: bool,
     pub verbose: bool,
     pub cursor_blink_enabled: bool,
+    pub auto_copy_enabled: bool,
 }
 
 impl SettingsScreen {
@@ -82,6 +83,7 @@ impl SettingsScreen {
             terminal_progress_bar: true,
             verbose: false,
             cursor_blink_enabled: false,
+            auto_copy_enabled: false,
         }
     }
 
@@ -104,6 +106,7 @@ impl SettingsScreen {
         self.terminal_progress_bar = read_setting_bool(&self.settings_snapshot, "terminalProgressBar", true);
         self.verbose = self.settings_snapshot.config.verbose;
         self.cursor_blink_enabled = read_setting_bool(&self.settings_snapshot, "cursorBlinkEnabled", false);
+        self.auto_copy_enabled = self.settings_snapshot.auto_copy_on_highlight;
     }
 
     pub fn close(&mut self) {
@@ -313,6 +316,13 @@ fn all_entries(screen: &SettingsScreen) -> Vec<SettingsEntry> {
             description: "Enable cursor blinking in the chat prompt.",
             kind: SettingKind::Bool,
             value: if screen.cursor_blink_enabled { "true" } else { "false" }.to_string(),
+        },
+        SettingsEntry {
+            key: "auto_copy_enabled",
+            label: "Auto-copy on highlight",
+            description: "Automatically copy highlighted text to clipboard.",
+            kind: SettingKind::Bool,
+            value: if screen.auto_copy_enabled { "true" } else { "false" }.to_string(),
         },
     ]
 }
@@ -629,6 +639,11 @@ fn toggle_or_cycle_current(screen: &mut SettingsScreen) {
                         screen.cursor_blink_enabled = new_value;
                         save_setting_bool("cursorBlinkEnabled", new_value);
                     }
+                    "auto_copy_enabled" => {
+                        screen.auto_copy_enabled = new_value;
+                        screen.settings_snapshot.auto_copy_on_highlight = new_value;
+                        let _ = screen.settings_snapshot.save_sync();
+                    }
                     _ => {}
                 }
             }
@@ -671,10 +686,10 @@ mod tests {
     }
 
     #[test]
-    fn all_entries_returns_nine_settings() {
+    fn all_entries_returns_ten_settings() {
         let screen = SettingsScreen::new();
         let entries = all_entries(&screen);
-        assert_eq!(entries.len(), 9, "Should have 9 editable settings");
+        assert_eq!(entries.len(), 10, "Should have 10 editable settings");
     }
 
     #[test]

--- a/src-rust/crates/tui/src/settings_screen.rs
+++ b/src-rust/crates/tui/src/settings_screen.rs
@@ -63,6 +63,10 @@ pub struct SettingsScreen {
     pub auto_copy_enabled: bool,
     pub show_cwd: bool,
     pub show_git_branch: bool,
+    pub compact_threshold: String,
+    pub auto_commits: bool,
+    pub output_format: String,
+    pub disable_claude_mds: bool,
 }
 
 impl SettingsScreen {
@@ -88,6 +92,10 @@ impl SettingsScreen {
             auto_copy_enabled: false,
             show_cwd: false,
             show_git_branch: false,
+            compact_threshold: "95".to_string(),
+            auto_commits: false,
+            output_format: "text".to_string(),
+            disable_claude_mds: false,
         }
     }
 
@@ -113,6 +121,10 @@ impl SettingsScreen {
         self.auto_copy_enabled = self.settings_snapshot.auto_copy_on_highlight;
         self.show_cwd = read_setting_bool(&self.settings_snapshot, "showCwd", false);
         self.show_git_branch = read_setting_bool(&self.settings_snapshot, "showGitBranch", false);
+        self.compact_threshold = read_setting_string(&self.settings_snapshot, "compactThreshold", "95");
+        self.auto_commits = read_setting_bool(&self.settings_snapshot, "autoCommits", false);
+        self.output_format = read_setting_string(&self.settings_snapshot, "outputFormat", "text");
+        self.disable_claude_mds = read_setting_bool(&self.settings_snapshot, "disableClaudeMds", false);
     }
 
     pub fn close(&mut self) {
@@ -178,6 +190,12 @@ impl SettingsScreen {
                     } else {
                         Some(value.clone())
                     };
+                }
+                "compact_threshold" => {
+                    if let Ok(n) = value.parse::<f32>() {
+                        config.compact_threshold = n;
+                        self.compact_threshold = value.clone();
+                    }
                 }
                 _ => {}
             }
@@ -343,6 +361,36 @@ fn all_entries(screen: &SettingsScreen) -> Vec<SettingsEntry> {
             description: "Display the current git branch in the footer.",
             kind: SettingKind::Bool,
             value: if screen.show_git_branch { "true" } else { "false" }.to_string(),
+        },
+        SettingsEntry {
+            key: "compact_threshold",
+            label: "Auto-compact threshold",
+            description: "Context usage % at which to trigger auto-compact (0-100).",
+            kind: SettingKind::Number,
+            value: screen.compact_threshold.clone(),
+        },
+        SettingsEntry {
+            key: "auto_commits",
+            label: "Auto-commits",
+            description: "Automatically snapshot changes to git via shadow-git.",
+            kind: SettingKind::Bool,
+            value: if screen.auto_commits { "true" } else { "false" }.to_string(),
+        },
+        SettingsEntry {
+            key: "output_format",
+            label: "Output format",
+            description: "How responses are formatted: text, JSON, or streaming JSON.",
+            kind: SettingKind::Enum {
+                options: vec!["text", "json", "streamjson"],
+            },
+            value: screen.output_format.clone(),
+        },
+        SettingsEntry {
+            key: "disable_claude_mds",
+            label: "Disable CLAUDE.md",
+            description: "Ignore CLAUDE.md files in projects (use defaults instead).",
+            kind: SettingKind::Bool,
+            value: if screen.disable_claude_mds { "true" } else { "false" }.to_string(),
         },
     ]
 }
@@ -672,6 +720,14 @@ fn toggle_or_cycle_current(screen: &mut SettingsScreen) {
                         screen.show_git_branch = new_value;
                         save_setting_bool("showGitBranch", new_value);
                     }
+                    "auto_commits" => {
+                        screen.auto_commits = new_value;
+                        save_setting_bool("autoCommits", new_value);
+                    }
+                    "disable_claude_mds" => {
+                        screen.disable_claude_mds = new_value;
+                        save_setting_bool("disableClaudeMds", new_value);
+                    }
                     _ => {}
                 }
             }
@@ -684,6 +740,10 @@ fn toggle_or_cycle_current(screen: &mut SettingsScreen) {
                     "output_style" => {
                         screen.output_style = new_value.to_string();
                         save_setting_string("outputStyle", new_value);
+                    }
+                    "output_format" => {
+                        screen.output_format = new_value.to_string();
+                        save_setting_string("outputFormat", new_value);
                     }
                     _ => {}
                 }
@@ -714,10 +774,10 @@ mod tests {
     }
 
     #[test]
-    fn all_entries_returns_twelve_settings() {
+    fn all_entries_returns_sixteen_settings() {
         let screen = SettingsScreen::new();
         let entries = all_entries(&screen);
-        assert_eq!(entries.len(), 12, "Should have 12 editable settings");
+        assert_eq!(entries.len(), 16, "Should have 16 editable settings");
     }
 
     #[test]

--- a/src-rust/crates/tui/src/settings_screen.rs
+++ b/src-rust/crates/tui/src/settings_screen.rs
@@ -61,6 +61,8 @@ pub struct SettingsScreen {
     pub verbose: bool,
     pub cursor_blink_enabled: bool,
     pub auto_copy_enabled: bool,
+    pub show_cwd: bool,
+    pub show_git_branch: bool,
 }
 
 impl SettingsScreen {
@@ -84,6 +86,8 @@ impl SettingsScreen {
             verbose: false,
             cursor_blink_enabled: false,
             auto_copy_enabled: false,
+            show_cwd: false,
+            show_git_branch: false,
         }
     }
 
@@ -107,6 +111,8 @@ impl SettingsScreen {
         self.verbose = self.settings_snapshot.config.verbose;
         self.cursor_blink_enabled = read_setting_bool(&self.settings_snapshot, "cursorBlinkEnabled", false);
         self.auto_copy_enabled = self.settings_snapshot.auto_copy_on_highlight;
+        self.show_cwd = read_setting_bool(&self.settings_snapshot, "showCwd", false);
+        self.show_git_branch = read_setting_bool(&self.settings_snapshot, "showGitBranch", false);
     }
 
     pub fn close(&mut self) {
@@ -323,6 +329,20 @@ fn all_entries(screen: &SettingsScreen) -> Vec<SettingsEntry> {
             description: "Automatically copy highlighted text to clipboard.",
             kind: SettingKind::Bool,
             value: if screen.auto_copy_enabled { "true" } else { "false" }.to_string(),
+        },
+        SettingsEntry {
+            key: "show_cwd",
+            label: "Show current directory",
+            description: "Display the current working directory in the footer.",
+            kind: SettingKind::Bool,
+            value: if screen.show_cwd { "true" } else { "false" }.to_string(),
+        },
+        SettingsEntry {
+            key: "show_git_branch",
+            label: "Show git branch",
+            description: "Display the current git branch in the footer.",
+            kind: SettingKind::Bool,
+            value: if screen.show_git_branch { "true" } else { "false" }.to_string(),
         },
     ]
 }
@@ -644,6 +664,14 @@ fn toggle_or_cycle_current(screen: &mut SettingsScreen) {
                         screen.settings_snapshot.auto_copy_on_highlight = new_value;
                         let _ = screen.settings_snapshot.save_sync();
                     }
+                    "show_cwd" => {
+                        screen.show_cwd = new_value;
+                        save_setting_bool("showCwd", new_value);
+                    }
+                    "show_git_branch" => {
+                        screen.show_git_branch = new_value;
+                        save_setting_bool("showGitBranch", new_value);
+                    }
                     _ => {}
                 }
             }
@@ -686,10 +714,10 @@ mod tests {
     }
 
     #[test]
-    fn all_entries_returns_ten_settings() {
+    fn all_entries_returns_twelve_settings() {
         let screen = SettingsScreen::new();
         let entries = all_entries(&screen);
-        assert_eq!(entries.len(), 10, "Should have 10 editable settings");
+        assert_eq!(entries.len(), 12, "Should have 12 editable settings");
     }
 
     #[test]

--- a/src-rust/crates/tui/src/settings_screen.rs
+++ b/src-rust/crates/tui/src/settings_screen.rs
@@ -110,21 +110,25 @@ impl SettingsScreen {
         self.visible = true;
 
         // Wire real settings from snapshot
-        self.auto_compact = read_setting_bool(&self.settings_snapshot, "autoCompact", false);
-        self.notifications = read_setting_bool(&self.settings_snapshot, "notifications", true);
-        self.show_turn_duration = read_setting_bool(&self.settings_snapshot, "showTurnDuration", false);
-        self.output_style = read_setting_string(&self.settings_snapshot, "outputStyle", "default");
-        self.reduce_motion = read_setting_bool(&self.settings_snapshot, "reduceMotion", false);
-        self.terminal_progress_bar = read_setting_bool(&self.settings_snapshot, "terminalProgressBar", true);
+        self.auto_compact = self.settings_snapshot.auto_compact;
+        self.notifications = self.settings_snapshot.notifications;
+        self.show_turn_duration = self.settings_snapshot.show_turn_duration;
+        self.output_style = self.settings_snapshot.config.output_style.clone().unwrap_or_else(|| "default".to_string());
+        self.reduce_motion = self.settings_snapshot.reduce_motion;
+        self.terminal_progress_bar = self.settings_snapshot.terminal_progress_bar;
         self.verbose = self.settings_snapshot.config.verbose;
-        self.cursor_blink_enabled = read_setting_bool(&self.settings_snapshot, "cursorBlinkEnabled", false);
+        self.cursor_blink_enabled = self.settings_snapshot.config.cursor_blink_enabled;
         self.auto_copy_enabled = self.settings_snapshot.auto_copy_on_highlight;
-        self.show_cwd = read_setting_bool(&self.settings_snapshot, "showCwd", false);
-        self.show_git_branch = read_setting_bool(&self.settings_snapshot, "showGitBranch", false);
-        self.compact_threshold = read_setting_string(&self.settings_snapshot, "compactThreshold", "95");
-        self.auto_commits = read_setting_bool(&self.settings_snapshot, "autoCommits", false);
-        self.output_format = read_setting_string(&self.settings_snapshot, "outputFormat", "text");
-        self.disable_claude_mds = read_setting_bool(&self.settings_snapshot, "disableClaudeMds", false);
+        self.show_cwd = self.settings_snapshot.show_cwd;
+        self.show_git_branch = self.settings_snapshot.show_git_branch;
+        self.compact_threshold = self.settings_snapshot.config.compact_threshold.to_string();
+        self.auto_commits = self.settings_snapshot.config.auto_commits.unwrap_or(false);
+        self.output_format = match &self.settings_snapshot.config.output_format {
+            claurst_core::config::OutputFormat::Text => "text".to_string(),
+            claurst_core::config::OutputFormat::Json => "json".to_string(),
+            claurst_core::config::OutputFormat::StreamJson => "stream_json".to_string(),
+        };
+        self.disable_claude_mds = self.settings_snapshot.config.disable_claude_mds;
     }
 
     pub fn close(&mut self) {
@@ -209,62 +213,6 @@ impl SettingsScreen {
 impl Default for SettingsScreen {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Settings I/O helpers
-// ---------------------------------------------------------------------------
-
-fn read_setting_bool(_settings: &Settings, key: &str, default: bool) -> bool {
-    let path = claurst_core::config::Settings::config_dir().join("settings.json");
-    if let Ok(content) = std::fs::read_to_string(&path) {
-        if let Ok(val) = serde_json::from_str::<serde_json::Value>(&content) {
-            if let Some(b) = val.get(key).and_then(|v| v.as_bool()) {
-                return b;
-            }
-        }
-    }
-    default
-}
-
-fn read_setting_string(_settings: &Settings, key: &str, default: &str) -> String {
-    let path = claurst_core::config::Settings::config_dir().join("settings.json");
-    if let Ok(content) = std::fs::read_to_string(&path) {
-        if let Ok(val) = serde_json::from_str::<serde_json::Value>(&content) {
-            if let Some(s) = val.get(key).and_then(|v| v.as_str()) {
-                return s.to_string();
-            }
-        }
-    }
-    default.to_string()
-}
-
-fn save_setting_bool(key: &str, value: bool) {
-    let path = claurst_core::config::Settings::config_dir().join("settings.json");
-    let mut val: serde_json::Value = std::fs::read_to_string(&path)
-        .ok()
-        .and_then(|s| serde_json::from_str(&s).ok())
-        .unwrap_or_else(|| serde_json::Value::Object(Default::default()));
-    if let Some(obj) = val.as_object_mut() {
-        obj.insert(key.to_string(), serde_json::Value::Bool(value));
-    }
-    if let Ok(json) = serde_json::to_string_pretty(&val) {
-        let _ = std::fs::write(&path, json);
-    }
-}
-
-fn save_setting_string(key: &str, value: &str) {
-    let path = claurst_core::config::Settings::config_dir().join("settings.json");
-    let mut val: serde_json::Value = std::fs::read_to_string(&path)
-        .ok()
-        .and_then(|s| serde_json::from_str(&s).ok())
-        .unwrap_or_else(|| serde_json::Value::Object(Default::default()));
-    if let Some(obj) = val.as_object_mut() {
-        obj.insert(key.to_string(), serde_json::Value::String(value.to_string()));
-    }
-    if let Ok(json) = serde_json::to_string_pretty(&val) {
-        let _ = std::fs::write(&path, json);
     }
 }
 
@@ -680,23 +628,28 @@ fn toggle_or_cycle_current(screen: &mut SettingsScreen) {
                 match entry.key {
                     "auto_compact" => {
                         screen.auto_compact = new_value;
-                        save_setting_bool("autoCompact", new_value);
+                        screen.settings_snapshot.auto_compact = new_value;
+                        let _ = screen.settings_snapshot.save_sync();
                     }
                     "notifications" => {
                         screen.notifications = new_value;
-                        save_setting_bool("notifications", new_value);
+                        screen.settings_snapshot.notifications = new_value;
+                        let _ = screen.settings_snapshot.save_sync();
                     }
                     "show_turn_duration" => {
                         screen.show_turn_duration = new_value;
-                        save_setting_bool("showTurnDuration", new_value);
+                        screen.settings_snapshot.show_turn_duration = new_value;
+                        let _ = screen.settings_snapshot.save_sync();
                     }
                     "reduce_motion" => {
                         screen.reduce_motion = new_value;
-                        save_setting_bool("reduceMotion", new_value);
+                        screen.settings_snapshot.reduce_motion = new_value;
+                        let _ = screen.settings_snapshot.save_sync();
                     }
                     "terminal_progress_bar" => {
                         screen.terminal_progress_bar = new_value;
-                        save_setting_bool("terminalProgressBar", new_value);
+                        screen.settings_snapshot.terminal_progress_bar = new_value;
+                        let _ = screen.settings_snapshot.save_sync();
                     }
                     "verbose" => {
                         screen.verbose = new_value;
@@ -705,7 +658,8 @@ fn toggle_or_cycle_current(screen: &mut SettingsScreen) {
                     }
                     "cursor_blink_enabled" => {
                         screen.cursor_blink_enabled = new_value;
-                        save_setting_bool("cursorBlinkEnabled", new_value);
+                        screen.settings_snapshot.config.cursor_blink_enabled = new_value;
+                        let _ = screen.settings_snapshot.save_sync();
                     }
                     "auto_copy_enabled" => {
                         screen.auto_copy_enabled = new_value;
@@ -714,19 +668,23 @@ fn toggle_or_cycle_current(screen: &mut SettingsScreen) {
                     }
                     "show_cwd" => {
                         screen.show_cwd = new_value;
-                        save_setting_bool("showCwd", new_value);
+                        screen.settings_snapshot.show_cwd = new_value;
+                        let _ = screen.settings_snapshot.save_sync();
                     }
                     "show_git_branch" => {
                         screen.show_git_branch = new_value;
-                        save_setting_bool("showGitBranch", new_value);
+                        screen.settings_snapshot.show_git_branch = new_value;
+                        let _ = screen.settings_snapshot.save_sync();
                     }
                     "auto_commits" => {
                         screen.auto_commits = new_value;
-                        save_setting_bool("autoCommits", new_value);
+                        screen.settings_snapshot.config.auto_commits = if new_value { Some(true) } else { None };
+                        let _ = screen.settings_snapshot.save_sync();
                     }
                     "disable_claude_mds" => {
                         screen.disable_claude_mds = new_value;
-                        save_setting_bool("disableClaudeMds", new_value);
+                        screen.settings_snapshot.config.disable_claude_mds = new_value;
+                        let _ = screen.settings_snapshot.save_sync();
                     }
                     _ => {}
                 }
@@ -739,11 +697,17 @@ fn toggle_or_cycle_current(screen: &mut SettingsScreen) {
                 match entry.key {
                     "output_style" => {
                         screen.output_style = new_value.to_string();
-                        save_setting_string("outputStyle", new_value);
+                        screen.settings_snapshot.config.output_style = Some(new_value.to_string());
+                        let _ = screen.settings_snapshot.save_sync();
                     }
                     "output_format" => {
                         screen.output_format = new_value.to_string();
-                        save_setting_string("outputFormat", new_value);
+                        screen.settings_snapshot.config.output_format = match new_value {
+                            "json" => claurst_core::config::OutputFormat::Json,
+                            "stream_json" => claurst_core::config::OutputFormat::StreamJson,
+                            _ => claurst_core::config::OutputFormat::Text,
+                        };
+                        let _ = screen.settings_snapshot.save_sync();
                     }
                     _ => {}
                 }


### PR DESCRIPTION
- Refactor: eliminate expensive file I/O from settings initialization
- Add footer options: show current directory and git branch display
- Add config settings: compact threshold, auto-commits, output format, disable CLAUDE.md
- Expose auto-copy on highlight setting in config dialog

@Kuberwastaken - this is ready for review.
