### PR TITLE
feat(config): support {env:VAR_NAME} substitution in api_key/api_base config values

### DIFF
--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -1337,6 +1337,8 @@ pub mod config {
                         .find_map(|var| std::env::var(var).ok().filter(|v| !v.is_empty()))
                 })
                 .or_else(|| crate::AuthStore::load().api_key_for(provider_id))
+                // Support {env:VAR_NAME} patterns in the resolved value
+                .map(|key| substitute_env_vars(&key))
         }
 
         pub fn resolve_anthropic_api_key(&self) -> Option<String> {
@@ -1354,6 +1356,8 @@ pub mod config {
                         .iter()
                         .find_map(|var| std::env::var(var).ok().filter(|v| !v.is_empty()))
                 })
+                // Support {env:VAR_NAME} patterns in the resolved value
+                .map(|key| substitute_env_vars(&key))
         }
 
         /// Resolve the API key for the active provider.
@@ -1450,6 +1454,8 @@ pub mod config {
                         .filter(|base| !base.is_empty())
                 })
                 .or_else(|| default_api_base_for_provider(provider_id).map(str::to_owned))
+                // Support {env:VAR_NAME} patterns in the resolved base URL
+                .map(|base| substitute_env_vars(&base))
         }
 
         pub fn resolve_anthropic_api_base(&self) -> String {


### PR DESCRIPTION
Fixes #182

Adds env var substitution support for api_key and api_base fields in settings.json and provider_configs.

**Problem:** When configuring providers in `~/.claurst/settings.json`, the `api_key` and `api_base` fields only accept raw values. There is no way to reference environment variables, forcing users to either store secrets in plaintext or rely on hardcoded per-provider env var names.

**Solution:** The `substitute_env_vars()` function already existed but was dead code. This PR wires it into the three key resolution methods:
- `resolve_provider_api_key()`
- `resolve_anthropic_api_key()`
- `resolve_provider_api_base()`

**Usage:**
```json
{
  "config": {
    "api_key": "{env:MY_CUSTOM_KEY}",
    "provider_configs": {
      "deepseek": {
        "api_key": "{env:ANOTHER_KEY}",
        "api_base": "{env:API_BASE_URL}"
      }
    }
  }
}
```

Missing variables resolve to empty string (provider won't register).

**Justification for placement:** Substitution happens at resolution time, not at load time. This ensures `save()` writes the original `{env:...}` template back to disk, not the expanded value.