### PR TITLE
fix(ollama): honor configured base URL for remote servers

### DIFF
--- a/src-rust/crates/api/src/providers/openai_compat.rs
+++ b/src-rust/crates/api/src/providers/openai_compat.rs
@@ -152,8 +152,23 @@ impl OpenAiCompatProvider {
     }
 
     /// Override the base URL (e.g. from a user-supplied --api-base flag).
+    ///
+    /// When the provider uses Ollama's native API host (set by the `ollama()`
+    /// factory), keep it in sync with the new base URL.  Otherwise health
+    /// checks and native model discovery would keep targeting the original
+    /// (localhost) host even though chat completions go to the overridden
+    /// server.
     pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
         self.base_url = base_url.into();
+        if self.quirks.ollama_native_host.is_some() {
+            let native_host = self
+                .base_url
+                .trim_end_matches('/')
+                .trim_end_matches("/v1")
+                .trim_end_matches('/')
+                .to_string();
+            self.quirks.ollama_native_host = Some(native_host);
+        }
         self
     }
 
@@ -1293,5 +1308,28 @@ mod tests {
         assert_eq!(messages.len(), 3);
         assert_eq!(messages[1]["role"], json!("assistant"));
         assert_eq!(messages[1]["content"], json!("Done."));
+    }
+
+    #[test]
+    fn with_base_url_retargets_ollama_native_host() {
+        // Mirror the ollama() factory default: both the /v1 base URL and the
+        // native host point at localhost initially.
+        let provider = OpenAiCompatProvider::new("ollama", "Ollama", "http://localhost:11434/v1")
+            .with_quirks(ProviderQuirks {
+                no_api_key_required: true,
+                ollama_native_host: Some("http://localhost:11434".to_string()),
+                ..Default::default()
+            });
+
+        // Overriding the base URL with a configured remote api_base (as the
+        // registry does for `providers.ollama.api_base`) must also retarget the
+        // native host used by health_check() and native model discovery.
+        let provider = provider.with_base_url("http://192.0.2.10:11434/v1");
+
+        assert_eq!(provider.base_url, "http://192.0.2.10:11434/v1");
+        assert_eq!(
+            provider.quirks.ollama_native_host.as_deref(),
+            Some("http://192.0.2.10:11434"),
+        );
     }
 }

--- a/src-rust/crates/api/src/providers/openai_compat_providers.rs
+++ b/src-rust/crates/api/src/providers/openai_compat_providers.rs
@@ -58,19 +58,43 @@ pub fn provider_for_id(provider_id: &str) -> Option<OpenAiCompatProvider> {
 // Local / self-hosted providers (no API key required)
 // ---------------------------------------------------------------------------
 
-/// Ollama — local inference server.
-/// Reads `OLLAMA_HOST` for the base URL; defaults to `http://localhost:11434`.
+/// Ollama — local or remote inference server.
+/// Resolves the host from `providers.ollama.api_base` in settings first, then
+/// the `OLLAMA_HOST` env var, then defaults to `http://localhost:11434`.  Both
+/// the OpenAI-compatible `/v1` base URL and the native API host (used for
+/// health checks and model discovery) are derived from the same resolved host
+/// so a configured remote server is honored everywhere.
 pub fn ollama() -> OpenAiCompatProvider {
-    let host =
-        std::env::var("OLLAMA_HOST").unwrap_or_else(|_| "http://localhost:11434".to_string());
-    let base_url = format!("{}/v1", host.trim_end_matches('/'));
+    let settings = Settings::load_sync().unwrap_or_default();
+    let host = settings
+        .providers
+        .get("ollama")
+        .and_then(|config| config.api_base.as_deref())
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            std::env::var("OLLAMA_HOST")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
+        .unwrap_or_else(|| "http://localhost:11434".to_string());
+
+    // Strip a trailing `/v1` (and slashes) so the native host targets the
+    // Ollama root, then rebuild the `/v1` base URL for chat completions.
+    let native_host = host
+        .trim_end_matches('/')
+        .trim_end_matches("/v1")
+        .trim_end_matches('/')
+        .to_string();
+    let base_url = format!("{}/v1", native_host);
     OpenAiCompatProvider::new(ProviderId::OLLAMA, "Ollama", base_url).with_quirks(ProviderQuirks {
         overflow_patterns: vec![
             "prompt too long".to_string(),
             "exceeded.*context length".to_string(),
         ],
         no_api_key_required: true,
-        ollama_native_host: Some(host),
+        ollama_native_host: Some(native_host),
         ..Default::default()
     })
 }


### PR DESCRIPTION
## Problem

A remote Ollama server configured via `providers.ollama.api_base` in
`settings.json` (e.g. `http://VPS_IP:11434`) was ignored — requests still
hit `localhost:11434`.

## Root cause

Two distinct gaps in `crates/api`:

1. `openai_compat_providers.rs::ollama()` read only the `OLLAMA_HOST`
   env var and defaulted to `http://localhost:11434`. It never consulted
   `settings.providers["ollama"].api_base`, unlike `custom_openai()`.
   The `runtime_provider_for("ollama")` path builds the provider straight
   from this factory with no base-URL override, so a configured remote
   host was dropped entirely.

2. `openai_compat.rs::with_base_url()` overrode only `base_url` and left
   `ollama_native_host` pointing at localhost. Even on the
   `provider_from_config` path (which does call `with_base_url` with the
   resolved api_base), `health_check()` and native model discovery use
   `ollama_native_host` for `/api/tags`, so they kept targeting the wrong
   endpoint.

## Fix

- `ollama()` now resolves the host from `providers.ollama.api_base`
  first, then `OLLAMA_HOST`, then the `http://localhost:11434` default —
  mirroring the `custom_openai()` pattern. Both the `/v1` base URL and
  `ollama_native_host` are derived from the same resolved host (a
  trailing `/v1` is stripped for the native host).
- `with_base_url()` keeps `ollama_native_host` in sync with the new base
  URL when the quirk is set, so health checks and native model listing
  follow the configured server.

## Tests

- Added `with_base_url_retargets_ollama_native_host` in
  `openai_compat.rs`, asserting an overridden remote `/v1` base URL also
  retargets the native host.
- `cargo test -p claurst-api` passes (42 tests); `cargo check -p
  claurst-api` is clean.

## Caveat

Full end-to-end verification requires an actual remote Ollama server;
this was validated by code inspection and unit tests, not against a live
VPS instance.

Closes #86
