### PR TITLE
Implement alternating exit key confirmation for Ctrl+C and Ctrl+D

### DIFF
--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -340,10 +340,29 @@ fn resolve_bridge_config(
     bridge_config.is_active().then_some(bridge_config)
 }
 
-// ---------------------------------------------------------------------------
-// Entry point
-// ---------------------------------------------------------------------------
+fn handle_exit_key(app: &mut claurst_tui::app::App, key: crossterm::event::KeyEvent, cancel: &Option<tokio_util::sync::CancellationToken>) -> bool {
+    if !key.modifiers.contains(crossterm::event::KeyModifiers::CONTROL) {
+        return false;
+    }
 
+    match key.code {
+        crossterm::event::KeyCode::Char('c') => {
+            // Cancel background task first, then let app handle state cleanup
+            if app.is_streaming {
+                if let Some(ref ct) = cancel {
+                    ct.cancel();
+                }
+            }
+            app.handle_key_event(key);
+            true
+        }
+        crossterm::event::KeyCode::Char('d') => {
+            app.handle_key_event(key);
+            true
+        }
+        _ => false,
+    }
+}
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // Fast-path: handle --version before parsing everything
@@ -1974,43 +1993,12 @@ async fn run_interactive(
                         continue;
                     }
 
-                    // Ctrl+C: copy selected text if there's a selection, otherwise cancel/quit
-                    if key.code == KeyCode::Char('c')
-                        && key.modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
-                    {
-                        // Check if there's an active text selection — copy instead of cancel/quit
-                        let has_selection = app.selection_anchor.is_some() && !app.selection_text.borrow().is_empty();
-                        if has_selection {
-                            // Let the app handle the copy via its normal key handler
-                            app.handle_key_event(key);
-                            continue;
-                        }
-
-                        // No selection — handle as cancel (if streaming) or
-                        // clear-prompt (if non-empty) or quit.
-                        if app.is_streaming {
-                            if let Some(ref ct) = cancel {
-                                ct.cancel();
-                            }
-                            app.is_streaming = false;
-                            app.status_message = Some("Cancelled.".to_string());
-                            continue;
-                        } else if !app.prompt_input.is_empty() {
-                            // Non-empty prompt — let the app clear it via Ctrl+C
-                            // handler instead of quitting (matches readline).
-                            app.handle_key_event(key);
-                            continue;
-                        } else {
+                    // Ctrl+C and Ctrl+D: exit confirmation handling
+                    if handle_exit_key(&mut app, key, &cancel) {
+                        if app.should_exit {
                             break 'main;
                         }
-                    }
-
-                    // Ctrl+D on empty input => quit
-                    if key.code == KeyCode::Char('d')
-                        && key.modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
-                        && app.prompt_input.is_empty()
-                    {
-                        break 'main;
+                        continue;
                     }
 
                     // Enter => submit input (but NOT when ANY dialog/overlay is open —
@@ -2124,7 +2112,7 @@ async fn run_interactive(
                             }
 
                             // Honour exit/quit triggered by TUI intercept immediately.
-                            if app.should_quit {
+                            if app.should_exit {
                                 break 'main;
                             }
 
@@ -3733,7 +3721,7 @@ async fn run_interactive(
             });
         }
 
-        if app.should_quit {
+        if app.should_exit {
             break 'main;
         }
     }

--- a/src-rust/crates/core/src/keybindings.rs
+++ b/src-rust/crates/core/src/keybindings.rs
@@ -138,8 +138,8 @@ pub const NON_REBINDABLE: &[&str] = &["ctrl+c", "ctrl+d", "ctrl+m"];
 pub fn default_bindings() -> Vec<ParsedBinding> {
     let defaults: &[(&str, &str, KeyContext)] = &[
         // ========== GLOBAL CONTROL ==========
-        ("ctrl+c", "interrupt", KeyContext::Global),
-        ("ctrl+d", "exit", KeyContext::Global),
+        // ("ctrl+c", "interrupt", KeyContext::Global), // Handled directly in handle_key_event for two-press confirmation
+        // ("ctrl+d", "exit", KeyContext::Global), // Handled directly in handle_key_event for two-press confirmation
         ("ctrl+l", "redraw", KeyContext::Global),
         ("ctrl+r", "historySearch", KeyContext::Global),
         ("ctrl+b", "createBranch", KeyContext::Global),

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -82,7 +82,7 @@ const PROMPT_SLASH_COMMANDS: &[(&str, &str)] = &[
     ("caveman", "Caveman speech mode — save big token"),
     ("rocky", "Rocky speech mode — amaze amaze amaze"),
     ("normal", "Deactivate speech mode"),
-    ("quit", "Quit Claurst"),
+    ("quit", "Exit Claurst"),
     ("refresh", "Clear saved provider auth and model caches"),
     ("rename", "Rename this session"),
     ("resume", "Resume a previous session"),
@@ -712,7 +712,7 @@ pub struct App {
     pub status_message: Option<String>,
     /// Randomly chosen thinking verb shown next to the spinner while streaming.
     pub spinner_verb: Option<String>,
-    pub should_quit: bool,
+    pub should_exit: bool,
     pub show_help: bool,
 
     // Extended state
@@ -1069,6 +1069,10 @@ pub struct App {
     pub managed_agent_cost_breakdown: Option<(f64, f64, f64)>,
     /// Whether managed agent mode is currently active.
     pub managed_agents_active: bool,
+    /// Timestamp of the first exit key press that showed confirmation (valid for ~2 seconds).
+    pub last_exit_key_warning: Option<std::time::Instant>,
+    /// Which exit key ('c' or 'd') started the current confirmation sequence.
+    pub exit_key_sequence_start: Option<char>,
 }
 
 const SPINNER_VERBS: &[&str] = &[
@@ -1249,7 +1253,7 @@ impl App {
             streaming_thinking: String::new(),
             status_message: None,
             spinner_verb: None,
-            should_quit: false,
+            should_exit: false,
             show_help: false,
             tool_use_blocks: Vec::new(),
             permission_request: None,
@@ -1455,6 +1459,8 @@ impl App {
             update_available: None,
             managed_agent_cost_breakdown: None,
             managed_agents_active: false,
+            last_exit_key_warning: None,
+            exit_key_sequence_start: None,
         }
     }
 
@@ -2083,7 +2089,7 @@ impl App {
                 true
             }
             "exit" | "quit" => {
-                self.should_quit = true;
+                self.should_exit = true;
                 true
             }
             "vim" => {
@@ -2852,7 +2858,7 @@ impl App {
             match key.code {
                 KeyCode::Char('1') | KeyCode::Esc => {
                     // "No, exit" — quit immediately
-                    self.should_quit = true;
+                    self.should_exit = true;
                 }
                 KeyCode::Char('2') => {
                     // "Yes, I accept" — dismiss and continue
@@ -2864,7 +2870,7 @@ impl App {
                     if self.bypass_permissions_dialog.is_accept_selected() {
                         self.bypass_permissions_dialog.dismiss();
                     } else {
-                        self.should_quit = true;
+                        self.should_exit = true;
                     }
                 }
                 _ => {}
@@ -3927,6 +3933,7 @@ impl App {
                 // If text is selected, copy it to clipboard instead of quitting.
                 let sel_text = self.selection_text.borrow().clone();
                 if self.selection_anchor.is_some() && !sel_text.is_empty() {
+                    // Text is selected: copy to clipboard.
                     let copied = crate::image_paste::write_clipboard_text(&sel_text);
                     self.selection_anchor = None;
                     self.selection_focus = None;
@@ -3935,23 +3942,28 @@ impl App {
                         self.notifications.push(NotificationKind::Info, "Copied to clipboard".to_string(), Some(2));
                     }
                 } else if self.is_streaming {
+                    // Cancel streaming.
                     self.is_streaming = false;
                     self.spinner_verb = None;
                     self.streaming_text.clear();
                     self.streaming_thinking.clear();
                     self.tool_use_blocks.clear();
                     self.status_message = Some("Cancelled.".to_string());
-                } else if !self.prompt_input.is_empty() {
-                    // Non-empty prompt — clear it (matches bash/readline Ctrl+C).
-                    self.prompt_input.clear();
-                    self.refresh_prompt_input();
+                    self.complete_current_turn_snapshot(true);
                 } else {
-                    self.should_quit = true;
+                    // No text selected and not streaming: handle exit confirmation sequence.
+                    // Always clear the prompt input on Ctrl+C.
+                    if !self.prompt_input.is_empty() {
+                        self.prompt_input.clear();
+                        self.refresh_prompt_input();
+                    }
+                    self.handle_exit_key_confirmation('c');
                 }
             }
             KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                // Ctrl+D on empty input: trigger two-press exit confirmation (like Ctrl+C).
                 if self.prompt_input.is_empty() {
-                    self.should_quit = true;
+                    self.handle_exit_key_confirmation('d');
                 }
             }
 
@@ -4230,6 +4242,14 @@ impl App {
 
             _ => {}
         }
+
+        // Reset exit confirmation sequence if user presses any key other than Ctrl+C or Ctrl+D.
+        let is_exit_key = key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char(c) if c == 'c' || c == 'd' || c == 'C' || c == 'D');
+        if !is_exit_key {
+            self.last_exit_key_warning = None;
+            self.exit_key_sequence_start = None;
+        }
+
         false
     }
 
@@ -4550,6 +4570,38 @@ impl App {
         false
     }
 
+    fn handle_exit_key_confirmation(&mut self, mut key_char: char) {
+        fn exit_message(key: char) -> &'static str {
+            if key == 'c' {
+                "Press Ctrl+C again to exit"
+            } else {
+                "Press Ctrl+D again to exit"
+            }
+        }
+
+        // Check if we have an active warning within the timeout
+        if let Some(warning_time) = self.last_exit_key_warning {
+            if warning_time.elapsed().as_secs_f64() <= 2.0 {
+                if self.exit_key_sequence_start == Some(key_char) {
+                    // Matching key - exit
+                    self.should_exit = true;
+                    self.last_exit_key_warning = None;
+                    self.exit_key_sequence_start = None;
+                    return;
+                }
+                if let Some(other_key) = self.exit_key_sequence_start {
+                    // Wrong key pressed - show message for the original key and reset timer
+                    key_char = other_key;
+                }
+            }
+        }
+
+        // Start new sequence (or show message for wrong key)
+        self.notifications.push(NotificationKind::Info, exit_message(key_char).to_string(), Some(2));
+        self.last_exit_key_warning = Some(std::time::Instant::now());
+        self.exit_key_sequence_start = Some(key_char);
+    }
+
     fn handle_keybinding_action(&mut self, action: &str) -> bool {
         match action {
             "interrupt" => {
@@ -4561,13 +4613,33 @@ impl App {
                     self.tool_use_blocks.clear();
                     self.status_message = Some("Cancelled.".to_string());
                 } else {
-                    self.should_quit = true;
+                    // Handle exit confirmation: require two exit key presses within 2 seconds.
+                    // Always clear the prompt input on Ctrl+C.
+                    if !self.prompt_input.is_empty() {
+                        self.prompt_input.clear();
+                        self.refresh_prompt_input();
+                    }
+
+                    let elapsed = self.last_exit_key_warning.map(|t| t.elapsed().as_secs_f64());
+                    let is_valid = elapsed.map(|e| e <= 2.0).unwrap_or(false);
+
+                    if self.last_exit_key_warning.is_some() && is_valid {
+                        // A warning is active and within 2 seconds: exit.
+                        self.should_exit = true;
+                        self.last_exit_key_warning = None;
+                        self.exit_key_sequence_start = None;
+                    } else {
+                        // First press or timeout expired: show exit confirmation.
+                        self.notifications.push(NotificationKind::Info, "Press Ctrl+C again to exit".to_string(), Some(2));
+                        self.last_exit_key_warning = Some(std::time::Instant::now());
+                        self.exit_key_sequence_start = Some('c');
+                    }
                 }
                 false
             }
             "exit" => {
                 if self.prompt_input.is_empty() {
-                    self.should_quit = true;
+                    self.should_exit = true;
                 }
                 false
             }
@@ -6061,9 +6133,9 @@ impl App {
                         // Honour `:q`/`:wq` from vim command-line mode
                         if self.prompt_input.vim_quit_requested {
                             self.prompt_input.vim_quit_requested = false;
-                            self.should_quit = true;
+                            self.should_exit = true;
                         }
-                        if self.should_quit {
+                        if self.should_exit {
                             return Ok(None);
                         }
                         if should_submit {
@@ -6318,9 +6390,9 @@ mod tests {
     #[test]
     fn test_exit_slash_command_sets_quit_flag() {
         let mut app = make_app();
-        assert!(!app.should_quit);
+        assert!(!app.should_exit);
         assert!(app.intercept_slash_command("exit"));
-        assert!(app.should_quit);
+        assert!(app.should_exit);
     }
 
     #[test]

--- a/src-rust/crates/tui/src/lib.rs
+++ b/src-rust/crates/tui/src/lib.rs
@@ -503,10 +503,61 @@ mod tests {
     }
 
     #[test]
-    fn test_ctrl_c_quits_when_idle() {
+    fn test_ctrl_c_requires_two_presses_to_exit() {
         let mut app = make_app();
+        // First Ctrl+C: shows warning, doesn't exit
         app.handle_key_event(ctrl(KeyCode::Char('c')));
-        assert!(app.should_quit);
+        assert!(!app.should_exit);
+        assert!(app.last_exit_key_warning.is_some());
+
+        // Second Ctrl+C within 1 second: exits
+        app.handle_key_event(ctrl(KeyCode::Char('c')));
+        assert!(app.should_exit);
+    }
+
+    #[test]
+    fn test_ctrl_c_clears_input_first_press() {
+        let mut app = make_app();
+        app.set_prompt_text("some text".to_string());
+        // First Ctrl+C: clears input
+        app.handle_key_event(ctrl(KeyCode::Char('c')));
+        assert!(app.prompt_input.is_empty());
+        assert!(!app.should_exit);
+        assert!(app.last_exit_key_warning.is_some());
+    }
+
+    #[test]
+    fn test_other_key_resets_exit_warning() {
+        let mut app = make_app();
+        // First Ctrl+C: shows warning
+        app.handle_key_event(ctrl(KeyCode::Char('c')));
+        assert!(app.last_exit_key_warning.is_some());
+
+        // Press a different key: resets warning
+        app.handle_key_event(key(KeyCode::Char('a')));
+        assert!(app.last_exit_key_warning.is_none());
+
+        // Now Ctrl+C starts over (doesn't exit)
+        app.handle_key_event(ctrl(KeyCode::Char('c')));
+        assert!(!app.should_exit);
+        assert!(app.last_exit_key_warning.is_some());
+    }
+
+    #[test]
+    fn test_ctrl_c_timeout_resets_after_two_seconds() {
+        let mut app = make_app();
+        // First Ctrl+C: shows warning
+        app.handle_key_event(ctrl(KeyCode::Char('c')));
+        assert!(app.last_exit_key_warning.is_some());
+
+        // Manually expire the timer by setting it to >2 seconds ago
+        app.last_exit_key_warning = Some(std::time::Instant::now()
+            - std::time::Duration::from_millis(2100));
+
+        // Second Ctrl+C after timeout: should show warning again, not exit
+        app.handle_key_event(ctrl(KeyCode::Char('c')));
+        assert!(!app.should_exit);
+        assert!(app.last_exit_key_warning.is_some());
     }
 
     #[test]
@@ -516,15 +567,21 @@ mod tests {
         app.streaming_text = "partial".to_string();
         app.handle_key_event(ctrl(KeyCode::Char('c')));
         assert!(!app.is_streaming);
-        assert!(!app.should_quit);
+        assert!(!app.should_exit);
         assert!(app.streaming_text.is_empty());
     }
 
     #[test]
-    fn test_ctrl_d_quits_on_empty_input() {
+    fn test_ctrl_d_requires_two_presses_to_exit() {
         let mut app = make_app();
+        // First Ctrl+D: shows warning, doesn't exit
         app.handle_key_event(ctrl(KeyCode::Char('d')));
-        assert!(app.should_quit);
+        assert!(!app.should_exit);
+        assert!(app.last_exit_key_warning.is_some());
+
+        // Second Ctrl+D within 2 seconds: exits
+        app.handle_key_event(ctrl(KeyCode::Char('d')));
+        assert!(app.should_exit);
     }
 
     #[test]
@@ -532,7 +589,43 @@ mod tests {
         let mut app = make_app();
         app.set_prompt_text("abc".to_string());
         app.handle_key_event(ctrl(KeyCode::Char('d')));
-        assert!(!app.should_quit);
+        assert!(!app.should_exit);
+    }
+
+    #[test]
+    fn test_ctrl_c_then_ctrl_d_then_ctrl_c_exits() {
+        let mut app = make_app();
+        // First Ctrl+C: shows warning, sets start_key = 'c'
+        app.handle_key_event(ctrl(KeyCode::Char('c')));
+        assert!(!app.should_exit);
+        assert_eq!(app.exit_key_sequence_start, Some('c'));
+
+        // Ctrl+D (wrong key): resets timer but keeps waiting for Ctrl+C
+        app.handle_key_event(ctrl(KeyCode::Char('d')));
+        assert!(!app.should_exit);
+        assert_eq!(app.exit_key_sequence_start, Some('c')); // Still waiting for Ctrl+C
+
+        // Ctrl+C again: exits
+        app.handle_key_event(ctrl(KeyCode::Char('c')));
+        assert!(app.should_exit);
+    }
+
+    #[test]
+    fn test_ctrl_d_then_ctrl_c_then_ctrl_d_exits() {
+        let mut app = make_app();
+        // First Ctrl+D: shows warning, sets start_key = 'd'
+        app.handle_key_event(ctrl(KeyCode::Char('d')));
+        assert!(!app.should_exit);
+        assert_eq!(app.exit_key_sequence_start, Some('d'));
+
+        // Ctrl+C (wrong key): resets timer but keeps waiting for Ctrl+D
+        app.handle_key_event(ctrl(KeyCode::Char('c')));
+        assert!(!app.should_exit);
+        assert_eq!(app.exit_key_sequence_start, Some('d')); // Still waiting for Ctrl+D
+
+        // Ctrl+D again: exits
+        app.handle_key_event(ctrl(KeyCode::Char('d')));
+        assert!(app.should_exit);
     }
 
     #[test]


### PR DESCRIPTION
Implement two-press confirmation sequences that accept either `Ctrl+C` or `Ctrl+D` as the initial press, requiring the same key again within 2 seconds to exit. Supports mixed-key sequences like `Ctrl+D`, `Ctrl+C`, `Ctrl+D` or `Ctrl+C`, `Ctrl+D`, `Ctrl+C`.