### PR TITLE
feat(tui): `@file` injection with typeahead autocomplete

### DIFF
--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -1947,7 +1947,7 @@ async fn run_interactive(
         app.notifications.tick();
 
         // Process file injection dialog outcome (if any)
-        if let Some((outcome, pending_input, _pending_imgs)) = app.file_injection_dialog.take_outcome() {
+        if let Some((outcome, pending_input, pending_imgs)) = app.file_injection_dialog.take_outcome() {
             use claurst_tui::FileInjectionOutcome;
 
             if matches!(outcome, FileInjectionOutcome::Abort) {
@@ -1955,9 +1955,14 @@ async fn run_interactive(
                 continue;
             }
 
-            // InjectAll or SkipOversized: restore input to prompt for resubmission
-            // Images attached when dialog was shown are discarded; user can re-attach if needed
+            // InjectAll: bypass size limit on resubmission, restore stashed input+images,
+            // then synthesize Enter to send immediately.
+            app.file_injection_force = true;
+            for img in pending_imgs {
+                app.prompt_input.add_image(img);
+            }
             app.set_prompt_text(pending_input);
+            app.pending_auto_submit = true;
         }
 
         // Draw the UI
@@ -2052,6 +2057,18 @@ async fn run_interactive(
                         continue;
                     }
                     if key.code == KeyCode::Enter && !app.is_streaming && !any_dialog_open {
+                        // If a file-ref suggestion is active, accept it instead of submitting.
+                        if !app.prompt_input.suggestions.is_empty()
+                            && app.prompt_input.suggestion_index.is_some()
+                            && app.prompt_input.suggestions.get(app.prompt_input.suggestion_index.unwrap())
+                                .map(|s| s.source == claurst_tui::prompt_input::TypeaheadSource::FileRef)
+                                .unwrap_or(false)
+                        {
+                            app.prompt_input.accept_suggestion();
+                            app.prompt_input.insert_char(' ');
+                            app.refresh_prompt_input();
+                            continue;
+                        }
                         // If a slash-command suggestion is active, accept and execute immediately.
                         if !app.prompt_input.suggestions.is_empty()
                             && app.prompt_input.suggestion_index.is_some()
@@ -2430,7 +2447,7 @@ async fn run_interactive(
                         }
 
                         // Fire UserPromptSubmit hook (non-blocking)
-                        if !config.hooks.is_empty() {
+                        if !cmd_ctx.config.hooks.is_empty() {
                             let hook_ctx = claurst_core::hooks::HookContext {
                                 event: "UserPromptSubmit".to_string(),
                                 tool_name: None,
@@ -2440,7 +2457,7 @@ async fn run_interactive(
                                 session_id: Some(tool_ctx.session_id.clone()),
                             };
                             claurst_core::hooks::run_hooks(
-                                &config.hooks,
+                                &cmd_ctx.config.hooks,
                                 claurst_core::config::HookEvent::UserPromptSubmit,
                                 &hook_ctx,
                                 &tool_ctx.working_dir,
@@ -2452,27 +2469,46 @@ async fn run_interactive(
                         let pending_imgs = app.prompt_input.clear_images();
 
                         // Check for file injection if enabled
-                        if config.file_injection_enabled {
+                        if app.config.file_injection_enabled {
                             use claurst_tui::file_injection::parse_at_refs;
 
-                            let (within_limit, oversized) = parse_at_refs(&input, &tool_ctx.working_dir, config.file_injection_max_size);
+                            // file_injection_force is set when user chose "inject anyways" in the
+                            // warning dialog — pass limit 0 so all files are treated as within
+                            // limit. Also drop any directory refs silently on force re-submit so
+                            // they don't loop back to the directory warning.
+                            let was_force = app.file_injection_force;
+                            let effective_limit = if app.file_injection_force {
+                                app.file_injection_force = false;
+                                0
+                            } else {
+                                app.config.file_injection_max_size
+                            };
+                            let (within_limit, mut oversized) = parse_at_refs(&input, &tool_ctx.working_dir, effective_limit);
+                            if was_force {
+                                oversized.retain(|f| !matches!(f.issue, Some(claurst_tui::AtFileIssue::IsDirectory)));
+                            }
 
                             if !oversized.is_empty() {
-                                // Show dialog with oversized files
-                                let oversized_summaries: Vec<(String, usize, String)> = oversized
+                                // Show either the directory warning or the file warning, never both.
+                                // Directories take precedence: if any are present, show only those.
+                                let has_dirs = oversized.iter().any(|f| matches!(f.issue, Some(claurst_tui::AtFileIssue::IsDirectory)));
+                                let oversized_summaries: Vec<(String, usize, claurst_tui::AtFileIssue)> = oversized
                                     .iter()
-                                    .map(|f| {
-                                        let issue_str = match &f.issue {
-                                            Some(claurst_tui::AtFileIssue::TooLarge(kb)) => format!("TooLarge: {} KB", kb),
-                                            Some(claurst_tui::AtFileIssue::Binary) => "Binary".to_string(),
-                                            Some(claurst_tui::AtFileIssue::Unreadable(e)) => e.clone(),
-                                            None => "Unknown".to_string(),
-                                        };
-                                        (f.path.display().to_string(), f.size_kb, issue_str)
+                                    .filter(|f| {
+                                        let is_dir = matches!(f.issue, Some(claurst_tui::AtFileIssue::IsDirectory));
+                                        if has_dirs { is_dir } else { !is_dir }
                                     })
+                                    .filter_map(|f| f.issue.clone().map(|issue| (f.path.display().to_string(), f.size_kb, issue)))
                                     .collect();
 
-                                app.file_injection_dialog.show(input.clone(), pending_imgs, oversized_summaries);
+                                app.file_injection_dialog.show(
+                                    input.clone(),
+                                    pending_imgs,
+                                    oversized_summaries,
+                                    app.config.file_injection_max_size,
+                                    Some(tool_ctx.working_dir.clone()),
+                                );
+                                app.set_prompt_text(input);
                                 continue;
                             }
 

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -1558,11 +1558,22 @@ pub mod config {
                     config.skills.urls.push(u.clone());
                 }
             }
-            // Copy file autocomplete and injection settings.
-            config.file_autocomplete_limit = self.file_autocomplete_limit;
-            config.file_autocomplete_show_hidden_files = self.file_autocomplete_show_hidden_files;
-            config.file_injection_enabled = self.file_injection_enabled;
-            config.file_injection_max_size = self.file_injection_max_size;
+            // Copy file autocomplete and injection settings from the top-level Settings
+            // fields, but only when they were explicitly set (differ from their defaults).
+            // If they're at defaults, the nested "config" section value (already in `config`
+            // via the clone above) takes precedence.
+            if self.file_autocomplete_limit != default_file_autocomplete_limit() {
+                config.file_autocomplete_limit = self.file_autocomplete_limit;
+            }
+            if self.file_autocomplete_show_hidden_files {
+                config.file_autocomplete_show_hidden_files = true;
+            }
+            if self.file_injection_enabled != default_true() {
+                config.file_injection_enabled = self.file_injection_enabled;
+            }
+            if self.file_injection_max_size != default_file_injection_max_size() {
+                config.file_injection_max_size = self.file_injection_max_size;
+            }
             config
         }
 

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -889,6 +889,9 @@ pub struct App {
     /// File injection warning dialog.
     /// Shown when oversized or binary files are detected in @refs.
     pub file_injection_dialog: crate::file_injection_dialog::FileInjectionDialogState,
+    /// When true, the next file injection size check uses limit 0 (no limit),
+    /// letting files that were "allowed" through the warning dialog be injected.
+    pub file_injection_force: bool,
     /// First-launch onboarding welcome dialog.
     pub onboarding_dialog: crate::onboarding_dialog::OnboardingDialogState,
     /// Effort-level picker (/effort with no args).
@@ -1340,6 +1343,7 @@ impl App {
             bypass_permissions_dialog: crate::bypass_permissions_dialog::BypassPermissionsDialogState::new(),
             bypass_permissions_dialog_shown: false,
             file_injection_dialog: crate::file_injection_dialog::FileInjectionDialogState::new(),
+            file_injection_force: false,
             onboarding_dialog: crate::onboarding_dialog::OnboardingDialogState::new(),
             effort_picker: crate::effort_picker::EffortPickerState::new(),
             key_input_dialog: crate::key_input_dialog::KeyInputDialogState::new(),
@@ -2647,9 +2651,16 @@ impl App {
         self.history_index = self.prompt_input.history_pos;
     }
 
-    fn refresh_prompt_input(&mut self) {
+    pub fn refresh_prompt_input(&mut self) {
         self.prompt_input.mode = self.prompt_mode();
-        self.prompt_input.update_suggestions(PROMPT_SLASH_COMMANDS);
+        if self.file_injection_dialog.visible {
+            // Don't update suggestions while the injection dialog is open.
+            self.sync_legacy_prompt_fields();
+            return;
+        }
+        let file_autocomplete_limit = self.config.file_autocomplete_limit;
+        let file_autocomplete_show_hidden = self.config.file_autocomplete_show_hidden_files;
+        self.prompt_input.update_suggestions(PROMPT_SLASH_COMMANDS, file_autocomplete_limit, file_autocomplete_show_hidden);
         self.sync_legacy_prompt_fields();
     }
 
@@ -2882,25 +2893,27 @@ impl App {
 
         // File injection dialog: shown when oversized files are detected in @refs.
         if self.file_injection_dialog.visible {
+            let is_directory_only = self.file_injection_dialog.is_directory_only();
             match key.code {
-                KeyCode::Char('i') | KeyCode::Char('I') => {
-                    self.file_injection_dialog.selected = 0; // InjectAll
-                }
-                KeyCode::Char('s') | KeyCode::Char('S') => {
-                    self.file_injection_dialog.selected = 1; // SkipOversized
-                }
-                KeyCode::Esc => {
-                    self.file_injection_dialog.selected = 2; // Abort
-                    self.file_injection_dialog.confirm();
-                    // Restore input to prompt when aborting
-                    if let Some(input) = &self.file_injection_dialog.pending_input {
-                        self.set_prompt_text(input.clone());
+                KeyCode::Enter => {
+                    if is_directory_only {
+                        // Directories can't be injected; Enter = abort, restore input.
+                        if let Some(input) = self.file_injection_dialog.pending_input.clone() {
+                            self.set_prompt_text(input);
+                        }
+                        self.file_injection_dialog.dismiss();
+                    } else {
+                        // Enter = inject (Allow).
+                        self.file_injection_dialog.selected = 0;
+                        self.file_injection_dialog.confirm();
                     }
                 }
-                KeyCode::Up | KeyCode::Char('k') => self.file_injection_dialog.select_prev(),
-                KeyCode::Down | KeyCode::Char('j') => self.file_injection_dialog.select_next(),
-                KeyCode::Enter => {
-                    self.file_injection_dialog.confirm();
+                KeyCode::Esc => {
+                    // Esc = abort, restore input.
+                    if let Some(input) = self.file_injection_dialog.pending_input.clone() {
+                        self.set_prompt_text(input);
+                    }
+                    self.file_injection_dialog.dismiss();
                 }
                 _ => {}
             }
@@ -4171,12 +4184,17 @@ impl App {
                 self.refresh_prompt_input();
             }
             KeyCode::Enter if !self.is_streaming => {
-                // If a slash-command suggestion is selected, accept it instead of submitting.
+                // If a suggestion is selected, accept it instead of submitting.
                 if !self.prompt_input.suggestions.is_empty()
                     && self.prompt_input.suggestion_index.is_some()
-                    && self.prompt_input.text.starts_with('/')
                 {
+                    let is_file_ref = self.prompt_input.suggestions
+                        .get(self.prompt_input.suggestion_index.unwrap())
+                        .map_or(false, |s| s.source == crate::prompt_input::TypeaheadSource::FileRef);
                     self.prompt_input.accept_suggestion();
+                    if is_file_ref {
+                        self.prompt_input.insert_char(' ');
+                    }
                     self.refresh_prompt_input();
                     return false;
                 }
@@ -4209,7 +4227,7 @@ impl App {
             // when the cursor is already on the first/last visual row
             // (issue #149 follow-up).
             KeyCode::Up => {
-                if !self.prompt_input.suggestions.is_empty() && self.prompt_input.text.starts_with('/') {
+                if !self.prompt_input.suggestions.is_empty() && (self.prompt_input.text.starts_with('/') || self.prompt_input.has_active_file_ref()) {
                     self.prompt_input.suggestion_prev();
                 } else {
                     let area = self.last_input_area.get();
@@ -4223,7 +4241,7 @@ impl App {
                 self.refresh_prompt_input();
             }
             KeyCode::Down => {
-                if !self.prompt_input.suggestions.is_empty() && self.prompt_input.text.starts_with('/') {
+                if !self.prompt_input.suggestions.is_empty() && (self.prompt_input.text.starts_with('/') || self.prompt_input.has_active_file_ref()) {
                     self.prompt_input.suggestion_next();
                 } else {
                     let area = self.last_input_area.get();
@@ -4673,29 +4691,53 @@ impl App {
                 self.refresh_global_search();
                 false
             }
-            "submit" => !self.is_streaming,
+            "submit" => {
+                if !self.is_streaming {
+                    if !self.prompt_input.suggestions.is_empty()
+                        && self.prompt_input.suggestion_index.is_some()
+                    {
+                        self.prompt_input.accept_suggestion();
+                        self.refresh_prompt_input();
+                        false
+                    } else {
+                        true
+                    }
+                } else {
+                    false
+                }
+            }
             "historyPrev" => {
-                // Slash-command suggestions take priority over history.
+                // Suggestions (slash commands or file refs) take priority over cursor/history.
                 if !self.prompt_input.suggestions.is_empty()
-                    && self.prompt_input.text.starts_with('/')
+                    && (self.prompt_input.text.starts_with('/') || self.prompt_input.has_active_file_ref())
                 {
                     self.prompt_input.suggestion_prev();
                     self.refresh_prompt_input();
-                } else if !self.prompt_input.history.is_empty() {
-                    self.prompt_input.history_up();
+                } else {
+                    let width = self.last_input_area.get().width.saturating_sub(4) as usize;
+                    let moved = !self.prompt_input.text.is_empty()
+                        && self.prompt_input.move_visual_up(width);
+                    if !moved && !self.prompt_input.history.is_empty() {
+                        self.prompt_input.history_up();
+                    }
                     self.refresh_prompt_input();
                 }
                 false
             }
             "historyNext" => {
-                // Slash-command suggestions take priority over history.
+                // Suggestions (slash commands or file refs) take priority over cursor/history.
                 if !self.prompt_input.suggestions.is_empty()
-                    && self.prompt_input.text.starts_with('/')
+                    && (self.prompt_input.text.starts_with('/') || self.prompt_input.has_active_file_ref())
                 {
                     self.prompt_input.suggestion_next();
                     self.refresh_prompt_input();
-                } else if self.prompt_input.history_pos.is_some() {
-                    self.prompt_input.history_down();
+                } else {
+                    let width = self.last_input_area.get().width.saturating_sub(4) as usize;
+                    let moved = !self.prompt_input.text.is_empty()
+                        && self.prompt_input.move_visual_down(width);
+                    if !moved && self.prompt_input.history_pos.is_some() {
+                        self.prompt_input.history_down();
+                    }
                     self.refresh_prompt_input();
                 }
                 false

--- a/src-rust/crates/tui/src/file_injection.rs
+++ b/src-rust/crates/tui/src/file_injection.rs
@@ -7,6 +7,7 @@ pub enum AtFileIssue {
     TooLarge(usize), // size in KB that exceeds limit
     Binary,
     Unreadable(String), // error message
+    IsDirectory, // Path points to a directory, not a file
 }
 
 /// A parsed file reference from the user's input (e.g., "@src/main.rs").
@@ -43,12 +44,15 @@ pub fn parse_at_refs(text: &str, cwd: &Path, max_size_kb: usize) -> (Vec<AtFileR
         // For now, we'll be permissive and accept the @ and everything after, trimming punctuation.
         let mut token = word.to_string();
 
-        // Remove trailing punctuation if present
-        while token.ends_with(|c: char| c.is_ascii_punctuation()) && !token.ends_with('/') {
+        // Remove trailing punctuation, but never strip the leading '@' itself.
+        while token.len() > 1 && token.ends_with(|c: char| c.is_ascii_punctuation()) && !token.ends_with('/') {
             token.pop();
         }
 
         let path_part = &token[1..]; // Skip the '@'
+        if path_part.is_empty() {
+            continue; // bare '@' with no path — skip
+        }
 
         // Expand ~ to home directory
         let expanded_path = if path_part.starts_with("~/") {
@@ -63,9 +67,20 @@ pub fn parse_at_refs(text: &str, cwd: &Path, max_size_kb: usize) -> (Vec<AtFileR
             cwd.join(path_part)
         };
 
-        // Try to read the file
-        if !expanded_path.exists() || !expanded_path.is_file() {
-            continue; // Skip non-existent files
+        // Check if path exists and is a file (not a directory)
+        if !expanded_path.exists() {
+            continue; // Skip non-existent paths
+        }
+
+        if expanded_path.is_dir() {
+            oversized.push(AtFileRef {
+                token: token.clone(),
+                path: expanded_path,
+                size_kb: 0,
+                contents: None,
+                issue: Some(AtFileIssue::IsDirectory),
+            });
+            continue;
         }
 
         let size_kb = match fs::metadata(&expanded_path) {

--- a/src-rust/crates/tui/src/file_injection_dialog.rs
+++ b/src-rust/crates/tui/src/file_injection_dialog.rs
@@ -1,19 +1,19 @@
+use std::path::PathBuf;
+
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget, Wrap};
+use ratatui::widgets::{Block, Borders, Clear, Padding, Paragraph, Widget, Wrap};
 use ratatui::Frame;
 
-use crate::overlays::centered_rect;
+use crate::file_injection::AtFileIssue;
 use crate::image_paste::PastedImage;
 
 /// Outcome of the file injection dialog.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FileInjectionOutcome {
-    /// Inject all files, including oversized/binary ones.
+    /// Inject all files, ignoring size/binary limits.
     InjectAll,
-    /// Inject only within-limit files; skip oversized/binary.
-    SkipOversized,
     /// Abort (restore input to prompt for editing).
     Abort,
 }
@@ -28,10 +28,14 @@ pub struct FileInjectionDialogState {
     pub pending_input: Option<String>,
     /// Stashed image attachments at submit time.
     pub pending_imgs: Vec<PastedImage>,
-    /// Files that exceeded limits or had issues: (path, size_kb, display_issue).
-    pub oversized: Vec<(String, usize, String)>,
-    /// Currently selected option: 0 = InjectAll, 1 = SkipOversized, 2 = Abort.
+    /// Files that exceeded limits or had issues: (path, size_kb, issue).
+    pub oversized: Vec<(String, usize, AtFileIssue)>,
+    /// Currently selected option: 0 = Allow, 1 = Abort.
     pub selected: usize,
+    /// Size limit in KB, for display in the dialog.
+    pub limit_kb: usize,
+    /// Working directory for relative path display.
+    pub cwd: Option<PathBuf>,
     /// Set when user confirms; consumed by main.rs to trigger send.
     pub outcome: Option<FileInjectionOutcome>,
 }
@@ -43,7 +47,9 @@ impl FileInjectionDialogState {
             pending_input: None,
             pending_imgs: Vec::new(),
             oversized: Vec::new(),
-            selected: 0, // Default to "Inject anyway"
+            selected: 0,
+            limit_kb: 0,
+            cwd: None,
             outcome: None,
         }
     }
@@ -53,38 +59,38 @@ impl FileInjectionDialogState {
         &mut self,
         input: String,
         imgs: Vec<PastedImage>,
-        oversized: Vec<(String, usize, String)>,
+        oversized: Vec<(String, usize, AtFileIssue)>,
+        limit_kb: usize,
+        cwd: Option<PathBuf>,
     ) {
         self.visible = true;
         self.pending_input = Some(input);
         self.pending_imgs = imgs;
         self.oversized = oversized;
-        self.selected = 0; // Default to "Inject anyway"
+        self.limit_kb = limit_kb;
+        self.cwd = cwd;
+        // Directory-only: default to Abort (Allow does nothing useful for dirs)
+        self.selected = if self.is_directory_only() { 1 } else { 0 };
         self.outcome = None;
     }
 
-    /// Move selection up (wraps).
-    pub fn select_prev(&mut self) {
-        self.selected = if self.selected == 0 { 2 } else { self.selected - 1 };
-    }
-
-    /// Move selection down (wraps).
-    pub fn select_next(&mut self) {
-        self.selected = if self.selected == 2 { 0 } else { self.selected + 1 };
+    /// Check if all oversized items are directories.
+    pub fn is_directory_only(&self) -> bool {
+        !self.oversized.is_empty() && self.oversized.iter().all(|(_, _, issue)| matches!(issue, AtFileIssue::IsDirectory))
     }
 
     /// Returns the currently-selected outcome option.
     pub fn current_outcome(&self) -> FileInjectionOutcome {
-        match self.selected {
-            0 => FileInjectionOutcome::InjectAll,
-            1 => FileInjectionOutcome::SkipOversized,
-            _ => FileInjectionOutcome::Abort,
+        if self.selected == 0 {
+            FileInjectionOutcome::InjectAll
+        } else {
+            FileInjectionOutcome::Abort
         }
     }
 
-    /// Returns `true` if the currently-selected option is not "Abort".
+    /// Returns `true` if the currently-selected option is Allow.
     pub fn is_accept_selected(&self) -> bool {
-        self.current_outcome() != FileInjectionOutcome::Abort
+        self.current_outcome() == FileInjectionOutcome::InjectAll
     }
 
     /// Confirm the selected option.
@@ -92,7 +98,7 @@ impl FileInjectionDialogState {
         self.outcome = Some(self.current_outcome());
     }
 
-    /// Dismiss the dialog.
+    /// Dismiss the dialog (Abort path).
     pub fn dismiss(&mut self) {
         self.visible = false;
         self.pending_input = None;
@@ -109,6 +115,22 @@ impl FileInjectionDialogState {
         let imgs = std::mem::take(&mut self.pending_imgs);
         self.visible = false;
         Some((outcome, input, imgs))
+    }
+
+    /// Return a display path: relative to cwd when possible, otherwise absolute.
+    pub fn display_path<'a>(&self, abs_path: &'a str) -> &'a str {
+        if let Some(cwd) = &self.cwd {
+            let cwd_str = cwd.to_string_lossy();
+            // Strip cwd prefix plus trailing slash
+            let prefix = format!("{}/", cwd_str);
+            if let Some(rel) = abs_path.strip_prefix(prefix.as_str()) {
+                return rel;
+            }
+            if abs_path == cwd_str.as_ref() {
+                return ".";
+            }
+        }
+        abs_path
     }
 }
 
@@ -128,38 +150,72 @@ pub fn render_file_injection_dialog(
         return;
     }
 
-    let dialog_width = 72u16.min(area.width.saturating_sub(4));
-    let dialog_height = 16u16.min(area.height.saturating_sub(4));
-    let dialog_area = centered_rect(dialog_width, dialog_height, area);
+    let is_directory = state.is_directory_only();
+    let n_files = state.oversized.len();
 
-    frame.render_widget(Clear, dialog_area);
+    // Height: 1 blank + 1 label + 1 blank + N files + 1 blank + 1 hint + 1 blank
+    let content_rows = 5 + n_files;
+    let dialog_height = (content_rows as u16 + 2).min(area.height.saturating_sub(4));
+    let dialog_width = 72u16.min(area.width.saturating_sub(4));
+    let dialog_area = Rect {
+        x: (area.width.saturating_sub(dialog_width)) / 2,
+        y: (area.height.saturating_sub(dialog_height).saturating_sub(3)) / 2,
+        width: dialog_width,
+        height: dialog_height,
+    };
+
+    let title = if is_directory {
+        " ⚠  Directory Injection Warning "
+    } else {
+        " ⚠  File Injection Warning "
+    };
+
+    let bg = Color::Rgb(35, 35, 35);
 
     let block = Block::default()
         .borders(Borders::ALL)
         .title(Line::from(vec![Span::styled(
-            " ⚠  File Injection Warning ",
+            title,
             Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
         )]))
-        .border_style(Style::default().fg(Color::Yellow));
+        .border_style(Style::default().fg(Color::Yellow))
+        .style(Style::default().bg(bg))
+        .padding(Padding { left: 2, right: 2, top: 0, bottom: 0 });
 
     let inner = block.inner(dialog_area);
+    frame.render_widget(Clear, dialog_area);
     frame.render_widget(block, dialog_area);
 
     let mut lines: Vec<Line<'static>> = Vec::new();
 
+    lines.push(Line::from(""));
+
+    // Header: label + limit info
+    let label_word = if is_directory {
+        if n_files == 1 { "directory" } else { "directories" }
+    } else if n_files == 1 { "file" } else { "files" }
+    ;
+    let header = if is_directory {
+        format!("The following {} cannot be auto-injected:", label_word)
+    } else if state.limit_kb > 0 {
+        format!("The following {} is over the file size limit ({} KB):", label_word, state.limit_kb)
+    } else {
+        format!("The following {} cannot be auto-injected:", label_word)
+    };
+
     lines.push(Line::from(vec![Span::styled(
-        "The following file(s) cannot be auto-injected:",
+        header,
         Style::default().fg(Color::White),
     )]));
     lines.push(Line::from(""));
 
-    for (path, size_kb, issue) in &state.oversized {
-        let text = if issue.contains("TooLarge") {
-            format!("• {} ({} KB, exceeds limit)", path, size_kb)
-        } else if issue.contains("Binary") {
-            format!("• {} (binary file)", path)
-        } else {
-            format!("• {} ({})", path, issue)
+    for (path, _size_kb, issue) in &state.oversized {
+        let display = state.display_path(path).to_owned();
+        let text = match issue {
+            AtFileIssue::Binary => format!("• {} (binary)", display),
+            AtFileIssue::TooLarge(_) => format!("• {} (too large)", display),
+            AtFileIssue::Unreadable(msg) => format!("• {} (unreadable: {})", display, msg),
+            AtFileIssue::IsDirectory => format!("• {}", display),
         };
 
         lines.push(Line::from(vec![Span::styled(
@@ -170,43 +226,31 @@ pub fn render_file_injection_dialog(
 
     lines.push(Line::from(""));
 
-    // Options
-    let inject_style = if state.selected == 0 {
-        Style::default().fg(Color::Green).add_modifier(Modifier::BOLD | Modifier::REVERSED)
+    if is_directory {
+        lines.push(Line::from(vec![Span::styled(
+            "  Enter or Esc to dismiss",
+            Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC),
+        )]));
     } else {
-        Style::default().fg(Color::Green)
-    };
-    let skip_style = if state.selected == 1 {
-        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD | Modifier::REVERSED)
-    } else {
-        Style::default().fg(Color::Yellow)
-    };
-    let abort_style = if state.selected == 2 {
-        Style::default().fg(Color::Red).add_modifier(Modifier::BOLD | Modifier::REVERSED)
-    } else {
-        Style::default().fg(Color::Red)
-    };
+        lines.push(Line::from(vec![
+            Span::styled(
+                "  Enter to inject anyway",
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                "  ·  Esc to abort",
+                Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC),
+            ),
+        ]));
+    }
 
-    lines.push(Line::from(vec![
-        Span::styled("[I] ", Style::default().fg(Color::DarkGray)),
-        Span::styled("Inject anyway", inject_style),
-        Span::raw("    "),
-        Span::styled("[S] ", Style::default().fg(Color::DarkGray)),
-        Span::styled("Skip these", skip_style),
-        Span::raw("    "),
-        Span::styled("[Esc] ", Style::default().fg(Color::DarkGray)),
-        Span::styled("Abort", abort_style),
-    ]));
     lines.push(Line::from(""));
-    lines.push(Line::from(vec![Span::styled(
-        "  ↑↓ / I/S/Esc to select  ·  Enter to confirm",
-        Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC),
-    )]));
 
     Paragraph::new(lines)
         .wrap(Wrap { trim: false })
         .render(inner, frame.buffer_mut());
 }
+
 
 #[cfg(test)]
 mod tests {
@@ -224,54 +268,43 @@ mod tests {
     #[test]
     fn file_injection_dialog_show_sets_visible() {
         let mut state = FileInjectionDialogState::new();
-        state.show("input".to_string(), vec![], vec![("file.txt".to_string(), 100, "TooLarge".to_string())]);
+        state.show("input".to_string(), vec![], vec![("file.txt".to_string(), 100, AtFileIssue::TooLarge(100))], 100, None);
         assert!(state.visible);
         assert_eq!(state.selected, 0);
         assert!(!state.oversized.is_empty());
     }
 
     #[test]
-    fn file_injection_dialog_navigate() {
+    fn file_injection_dialog_directory_only_defaults_to_abort() {
         let mut state = FileInjectionDialogState::new();
-        state.show("input".to_string(), vec![], vec![]);
-        assert_eq!(state.current_outcome(), FileInjectionOutcome::InjectAll);
-        state.select_next();
-        assert_eq!(state.current_outcome(), FileInjectionOutcome::SkipOversized);
-        state.select_next();
-        assert_eq!(state.current_outcome(), FileInjectionOutcome::Abort);
-        state.select_prev();
-        assert_eq!(state.current_outcome(), FileInjectionOutcome::SkipOversized);
-    }
-
-    #[test]
-    fn file_injection_dialog_navigate_wraps() {
-        let mut state = FileInjectionDialogState::new();
-        state.show("input".to_string(), vec![], vec![]);
-        state.select_next(); // 0 → 1
-        state.select_next(); // 1 → 2
-        state.select_next(); // 2 → 0
-        assert_eq!(state.current_outcome(), FileInjectionOutcome::InjectAll);
-        state.select_prev(); // 0 → 2
+        state.show("input".to_string(), vec![], vec![("dir".to_string(), 0, AtFileIssue::IsDirectory)], 0, None);
         assert_eq!(state.current_outcome(), FileInjectionOutcome::Abort);
     }
 
     #[test]
-    fn file_injection_dialog_confirm() {
+    fn file_injection_dialog_confirm_allow() {
         let mut state = FileInjectionDialogState::new();
-        state.show("input".to_string(), vec![], vec![]);
-        state.select_next(); // Go to SkipOversized
+        state.show("input".to_string(), vec![], vec![], 100, None);
         state.confirm();
-        assert_eq!(state.outcome, Some(FileInjectionOutcome::SkipOversized));
+        assert_eq!(state.outcome, Some(FileInjectionOutcome::InjectAll));
+    }
+
+    #[test]
+    fn file_injection_dialog_confirm_abort() {
+        let mut state = FileInjectionDialogState::new();
+        state.show("input".to_string(), vec![], vec![], 100, None);
+        state.selected = 1; // Abort
+        state.confirm();
+        assert_eq!(state.outcome, Some(FileInjectionOutcome::Abort));
     }
 
     #[test]
     fn file_injection_dialog_take_outcome() {
         let mut state = FileInjectionDialogState::new();
-        state.show("test input".to_string(), vec![], vec![]);
-        state.select_next();
-        state.confirm();
+        state.show("test input".to_string(), vec![], vec![], 100, None);
+        state.confirm(); // Allow
         let (outcome, input, _) = state.take_outcome().unwrap();
-        assert_eq!(outcome, FileInjectionOutcome::SkipOversized);
+        assert_eq!(outcome, FileInjectionOutcome::InjectAll);
         assert_eq!(input, "test input");
         assert!(!state.visible);
         assert_eq!(state.outcome, None);
@@ -284,7 +317,9 @@ mod tests {
         state.show(
             "input".to_string(),
             vec![],
-            vec![("large_file.rs".to_string(), 250, "TooLarge".to_string())],
+            vec![("large_file.rs".to_string(), 250, AtFileIssue::TooLarge(250))],
+            100,
+            None,
         );
         terminal
             .draw(|frame| {
@@ -314,5 +349,52 @@ mod tests {
             })
             .unwrap();
         assert_eq!(terminal.backend().buffer().content(), before.content());
+    }
+
+    #[test]
+    fn display_path_strips_cwd() {
+        let mut state = FileInjectionDialogState::new();
+        state.cwd = Some(PathBuf::from("/home/user/project"));
+        assert_eq!(state.display_path("/home/user/project/src/main.rs"), "src/main.rs");
+        assert_eq!(state.display_path("/other/path"), "/other/path");
+    }
+
+    #[test]
+    fn display_path_without_cwd_returns_input_unchanged() {
+        let state = FileInjectionDialogState::new(); // cwd = None
+        assert_eq!(state.display_path("/some/absolute/path.rs"), "/some/absolute/path.rs");
+    }
+
+    fn render_to_string(state: &FileInjectionDialogState) -> String {
+        let mut terminal = Terminal::new(TestBackend::new(100, 30)).unwrap();
+        terminal.draw(|frame| {
+            render_file_injection_dialog(frame, state, frame.area());
+        }).unwrap();
+        terminal.backend().buffer().clone().content().iter().map(|c| c.symbol().chars().next().unwrap_or(' ')).collect()
+    }
+
+    #[test]
+    fn file_injection_dialog_renders_too_large_annotation() {
+        let mut state = FileInjectionDialogState::new();
+        state.show("input".to_string(), vec![], vec![("large.rs".to_string(), 250, AtFileIssue::TooLarge(250))], 100, None);
+        let content = render_to_string(&state);
+        assert!(content.contains("too large"), "Expected '(too large)' annotation in rendered output");
+    }
+
+    #[test]
+    fn file_injection_dialog_renders_unreadable_annotation() {
+        let mut state = FileInjectionDialogState::new();
+        state.show("input".to_string(), vec![], vec![("secret.rs".to_string(), 0, AtFileIssue::Unreadable("Permission denied".to_string()))], 0, None);
+        let content = render_to_string(&state);
+        assert!(content.contains("unreadable"), "Expected '(unreadable: ...)' annotation in rendered output");
+    }
+
+    #[test]
+    fn file_injection_dialog_hint_uses_anyway_not_anyways() {
+        let mut state = FileInjectionDialogState::new();
+        state.show("input".to_string(), vec![], vec![("file.rs".to_string(), 250, AtFileIssue::TooLarge(250))], 100, None);
+        let content = render_to_string(&state);
+        assert!(!content.contains("anyways"), "Should use 'anyway' not 'anyways'");
+        assert!(content.contains("anyway"), "Expected 'anyway' in hint text");
     }
 }

--- a/src-rust/crates/tui/src/messages/mod.rs
+++ b/src-rust/crates/tui/src/messages/mod.rs
@@ -207,12 +207,22 @@ fn title_case_mode(mode: &str) -> String {
 }
 
 fn render_attachment_chip(kind: &str, label: String) -> Line<'static> {
+    render_attachment_chip_colored(kind, label, CLAUDE_ORANGE, Color::Black)
+}
+
+fn render_file_chip(label: String) -> Line<'static> {
+    // Use a steel-blue badge with white text for file injections — distinct from
+    // the orange img/doc chips and readable on dark terminal backgrounds.
+    render_attachment_chip_colored("file", label, Color::Rgb(51, 102, 170), Color::White)
+}
+
+fn render_attachment_chip_colored(kind: &str, label: String, badge_bg: Color, badge_fg: Color) -> Line<'static> {
     Line::from(vec![
         Span::styled(
             format!(" {} ", kind),
             Style::default()
-                .fg(Color::Black)
-                .bg(CLAUDE_ORANGE)
+                .fg(badge_fg)
+                .bg(badge_bg)
                 .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
@@ -285,6 +295,98 @@ pub fn render_transcript_live_text(text: &str, width: u16) -> Vec<Line<'static>>
     )
 }
 
+/// Segments of a potentially file-injected text block.
+enum TextSegment {
+    Plain(String),
+    FileBlock(String), // path attribute value
+}
+
+/// Normalize `@token` references in user text when those files were already shown
+/// as chips. Replaces `@long/absolute/path/file.rs` with just `@file.rs` so the
+/// text stays readable ("Delete @file.rs" still makes sense) without showing the
+/// full path noise.
+fn normalize_at_tokens(
+    text: &str,
+    injected: &std::collections::HashSet<String>,
+) -> String {
+    let mut result = String::with_capacity(text.len());
+    for word in text.split_inclusive(|c: char| c.is_whitespace()) {
+        let trimmed = word.trim_end_matches(|c: char| c.is_whitespace());
+        let trailing: &str = &word[trimmed.len()..];
+
+        if trimmed.starts_with('@') && trimmed.len() > 1 {
+            let mut path_part = trimmed[1..].to_string();
+            // Strip trailing punctuation (same logic as parse_at_refs)
+            while path_part.len() > 0 && path_part.ends_with(|c: char| c.is_ascii_punctuation()) && !path_part.ends_with('/') {
+                path_part.pop();
+            }
+            let punct_suffix = &trimmed[1 + path_part.len()..];
+
+            let basename = std::path::Path::new(&path_part)
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| path_part.clone());
+
+            let matches = injected.iter().any(|p| {
+                p == &path_part
+                    || std::path::Path::new(p).file_name().map(|n| n.to_string_lossy().as_ref() == path_part.as_str()).unwrap_or(false)
+                    || p.ends_with(&format!("/{}", path_part))
+            });
+
+            if matches && basename != path_part {
+                // Shorten to just the filename
+                result.push('@');
+                result.push_str(&basename);
+                result.push_str(punct_suffix);
+                result.push_str(trailing);
+                continue;
+            }
+        }
+        result.push_str(word);
+    }
+    result
+}
+
+/// Split text that may contain `<file path="...">...</file>` injection blocks
+/// into alternating Plain and FileBlock segments.
+fn extract_file_segments(text: &str) -> Vec<TextSegment> {
+    let mut result = Vec::new();
+    let mut remaining = text;
+    const OPEN: &str = "<file path=\"";
+    const CLOSE: &str = "</file>";
+
+    while let Some(start) = remaining.find(OPEN) {
+        if start > 0 {
+            result.push(TextSegment::Plain(remaining[..start].to_string()));
+        }
+        let after = &remaining[start + OPEN.len()..];
+        if let Some(path_end) = after.find('"') {
+            let path = after[..path_end].to_string();
+            let after_open_tag = &remaining[start..];
+            if let Some(close_pos) = after_open_tag.find(CLOSE) {
+                let consumed = start + close_pos + CLOSE.len();
+                // skip one trailing newline if present
+                let consumed = if remaining[consumed..].starts_with('\n') { consumed + 1 } else { consumed };
+                result.push(TextSegment::FileBlock(path));
+                remaining = &remaining[consumed..];
+            } else {
+                result.push(TextSegment::Plain(remaining[start..].to_string()));
+                remaining = "";
+                break;
+            }
+        } else {
+            result.push(TextSegment::Plain(remaining[start..].to_string()));
+            remaining = "";
+            break;
+        }
+    }
+
+    if !remaining.is_empty() {
+        result.push(TextSegment::Plain(remaining.to_string()));
+    }
+    result
+}
+
 pub fn render_transcript_user_message(
     msg: &Message,
     meta: Option<&TurnMetadata>,
@@ -308,6 +410,24 @@ pub fn render_transcript_user_message(
     let mut lines = Vec::new();
     let mut pending_text = String::new();
 
+    // Collect the absolute paths of every injected file so we can strip the
+    // corresponding @token references from the user's original text block.
+    let injected_paths: std::collections::HashSet<String> = msg.content_blocks()
+        .iter()
+        .filter_map(|b| {
+            if let ContentBlock::Text { text } = b {
+                if text.contains("<file path=\"") { Some(text) } else { None }
+            } else {
+                None
+            }
+        })
+        .flat_map(|text| {
+            extract_file_segments(text).into_iter().filter_map(|s| {
+                if let TextSegment::FileBlock(p) = s { Some(p) } else { None }
+            })
+        })
+        .collect();
+
     let flush_text = |buffer: &mut String, target: &mut Vec<Line<'static>>| {
         if buffer.is_empty() {
             return;
@@ -322,10 +442,44 @@ pub fn render_transcript_user_message(
     for block in msg.content_blocks() {
         match block {
             ContentBlock::Text { text } => {
-                if !pending_text.is_empty() {
-                    pending_text.push('\n');
+                if text.contains("<file path=\"") {
+                    flush_text(&mut pending_text, &mut lines);
+                    for segment in extract_file_segments(&text) {
+                        match segment {
+                            TextSegment::FileBlock(path) => {
+                                let label = std::path::Path::new(&path)
+                                    .file_name()
+                                    .map(|n| n.to_string_lossy().into_owned())
+                                    .unwrap_or(path);
+                                lines.push(render_file_chip(label));
+                            }
+                            TextSegment::Plain(t) => {
+                                if !t.trim().is_empty() {
+                                    if !pending_text.is_empty() {
+                                        pending_text.push('\n');
+                                    }
+                                    pending_text.push_str(&t);
+                                }
+                            }
+                        }
+                    }
+                } else if !injected_paths.is_empty() {
+                    // Shorten @long/path/file.rs → @file.rs since the chips already
+                    // show the full path context.
+                    let cleaned = normalize_at_tokens(&text, &injected_paths);
+                    let trimmed = cleaned.trim();
+                    if !trimmed.is_empty() {
+                        if !pending_text.is_empty() {
+                            pending_text.push('\n');
+                        }
+                        pending_text.push_str(trimmed);
+                    }
+                } else {
+                    if !pending_text.is_empty() {
+                        pending_text.push('\n');
+                    }
+                    pending_text.push_str(&text);
                 }
-                pending_text.push_str(&text);
             }
             ContentBlock::Image { source } => {
                 flush_text(&mut pending_text, &mut lines);

--- a/src-rust/crates/tui/src/prompt_input.rs
+++ b/src-rust/crates/tui/src/prompt_input.rs
@@ -1119,7 +1119,7 @@ pub(crate) fn compute_file_suggestions(
 
         if at_word_boundary {
             let file_prefix = &input[at_idx + 1..];
-            suggestions = suggest_files(file_prefix, 0, file_autocomplete_limit, file_autocomplete_show_hidden);
+            suggestions = suggest_files(file_prefix, file_autocomplete_limit, file_autocomplete_show_hidden);
         }
     }
 
@@ -1135,12 +1135,9 @@ pub(crate) fn compute_file_suggestions(
 /// - `"/"` → files in root with full paths (e.g., ["/Users", "/Applications"])
 /// - `"~"` → suggest "~/" if it exists
 /// - `"~/"` → files in home with names only
-fn suggest_files(prefix: &str, depth: usize, max_suggestions: usize, show_hidden: bool) -> Vec<TypeaheadSuggestion> {
-    const MAX_DEPTH: usize = 3;
-
-    if depth > MAX_DEPTH {
-        return Vec::new();
-    }
+/// Note: calls `fs::read_dir` synchronously on every invocation; may stall on slow/network
+/// filesystems. Consider debouncing at the call site if this becomes a problem.
+fn suggest_files(prefix: &str, max_suggestions: usize, show_hidden: bool) -> Vec<TypeaheadSuggestion> {
     use std::path::PathBuf;
     use std::fs;
 
@@ -1163,11 +1160,11 @@ fn suggest_files(prefix: &str, depth: usize, max_suggestions: usize, show_hidden
         };
 
         let path = PathBuf::from(&expanded);
-        if path.is_dir() {
-            // User typed a complete directory: list its contents
+        if path.is_dir() && prefix.ends_with('/') {
+            // User typed a complete directory with trailing slash: list its contents
             (path, true, String::new())
         } else if let Some(parent) = path.parent() {
-            // User typed a partial path: list parent's contents and filter
+            // User typed a partial path or directory without slash: list parent's contents and filter
             let partial = path
                 .file_name()
                 .and_then(|n| n.to_str())
@@ -1181,11 +1178,11 @@ fn suggest_files(prefix: &str, depth: usize, max_suggestions: usize, show_hidden
         // Relative path in cwd
         if let Ok(cwd) = std::env::current_dir() {
             let path = cwd.join(prefix);
-            if path.is_dir() {
-                // Complete directory: list its contents
+            if path.is_dir() && prefix.ends_with('/') {
+                // Complete directory with trailing slash: list its contents
                 (path, false, String::new())
             } else if let Some(parent) = path.parent() {
-                // Partial path: list parent and filter
+                // Partial path or directory without slash: list parent and filter
                 let partial = path
                     .file_name()
                     .and_then(|n| n.to_str())
@@ -1211,13 +1208,13 @@ fn suggest_files(prefix: &str, depth: usize, max_suggestions: usize, show_hidden
                         .and_then(|n| n.to_str())
                         .map(|s| s.to_string())?;
 
-                    // Filter by partial name
-                    if !partial_name.is_empty() && !name.starts_with(&partial_name) {
+                    // Filter by partial name (case-insensitive)
+                    if !partial_name.is_empty() && !name.to_lowercase().starts_with(&partial_name.to_lowercase()) {
                         return None;
                     }
 
                     // Filter hidden files unless user explicitly types a dot or show_hidden_files is enabled
-                    if !show_hidden && name.starts_with('.') && !partial_name.starts_with('.') {
+                    if !show_hidden && name.starts_with('.') && !partial_name.to_lowercase().starts_with('.') {
                         return None;
                     }
 
@@ -1225,7 +1222,7 @@ fn suggest_files(prefix: &str, depth: usize, max_suggestions: usize, show_hidden
                     let is_symlink = entry.file_type().ok().map(|ft| ft.is_symlink()).unwrap_or(false);
                     let is_dir = path.is_dir();
 
-                    Some((name, is_dir, is_symlink))
+                    Some((name, is_dir, is_symlink, path))
                 })
             })
             .collect();
@@ -1239,16 +1236,29 @@ fn suggest_files(prefix: &str, depth: usize, max_suggestions: usize, show_hidden
             }
         });
 
-        for (name, is_dir, is_symlink) in files {
+        for (name, is_dir, is_symlink, full_path) in files {
             if suggestions.len() >= max_suggestions {
                 break;
             }
 
+            if is_dir && !dir_has_visible_contents(&full_path, show_hidden) {
+                continue;
+            }
+
+            let is_listing_mode = prefix.ends_with('/');
             let suggestion_text = if show_full_paths {
                 let full = search_dir.join(&name);
                 full.to_string_lossy().to_string()
                     + if is_dir { "/" } else { "" }
+            } else if is_listing_mode {
+                // When listing a directory's contents, prepend the full prefix path
+                format!("{}{}{}", prefix, name, if is_dir { "/" } else { "" })
+            } else if !partial_name.is_empty() && prefix.ends_with(&partial_name) {
+                // When filtering in a subdirectory, prepend the parent path
+                let parent_path = &prefix[..prefix.len() - partial_name.len()];
+                format!("{}{}{}", parent_path, name, if is_dir { "/" } else { "" })
             } else {
+                // Fallback: just use the matched filename
                 name.clone() + if is_dir { "/" } else { "" }
             };
 
@@ -1273,6 +1283,19 @@ fn suggest_files(prefix: &str, depth: usize, max_suggestions: usize, show_hidden
     }
 
     suggestions
+}
+
+/// Returns true if `dir` contains at least one visible entry.
+/// When `show_hidden` is false, dotfiles are not counted as visible.
+fn dir_has_visible_contents(dir: &std::path::Path, show_hidden: bool) -> bool {
+    match std::fs::read_dir(dir) {
+        Ok(entries) => entries.filter_map(|e| e.ok()).any(|entry| {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            show_hidden || !name_str.starts_with('.')
+        }),
+        Err(_) => false,
+    }
 }
 
 /// Get the home directory path.
@@ -2554,9 +2577,21 @@ impl PromptInputState {
         text
     }
 
-    /// Update typeahead suggestions for slash commands in the current text.
-    pub fn update_suggestions(&mut self, slash_commands: &[(&str, &str)]) {
-        self.suggestions = compute_slash_suggestions(&self.text, slash_commands);
+    /// Returns true if the text (up to cursor) contains a word-boundary `@` token,
+    /// meaning an `@file` reference is actively being typed.
+    pub fn has_active_file_ref(&self) -> bool {
+        let text = &self.text[..self.cursor];
+        text.rfind('@').map_or(false, |at_idx| {
+            at_idx == 0 || text[..at_idx].chars().last().map_or(false, |c| c.is_whitespace())
+        })
+    }
+
+    /// Update typeahead suggestions for slash commands and file references in the current text.
+    pub fn update_suggestions(&mut self, slash_commands: &[(&str, &str)], file_autocomplete_limit: usize, file_autocomplete_show_hidden: bool) {
+        // Only look at text up to the cursor — text after the cursor belongs to a
+        // different editing position and would confuse rfind('@') / rfind('/').
+        let text_before_cursor = &self.text[..self.cursor];
+        self.suggestions = compute_typeahead(text_before_cursor, slash_commands, file_autocomplete_limit, file_autocomplete_show_hidden);
 
         if self.suggestions.is_empty() {
             self.suggestion_index = None;
@@ -2587,8 +2622,47 @@ impl PromptInputState {
     pub fn accept_suggestion(&mut self) {
         if let Some(idx) = self.suggestion_index {
             if let Some(s) = self.suggestions.get(idx) {
-                self.text = s.text.clone();
-                self.cursor = self.text.len();
+                let new_cursor = match s.source {
+                    TypeaheadSource::SlashCommand | TypeaheadSource::History => {
+                        // Replace entire text; discard anything after cursor too.
+                        self.text = s.text.clone();
+                        self.text.len()
+                    }
+                    TypeaheadSource::FileRef => {
+                        // Replace from the last word-boundary @ up to the cursor.
+                        // Preserve any text that was already after the cursor.
+                        let tail = self.text[self.cursor..].to_string();
+                        if let Some(at_idx) = self.text[..self.cursor].rfind('@') {
+                            let at_word_boundary = at_idx == 0
+                                || self.text[..at_idx]
+                                    .chars()
+                                    .last()
+                                    .map(|c| c.is_whitespace())
+                                    .unwrap_or(false);
+                            if at_word_boundary {
+                                let mut new_text = self.text[..at_idx].to_string();
+                                new_text.push_str(&s.text);
+                                let cursor = new_text.len();
+                                new_text.push_str(&tail);
+                                self.text = new_text;
+                                cursor
+                            } else {
+                                let mut new_text = s.text.clone();
+                                let cursor = new_text.len();
+                                new_text.push_str(&tail);
+                                self.text = new_text;
+                                cursor
+                            }
+                        } else {
+                            let mut new_text = s.text.clone();
+                            let cursor = new_text.len();
+                            new_text.push_str(&tail);
+                            self.text = new_text;
+                            cursor
+                        }
+                    }
+                };
+                self.cursor = new_cursor;
                 self.suggestions.clear();
                 self.suggestion_index = None;
                 self.update_token_estimate();
@@ -3462,7 +3536,8 @@ mod tests {
         let mut s = PromptInputState::new();
         let cmds = [("help", "Help"), ("history", "History"), ("compact", "Compact")];
         s.text = "/h".to_string();
-        s.update_suggestions(&cmds);
+        s.cursor = s.text.len();
+        s.update_suggestions(&cmds, 15, false);
         assert_eq!(s.suggestions.len(), 2);
         assert_eq!(s.suggestion_index, Some(0));
         s.suggestion_next();
@@ -3476,7 +3551,8 @@ mod tests {
         let mut s = PromptInputState::new();
         let cmds = [("help", "Show help")];
         s.text = "/he".to_string();
-        s.update_suggestions(&cmds);
+        s.cursor = s.text.len();
+        s.update_suggestions(&cmds, 15, false);
         s.suggestion_next();
         s.accept_suggestion();
         assert_eq!(s.text, "/help");
@@ -4304,5 +4380,93 @@ mod tests {
                 suggestion.description
             );
         }
+    }
+
+    // ---- has_active_file_ref tests ----------------------------------------
+
+    #[test]
+    fn has_active_file_ref_at_start() {
+        let mut s = PromptInputState::new();
+        s.text = "@src/".to_string();
+        s.cursor = s.text.len();
+        assert!(s.has_active_file_ref());
+    }
+
+    #[test]
+    fn has_active_file_ref_after_space() {
+        let mut s = PromptInputState::new();
+        s.text = "hello @".to_string();
+        s.cursor = s.text.len();
+        assert!(s.has_active_file_ref());
+    }
+
+    #[test]
+    fn has_active_file_ref_email_not_boundary() {
+        let mut s = PromptInputState::new();
+        s.text = "email@host".to_string();
+        s.cursor = s.text.len();
+        assert!(!s.has_active_file_ref());
+    }
+
+    #[test]
+    fn has_active_file_ref_no_at() {
+        let mut s = PromptInputState::new();
+        s.text = "no at sign here".to_string();
+        s.cursor = s.text.len();
+        assert!(!s.has_active_file_ref());
+    }
+
+    // ---- accept_suggestion FileRef tests ------------------------------------
+
+    #[test]
+    fn accept_suggestion_file_ref_at_start() {
+        let mut s = PromptInputState::new();
+        s.text = "@src/ma".to_string();
+        s.cursor = s.text.len();
+        s.suggestions = vec![TypeaheadSuggestion {
+            text: "@src/main.rs".to_string(),
+            description: "file".to_string(),
+            source: TypeaheadSource::FileRef,
+        }];
+        s.suggestion_index = Some(0);
+        s.accept_suggestion();
+        assert_eq!(s.text, "@src/main.rs");
+        assert_eq!(s.cursor, "@src/main.rs".len());
+        assert!(s.suggestions.is_empty());
+    }
+
+    #[test]
+    fn accept_suggestion_file_ref_after_text_preserves_prefix() {
+        let mut s = PromptInputState::new();
+        s.text = "some text @src/ma".to_string();
+        s.cursor = s.text.len();
+        s.suggestions = vec![TypeaheadSuggestion {
+            text: "@src/main.rs".to_string(),
+            description: "file".to_string(),
+            source: TypeaheadSource::FileRef,
+        }];
+        s.suggestion_index = Some(0);
+        s.accept_suggestion();
+        assert_eq!(s.text, "some text @src/main.rs");
+        assert_eq!(s.cursor, "some text @src/main.rs".len());
+    }
+
+    #[test]
+    fn accept_suggestion_file_ref_preserves_tail() {
+        let mut s = PromptInputState::new();
+        // Cursor is mid-string; tail after cursor is preserved
+        let prefix = "@src/ma";
+        let tail = " more text";
+        s.text = format!("{}{}", prefix, tail);
+        s.cursor = prefix.len();
+        s.suggestions = vec![TypeaheadSuggestion {
+            text: "@src/main.rs".to_string(),
+            description: "file".to_string(),
+            source: TypeaheadSource::FileRef,
+        }];
+        s.suggestion_index = Some(0);
+        s.accept_suggestion();
+        assert_eq!(s.text, "@src/main.rs more text");
+        assert_eq!(s.cursor, "@src/main.rs".len());
     }
 }


### PR DESCRIPTION
Implements end-to-end `@file` injection for the TUI prompt. Users type `@path` to reference files whose contents are automatically injected into the message before sending.

## Typeahead autocomplete

- Suggestions appear while typing `@path`, listing files and directories from cwd, absolute paths, or `~/` paths.
- Only directories with visible contents are shown (empty dirs or dirs that appear empty when show_hidden is off are suppressed).
- `Up`/`Down`/`Tab`/`Enter` navigate and accept suggestions; Enter also inserts a trailing space.
- Autocomplete is suppressed while the file injection dialog is open.
- Cursor-aware: `rfind('@')` scans only `text[..cursor]` so a mid-prompt `@` is handled correctly.

## File injection on submit
- `@refs` are resolved at submit time via `parse_at_refs`, which reads file contents and checks size limits.
- Directory refs are collected as `AtFileIssue::IsDirectory` and routed to a separate dismissible warning; they are never injected.
	<img width="856" height="387" alt="image" src="https://github.com/user-attachments/assets/759d7ba9-26e0-4e82-b417-51aef45df6dd" />

- Oversized or binary files show a warning dialog offering "Enter to inject anyways" (bold red) or Esc to abort.
	<img width="850" height="388" alt="image" src="https://github.com/user-attachments/assets/9b838e43-8027-4cfe-b768-3f0cbdbcc635" />

- When both directories and file issues are present, the directory warning is shown first; on re-submit with force-inject, directory refs are silently dropped to prevent looping.

## Dialog and rendering
- `FileInjectionDialogState.oversized` now stores typed `AtFileIssue` values instead of serialized strings, eliminating the fragile string-contains pattern for `IsDirectory` detection.
- Dead path_relative_to helper removed; `is_directory_only()` uses `matches!` macro.
- Injected file contents are rendered as compact chips in the chat transcript rather than raw XML blocks.
- `@path` tokens in user message text are shortened to just `@filename` when chips are present.
