### PR TITLE
fix(providers): recognize alibaba/DashScope provider id

### DIFF
--- a/src-rust/crates/api/src/providers/openai_compat_providers.rs
+++ b/src-rust/crates/api/src/providers/openai_compat_providers.rs
@@ -24,7 +24,7 @@ pub fn provider_for_id(provider_id: &str) -> Option<OpenAiCompatProvider> {
         "together-ai" => Some(together_ai()),
         "perplexity" => Some(perplexity()),
         "venice" => Some(venice()),
-        "qwen" => Some(qwen()),
+        "qwen" | "alibaba" => Some(qwen()),
         "mistral" => Some(mistral()),
         "openrouter" => Some(openrouter()),
         "sambanova" => Some(sambanova()),
@@ -583,4 +583,20 @@ pub fn neuralwatt() -> OpenAiCompatProvider {
         include_usage_in_stream: true,
         ..Default::default()
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::LlmProvider;
+
+    #[test]
+    fn alibaba_resolves_to_qwen_backend() {
+        // "alibaba" is an alias for "qwen" — Alibaba's DashScope is the
+        // OpenAI-compatible backend behind both ids.
+        let alibaba = provider_for_id("alibaba").expect("alibaba should resolve");
+        let qwen = provider_for_id("qwen").expect("qwen should resolve");
+        assert_eq!(alibaba.id(), qwen.id());
+        assert_eq!(alibaba.name(), qwen.name());
+    }
 }

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -250,6 +250,7 @@ fn is_openaiish_provider(provider_id: &str) -> bool {
             | "zhipu"
             | "zai"
             | "qwen"
+            | "alibaba"
             | "nebius"
             | "novita"
             | "ovhcloud"
@@ -989,7 +990,7 @@ pub async fn run_query_loop(
                     "openrouter", "togetherai", "together-ai", "deepinfra", "venice",
                     "huggingface", "nvidia", "fireworks", "sambanova",
                     // Additional OpenAI-compat providers
-                    "qwen", "siliconflow",
+                    "qwen", "alibaba", "siliconflow",
                     "moonshot", "moonshotai",
                     "zhipu", "zhipuai",
                     "zai",
@@ -2512,6 +2513,14 @@ mod tests {
             options["reasoningConfig"]["budgetTokens"],
             serde_json::json!(10_000)
         );
+    }
+
+    #[test]
+    fn test_alibaba_is_openaiish_provider() {
+        // "alibaba" is an alias for "qwen" (Alibaba's DashScope backend);
+        // both must be treated as OpenAI-compatible providers.
+        assert!(is_openaiish_provider("alibaba"));
+        assert!(is_openaiish_provider("qwen"));
     }
 }
 


### PR DESCRIPTION
## Root cause

Configuring the provider `alibaba` (Alibaba DashScope, Qwen models) with an API key and base URL failed with `No API key for provider 'alibaba'`. The auth store already mapped `alibaba` to `DASHSCOPE_API_KEY` (`crates/core/src/auth_store.rs`), and the TUI offered `alibaba` as a selectable provider, but provider resolution did not recognize the id. DashScope uses the same OpenAI-compatible backend as `qwen`, but `alibaba` was missing from the resolution paths, so it never reached the `qwen()` provider factory.

Three places gated this:
- `crates/api/src/providers/openai_compat_providers.rs` — `provider_for_id` matched `"qwen"` but not `"alibaba"`.
- `crates/query/src/lib.rs` — `is_openaiish_provider()` was missing `"alibaba"`.
- `crates/query/src/lib.rs` — the `known_providers` array (used to disambiguate `provider/model` strings) was missing `"alibaba"`.

## Fix

Add `alibaba` as an alias of `qwen` in all three places, following the existing multi-name alias pattern (e.g. `moonshot`/`moonshotai`). Both ids now route to the shared DashScope OpenAI-compatible backend via `qwen()`.

Added unit tests:
- `alibaba_resolves_to_qwen_backend` (claurst-api) — asserts `provider_for_id("alibaba")` resolves to the same backend (id + name) as `provider_for_id("qwen")`.
- `test_alibaba_is_openaiish_provider` (claurst-query) — asserts `is_openaiish_provider("alibaba")` is true.

## Verification

`cargo test -p claurst-api -p claurst-query` passes (87 + 42 tests) and `cargo check -p claurst-api -p claurst-query` is clean. No version bumps.

Closes #173
