### PR TITLE
feat(tui): implement @file injection and autocomplete

### DIFF
--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -1907,6 +1907,20 @@ async fn run_interactive(
         app.tick_rustle_pose();
         app.notifications.tick();
 
+        // Process file injection dialog outcome (if any)
+        if let Some((outcome, pending_input, _pending_imgs)) = app.file_injection_dialog.take_outcome() {
+            use claurst_tui::FileInjectionOutcome;
+
+            if matches!(outcome, FileInjectionOutcome::Abort) {
+                // Abort: input already restored to prompt by app.rs handler
+                continue;
+            }
+
+            // InjectAll or SkipOversized: restore input to prompt for resubmission
+            // Images attached when dialog was shown are discarded; user can re-attach if needed
+            app.set_prompt_text(pending_input);
+        }
+
         // Draw the UI
         terminal.draw(|f| render_app(f, &app))?;
 
@@ -1991,6 +2005,7 @@ async fn run_interactive(
                         || app.model_picker.visible
                         || app.onboarding_dialog.visible
                         || app.bypass_permissions_dialog.visible
+                        || app.file_injection_dialog.visible
                         || app.ask_user_dialog.visible
                         || app.settings_screen.visible
                         || app.export_dialog.visible
@@ -2425,32 +2440,99 @@ async fn run_interactive(
                             .await;
                         }
 
-                        // Regular user message (with optional image attachments)
+                        // Regular user message (with optional image attachments + file injection)
                         let pending_imgs = app.prompt_input.clear_images();
-                        let user_msg = if pending_imgs.is_empty() {
-                            claurst_core::types::Message::user(input.clone())
-                        } else {
-                            let mut blocks: Vec<claurst_core::types::ContentBlock> = pending_imgs
-                                .iter()
-                                .filter_map(|img| {
-                                    claurst_tui::image_paste::encode_image_base64(&img.path)
-                                        .map(|b64| claurst_core::types::ContentBlock::Image {
+
+                        // Check for file injection if enabled
+                        if config.file_injection_enabled {
+                            use claurst_tui::file_injection::parse_at_refs;
+
+                            let (within_limit, oversized) = parse_at_refs(&input, &tool_ctx.working_dir, config.file_injection_max_size);
+
+                            if !oversized.is_empty() {
+                                // Show dialog with oversized files
+                                let oversized_summaries: Vec<(String, usize, String)> = oversized
+                                    .iter()
+                                    .map(|f| {
+                                        let issue_str = match &f.issue {
+                                            Some(claurst_tui::AtFileIssue::TooLarge(kb)) => format!("TooLarge: {} KB", kb),
+                                            Some(claurst_tui::AtFileIssue::Binary) => "Binary".to_string(),
+                                            Some(claurst_tui::AtFileIssue::Unreadable(e)) => e.clone(),
+                                            None => "Unknown".to_string(),
+                                        };
+                                        (f.path.display().to_string(), f.size_kb, issue_str)
+                                    })
+                                    .collect();
+
+                                app.file_injection_dialog.show(input.clone(), pending_imgs, oversized_summaries);
+                                continue;
+                            }
+
+                            // No oversized files: inject within-limit files and send
+                            let file_prefix = claurst_tui::file_injection::build_file_blocks(&within_limit);
+
+                            let user_msg = if !file_prefix.is_empty() || !pending_imgs.is_empty() {
+                                let mut blocks: Vec<claurst_core::types::ContentBlock> = Vec::new();
+
+                                // Add file blocks if there's any file content
+                                if !file_prefix.is_empty() {
+                                    blocks.push(claurst_core::types::ContentBlock::Text { text: file_prefix });
+                                }
+
+                                // Add image blocks
+                                for img in &pending_imgs {
+                                    if let Some(b64) = claurst_tui::image_paste::encode_image_base64(&img.path) {
+                                        blocks.push(claurst_core::types::ContentBlock::Image {
                                             source: claurst_core::types::ImageSource {
                                                 source_type: "base64".to_string(),
                                                 media_type: Some("image/png".to_string()),
                                                 data: Some(b64),
                                                 url: None,
                                             },
-                                        })
-                                })
-                                .collect();
-                            blocks.push(claurst_core::types::ContentBlock::Text { text: input.clone() });
-                            claurst_core::types::Message::user_blocks(blocks)
-                        };
-                        messages.push(user_msg.clone());
-                        app.push_message(user_msg);
-                        session.messages = messages.clone();
-                        session.updated_at = chrono::Utc::now();
+                                        });
+                                    }
+                                }
+
+                                // Add the original input text
+                                blocks.push(claurst_core::types::ContentBlock::Text { text: input.clone() });
+
+                                claurst_core::types::Message::user_blocks(blocks)
+                            } else {
+                                claurst_core::types::Message::user(input.clone())
+                            };
+
+                            messages.push(user_msg.clone());
+                            app.push_message(user_msg);
+                            session.messages = messages.clone();
+                            session.updated_at = chrono::Utc::now();
+                        } else {
+                            // File injection disabled: send as-is
+                            let user_msg = if pending_imgs.is_empty() {
+                                claurst_core::types::Message::user(input.clone())
+                            } else {
+                                let mut blocks: Vec<claurst_core::types::ContentBlock> = pending_imgs
+                                    .iter()
+                                    .filter_map(|img| {
+                                        claurst_tui::image_paste::encode_image_base64(&img.path)
+                                            .map(|b64| claurst_core::types::ContentBlock::Image {
+                                                source: claurst_core::types::ImageSource {
+                                                    source_type: "base64".to_string(),
+                                                    media_type: Some("image/png".to_string()),
+                                                    data: Some(b64),
+                                                    url: None,
+                                                },
+                                            })
+                                    })
+                                    .collect();
+                                blocks.push(claurst_core::types::ContentBlock::Text { text: input.clone() });
+                                claurst_core::types::Message::user_blocks(blocks)
+                            };
+
+                            messages.push(user_msg.clone());
+                            app.push_message(user_msg);
+                            session.messages = messages.clone();
+                            session.updated_at = chrono::Utc::now();
+                        }
 
                         // Update terminal title from session title or first message
                         if session.title.is_some() {

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -638,6 +638,14 @@ pub mod config {
         true
     }
 
+    fn default_file_autocomplete_limit() -> usize {
+        15
+    }
+
+    fn default_file_injection_max_size() -> usize {
+        100  // 100 KB
+    }
+
     /// Definition of a named agent with per-agent model, permissions,
     /// temperature, and system prompt.
     pub fn api_key_env_vars_for_provider(provider_id: &str) -> &'static [&'static str] {
@@ -965,6 +973,23 @@ pub mod config {
         /// Enable cursor blinking in the chat prompt. Defaults to false (disabled).
         #[serde(default, rename = "cursorBlinkEnabled", skip_serializing_if = "is_false")]
         pub cursor_blink_enabled: bool,
+        /// Maximum number of file suggestions shown in autocomplete. Defaults to 15.
+        #[serde(default = "default_file_autocomplete_limit", rename = "fileAutocompleteLimit")]
+        pub file_autocomplete_limit: usize,
+        /// Whether to show hidden files in file autocomplete. Defaults to false.
+        #[serde(default, rename = "fileAutocompleteShowHiddenFiles")]
+        pub file_autocomplete_show_hidden_files: bool,
+        /// Whether @ file references are automatically injected into message context. Defaults to true.
+        /// When true: @file auto-injects file contents into your message before sending.
+        /// When false: @ is just autocomplete and reference (no auto-injection).
+        /// Note: This only affects user messages. @include in CLAUDE.md/AGENTS.md always injects with no size limits.
+        #[serde(default = "default_true", rename = "fileInjectionEnabled")]
+        pub file_injection_enabled: bool,
+        /// Maximum file size to auto-inject (in KB). Defaults to 100. Set to 0 for no limit.
+        /// When a file exceeds this limit, users get a warning and can choose to override or cancel.
+        /// Note: @include in CLAUDE.md/AGENTS.md always injects regardless of this limit.
+        #[serde(default = "default_file_injection_max_size", rename = "fileInjectionMaxSize")]
+        pub file_injection_max_size: usize,
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -1102,6 +1127,23 @@ pub mod config {
         /// Whether to enable auto-compact. Defaults to true.
         #[serde(default = "default_true", rename = "autoCompact")]
         pub auto_compact: bool,
+        /// Maximum number of file suggestions shown in autocomplete. Defaults to 15.
+        #[serde(default = "default_file_autocomplete_limit", rename = "fileAutocompleteLimit")]
+        pub file_autocomplete_limit: usize,
+        /// Whether to show hidden files in file autocomplete. Defaults to false.
+        #[serde(default, rename = "fileAutocompleteShowHiddenFiles")]
+        pub file_autocomplete_show_hidden_files: bool,
+        /// Whether @ file references are automatically injected into message context. Defaults to true.
+        /// When true: @file auto-injects file contents into your message before sending.
+        /// When false: @ is just autocomplete and reference (no auto-injection).
+        /// Note: This only affects user messages. @include in CLAUDE.md/AGENTS.md always injects with no size limits.
+        #[serde(default = "default_true", rename = "fileInjectionEnabled")]
+        pub file_injection_enabled: bool,
+        /// Maximum file size to auto-inject (in KB). Defaults to 100. Set to 0 for no limit.
+        /// When a file exceeds this limit, users get a warning and can choose to override or cancel.
+        /// Note: @include in CLAUDE.md/AGENTS.md always injects regardless of this limit.
+        #[serde(default = "default_file_injection_max_size", rename = "fileInjectionMaxSize")]
+        pub file_injection_max_size: usize,
     }
 
     /// A user-defined slash command template.
@@ -1513,6 +1555,11 @@ pub mod config {
                     config.skills.urls.push(u.clone());
                 }
             }
+            // Copy file autocomplete and injection settings.
+            config.file_autocomplete_limit = self.file_autocomplete_limit;
+            config.file_autocomplete_show_hidden_files = self.file_autocomplete_show_hidden_files;
+            config.file_injection_enabled = self.file_injection_enabled;
+            config.file_injection_max_size = self.file_injection_max_size;
             config
         }
 
@@ -1612,6 +1659,10 @@ pub mod config {
                 managed_agents: over.config.managed_agents.or(base.config.managed_agents),
                 auto_commits: over.config.auto_commits.or(base.config.auto_commits),
                 cursor_blink_enabled: over.config.cursor_blink_enabled || base.config.cursor_blink_enabled,
+                file_autocomplete_limit: if over.config.file_autocomplete_limit != 0 { over.config.file_autocomplete_limit } else { base.config.file_autocomplete_limit },
+                file_autocomplete_show_hidden_files: over.config.file_autocomplete_show_hidden_files || base.config.file_autocomplete_show_hidden_files,
+                file_injection_enabled: over.config.file_injection_enabled || base.config.file_injection_enabled,
+                file_injection_max_size: if over.config.file_injection_max_size != 0 { over.config.file_injection_max_size } else { base.config.file_injection_max_size },
             };
             Self {
                 config: merged_config,
@@ -1644,6 +1695,10 @@ pub mod config {
                 show_cwd: over.show_cwd || base.show_cwd,
                 show_git_branch: over.show_git_branch || base.show_git_branch,
                 auto_compact: over.auto_compact || base.auto_compact,
+                file_autocomplete_limit: if over.file_autocomplete_limit != 0 { over.file_autocomplete_limit } else { base.file_autocomplete_limit },
+                file_autocomplete_show_hidden_files: over.file_autocomplete_show_hidden_files || base.file_autocomplete_show_hidden_files,
+                file_injection_enabled: over.file_injection_enabled || base.file_injection_enabled,
+                file_injection_max_size: if over.file_injection_max_size != 0 { over.file_injection_max_size } else { base.file_injection_max_size },
             }
         }
     }

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -836,6 +836,9 @@ pub struct App {
     pub bypass_permissions_dialog: crate::bypass_permissions_dialog::BypassPermissionsDialogState,
     /// Whether the bypass-permissions dialog has been shown this session.
     pub bypass_permissions_dialog_shown: bool,
+    /// File injection warning dialog.
+    /// Shown when oversized or binary files are detected in @refs.
+    pub file_injection_dialog: crate::file_injection_dialog::FileInjectionDialogState,
     /// First-launch onboarding welcome dialog.
     pub onboarding_dialog: crate::onboarding_dialog::OnboardingDialogState,
     /// Effort-level picker (/effort with no args).
@@ -1282,6 +1285,7 @@ impl App {
             go_to_line_dialog: GoToLineDialog::new(),
             bypass_permissions_dialog: crate::bypass_permissions_dialog::BypassPermissionsDialogState::new(),
             bypass_permissions_dialog_shown: false,
+            file_injection_dialog: crate::file_injection_dialog::FileInjectionDialogState::new(),
             onboarding_dialog: crate::onboarding_dialog::OnboardingDialogState::new(),
             effort_picker: crate::effort_picker::EffortPickerState::new(),
             key_input_dialog: crate::key_input_dialog::KeyInputDialogState::new(),
@@ -2814,6 +2818,33 @@ impl App {
                     } else {
                         self.should_quit = true;
                     }
+                }
+                _ => {}
+            }
+            return false;
+        }
+
+        // File injection dialog: shown when oversized files are detected in @refs.
+        if self.file_injection_dialog.visible {
+            match key.code {
+                KeyCode::Char('i') | KeyCode::Char('I') => {
+                    self.file_injection_dialog.selected = 0; // InjectAll
+                }
+                KeyCode::Char('s') | KeyCode::Char('S') => {
+                    self.file_injection_dialog.selected = 1; // SkipOversized
+                }
+                KeyCode::Esc => {
+                    self.file_injection_dialog.selected = 2; // Abort
+                    self.file_injection_dialog.confirm();
+                    // Restore input to prompt when aborting
+                    if let Some(input) = &self.file_injection_dialog.pending_input {
+                        self.set_prompt_text(input.clone());
+                    }
+                }
+                KeyCode::Up | KeyCode::Char('k') => self.file_injection_dialog.select_prev(),
+                KeyCode::Down | KeyCode::Char('j') => self.file_injection_dialog.select_next(),
+                KeyCode::Enter => {
+                    self.file_injection_dialog.confirm();
                 }
                 _ => {}
             }

--- a/src-rust/crates/tui/src/file_injection.rs
+++ b/src-rust/crates/tui/src/file_injection.rs
@@ -1,0 +1,243 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Issues that can occur when processing an @file reference.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AtFileIssue {
+    TooLarge(usize), // size in KB that exceeds limit
+    Binary,
+    Unreadable(String), // error message
+}
+
+/// A parsed file reference from the user's input (e.g., "@src/main.rs").
+#[derive(Debug, Clone)]
+pub struct AtFileRef {
+    /// The token as it appears in the text: "@src/main.rs"
+    pub token: String,
+    /// Resolved absolute path
+    pub path: PathBuf,
+    /// File size in KB
+    pub size_kb: usize,
+    /// File contents (None if issue is Some)
+    pub contents: Option<String>,
+    /// Issue encountered (None if contents is Some)
+    pub issue: Option<AtFileIssue>,
+}
+
+/// Parse word-boundary @ tokens from text.
+/// Returns (within_limit, oversized).
+/// If max_size_kb == 0, oversized is always empty (accept all).
+pub fn parse_at_refs(text: &str, cwd: &Path, max_size_kb: usize) -> (Vec<AtFileRef>, Vec<AtFileRef>) {
+    let mut within_limit = Vec::new();
+    let mut oversized = Vec::new();
+
+    let words: Vec<&str> = text.split_whitespace().collect();
+
+    for word in words {
+        // Check if word starts with @
+        if !word.starts_with('@') {
+            continue;
+        }
+
+        // Extract the token: "@path/to/file" might be part of "@path/to/file," or "@path/to/file."
+        // For now, we'll be permissive and accept the @ and everything after, trimming punctuation.
+        let mut token = word.to_string();
+
+        // Remove trailing punctuation if present
+        while token.ends_with(|c: char| c.is_ascii_punctuation()) && !token.ends_with('/') {
+            token.pop();
+        }
+
+        let path_part = &token[1..]; // Skip the '@'
+
+        // Expand ~ to home directory
+        let expanded_path = if path_part.starts_with("~/") {
+            if let Some(home) = dirs::home_dir() {
+                home.join(&path_part[2..])
+            } else {
+                cwd.join(path_part)
+            }
+        } else if path_part.starts_with('/') {
+            PathBuf::from(path_part)
+        } else {
+            cwd.join(path_part)
+        };
+
+        // Try to read the file
+        if !expanded_path.exists() || !expanded_path.is_file() {
+            continue; // Skip non-existent files
+        }
+
+        let size_kb = match fs::metadata(&expanded_path) {
+            Ok(meta) => (meta.len() as usize + 1023) / 1024, // Round up to KB
+            Err(e) => {
+                oversized.push(AtFileRef {
+                    token: token.clone(),
+                    path: expanded_path,
+                    size_kb: 0,
+                    contents: None,
+                    issue: Some(AtFileIssue::Unreadable(e.to_string())),
+                });
+                continue;
+            }
+        };
+
+        // Check if file is binary
+        let contents = match fs::read_to_string(&expanded_path) {
+            Ok(contents) => contents,
+            Err(_) => {
+                oversized.push(AtFileRef {
+                    token: token.clone(),
+                    path: expanded_path,
+                    size_kb,
+                    contents: None,
+                    issue: Some(AtFileIssue::Binary),
+                });
+                continue;
+            }
+        };
+
+        // Check size limit
+        if max_size_kb > 0 && size_kb > max_size_kb {
+            oversized.push(AtFileRef {
+                token,
+                path: expanded_path,
+                size_kb,
+                contents: None,
+                issue: Some(AtFileIssue::TooLarge(size_kb)),
+            });
+        } else {
+            within_limit.push(AtFileRef {
+                token,
+                path: expanded_path,
+                size_kb,
+                contents: Some(contents),
+                issue: None,
+            });
+        }
+    }
+
+    (within_limit, oversized)
+}
+
+/// Build XML file blocks from a slice of resolved refs.
+/// Returns a string like:
+/// ```
+/// <file path="src/main.rs">
+/// ...contents...
+/// </file>
+/// ```
+pub fn build_file_blocks(files: &[AtFileRef]) -> String {
+    let mut result = String::new();
+
+    for file in files {
+        if let Some(contents) = &file.contents {
+            result.push_str("<file path=\"");
+            result.push_str(&file.path.display().to_string());
+            result.push_str("\">\n");
+            result.push_str(contents);
+            if !contents.ends_with('\n') {
+                result.push('\n');
+            }
+            result.push_str("</file>\n");
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_parse_at_refs_simple() {
+        let temp = TempDir::new().unwrap();
+        let file_path = temp.path().join("test.txt");
+        fs::write(&file_path, "test content").unwrap();
+
+        let input = format!("Please check @{}", file_path.display());
+        let cwd = temp.path();
+
+        let (within, oversized) = parse_at_refs(&input, cwd, 1024);
+        assert_eq!(within.len(), 1);
+        assert_eq!(oversized.len(), 0);
+        assert_eq!(within[0].contents.as_ref().unwrap(), "test content");
+    }
+
+    #[test]
+    fn test_parse_at_refs_nonexistent() {
+        let temp = TempDir::new().unwrap();
+        let input = format!("Please check @{}", temp.path().join("nonexistent.txt").display());
+
+        let (within, oversized) = parse_at_refs(&input, temp.path(), 1024);
+        assert_eq!(within.len(), 0);
+        assert_eq!(oversized.len(), 0);
+    }
+
+    #[test]
+    fn test_parse_at_refs_size_limit() {
+        let temp = TempDir::new().unwrap();
+        let file_path = temp.path().join("large.txt");
+        let large_content = "x".repeat(10 * 1024); // 10 KB
+        fs::write(&file_path, &large_content).unwrap();
+
+        let input = format!("Check @{}", file_path.display());
+        let (within, oversized) = parse_at_refs(&input, temp.path(), 5); // 5 KB limit
+
+        assert_eq!(within.len(), 0);
+        assert_eq!(oversized.len(), 1);
+        match &oversized[0].issue {
+            Some(AtFileIssue::TooLarge(kb)) => assert!(*kb >= 10),
+            _ => panic!("Expected TooLarge issue"),
+        }
+    }
+
+    #[test]
+    fn test_parse_at_refs_zero_limit_accepts_all() {
+        let temp = TempDir::new().unwrap();
+        let file_path = temp.path().join("large.txt");
+        let large_content = "x".repeat(10 * 1024); // 10 KB
+        fs::write(&file_path, &large_content).unwrap();
+
+        let input = format!("Check @{}", file_path.display());
+        let (within, oversized) = parse_at_refs(&input, temp.path(), 0); // 0 = no limit
+
+        assert_eq!(within.len(), 1);
+        assert_eq!(oversized.len(), 0);
+    }
+
+    #[test]
+    fn test_build_file_blocks() {
+        let temp = TempDir::new().unwrap();
+        let file1 = temp.path().join("file1.rs");
+        let file2 = temp.path().join("file2.rs");
+        fs::write(&file1, "fn main() {}").unwrap();
+        fs::write(&file2, "fn foo() {}").unwrap();
+
+        let refs = vec![
+            AtFileRef {
+                token: "@file1.rs".to_string(),
+                path: file1.clone(),
+                size_kb: 1,
+                contents: Some("fn main() {}".to_string()),
+                issue: None,
+            },
+            AtFileRef {
+                token: "@file2.rs".to_string(),
+                path: file2.clone(),
+                size_kb: 1,
+                contents: Some("fn foo() {}".to_string()),
+                issue: None,
+            },
+        ];
+
+        let blocks = build_file_blocks(&refs);
+        assert!(blocks.contains("<file path=\""));
+        assert!(blocks.contains("fn main() {}"));
+        assert!(blocks.contains("fn foo() {}"));
+        assert!(blocks.contains("</file>"));
+    }
+}

--- a/src-rust/crates/tui/src/file_injection_dialog.rs
+++ b/src-rust/crates/tui/src/file_injection_dialog.rs
@@ -1,0 +1,318 @@
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget, Wrap};
+use ratatui::Frame;
+
+use crate::overlays::centered_rect;
+use crate::image_paste::PastedImage;
+
+/// Outcome of the file injection dialog.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileInjectionOutcome {
+    /// Inject all files, including oversized/binary ones.
+    InjectAll,
+    /// Inject only within-limit files; skip oversized/binary.
+    SkipOversized,
+    /// Abort (restore input to prompt for editing).
+    Abort,
+}
+
+/// State for the file injection warning dialog.
+/// Shown when oversized or binary files are detected in @refs.
+#[derive(Debug, Clone)]
+pub struct FileInjectionDialogState {
+    /// Whether the dialog is currently visible.
+    pub visible: bool,
+    /// Stashed input text (taken from prompt, must be re-set or sent).
+    pub pending_input: Option<String>,
+    /// Stashed image attachments at submit time.
+    pub pending_imgs: Vec<PastedImage>,
+    /// Files that exceeded limits or had issues: (path, size_kb, display_issue).
+    pub oversized: Vec<(String, usize, String)>,
+    /// Currently selected option: 0 = InjectAll, 1 = SkipOversized, 2 = Abort.
+    pub selected: usize,
+    /// Set when user confirms; consumed by main.rs to trigger send.
+    pub outcome: Option<FileInjectionOutcome>,
+}
+
+impl FileInjectionDialogState {
+    pub fn new() -> Self {
+        Self {
+            visible: false,
+            pending_input: None,
+            pending_imgs: Vec::new(),
+            oversized: Vec::new(),
+            selected: 0, // Default to "Inject anyway"
+            outcome: None,
+        }
+    }
+
+    /// Show the dialog with stashed input and oversized files.
+    pub fn show(
+        &mut self,
+        input: String,
+        imgs: Vec<PastedImage>,
+        oversized: Vec<(String, usize, String)>,
+    ) {
+        self.visible = true;
+        self.pending_input = Some(input);
+        self.pending_imgs = imgs;
+        self.oversized = oversized;
+        self.selected = 0; // Default to "Inject anyway"
+        self.outcome = None;
+    }
+
+    /// Move selection up (wraps).
+    pub fn select_prev(&mut self) {
+        self.selected = if self.selected == 0 { 2 } else { self.selected - 1 };
+    }
+
+    /// Move selection down (wraps).
+    pub fn select_next(&mut self) {
+        self.selected = if self.selected == 2 { 0 } else { self.selected + 1 };
+    }
+
+    /// Returns the currently-selected outcome option.
+    pub fn current_outcome(&self) -> FileInjectionOutcome {
+        match self.selected {
+            0 => FileInjectionOutcome::InjectAll,
+            1 => FileInjectionOutcome::SkipOversized,
+            _ => FileInjectionOutcome::Abort,
+        }
+    }
+
+    /// Returns `true` if the currently-selected option is not "Abort".
+    pub fn is_accept_selected(&self) -> bool {
+        self.current_outcome() != FileInjectionOutcome::Abort
+    }
+
+    /// Confirm the selected option.
+    pub fn confirm(&mut self) {
+        self.outcome = Some(self.current_outcome());
+    }
+
+    /// Dismiss the dialog.
+    pub fn dismiss(&mut self) {
+        self.visible = false;
+        self.pending_input = None;
+        self.pending_imgs.clear();
+        self.oversized.clear();
+        self.outcome = None;
+    }
+
+    /// Take the outcome (if set) along with stashed input and images.
+    /// Returns None if no outcome is set.
+    pub fn take_outcome(&mut self) -> Option<(FileInjectionOutcome, String, Vec<PastedImage>)> {
+        let outcome = self.outcome.take()?;
+        let input = self.pending_input.take()?;
+        let imgs = std::mem::take(&mut self.pending_imgs);
+        self.visible = false;
+        Some((outcome, input, imgs))
+    }
+}
+
+impl Default for FileInjectionDialogState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Render the file injection warning dialog over the frame.
+pub fn render_file_injection_dialog(
+    frame: &mut Frame,
+    state: &FileInjectionDialogState,
+    area: Rect,
+) {
+    if !state.visible {
+        return;
+    }
+
+    let dialog_width = 72u16.min(area.width.saturating_sub(4));
+    let dialog_height = 16u16.min(area.height.saturating_sub(4));
+    let dialog_area = centered_rect(dialog_width, dialog_height, area);
+
+    frame.render_widget(Clear, dialog_area);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(Line::from(vec![Span::styled(
+            " ⚠  File Injection Warning ",
+            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+        )]))
+        .border_style(Style::default().fg(Color::Yellow));
+
+    let inner = block.inner(dialog_area);
+    frame.render_widget(block, dialog_area);
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+
+    lines.push(Line::from(vec![Span::styled(
+        "The following file(s) cannot be auto-injected:",
+        Style::default().fg(Color::White),
+    )]));
+    lines.push(Line::from(""));
+
+    for (path, size_kb, issue) in &state.oversized {
+        let text = if issue.contains("TooLarge") {
+            format!("• {} ({} KB, exceeds limit)", path, size_kb)
+        } else if issue.contains("Binary") {
+            format!("• {} (binary file)", path)
+        } else {
+            format!("• {} ({})", path, issue)
+        };
+
+        lines.push(Line::from(vec![Span::styled(
+            text,
+            Style::default().fg(Color::DarkGray),
+        )]));
+    }
+
+    lines.push(Line::from(""));
+
+    // Options
+    let inject_style = if state.selected == 0 {
+        Style::default().fg(Color::Green).add_modifier(Modifier::BOLD | Modifier::REVERSED)
+    } else {
+        Style::default().fg(Color::Green)
+    };
+    let skip_style = if state.selected == 1 {
+        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD | Modifier::REVERSED)
+    } else {
+        Style::default().fg(Color::Yellow)
+    };
+    let abort_style = if state.selected == 2 {
+        Style::default().fg(Color::Red).add_modifier(Modifier::BOLD | Modifier::REVERSED)
+    } else {
+        Style::default().fg(Color::Red)
+    };
+
+    lines.push(Line::from(vec![
+        Span::styled("[I] ", Style::default().fg(Color::DarkGray)),
+        Span::styled("Inject anyway", inject_style),
+        Span::raw("    "),
+        Span::styled("[S] ", Style::default().fg(Color::DarkGray)),
+        Span::styled("Skip these", skip_style),
+        Span::raw("    "),
+        Span::styled("[Esc] ", Style::default().fg(Color::DarkGray)),
+        Span::styled("Abort", abort_style),
+    ]));
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![Span::styled(
+        "  ↑↓ / I/S/Esc to select  ·  Enter to confirm",
+        Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC),
+    )]));
+
+    Paragraph::new(lines)
+        .wrap(Wrap { trim: false })
+        .render(inner, frame.buffer_mut());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    #[test]
+    fn file_injection_dialog_defaults_hidden() {
+        let state = FileInjectionDialogState::new();
+        assert!(!state.visible);
+        assert_eq!(state.selected, 0);
+    }
+
+    #[test]
+    fn file_injection_dialog_show_sets_visible() {
+        let mut state = FileInjectionDialogState::new();
+        state.show("input".to_string(), vec![], vec![("file.txt".to_string(), 100, "TooLarge".to_string())]);
+        assert!(state.visible);
+        assert_eq!(state.selected, 0);
+        assert!(!state.oversized.is_empty());
+    }
+
+    #[test]
+    fn file_injection_dialog_navigate() {
+        let mut state = FileInjectionDialogState::new();
+        state.show("input".to_string(), vec![], vec![]);
+        assert_eq!(state.current_outcome(), FileInjectionOutcome::InjectAll);
+        state.select_next();
+        assert_eq!(state.current_outcome(), FileInjectionOutcome::SkipOversized);
+        state.select_next();
+        assert_eq!(state.current_outcome(), FileInjectionOutcome::Abort);
+        state.select_prev();
+        assert_eq!(state.current_outcome(), FileInjectionOutcome::SkipOversized);
+    }
+
+    #[test]
+    fn file_injection_dialog_navigate_wraps() {
+        let mut state = FileInjectionDialogState::new();
+        state.show("input".to_string(), vec![], vec![]);
+        state.select_next(); // 0 → 1
+        state.select_next(); // 1 → 2
+        state.select_next(); // 2 → 0
+        assert_eq!(state.current_outcome(), FileInjectionOutcome::InjectAll);
+        state.select_prev(); // 0 → 2
+        assert_eq!(state.current_outcome(), FileInjectionOutcome::Abort);
+    }
+
+    #[test]
+    fn file_injection_dialog_confirm() {
+        let mut state = FileInjectionDialogState::new();
+        state.show("input".to_string(), vec![], vec![]);
+        state.select_next(); // Go to SkipOversized
+        state.confirm();
+        assert_eq!(state.outcome, Some(FileInjectionOutcome::SkipOversized));
+    }
+
+    #[test]
+    fn file_injection_dialog_take_outcome() {
+        let mut state = FileInjectionDialogState::new();
+        state.show("test input".to_string(), vec![], vec![]);
+        state.select_next();
+        state.confirm();
+        let (outcome, input, _) = state.take_outcome().unwrap();
+        assert_eq!(outcome, FileInjectionOutcome::SkipOversized);
+        assert_eq!(input, "test input");
+        assert!(!state.visible);
+        assert_eq!(state.outcome, None);
+    }
+
+    #[test]
+    fn file_injection_dialog_renders_without_panic() {
+        let mut terminal = Terminal::new(TestBackend::new(100, 30)).unwrap();
+        let mut state = FileInjectionDialogState::new();
+        state.show(
+            "input".to_string(),
+            vec![],
+            vec![("large_file.rs".to_string(), 250, "TooLarge".to_string())],
+        );
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                render_file_injection_dialog(frame, &state, area);
+            })
+            .unwrap();
+        let content: String = terminal
+            .backend()
+            .buffer()
+            .clone()
+            .content()
+            .iter()
+            .map(|c| c.symbol().chars().next().unwrap_or(' '))
+            .collect();
+        assert!(content.contains("Warning") || content.contains("File"));
+    }
+
+    #[test]
+    fn file_injection_dialog_hidden_renders_nothing() {
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).unwrap();
+        let state = FileInjectionDialogState::new(); // visible = false
+        let before = terminal.backend().buffer().clone();
+        terminal
+            .draw(|frame| {
+                render_file_injection_dialog(frame, &state, frame.area());
+            })
+            .unwrap();
+        assert_eq!(terminal.backend().buffer().content(), before.content());
+    }
+}

--- a/src-rust/crates/tui/src/lib.rs
+++ b/src-rust/crates/tui/src/lib.rs
@@ -135,6 +135,10 @@ pub mod import_config_dialog;
 pub mod session_branching;
 /// Model-initiated question dialog (AskUserQuestion tool).
 pub mod ask_user_dialog;
+/// File injection utilities for parsing @file references.
+pub mod file_injection;
+/// File injection warning dialog (shown when oversized files detected).
+pub mod file_injection_dialog;
 
 // ---------------------------------------------------------------------------
 // Public re-exports
@@ -168,6 +172,8 @@ pub use key_input_dialog::{KeyInputDialogState, render_key_input_dialog};
 pub use custom_provider_dialog::{CustomProviderDialogState, CustomProviderField, render_custom_provider_dialog};
 pub use free_mode_dialog::{FreeModeDialogState, FreeModeField, render_free_mode_dialog};
 pub use device_auth_dialog::{DeviceAuthDialogState, DeviceAuthStatus, DeviceAuthEvent, render_device_auth_dialog};
+pub use file_injection::{parse_at_refs, build_file_blocks, AtFileRef, AtFileIssue};
+pub use file_injection_dialog::{FileInjectionDialogState, FileInjectionOutcome, render_file_injection_dialog};
 
 // ---------------------------------------------------------------------------
 // Terminal initialization / teardown helpers (public API)

--- a/src-rust/crates/tui/src/prompt_input.rs
+++ b/src-rust/crates/tui/src/prompt_input.rs
@@ -1045,7 +1045,7 @@ pub fn apply_vim_command(
 // ---------------------------------------------------------------------------
 
 /// Typeahead source.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TypeaheadSource {
     SlashCommand,
     FileRef,
@@ -1061,10 +1061,27 @@ pub struct TypeaheadSuggestion {
 }
 
 /// Compute typeahead suggestions for the current input.
+///
+/// Handles two kinds of suggestions:
+/// - `/` slash commands (e.g. `/help`, `/clear`)
+/// - `@` file references (e.g. `@src/`, `@~/Documents/`)
 pub fn compute_typeahead(
     input: &str,
     slash_commands: &[(&str, &str)],
+    file_autocomplete_limit: usize,
+    file_autocomplete_show_hidden: bool,
 ) -> Vec<TypeaheadSuggestion> {
+    // Handle slash commands: /help, /clear, etc.
+    if input.starts_with('/') {
+        return compute_slash_suggestions(input, slash_commands);
+    }
+
+    // Handle file references: @, @/, @~/, @src/, etc.
+    compute_file_suggestions(input, file_autocomplete_limit, file_autocomplete_show_hidden)
+}
+
+/// Compute typeahead suggestions for slash commands only (e.g., `/help`).
+pub(crate) fn compute_slash_suggestions(input: &str, slash_commands: &[(&str, &str)]) -> Vec<TypeaheadSuggestion> {
     let mut suggestions = Vec::new();
 
     if let Some(cmd_prefix) = input.strip_prefix('/') {
@@ -1081,6 +1098,188 @@ pub fn compute_typeahead(
     }
 
     suggestions
+}
+
+/// Compute typeahead suggestions for file references (e.g., `@src/main.rs`).
+pub(crate) fn compute_file_suggestions(
+    input: &str,
+    file_autocomplete_limit: usize,
+    file_autocomplete_show_hidden: bool,
+) -> Vec<TypeaheadSuggestion> {
+    let mut suggestions = Vec::new();
+
+    if let Some(at_idx) = input.rfind('@') {
+        // Only suggest files if @ is at a word boundary (preceded by whitespace or start of string)
+        let at_word_boundary = at_idx == 0
+            || input[..at_idx]
+                .chars()
+                .last()
+                .map(|c| c.is_whitespace())
+                .unwrap_or(false);
+
+        if at_word_boundary {
+            let file_prefix = &input[at_idx + 1..];
+            suggestions = suggest_files(file_prefix, 0, file_autocomplete_limit, file_autocomplete_show_hidden);
+        }
+    }
+
+    suggestions
+}
+
+/// Suggest files matching a path prefix.
+///
+/// Examples:
+/// - `""` → files in cwd with names only (e.g., ["main.rs", "lib.rs"])
+/// - `"src"` → suggest "src/" if it exists
+/// - `"src/"` → files in src/ with names only (e.g., ["main.rs", "lib.rs"])
+/// - `"/"` → files in root with full paths (e.g., ["/Users", "/Applications"])
+/// - `"~"` → suggest "~/" if it exists
+/// - `"~/"` → files in home with names only
+fn suggest_files(prefix: &str, depth: usize, max_suggestions: usize, show_hidden: bool) -> Vec<TypeaheadSuggestion> {
+    const MAX_DEPTH: usize = 3;
+
+    if depth > MAX_DEPTH {
+        return Vec::new();
+    }
+    use std::path::PathBuf;
+    use std::fs;
+
+    let mut suggestions = Vec::new();
+
+    // Determine the directory to list and whether to show full paths
+    let (search_dir, show_full_paths, partial_name) = if prefix.is_empty() {
+        // Just @, show files from cwd
+        if let Ok(cwd) = std::env::current_dir() {
+            (cwd, false, String::new())
+        } else {
+            return suggestions;
+        }
+    } else if prefix.starts_with('/') || prefix.starts_with('~') {
+        // Absolute or home path: show full paths
+        let expanded = if prefix.starts_with('~') {
+            prefix.replacen('~', &home_dir().unwrap_or_default(), 1)
+        } else {
+            prefix.to_string()
+        };
+
+        let path = PathBuf::from(&expanded);
+        if path.is_dir() {
+            // User typed a complete directory: list its contents
+            (path, true, String::new())
+        } else if let Some(parent) = path.parent() {
+            // User typed a partial path: list parent's contents and filter
+            let partial = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("")
+                .to_string();
+            (parent.to_path_buf(), true, partial)
+        } else {
+            return suggestions;
+        }
+    } else {
+        // Relative path in cwd
+        if let Ok(cwd) = std::env::current_dir() {
+            let path = cwd.join(prefix);
+            if path.is_dir() {
+                // Complete directory: list its contents
+                (path, false, String::new())
+            } else if let Some(parent) = path.parent() {
+                // Partial path: list parent and filter
+                let partial = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("")
+                    .to_string();
+                (parent.to_path_buf(), false, partial)
+            } else {
+                return suggestions;
+            }
+        } else {
+            return suggestions;
+        }
+    };
+
+    // List files in the directory
+    if let Ok(entries) = fs::read_dir(&search_dir) {
+        let mut files: Vec<_> = entries
+            .filter_map(|e| {
+                e.ok().and_then(|entry| {
+                    let path = entry.path();
+                    let name = path
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .map(|s| s.to_string())?;
+
+                    // Filter by partial name
+                    if !partial_name.is_empty() && !name.starts_with(&partial_name) {
+                        return None;
+                    }
+
+                    // Filter hidden files unless user explicitly types a dot or show_hidden_files is enabled
+                    if !show_hidden && name.starts_with('.') && !partial_name.starts_with('.') {
+                        return None;
+                    }
+
+                    // Detect if this is a symlink or junction link
+                    let is_symlink = entry.file_type().ok().map(|ft| ft.is_symlink()).unwrap_or(false);
+                    let is_dir = path.is_dir();
+
+                    Some((name, is_dir, is_symlink))
+                })
+            })
+            .collect();
+
+        files.sort_by(|a, b| {
+            // Directories first, then alphabetically
+            match (b.1, a.1) {
+                (true, false) => std::cmp::Ordering::Greater,
+                (false, true) => std::cmp::Ordering::Less,
+                _ => a.0.cmp(&b.0),
+            }
+        });
+
+        for (name, is_dir, is_symlink) in files {
+            if suggestions.len() >= max_suggestions {
+                break;
+            }
+
+            let suggestion_text = if show_full_paths {
+                let full = search_dir.join(&name);
+                full.to_string_lossy().to_string()
+                    + if is_dir { "/" } else { "" }
+            } else {
+                name.clone() + if is_dir { "/" } else { "" }
+            };
+
+            let description = if is_symlink {
+                if is_dir {
+                    "directory link".to_string()
+                } else {
+                    "file link".to_string()
+                }
+            } else if is_dir {
+                "directory".to_string()
+            } else {
+                "file".to_string()
+            };
+
+            suggestions.push(TypeaheadSuggestion {
+                text: format!("@{}", suggestion_text),
+                description,
+                source: TypeaheadSource::FileRef,
+            });
+        }
+    }
+
+    suggestions
+}
+
+/// Get the home directory path.
+fn home_dir() -> Option<String> {
+    std::env::var("HOME")
+        .ok()
+        .or_else(|| std::env::var("USERPROFILE").ok())
 }
 
 // ---------------------------------------------------------------------------
@@ -2355,16 +2554,15 @@ impl PromptInputState {
         text
     }
 
-    /// Update typeahead suggestions for the current text.
+    /// Update typeahead suggestions for slash commands in the current text.
     pub fn update_suggestions(&mut self, slash_commands: &[(&str, &str)]) {
-        self.suggestions = compute_typeahead(&self.text, slash_commands);
+        self.suggestions = compute_slash_suggestions(&self.text, slash_commands);
+
         if self.suggestions.is_empty() {
             self.suggestion_index = None;
-        } else if self.text.starts_with('/') {
+        } else {
             let idx = self.suggestion_index.unwrap_or(0).min(self.suggestions.len() - 1);
             self.suggestion_index = Some(idx);
-        } else {
-            self.suggestion_index = None;
         }
     }
 
@@ -3227,26 +3425,23 @@ mod tests {
 
     // ---- compute_typeahead ---------------------------------------------
 
+    // Helper constants for tests
+    const TEST_FILE_AUTOCOMPLETE_LIMIT: usize = 15;
+    const TEST_FILE_AUTOCOMPLETE_SHOW_HIDDEN: bool = false;
+
     #[test]
     fn typeahead_slash_prefix_matches() {
         let cmds = [("help", "Show help"), ("history", "Show history"), ("compact", "Compact")];
-        let suggestions = compute_typeahead("/h", &cmds);
+        let suggestions = compute_slash_suggestions("/h", &cmds);
         assert_eq!(suggestions.len(), 2);
         assert_eq!(suggestions[0].text, "/help");
         assert_eq!(suggestions[1].text, "/history");
     }
 
     #[test]
-    fn typeahead_no_slash_returns_empty() {
-        let cmds = [("help", "Show help")];
-        let suggestions = compute_typeahead("hello", &cmds);
-        assert!(suggestions.is_empty());
-    }
-
-    #[test]
     fn typeahead_full_match() {
         let cmds = [("compact", "Compact conversation")];
-        let suggestions = compute_typeahead("/compact", &cmds);
+        let suggestions = compute_slash_suggestions("/compact", &cmds);
         assert_eq!(suggestions.len(), 1);
         assert_eq!(suggestions[0].text, "/compact");
         assert_eq!(suggestions[0].description, "Compact conversation");
@@ -3255,7 +3450,7 @@ mod tests {
     #[test]
     fn typeahead_case_insensitive() {
         let cmds = [("Help", "Show help")];
-        let suggestions = compute_typeahead("/H", &cmds);
+        let suggestions = compute_slash_suggestions("/H", &cmds);
         assert_eq!(suggestions.len(), 1);
         assert_eq!(suggestions[0].text, "/Help");
     }
@@ -4032,5 +4227,82 @@ mod tests {
         assert_eq!(VimMode::VisualLine.label(), "VISUAL LINE");
         assert_eq!(VimMode::Command.label(), "COMMAND");
         assert_eq!(VimMode::Search.label(), "SEARCH");
+    }
+
+    // ---- File reference (@) autocomplete tests ----
+
+    #[test]
+    fn file_autocomplete_slash_commands_still_work() {
+        let cmds = vec![("help", "Show help"), ("clear", "Clear messages")];
+        let suggestions = compute_slash_suggestions("/he", &cmds);
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].text, "/help");
+    }
+
+    #[test]
+    fn file_autocomplete_at_requires_word_boundary() {
+        // @ at word boundary: should suggest files (or be empty if cwd has no files)
+        let suggestions_at_boundary = compute_file_suggestions("@", TEST_FILE_AUTOCOMPLETE_LIMIT, TEST_FILE_AUTOCOMPLETE_SHOW_HIDDEN);
+        let suggestions_at_boundary_with_space = compute_file_suggestions("hello @", TEST_FILE_AUTOCOMPLETE_LIMIT, TEST_FILE_AUTOCOMPLETE_SHOW_HIDDEN);
+
+        // @ not at word boundary: should never suggest files
+        let suggestions_no_boundary = compute_file_suggestions("test@", TEST_FILE_AUTOCOMPLETE_LIMIT, TEST_FILE_AUTOCOMPLETE_SHOW_HIDDEN);
+        assert!(suggestions_no_boundary.is_empty(), "@ without word boundary should never suggest files");
+
+        // At least one of the boundary cases should work if cwd has files
+        // but more importantly, the non-boundary case should always be empty
+        for suggestion in suggestions_at_boundary.iter().chain(suggestions_at_boundary_with_space.iter()) {
+            assert_eq!(suggestion.source, TypeaheadSource::FileRef);
+        }
+    }
+
+    #[test]
+    fn file_autocomplete_returns_fileref_source() {
+        let suggestions = compute_file_suggestions("@", TEST_FILE_AUTOCOMPLETE_LIMIT, TEST_FILE_AUTOCOMPLETE_SHOW_HIDDEN);
+
+        for suggestion in suggestions {
+            assert_eq!(suggestion.source, TypeaheadSource::FileRef);
+        }
+    }
+
+    #[test]
+    fn file_autocomplete_format_filenames() {
+        let suggestions = compute_file_suggestions("@", TEST_FILE_AUTOCOMPLETE_LIMIT, TEST_FILE_AUTOCOMPLETE_SHOW_HIDDEN);
+
+        // All suggestions should start with @
+        for suggestion in suggestions {
+            assert!(suggestion.text.starts_with('@'));
+        }
+    }
+
+    #[test]
+    fn file_autocomplete_with_whitespace_prefix() {
+        // @ after whitespace: should suggest files
+        let suggestions = compute_file_suggestions("hello @", TEST_FILE_AUTOCOMPLETE_LIMIT, TEST_FILE_AUTOCOMPLETE_SHOW_HIDDEN);
+
+        // Check they all start with @ and are FileRef source
+        for suggestion in suggestions {
+            assert!(suggestion.text.starts_with('@'));
+            assert_eq!(suggestion.source, TypeaheadSource::FileRef);
+        }
+    }
+
+    #[test]
+    fn file_autocomplete_detects_symlinks() {
+        // This test verifies that symlinks/junction links are properly detected.
+        // On systems with symlinks/junctions, suggestions will include descriptions
+        // like "file link" or "directory link".
+        let suggestions = compute_file_suggestions("@", TEST_FILE_AUTOCOMPLETE_LIMIT, TEST_FILE_AUTOCOMPLETE_SHOW_HIDDEN);
+
+        // All suggestions should have a description (file, directory, file link, or directory link)
+        for suggestion in suggestions {
+            assert!(!suggestion.description.is_empty());
+            assert!(
+                suggestion.description.contains("file")
+                    || suggestion.description.contains("directory"),
+                "Unexpected description: {}",
+                suggestion.description
+            );
+        }
     }
 }

--- a/src-rust/crates/tui/src/render.rs
+++ b/src-rust/crates/tui/src/render.rs
@@ -21,6 +21,7 @@ use crate::memory_update_notification::render_memory_update_notification;
 use crate::import_config_dialog::render_import_config_dialog;
 use crate::invalid_config_dialog::render_invalid_config_dialog;
 use crate::bypass_permissions_dialog::render_bypass_permissions_dialog;
+use crate::file_injection_dialog::render_file_injection_dialog;
 use crate::ask_user_dialog::render_ask_user_dialog;
 use crate::onboarding_dialog::render_onboarding_dialog;
 use crate::dialog_select::render_dialog_select;
@@ -585,6 +586,11 @@ pub fn render_app(frame: &mut Frame, app: &App) {
     // Bypass-permissions confirmation dialog (topmost — rendered last so it sits above all)
     if app.bypass_permissions_dialog.visible {
         render_bypass_permissions_dialog(frame, &app.bypass_permissions_dialog, size);
+    }
+
+    // File injection warning dialog (shown when oversized/binary files detected)
+    if app.file_injection_dialog.visible {
+        render_file_injection_dialog(frame, &app.file_injection_dialog, size);
     }
 
     // AskUserQuestion dialog — renders above bypass-permissions so the model's

--- a/src-rust/crates/tui/src/settings_screen.rs
+++ b/src-rust/crates/tui/src/settings_screen.rs
@@ -67,6 +67,10 @@ pub struct SettingsScreen {
     pub auto_commits: bool,
     pub output_format: String,
     pub disable_claude_mds: bool,
+    pub file_injection_enabled: bool,
+    pub file_autocomplete_limit: String,
+    pub file_autocomplete_show_hidden_files: bool,
+    pub file_injection_max_size: String,
 }
 
 impl SettingsScreen {
@@ -96,6 +100,10 @@ impl SettingsScreen {
             auto_commits: false,
             output_format: "text".to_string(),
             disable_claude_mds: false,
+            file_injection_enabled: true,
+            file_autocomplete_limit: "15".to_string(),
+            file_autocomplete_show_hidden_files: false,
+            file_injection_max_size: "100".to_string(),
         }
     }
 
@@ -129,6 +137,10 @@ impl SettingsScreen {
             claurst_core::config::OutputFormat::StreamJson => "stream_json".to_string(),
         };
         self.disable_claude_mds = self.settings_snapshot.config.disable_claude_mds;
+        self.file_injection_enabled = self.settings_snapshot.config.file_injection_enabled;
+        self.file_autocomplete_limit = self.settings_snapshot.config.file_autocomplete_limit.to_string();
+        self.file_autocomplete_show_hidden_files = self.settings_snapshot.config.file_autocomplete_show_hidden_files;
+        self.file_injection_max_size = self.settings_snapshot.config.file_injection_max_size.to_string();
     }
 
     pub fn close(&mut self) {
@@ -201,6 +213,18 @@ impl SettingsScreen {
                         self.compact_threshold = value.clone();
                     }
                 }
+                "fileAutocompleteLimit" => {
+                    if let Ok(n) = value.parse::<usize>() {
+                        config.file_autocomplete_limit = n;
+                        self.file_autocomplete_limit = value.clone();
+                    }
+                }
+                "fileInjectionMaxSize" => {
+                    if let Ok(n) = value.parse::<usize>() {
+                        config.file_injection_max_size = n;
+                        self.file_injection_max_size = value.clone();
+                    }
+                }
                 _ => {}
             }
         }
@@ -221,7 +245,7 @@ impl Default for SettingsScreen {
 // ---------------------------------------------------------------------------
 
 fn all_entries(screen: &SettingsScreen) -> Vec<SettingsEntry> {
-    vec![
+    let mut entries = vec![
         SettingsEntry {
             key: "max_tokens",
             label: "Max Tokens",
@@ -340,7 +364,41 @@ fn all_entries(screen: &SettingsScreen) -> Vec<SettingsEntry> {
             kind: SettingKind::Bool,
             value: if screen.disable_claude_mds { "true" } else { "false" }.to_string(),
         },
-    ]
+        SettingsEntry {
+            key: "fileInjectionEnabled",
+            label: "File injection (@)",
+            description: "Auto-inject @file references into message context.",
+            kind: SettingKind::Bool,
+            value: if screen.file_injection_enabled { "true" } else { "false" }.to_string(),
+        },
+    ];
+
+    // Only show these if file injection is enabled
+    if screen.file_injection_enabled {
+        entries.push(SettingsEntry {
+            key: "fileAutocompleteLimit",
+            label: "File autocomplete limit",
+            description: "Max suggestions shown in @ autocomplete (type more to narrow results).",
+            kind: SettingKind::Number,
+            value: screen.file_autocomplete_limit.clone(),
+        });
+        entries.push(SettingsEntry {
+            key: "fileAutocompleteShowHiddenFiles",
+            label: "Show hidden files",
+            description: "Include hidden files (.) in @ autocomplete.",
+            kind: SettingKind::Bool,
+            value: if screen.file_autocomplete_show_hidden_files { "true" } else { "false" }.to_string(),
+        });
+        entries.push(SettingsEntry {
+            key: "fileInjectionMaxSize",
+            label: "File injection max size",
+            description: "Max file size to auto-inject (KB, 0=no limit).",
+            kind: SettingKind::Number,
+            value: screen.file_injection_max_size.clone(),
+        });
+    }
+
+    entries
 }
 
 // ---------------------------------------------------------------------------
@@ -684,6 +742,16 @@ fn toggle_or_cycle_current(screen: &mut SettingsScreen) {
                     "disable_claude_mds" => {
                         screen.disable_claude_mds = new_value;
                         screen.settings_snapshot.config.disable_claude_mds = new_value;
+                        let _ = screen.settings_snapshot.save_sync();
+                    }
+                    "fileInjectionEnabled" => {
+                        screen.file_injection_enabled = new_value;
+                        screen.settings_snapshot.config.file_injection_enabled = new_value;
+                        let _ = screen.settings_snapshot.save_sync();
+                    }
+                    "fileAutocompleteShowHiddenFiles" => {
+                        screen.file_autocomplete_show_hidden_files = new_value;
+                        screen.settings_snapshot.config.file_autocomplete_show_hidden_files = new_value;
                         let _ = screen.settings_snapshot.save_sync();
                     }
                     _ => {}


### PR DESCRIPTION
Add `@file` reference parsing to automatically inject file contents into messages with size warnings. Includes file/directory autocomplete triggered by `@`, configurable size limits, and a dialog to warn when files exceed limits with options to inject all, skip oversized, or abort.

Fixes #50