### PR TITLE
fix(api): respect Ollama base URL for native endpoints

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -246,11 +246,13 @@ Native Cohere API adapter.
 
 Connects to a locally running Ollama instance. No API key required.
 
-**Base URL:** Reads `OLLAMA_HOST` (defaults to `http://localhost:11434`). Claurst appends `/v1` to construct the OpenAI-compatible endpoint.
+**Base URL:** Reads `OLLAMA_HOST` (defaults to `http://localhost:11434`). Claurst appends `/v1` to construct the OpenAI-compatible endpoint. For a remote Ollama server, set `providers.ollama.api_base` to the remote host (for example `http://192.168.1.50:11434` or `http://192.168.1.50:11434/v1`).
 
 **Default model:** `llama3.2`
 
 **Model list:** When using `/connect` or `/model`, the picker queries your local Ollama server via `/api/tags` and shows only the models you have installed (`ollama list`). Cloud models (e.g., `kimi-k2.6:cloud`) appear after you run `ollama pull <model>:cloud`.
+
+When `api_base` points to a remote Ollama server, the model picker uses the same host for the native `/api/tags` request.
 
 **Configuration:**
 

--- a/src-rust/crates/api/src/providers/openai_compat.rs
+++ b/src-rust/crates/api/src/providers/openai_compat.rs
@@ -154,12 +154,23 @@ impl OpenAiCompatProvider {
     /// Override the base URL (e.g. from a user-supplied --api-base flag).
     pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
         self.base_url = base_url.into();
+        if self.quirks.ollama_native_host.is_some() {
+            self.quirks.ollama_native_host = Some(Self::ollama_host_from_base_url(&self.base_url));
+        }
         self
     }
 
     // -----------------------------------------------------------------------
     // Internal helpers
     // -----------------------------------------------------------------------
+
+    fn ollama_host_from_base_url(base_url: &str) -> String {
+        base_url
+            .trim_end_matches('/')
+            .strip_suffix("/v1")
+            .unwrap_or_else(|| base_url.trim_end_matches('/'))
+            .to_string()
+    }
 
     /// Returns `true` when the provider has no usable API key.
     fn has_no_key(&self) -> bool {
@@ -1293,5 +1304,24 @@ mod tests {
         assert_eq!(messages.len(), 3);
         assert_eq!(messages[1]["role"], json!("assistant"));
         assert_eq!(messages[1]["content"], json!("Done."));
+    }
+
+    #[test]
+    fn ollama_base_url_override_updates_native_host() {
+        let provider = OpenAiCompatProvider::new(
+            "ollama",
+            "Ollama",
+            "http://localhost:11434/v1",
+        )
+        .with_quirks(ProviderQuirks {
+            ollama_native_host: Some("http://localhost:11434".to_string()),
+            ..Default::default()
+        })
+        .with_base_url("http://192.168.1.50:11434/v1");
+
+        assert_eq!(
+            provider.quirks.ollama_native_host.as_deref(),
+            Some("http://192.168.1.50:11434")
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes remote Ollama configuration so the native Ollama endpoints follow the configured base URL.

When an Ollama provider is created, it keeps both:

- an OpenAI-compatible base URL used for chat completions, usually `<host>/v1`
- an Ollama native host used for `/api/tags` model discovery and health checks

`with_base_url()` updated the OpenAI-compatible base URL but left the native host pointing at the original `OLLAMA_HOST`/localhost value. That meant a remote `providers.ollama.api_base` could still leave model discovery or health checks targeting localhost.

## Changes

- Sync `ollama_native_host` when overriding an Ollama provider base URL.
- Strip a trailing `/v1` when deriving the native Ollama host.
- Add a regression test for a remote Ollama base URL override.
- Clarify the remote Ollama `api_base` behavior in the provider docs.

## Validation

```bash
cargo test --package claurst-api ollama_base_url_override_updates_native_host -j 2
cargo test --package claurst-api openai_compat -j 2
```
