### PR TITLE
feat: --resume without argument defaults to last session

### DIFF
--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -134,8 +134,8 @@ struct Cli {
     #[arg(long = "permission-mode", value_enum, default_value_t = CliPermissionMode::Default)]
     permission_mode: CliPermissionMode,
 
-    /// Resume a previous session by ID
-    #[arg(long = "resume")]
+    /// Resume a previous session by ID (omit ID to resume the most recent session)
+    #[arg(long = "resume", num_args(0..=1), default_missing_value("__last__"))]
     resume: Option<String>,
 
     /// Maximum number of agentic turns
@@ -1600,6 +1600,22 @@ async fn run_interactive(
     let mut client = client;
     let mut model_registry = model_registry;
     let mut tool_ctx = tool_ctx;
+    let resume_id = if resume_id.as_deref() == Some("__last__") {
+        let sessions = claurst_core::history::list_sessions().await;
+        match sessions.first() {
+            Some(last) => {
+                println!("Resuming most recent session: {}", last.id);
+                Some(last.id.clone())
+            }
+            None => {
+                eprintln!("No previous sessions found to resume.");
+                None
+            }
+        }
+    } else {
+        resume_id
+    };
+
     let mut session = if let Some(ref id) = resume_id {
         match claurst_core::history::load_session(id).await {
             Ok(session) => {

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -1631,7 +1631,7 @@ async fn run_interactive(
                 session
             }
             Err(e) => {
-                eprintln!("Warning: could not load session {}: {}", id, e);
+                resume_warning = Some(format!("Could not load session {}: {}. Starting new session.", id, e));
                 let mut session =
                     claurst_core::history::ConversationSession::new(
                         claurst_api::effective_model_for_config(&config, &model_registry),

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -1600,6 +1600,7 @@ async fn run_interactive(
     let mut client = client;
     let mut model_registry = model_registry;
     let mut tool_ctx = tool_ctx;
+    let mut resume_warning: Option<String> = None;
     let resume_id = if resume_id.as_deref() == Some("__last__") {
         let sessions = claurst_core::history::list_sessions().await;
         match sessions.first() {
@@ -1608,8 +1609,8 @@ async fn run_interactive(
                 Some(last.id.clone())
             }
             None => {
-                eprintln!("claurst: no previous sessions found to resume.");
-                std::process::exit(1)
+                resume_warning = Some("No previous sessions found, starting new session.".into());
+                None
             }
         }
     } else {
@@ -1664,6 +1665,9 @@ async fn run_interactive(
     // Set up terminal
     let mut terminal = setup_terminal()?;
     let mut app = App::new(live_config.clone(), cost_tracker.clone());
+    if let Some(warning) = resume_warning {
+        app.status_message = Some(warning);
+    }
     // Sync initial effort level (from --effort flag or /effort command) to TUI indicator.
     if let Some(level) = base_query_config.effort_level {
         use claurst_tui::EffortLevel as TuiEL;

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -1608,8 +1608,8 @@ async fn run_interactive(
                 Some(last.id.clone())
             }
             None => {
-                eprintln!("No previous sessions found to resume.");
-                None
+                eprintln!("claurst: no previous sessions found to resume.");
+                std::process::exit(1)
             }
         }
     } else {

--- a/src-rust/crates/commands/src/lib.rs
+++ b/src-rust/crates/commands/src/lib.rs
@@ -1224,23 +1224,14 @@ impl SlashCommand for ResumeCommand {
             if sessions.is_empty() {
                 return CommandResult::Message("No previous sessions found.".to_string());
             }
-            let mut output = String::from("Recent sessions:\n\n");
-            for (i, session) in sessions.iter().take(10).enumerate() {
-                let title = session
-                    .title
-                    .as_deref()
-                    .unwrap_or("(untitled)");
-                let id_short = &session.id[..session.id.len().min(8)];
-                output.push_str(&format!(
-                    "  {}. {} - {} ({} messages)\n",
-                    i + 1,
-                    id_short,
-                    title,
-                    session.messages.len()
-                ));
+            let last = &sessions[0];
+            match claurst_core::history::load_session(&last.id).await {
+                Ok(session) => CommandResult::ResumeSession(session),
+                Err(e) => CommandResult::Error(format!(
+                    "Failed to load session {}: {}",
+                    last.id, e
+                )),
             }
-            output.push_str("\nUse /resume <id> to resume a session.");
-            CommandResult::Message(output)
         } else {
             match claurst_core::history::load_session(args.trim()).await {
                 Ok(session) => CommandResult::ResumeSession(session),


### PR DESCRIPTION
When --resume is passed without a session ID, automatically resume the most recently active session from the session store instead of requiring the user to provide a specific session ID.

Also updates /resume slash command to match.