### PR TITLE
chore(tui): remove unused mut in settings test

### DIFF
--- a/src-rust/crates/tui/src/settings_screen.rs
+++ b/src-rust/crates/tui/src/settings_screen.rs
@@ -825,7 +825,7 @@ mod tests {
 
     #[test]
     fn search_filters_entries_correctly() {
-        let mut screen = SettingsScreen::new();
+        let screen = SettingsScreen::new();
         let all = all_entries(&screen);
         let filtered: Vec<_> = all
             .iter()


### PR DESCRIPTION
## Summary

Removes an unnecessary `mut` from a settings screen unit test.

This clears the `unused_mut` warning emitted when compiling the `claurst-tui` test target.

## Validation

```bash
cargo test --package claurst-tui settings_screen --no-run -j 2
```

Before this change, the command reported 10 warnings including the `settings_screen.rs` `unused_mut` warning. After this change, that warning is gone and the remaining warnings are the existing non-snake-case test names in `prompt_input.rs`.
