### PR TITLE
Make devcontainers working

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-FROM rust:1-bullseye
+FROM rust:1-bookworm
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends gnupg2 libasound2-dev libxdo-dev pkg-config \
+    && apt-get install -y --no-install-recommends gnupg2 libasound2-dev libxdo-dev pkg-config cmake build-essential clang-15 \
     && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,6 +26,7 @@
     "GNUPGHOME": "/home/vscode/.gnupg",
     "PATH": "${containerWorkspaceFolder}/src-rust/target/debug:${containerWorkspaceFolder}/src-rust/target/release:${containerEnv:PATH}"
   },
+  "initializeCommand": "mkdir -p ${localWorkspaceFolder}/.claurst",
   "postCreateCommand": "mkdir -p /home/vscode/.gnupg && chmod 700 /home/vscode/.gnupg && sudo chown -R vscode:vscode /usr/local/cargo",
   "customizations": {
     "vscode": {


### PR DESCRIPTION
This PR:
fixes the dependencies issues preventing it from compiling the release
fixes missing .claurst folder - adds .claurst folder before devcontainer mount