### PR TITLE
Improve keybinding system - schema versioning & better defaults

### DIFF
--- a/src-rust/crates/core/src/keybindings.rs
+++ b/src-rust/crates/core/src/keybindings.rs
@@ -151,7 +151,6 @@ pub const NON_REBINDABLE: &[&str] = &["ctrl+c", "ctrl+d", "ctrl+m"];
 /// - **Alt+←/Alt+→**: Navigate to previous/next message in transcript
 /// - **Ctrl+. (Ctrl+>)**: Jump to next error/issue in messages
 /// - **Ctrl+Shift+.**: Jump to previous error/issue
-/// - **Ctrl+M**: Send message (alternative to Enter)
 /// - **Shift+Tab**: Reverse indent/unindent in input (cycle permission mode)
 /// - **Ctrl+H**: Delete character before cursor (Chat context, Emacs-style)
 /// - **Alt+H**: Open help (alternative to F1)
@@ -172,7 +171,6 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         // ========== CHAT / INPUT CONTEXT ==========
         // Message submission
         ("enter", "submit", KeyContext::Chat),
-        ("ctrl+m", "sendMessage", KeyContext::Chat),
 
         // Newline insertion (Shift+Enter / Ctrl+J for multi-line composing)
         ("shift+enter", "newline", KeyContext::Chat),
@@ -849,7 +847,7 @@ mod tests {
 
         // Check Phase 1 keybinding actions exist
         assert!(actions.contains(&"clearLine".to_string()), "clearLine action not found");
-        assert!(actions.contains(&"sendMessage".to_string()), "sendMessage action not found");
+        assert!(actions.contains(&"submit".to_string()), "submit action not found");
         assert!(actions.contains(&"jumpToNextError".to_string()), "jumpToNextError action not found");
         assert!(actions.contains(&"jumpToPreviousError".to_string()), "jumpToPreviousError action not found");
         assert!(actions.contains(&"previousMessage".to_string()), "previousMessage action not found");

--- a/src-rust/crates/core/src/keybindings.rs
+++ b/src-rust/crates/core/src/keybindings.rs
@@ -145,7 +145,7 @@ pub const NON_REBINDABLE: &[&str] = &["ctrl+c", "ctrl+d", "ctrl+m"];
 ///
 /// # Standard Keybindings (Phase 1 Implementation)
 /// - **Ctrl+L**: Clear current input line (like bash) [Chat context only due to conflict]
-/// - **Ctrl+A**: Open the model picker
+/// - **Ctrl+Shift+A**: Open the model picker
 /// - **Ctrl+K**: Open the command palette
 /// - **Ctrl+U**: Kill input from cursor to start of line (Emacs-style)
 /// - **Alt+←/Alt+→**: Navigate to previous/next message in transcript
@@ -190,6 +190,7 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         // Line start/end navigation
         ("home", "goLineStart", KeyContext::Chat),
         ("cmd+left", "goLineStart", KeyContext::Chat),
+        ("ctrl+a", "goLineStart", KeyContext::Chat),
         ("end", "goLineEnd", KeyContext::Chat),
         ("cmd+right", "goLineEnd", KeyContext::Chat),
         ("ctrl+e", "goLineEnd", KeyContext::Chat),
@@ -240,7 +241,7 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         ("pagedown", "scrollDown", KeyContext::Chat),
 
         // App shortcuts
-        ("ctrl+a", "openModelPicker", KeyContext::Chat),
+        ("ctrl+shift+a", "openModelPicker", KeyContext::Chat),
         ("ctrl+k", "openCommandPalette", KeyContext::Chat),
 
         // ========== CONFIRMATION DIALOGS ==========
@@ -456,7 +457,7 @@ impl UserKeybindings {
             })
             .collect();
         Ok(Self {
-            schema_version: KEYBINDINGS_SCHEMA_VERSION,
+            schema_version: 0,
             bindings,
         })
     }
@@ -475,6 +476,22 @@ impl UserKeybindings {
         let mut user_customizations: std::collections::HashMap<String, Option<String>> =
             std::collections::HashMap::new();
         for binding in &self.bindings {
+            // Migration: remove old bindings that have changed in defaults
+            // This distinguishes between "user customized" and "old default that changed"
+
+            // Old: ctrl+a -> openModelPicker (moved to ctrl+shift+a)
+            if binding.chord == "ctrl+a" && binding.action.as_deref() == Some("openModelPicker") {
+                continue;
+            }
+
+            // Old: tab -> togglePreview in Chat context (changed to indent)
+            if binding.chord == "tab"
+                && binding.context.as_deref() == Some("Chat")
+                && binding.action.as_deref() == Some("togglePreview")
+            {
+                continue;
+            }
+
             user_customizations
                 .insert(binding.chord.clone(), binding.action.clone());
         }
@@ -713,12 +730,13 @@ mod tests {
     }
 
     #[test]
-    fn test_default_bindings_map_ctrl_a_and_ctrl_k_to_app_shortcuts() {
+    fn test_default_bindings_map_ctrl_shift_a_and_ctrl_k_to_app_shortcuts() {
         let bindings = default_bindings();
 
-        let ctrl_a = bindings.iter().find(|b| {
+        let ctrl_shift_a = bindings.iter().find(|b| {
             b.chord.len() == 1
                 && b.chord[0].ctrl
+                && b.chord[0].shift
                 && b.chord[0].key == "a"
                 && b.context == KeyContext::Chat
         });
@@ -729,7 +747,7 @@ mod tests {
                 && b.context == KeyContext::Chat
         });
 
-        assert_eq!(ctrl_a.and_then(|b| b.action.as_deref()), Some("openModelPicker"));
+        assert_eq!(ctrl_shift_a.and_then(|b| b.action.as_deref()), Some("openModelPicker"));
         assert_eq!(
             ctrl_k.and_then(|b| b.action.as_deref()),
             Some("openCommandPalette")
@@ -846,5 +864,58 @@ mod tests {
             "Expected at least 40 keybindings, found {}",
             actions.len()
         );
+    }
+
+    #[test]
+    fn test_old_format_keybindings_get_upgraded() {
+        let old_format_json = r#"{
+            "bindings": [
+                {
+                    "context": "Chat",
+                    "bindings": {
+                        "ctrl+shift+a": "openModelPicker",
+                        "ctrl+e": "goLineEnd"
+                    }
+                }
+            ]
+        }"#;
+
+        let mut kb = UserKeybindings::from_json_str(old_format_json);
+        assert_eq!(kb.schema_version, 0, "Old format should start at version 0");
+
+        kb.smart_merge_with_defaults();
+
+        assert_eq!(kb.schema_version, 1, "Should be upgraded to version 1");
+        assert!(
+            kb.bindings.iter().any(|b| b.chord == "meta+left"),
+            "meta+left (cmd+left) should be added from defaults after merge"
+        );
+        assert!(
+            kb.bindings.iter().any(|b| b.chord == "ctrl+shift+a" && b.action.as_deref() == Some("openModelPicker")),
+            "User customization (ctrl+shift+a -> openModelPicker) should be preserved"
+        );
+    }
+
+    #[test]
+    fn test_cmd_left_resolves_to_go_line_start() {
+        let user = UserKeybindings::default();
+        let mut resolver = KeybindingResolver::new(&user);
+
+        // Create a keystroke for CMD+Left (SUPER modifier + left arrow)
+        let keystroke = ParsedKeystroke {
+            key: "left".to_string(),
+            ctrl: false,
+            alt: false,
+            shift: false,
+            meta: true,
+        };
+
+        let result = resolver.process(keystroke, &KeyContext::Chat);
+        match result {
+            KeybindingResult::Action(action) => {
+                assert_eq!(action, "goLineStart", "CMD+Left should map to goLineStart");
+            }
+            other => panic!("Expected Action(\"goLineStart\"), got {:?}", other),
+        }
     }
 }

--- a/src-rust/crates/core/src/keybindings.rs
+++ b/src-rust/crates/core/src/keybindings.rs
@@ -167,6 +167,8 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         ("ctrl+j", "newline", KeyContext::Chat),
         ("home", "goLineStart", KeyContext::Chat),
         ("end", "goLineEnd", KeyContext::Chat),
+        ("cmd+left", "goLineStart", KeyContext::Chat),
+        ("cmd+right", "goLineEnd", KeyContext::Chat),
 
         // Text Editing (Emacs-style) + app shortcuts
         ("ctrl+a", "openModelPicker", KeyContext::Chat),

--- a/src-rust/crates/core/src/keybindings.rs
+++ b/src-rust/crates/core/src/keybindings.rs
@@ -170,13 +170,11 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         ("alt+h", "openHelp", KeyContext::Global),
 
         // ========== CHAT / INPUT CONTEXT ==========
+        // Message submission
         ("enter", "submit", KeyContext::Chat),
-        ("up", "historyPrev", KeyContext::Chat),
-        ("down", "historyNext", KeyContext::Chat),
-        ("shift+tab", "reverseIndent", KeyContext::Chat),
-        ("pageup", "scrollUp", KeyContext::Chat),
-        ("pagedown", "scrollDown", KeyContext::Chat),
-        ("tab", "indent", KeyContext::Chat),
+        ("ctrl+m", "sendMessage", KeyContext::Chat),
+
+        // Newline insertion (Shift+Enter / Ctrl+J for multi-line composing)
         ("shift+enter", "newline", KeyContext::Chat),
         // Fallback for terminals that do not support the kitty keyboard protocol
         // (e.g. Terminal.app, older iTerm2, Windows Terminal, or SSH sessions).
@@ -188,41 +186,62 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         // fallback is not needed there. Keep it as a compatibility belt-and-braces
         // for terminals that do not support the protocol.
         ("ctrl+j", "newline", KeyContext::Chat),
+
+        // Line start/end navigation
         ("home", "goLineStart", KeyContext::Chat),
-        ("end", "goLineEnd", KeyContext::Chat),
         ("cmd+left", "goLineStart", KeyContext::Chat),
+        ("end", "goLineEnd", KeyContext::Chat),
         ("cmd+right", "goLineEnd", KeyContext::Chat),
+        ("ctrl+e", "goLineEnd", KeyContext::Chat),
+
+        // Word navigation
         ("ctrl+left", "moveWordBackward", KeyContext::Chat),
         ("ctrl+right", "moveWordForward", KeyContext::Chat),
 
-        // Text Editing (Emacs-style) + app shortcuts
-        ("ctrl+a", "openModelPicker", KeyContext::Chat),
-        ("ctrl+e", "goLineEnd", KeyContext::Chat),
-        ("ctrl+h", "deleteCharBefore", KeyContext::Chat),
-        ("ctrl+k", "openCommandPalette", KeyContext::Chat),
-        ("ctrl+u", "killToStart", KeyContext::Chat),
+        // Word deletion
         ("ctrl+w", "killWord", KeyContext::Chat),
-        ("alt+d", "deleteWord", KeyContext::Chat),
         ("alt+backspace", "killWord", KeyContext::Chat),
+        ("alt+d", "deleteWord", KeyContext::Chat),
 
-        // New Text Editing & Navigation
-        ("ctrl+m", "sendMessage", KeyContext::Chat),
+        // Character/line deletion
+        ("ctrl+h", "deleteCharBefore", KeyContext::Chat),
+        ("ctrl+u", "killToStart", KeyContext::Chat),
         ("ctrl+l", "clearLine", KeyContext::Chat),
-        ("ctrl+.", "jumpToNextError", KeyContext::Chat),
-        ("ctrl+shift+.", "jumpToPreviousError", KeyContext::Chat),
+
+        // History navigation
+        ("up", "historyPrev", KeyContext::Chat),
+        ("ctrl+o", "historyPrev", KeyContext::Chat),
+        ("down", "historyNext", KeyContext::Chat),
+        ("ctrl+i", "historyNext", KeyContext::Chat),
+
+        // Message navigation
         ("alt+left", "previousMessage", KeyContext::Chat),
         ("alt+right", "nextMessage", KeyContext::Chat),
-        ("ctrl+o", "historyPrev", KeyContext::Chat),
-        ("ctrl+i", "historyNext", KeyContext::Chat),
+
+        // Error/issue navigation
+        ("ctrl+.", "jumpToNextError", KeyContext::Chat),
+        ("ctrl+shift+.", "jumpToPreviousError", KeyContext::Chat),
 
         // Searching
         ("ctrl+f", "findInMessage", KeyContext::Chat),
         ("ctrl+shift+f", "globalSearch", KeyContext::Chat),
-        ("ctrl+g", "goToLine", KeyContext::Chat),
         ("f3", "findNext", KeyContext::Chat),
         ("ctrl+]", "findNext", KeyContext::Chat),
         ("shift+f3", "findPrev", KeyContext::Chat),
         ("ctrl+[", "findPrev", KeyContext::Chat),
+        ("ctrl+g", "goToLine", KeyContext::Chat),
+
+        // Indentation
+        ("tab", "indent", KeyContext::Chat),
+        ("shift+tab", "reverseIndent", KeyContext::Chat),
+
+        // Scrolling
+        ("pageup", "scrollUp", KeyContext::Chat),
+        ("pagedown", "scrollDown", KeyContext::Chat),
+
+        // App shortcuts
+        ("ctrl+a", "openModelPicker", KeyContext::Chat),
+        ("ctrl+k", "openCommandPalette", KeyContext::Chat),
 
         // ========== CONFIRMATION DIALOGS ==========
         ("y", "yes", KeyContext::Confirmation),
@@ -241,10 +260,10 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         ("pagedown", "pageDown", KeyContext::Help),
 
         // ========== HISTORY SEARCH ==========
-        ("enter", "select", KeyContext::HistorySearch),
-        ("escape", "cancel", KeyContext::HistorySearch),
         ("up", "prevResult", KeyContext::HistorySearch),
         ("down", "nextResult", KeyContext::HistorySearch),
+        ("enter", "select", KeyContext::HistorySearch),
+        ("escape", "cancel", KeyContext::HistorySearch),
         ("tab", "togglePreview", KeyContext::HistorySearch),
 
         // ========== TRANSCRIPT / MESSAGE SELECTION ==========
@@ -260,20 +279,20 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         // ========== MESSAGE SELECTOR OVERLAY ==========
         ("up", "prevMessage", KeyContext::MessageSelector),
         ("down", "nextMessage", KeyContext::MessageSelector),
+        ("k", "prevMessage", KeyContext::MessageSelector),
+        ("j", "nextMessage", KeyContext::MessageSelector),
         ("enter", "select", KeyContext::MessageSelector),
         ("escape", "cancel", KeyContext::MessageSelector),
-        ("j", "nextMessage", KeyContext::MessageSelector),
-        ("k", "prevMessage", KeyContext::MessageSelector),
 
         // ========== THEME & MODEL PICKERS ==========
         ("up", "prev", KeyContext::ThemePicker),
         ("down", "next", KeyContext::ThemePicker),
+        ("k", "prev", KeyContext::ThemePicker),
+        ("j", "next", KeyContext::ThemePicker),
         ("pageup", "pageUp", KeyContext::ThemePicker),
         ("pagedown", "pageDown", KeyContext::ThemePicker),
         ("enter", "select", KeyContext::ThemePicker),
         ("escape", "cancel", KeyContext::ThemePicker),
-        ("j", "next", KeyContext::ThemePicker),
-        ("k", "prev", KeyContext::ThemePicker),
 
         // ========== TASK LIST ==========
         ("up", "prevTask", KeyContext::Task),
@@ -285,22 +304,22 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         // ========== DIFF DIALOG ==========
         ("up", "prevDiff", KeyContext::DiffDialog),
         ("down", "nextDiff", KeyContext::DiffDialog),
+        ("a", "acceptDiff", KeyContext::DiffDialog),
+        ("enter", "acceptDiff", KeyContext::DiffDialog),
+        ("r", "rejectDiff", KeyContext::DiffDialog),
+        ("escape", "rejectDiff", KeyContext::DiffDialog),
         ("pageup", "pageUp", KeyContext::DiffDialog),
         ("pagedown", "pageDown", KeyContext::DiffDialog),
-        ("enter", "acceptDiff", KeyContext::DiffDialog),
-        ("escape", "rejectDiff", KeyContext::DiffDialog),
-        ("r", "rejectDiff", KeyContext::DiffDialog),
-        ("a", "acceptDiff", KeyContext::DiffDialog),
 
         // ========== MODAL SELECT (Generic) ==========
         ("up", "prev", KeyContext::Select),
         ("down", "next", KeyContext::Select),
+        ("k", "prev", KeyContext::Select),
+        ("j", "next", KeyContext::Select),
         ("pageup", "pageUp", KeyContext::Select),
         ("pagedown", "pageDown", KeyContext::Select),
         ("enter", "select", KeyContext::Select),
         ("escape", "cancel", KeyContext::Select),
-        ("j", "next", KeyContext::Select),
-        ("k", "prev", KeyContext::Select),
         ("/", "search", KeyContext::Select),
 
         // ========== PLUGIN & ATTACHMENTS ==========

--- a/src-rust/crates/core/src/keybindings.rs
+++ b/src-rust/crates/core/src/keybindings.rs
@@ -3,6 +3,7 @@
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
+use tracing::warn;
 
 /// All keybinding contexts
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -324,9 +325,31 @@ pub struct UserBinding {
 
 impl UserKeybindings {
     pub fn from_json_str(content: &str) -> Self {
-        serde_json::from_str(content)
+        let mut kb = serde_json::from_str(content)
             .or_else(|_| Self::from_block_config(content))
-            .unwrap_or_default()
+            .unwrap_or_default();
+
+        // Warn about and filter out non-rebindable keys
+        let original_len = kb.bindings.len();
+        kb.bindings.retain(|binding| {
+            let normalized = binding.chord.to_lowercase();
+            if NON_REBINDABLE.iter().any(|protected| normalized == *protected) {
+                warn!("Cannot rebind protected key '{}' in keybindings.json", binding.chord);
+                return false;
+            }
+            true
+        });
+
+        if kb.bindings.len() < original_len {
+            let filtered_count = original_len - kb.bindings.len();
+            warn!(
+                "Filtered out {} protected keybinding(s). Protected keys: {}",
+                filtered_count,
+                NON_REBINDABLE.join(", ")
+            );
+        }
+
+        kb
     }
 
     pub fn load(config_dir: &Path) -> Self {

--- a/src-rust/crates/core/src/keybindings.rs
+++ b/src-rust/crates/core/src/keybindings.rs
@@ -84,6 +84,29 @@ pub fn parse_keystroke(s: &str) -> Option<ParsedKeystroke> {
     })
 }
 
+fn format_chord_string(chord: &Chord) -> String {
+    chord
+        .iter()
+        .map(|ks| {
+            let mut parts = Vec::new();
+            if ks.ctrl {
+                parts.push("ctrl");
+            }
+            if ks.alt {
+                parts.push("alt");
+            }
+            if ks.shift {
+                parts.push("shift");
+            }
+            if ks.meta {
+                parts.push("meta");
+            }
+            parts.push(&ks.key);
+            parts.join("+")
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
 fn normalize_key(k: &str) -> String {
     match k {
         "esc" | "escape" => "escape".to_string(),
@@ -169,6 +192,8 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         ("end", "goLineEnd", KeyContext::Chat),
         ("cmd+left", "goLineStart", KeyContext::Chat),
         ("cmd+right", "goLineEnd", KeyContext::Chat),
+        ("ctrl+left", "moveWordBackward", KeyContext::Chat),
+        ("ctrl+right", "moveWordForward", KeyContext::Chat),
 
         // Text Editing (Emacs-style) + app shortcuts
         ("ctrl+a", "openModelPicker", KeyContext::Chat),
@@ -300,12 +325,28 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         .collect()
 }
 
+/// Current schema version for keybindings
+pub const KEYBINDINGS_SCHEMA_VERSION: u32 = 1;
 /// User keybindings loaded from ~/.claurst/keybindings.json
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UserKeybindings {
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
     pub bindings: Vec<UserBinding>,
 }
 
+fn default_schema_version() -> u32 {
+    KEYBINDINGS_SCHEMA_VERSION
+}
+
+impl Default for UserKeybindings {
+    fn default() -> Self {
+        Self {
+            schema_version: KEYBINDINGS_SCHEMA_VERSION,
+            bindings: Vec::new(),
+        }
+    }
+}
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct JsonKeybindingConfig {
     #[serde(default)]
@@ -357,7 +398,18 @@ impl UserKeybindings {
     pub fn load(config_dir: &Path) -> Self {
         let path = config_dir.join("keybindings.json");
         if let Ok(content) = std::fs::read_to_string(&path) {
-            Self::from_json_str(&content)
+            let mut kb = Self::from_json_str(&content);
+            let old_version = kb.schema_version;
+            kb.smart_merge_with_defaults();
+
+            // Save back if schema was updated
+            if kb.schema_version > old_version {
+                if let Err(e) = kb.save(config_dir) {
+                    warn!("Failed to save updated keybindings: {}", e);
+                }
+            }
+
+            kb
         } else {
             Self::default()
         }
@@ -384,7 +436,68 @@ impl UserKeybindings {
                 })
             })
             .collect();
-        Ok(Self { bindings })
+        Ok(Self {
+            schema_version: KEYBINDINGS_SCHEMA_VERSION,
+            bindings,
+        })
+    }
+
+    /// Smart merge: preserve user customizations while adding new defaults
+    pub fn smart_merge_with_defaults(&mut self) {
+        if self.schema_version >= KEYBINDINGS_SCHEMA_VERSION {
+            return; // Already up to date
+        }
+
+        let old_version = self.schema_version;
+        self.schema_version = KEYBINDINGS_SCHEMA_VERSION;
+
+        // Build a set of user-customized bindings (those that differ from old defaults)
+        // and bindings user explicitly unbound
+        let mut user_customizations: std::collections::HashMap<String, Option<String>> =
+            std::collections::HashMap::new();
+        for binding in &self.bindings {
+            user_customizations
+                .insert(binding.chord.clone(), binding.action.clone());
+        }
+
+        // Get current defaults and integrate customizations
+        let mut merged_bindings = Vec::new();
+        for default in default_bindings() {
+            let chord_str = format_chord_string(&default.chord);
+            let context_str = format!("{:?}", default.context);
+
+            if let Some(custom_action) = user_customizations.get(&chord_str) {
+                // User has customized this binding, use their version
+                merged_bindings.push(UserBinding {
+                    chord: chord_str.clone(),
+                    action: custom_action.clone(),
+                    context: Some(context_str),
+                });
+                user_customizations.remove(&chord_str);
+            } else {
+                // Use the default
+                merged_bindings.push(UserBinding {
+                    chord: chord_str,
+                    action: default.action.clone(),
+                    context: Some(context_str),
+                });
+            }
+        }
+
+        // Add any remaining user customizations that aren't in current defaults
+        for (chord, action) in user_customizations {
+            merged_bindings.push(UserBinding {
+                chord,
+                action,
+                context: None,
+            });
+        }
+
+        self.bindings = merged_bindings;
+        warn!(
+            "Keybindings schema upgraded from v{} to v{}. User customizations preserved.",
+            old_version, KEYBINDINGS_SCHEMA_VERSION
+        );
     }
 }
 

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -4898,10 +4898,6 @@ impl App {
                 }
                 false
             }
-            "sendMessage" => {
-                // Ctrl+M: Send message (alternative to Enter)
-                !self.is_streaming
-            }
             "newline" => {
                 // Shift+Enter: insert a literal newline into the prompt.
                 if !self.is_streaming {

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -4093,7 +4093,9 @@ impl App {
                 self.refresh_prompt_input();
             }
             KeyCode::Left => {
-                if key.modifiers.contains(KeyModifiers::CONTROL) {
+                if key.modifiers.contains(KeyModifiers::SUPER) {
+                    self.prompt_input.cursor = 0;
+                } else if key.modifiers.contains(KeyModifiers::CONTROL) {
                     self.prompt_input.move_word_backward();
                 } else {
                     self.prompt_input.move_left();
@@ -4101,7 +4103,9 @@ impl App {
                 self.sync_legacy_prompt_fields();
             }
             KeyCode::Right => {
-                if key.modifiers.contains(KeyModifiers::CONTROL) {
+                if key.modifiers.contains(KeyModifiers::SUPER) {
+                    self.prompt_input.cursor = self.prompt_input.text.len();
+                } else if key.modifiers.contains(KeyModifiers::CONTROL) {
                     self.prompt_input.move_word_forward();
                 } else {
                     self.prompt_input.move_right();

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -3767,9 +3767,11 @@ impl App {
                 KeybindingResult::Action(action) => {
                     return self.handle_keybinding_action(&action);
                 }
-                KeybindingResult::Unbound | KeybindingResult::Pending => return false,
+                KeybindingResult::Pending => return false,
                 KeybindingResult::NoMatch if had_pending_chord => return false,
-                KeybindingResult::NoMatch => {}
+                KeybindingResult::Unbound | KeybindingResult::NoMatch => {
+                    // Fall through to hardcoded keybinding handlers
+                }
             }
         } else {
             self.keybindings.cancel_chord();

--- a/src-rust/crates/tui/src/onboarding_dialog.rs
+++ b/src-rust/crates/tui/src/onboarding_dialog.rs
@@ -346,7 +346,7 @@ fn render_keybindings_page(frame: &mut Frame, area: Rect) {
         Line::from(Span::styled("  Navigation", Style::default().fg(pink).add_modifier(Modifier::BOLD))),
         kb("PgUp/PgDn", "scroll transcript"),
         kb("Ctrl+K", "command palette"),
-        kb("Ctrl+A", "model picker"),
+        kb("Ctrl+Shift+A", "model picker"),
         Line::from(""),
         Line::from(Span::styled("  Permissions", Style::default().fg(pink).add_modifier(Modifier::BOLD))),
         kb("y", "allow tool once"),

--- a/src-rust/crates/tui/src/overlays.rs
+++ b/src-rust/crates/tui/src/overlays.rs
@@ -415,7 +415,7 @@ pub fn render_help_overlay(frame: &mut Frame, overlay: &HelpOverlay, area: Rect)
     )));
     for (key, desc) in &[
         ("F1 / ?",          "Toggle help"),
-        ("Ctrl+A",          "Model picker"),
+        ("Ctrl+Shift+A",    "Model picker"),
         ("Ctrl+K",          "Command palette"),
         ("Ctrl+C",          "Cancel / quit"),
         ("Ctrl+D",          "Quit (empty input)"),


### PR DESCRIPTION
Overhauls the keybinding system with schema versioning, smart default merging, and better safeguards.

  - Adds `schema_version` tracking to enable automatic keybinding updates
  - Intelligently merges defaults with user configuration, preserving user overrides
  - Groups related keybindings together for better maintainability
  - Protects non-rebindable keys (`Ctrl+C`, `Ctrl+D`, etc.) from user override attempts
  - Falls through to hardcoded handlers when keybindings don't match, fixing edge cases
  - Adds `Cmd+Left` and `Cmd+Right` shortcuts and removes unused `Ctrl+M` binding
  - Fixes `Ctrl+A` conflict during schema upgrades. This moves model selection to `Ctrl+Shift+A` and allows `Cmd+Left` to function.