### PR TITLE
fix: remove runtime OpenSSL dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,15 +98,15 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      # Linux native: install system libraries for ALSA (voice feature) and OpenSSL.
+      # Linux native: install system libraries for ALSA (voice feature).
       - name: Install Linux system dependencies
         if: runner.os == 'Linux' && !matrix.cross
         run: |
           sudo apt-get update
-          sudo apt-get install -y libasound2-dev libssl-dev pkg-config
+          sudo apt-get install -y libasound2-dev pkg-config
 
       # Linux ARM64: use cross for reliable cross-compilation (handles
-      # sysroot, OpenSSL, pkg-config, ALSA automatically via Docker).
+      # sysroot, pkg-config, ALSA automatically via Docker).
       - name: Install cross (aarch64-linux)
         if: matrix.cross
         run: cargo install cross --git https://github.com/cross-rs/cross
@@ -135,7 +135,7 @@ jobs:
           pre-build = [
             "dpkg --add-architecture $CROSS_DEB_ARCH",
             "apt-get update",
-            "apt-get install -y pkg-config libssl-dev:$CROSS_DEB_ARCH libasound2-dev:$CROSS_DEB_ARCH"
+            "apt-get install -y pkg-config libasound2-dev:$CROSS_DEB_ARCH"
           ]
           EOF
 

--- a/src-rust/Cargo.lock
+++ b/src-rust/Cargo.lock
@@ -3029,6 +3029,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.0+3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3036,6 +3045,7 @@ checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/src-rust/Cargo.toml
+++ b/src-rust/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = "0.1"
 async-stream = "0.3"
 
 # HTTP
-reqwest = { version = "0.13", features = ["json", "stream", "native-tls", "multipart", "form", "query"], default-features = false }
+reqwest = { version = "0.13", features = ["json", "stream", "native-tls-vendored", "multipart", "form", "query"], default-features = false }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
@@ -94,7 +94,7 @@ nix = { version = "0.29", features = ["process", "signal", "user"] }
 tokio-util = { version = "0.7", features = ["codec", "rt"] }
 
 # WebSocket
-tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.24", features = ["native-tls-vendored"] }
 
 # JSON Schema
 schemars = { version = "0.8", features = ["derive"] }

--- a/src-rust/crates/commands/Cargo.toml
+++ b/src-rust/crates/commands/Cargo.toml
@@ -31,7 +31,7 @@ open = { workspace = true }
 qrcode = { workspace = true }
 claurst-bridge = { workspace = true }
 hostname = "0.4"
-tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.24", features = ["native-tls-vendored"] }
 futures = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }


### PR DESCRIPTION
Switch reqwest and tokio-tungstenite to vendored TLS so Linux release binaries no longer depend on system libssl.so.1.1. Also drop the OpenSSL development package from the Linux release workflow and update Cargo.lock for openssl-src.