### PR TITLE
feat(tui): make mouse capture toggleable (restore native selection)

### DIFF
--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -1702,7 +1702,7 @@ async fn run_interactive(
 
 
     // Set up terminal
-    let mut terminal = setup_terminal()?;
+    let mut terminal = setup_terminal(live_config.mouse_capture_enabled())?;
     let mut app = App::new(live_config.clone(), cost_tracker.clone());
     // Gate input shift-normalization on whether the terminal speaks the kitty
     // keyboard protocol (detected in setup_terminal). On terminals that don't —
@@ -2396,7 +2396,7 @@ async fn run_interactive(
                                             eprintln!("\nLogin failed: {}", e);
                                         }
                                     }
-                                    terminal = claurst_tui::setup_terminal()?;
+                                    terminal = claurst_tui::setup_terminal(app.config.mouse_capture_enabled())?;
                                     app.kitty_keyboard_active =
                                         claurst_tui::keyboard_enhancement_active();
                                 }
@@ -2463,7 +2463,7 @@ async fn run_interactive(
                                             }
                                         }
                                     }
-                                    terminal = claurst_tui::setup_terminal()?;
+                                    terminal = claurst_tui::setup_terminal(app.config.mouse_capture_enabled())?;
                                     app.kitty_keyboard_active =
                                         claurst_tui::keyboard_enhancement_active();
                                 }

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -1024,6 +1024,14 @@ pub mod config {
             skip_serializing_if = "Option::is_none"
         )]
         pub request_timeout_secs: Option<u64>,
+        /// Whether app-level mouse capture is enabled. `None` (default) or
+        /// `Some(true)` means claurst captures the mouse for scroll / right-click
+        /// context menu / middle-click paste / drag text-selection. Set
+        /// `"mouseCapture": false` to release the mouse to the terminal so native
+        /// click-drag selection and copy/paste work without lag (issue #104).
+        /// Keyboard scrolling (PageUp/PageDown, etc.) is unaffected either way.
+        #[serde(default, rename = "mouseCapture", skip_serializing_if = "Option::is_none")]
+        pub mouse_capture: Option<bool>,
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -1262,6 +1270,14 @@ pub mod config {
     }
 
     impl Config {
+        /// Whether app-level mouse capture should be enabled. Defaults to `true`
+        /// (capture on) when unset, preserving historical behaviour; users opt out
+        /// via `"mouseCapture": false` to restore native terminal text selection
+        /// and copy/paste (issue #104).
+        pub fn mouse_capture_enabled(&self) -> bool {
+            self.mouse_capture.unwrap_or(true)
+        }
+
         pub fn selected_provider_id(&self) -> &str {
             self.provider
                 .as_deref()
@@ -1727,6 +1743,7 @@ pub mod config {
                 },
                 managed_agents: over.config.managed_agents.or(base.config.managed_agents),
                 auto_commits: over.config.auto_commits.or(base.config.auto_commits),
+                mouse_capture: over.config.mouse_capture.or(base.config.mouse_capture),
                 cursor_blink_enabled: over.config.cursor_blink_enabled || base.config.cursor_blink_enabled,
                 file_autocomplete_limit: if over.config.file_autocomplete_limit != 0 { over.config.file_autocomplete_limit } else { base.config.file_autocomplete_limit },
                 file_autocomplete_show_hidden_files: over.config.file_autocomplete_show_hidden_files || base.config.file_autocomplete_show_hidden_files,
@@ -4255,6 +4272,44 @@ mod tests {
     }
 
     // ---- Config tests -------------------------------------------------------
+
+    #[test]
+    fn test_config_mouse_capture_defaults_on() {
+        // Unset (None) must read as enabled to preserve historical behaviour.
+        let cfg = crate::config::Config::default();
+        assert_eq!(cfg.mouse_capture, None);
+        assert!(cfg.mouse_capture_enabled());
+    }
+
+    #[test]
+    fn test_config_mouse_capture_explicit_off() {
+        let mut cfg = crate::config::Config::default();
+        cfg.mouse_capture = Some(false);
+        assert!(!cfg.mouse_capture_enabled());
+        cfg.mouse_capture = Some(true);
+        assert!(cfg.mouse_capture_enabled());
+    }
+
+    #[test]
+    fn test_config_mouse_capture_serde_roundtrip() {
+        // Unset round-trips as None and is omitted from the serialized JSON
+        // (skip_serializing_if), so existing settings files stay unchanged.
+        let cfg = crate::config::Config::default();
+        let json = serde_json::to_string(&cfg).unwrap();
+        assert!(!json.contains("mouseCapture"));
+        let back: crate::config::Config = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.mouse_capture, None);
+        assert!(back.mouse_capture_enabled());
+
+        // Explicit off serializes the key and round-trips as disabled.
+        let mut cfg = crate::config::Config::default();
+        cfg.mouse_capture = Some(false);
+        let json = serde_json::to_string(&cfg).unwrap();
+        assert!(json.contains("\"mouseCapture\":false"));
+        let back: crate::config::Config = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.mouse_capture, Some(false));
+        assert!(!back.mouse_capture_enabled());
+    }
 
     #[test]
     fn test_config_effective_model_default() {

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -5646,6 +5646,15 @@ impl App {
     pub fn handle_mouse_event(&mut self, mouse_event: MouseEvent) {
         use crossterm::event::MouseButton;
 
+        // When mouse capture is disabled (mouseCapture: false, issue #104) the
+        // terminal keeps the mouse for native click-drag selection / copy-paste,
+        // so the app must not act on any mouse events that still slip through.
+        // Keyboard scrolling (PageUp/PageDown, etc.) is handled elsewhere and is
+        // unaffected by this gate.
+        if !self.config.mouse_capture_enabled() {
+            return;
+        }
+
         // Fast-reject mouse-move events — they flood at 60+ Hz and we don't
         // need hover tracking. Exception: context menu needs hover to update
         // the selected item highlight.
@@ -6522,6 +6531,39 @@ mod tests {
             kind: KeyEventKind::Press,
             state: KeyEventState::NONE,
         }
+    }
+
+    // ---- mouse capture gate (issue #104) ----
+
+    fn scroll_up_event() -> crossterm::event::MouseEvent {
+        crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::ScrollUp,
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::NONE,
+        }
+    }
+
+    #[test]
+    fn mouse_events_processed_when_capture_enabled() {
+        // Default config leaves mouse capture on, so a scroll wheel event
+        // should move the scroll offset.
+        let mut app = make_app();
+        assert!(app.config.mouse_capture_enabled());
+        assert_eq!(app.scroll_offset, 0);
+        app.handle_mouse_event(scroll_up_event());
+        assert!(app.scroll_offset > 0, "scroll should advance when capture is on");
+    }
+
+    #[test]
+    fn mouse_events_ignored_when_capture_disabled() {
+        // With mouseCapture: false the app must not act on mouse events that
+        // still slip through, so the scroll offset stays put.
+        let mut app = make_app();
+        app.config.mouse_capture = Some(false);
+        assert!(!app.config.mouse_capture_enabled());
+        app.handle_mouse_event(scroll_up_event());
+        assert_eq!(app.scroll_offset, 0, "scroll must not move when capture is off");
     }
 
     // ---- normalize_char_with_shift tests ----

--- a/src-rust/crates/tui/src/lib.rs
+++ b/src-rust/crates/tui/src/lib.rs
@@ -47,6 +47,13 @@ pub fn keyboard_enhancement_active() -> bool {
     KEYBOARD_ENHANCEMENT_ACTIVE.load(Ordering::Relaxed)
 }
 
+/// Whether app-level mouse capture was enabled during [`setup_terminal`].
+/// Mirrors [`KEYBOARD_ENHANCEMENT_ACTIVE`]: set once at setup from the user's
+/// `mouseCapture` config so the panic hook and restore path know whether to
+/// emit `DisableMouseCapture` (issue #104). Defaults to `true` so a restore
+/// that runs before setup keeps the historical always-disable behaviour.
+static MOUSE_CAPTURE_ACTIVE: AtomicBool = AtomicBool::new(true);
+
 // ---------------------------------------------------------------------------
 // Sub-modules
 // ---------------------------------------------------------------------------
@@ -202,10 +209,13 @@ pub use file_injection_dialog::{FileInjectionDialogState, FileInjectionOutcome, 
 /// Used by both restore_terminal and the panic hook.
 fn restore_terminal_cleanup() -> io::Result<()> {
     #[cfg(not(target_os = "windows"))]
+    if MOUSE_CAPTURE_ACTIVE.load(Ordering::Relaxed) {
+        execute!(io::stdout(), DisableMouseCapture)?;
+    }
+    #[cfg(not(target_os = "windows"))]
     execute!(
         io::stdout(),
         LeaveAlternateScreen,
-        DisableMouseCapture,
         DisableBracketedPaste,
         PopKeyboardEnhancementFlags,
     )?;
@@ -218,7 +228,10 @@ fn restore_terminal_cleanup() -> io::Result<()> {
         // Pop may fail on legacy Windows conhost where the push was a no-op;
         // do it best-effort so cleanup never errors out the process.
         let _ = execute!(io::stdout(), PopKeyboardEnhancementFlags);
-        execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture)?;
+        if MOUSE_CAPTURE_ACTIVE.load(Ordering::Relaxed) {
+            let _ = execute!(io::stdout(), DisableMouseCapture);
+        }
+        execute!(io::stdout(), LeaveAlternateScreen)?;
     }
 
     Ok(())
@@ -230,13 +243,16 @@ fn restore_terminal_cleanup() -> io::Result<()> {
 /// panic message.  Without this, any panic in rendering code leaves the
 /// terminal in raw mode with mouse capture enabled — the user sees garbage
 /// input until they run `reset`.
-pub fn setup_terminal() -> io::Result<Terminal<CrosstermBackend<Stdout>>> {
+pub fn setup_terminal(mouse_capture: bool) -> io::Result<Terminal<CrosstermBackend<Stdout>>> {
     // Chain on top of any existing hook (e.g. from a previous call or test harness).
     // Only restore the terminal when the panic originates on the main thread.
     // Tokio worker threads also trigger this process-wide hook (Tokio catches
     // the panic internally but the hook still fires), so without this guard any
     // panicking background task would destroy the live TUI display while the
     // main render loop is still running.
+    // Record whether mouse capture is on so the panic hook / restore path
+    // know whether to emit DisableMouseCapture (issue #104).
+    MOUSE_CAPTURE_ACTIVE.store(mouse_capture, Ordering::Relaxed);
     let main_thread_id = std::thread::current().id();
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {
@@ -256,13 +272,19 @@ pub fn setup_terminal() -> io::Result<Terminal<CrosstermBackend<Stdout>>> {
     execute!(
         stdout,
         EnterAlternateScreen,
-        EnableMouseCapture,
         EnableBracketedPaste,
         PushKeyboardEnhancementFlags(
             KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
                 | KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES,
         ),
     )?;
+    // Mouse capture is opt-out (issue #104): when on, the app handles scroll /
+    // right-click menu / drag-select but the terminal can no longer do native
+    // text selection. Skip it when the user set mouseCapture: false.
+    #[cfg(not(target_os = "windows"))]
+    if mouse_capture {
+        execute!(stdout, EnableMouseCapture)?;
+    }
 
     // On Windows, keyboard enhancement is best-effort: conhost and older
     // terminal builds do not support the kitty keyboard protocol.
@@ -270,7 +292,10 @@ pub fn setup_terminal() -> io::Result<Terminal<CrosstermBackend<Stdout>>> {
     // configurations.  Warn the user when it fails, then continue.
     #[cfg(target_os = "windows")]
     {
-        execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+        execute!(stdout, EnterAlternateScreen)?;
+        if mouse_capture {
+            execute!(stdout, EnableMouseCapture)?;
+        }
         // Kitty keyboard protocol is unsupported on legacy Windows conhost;
         // best-effort — modern Windows Terminal accepts it, conhost returns
         // "Keyboard progressive enhancement not implemented for the legacy

--- a/src-rust/crates/tui/src/settings_screen.rs
+++ b/src-rust/crates/tui/src/settings_screen.rs
@@ -61,6 +61,7 @@ pub struct SettingsScreen {
     pub verbose: bool,
     pub cursor_blink_enabled: bool,
     pub auto_copy_enabled: bool,
+    pub mouse_capture: bool,
     pub show_cwd: bool,
     pub show_git_branch: bool,
     pub compact_threshold: String,
@@ -94,6 +95,7 @@ impl SettingsScreen {
             verbose: false,
             cursor_blink_enabled: false,
             auto_copy_enabled: false,
+            mouse_capture: true,
             show_cwd: false,
             show_git_branch: false,
             compact_threshold: "95".to_string(),
@@ -122,6 +124,7 @@ impl SettingsScreen {
         self.verbose = self.settings_snapshot.config.verbose;
         self.cursor_blink_enabled = self.settings_snapshot.config.cursor_blink_enabled;
         self.auto_copy_enabled = self.settings_snapshot.auto_copy_on_highlight;
+        self.mouse_capture = self.settings_snapshot.config.mouse_capture_enabled();
         self.show_cwd = self.settings_snapshot.show_cwd;
         self.show_git_branch = self.settings_snapshot.show_git_branch;
         self.compact_threshold = self.settings_snapshot.config.compact_threshold.to_string();
@@ -328,6 +331,13 @@ fn all_entries(screen: &SettingsScreen) -> Vec<SettingsEntry> {
             description: "Automatically copy highlighted text to clipboard.",
             kind: SettingKind::Bool,
             value: if screen.auto_copy_enabled { "true" } else { "false" }.to_string(),
+        },
+        SettingsEntry {
+            key: "mouse_capture",
+            label: "Mouse capture",
+            description: "Capture the mouse for scroll/right-click/drag-select. Turn off for native terminal text selection. Takes effect on next session.",
+            kind: SettingKind::Bool,
+            value: if screen.mouse_capture { "true" } else { "false" }.to_string(),
         },
         SettingsEntry {
             key: "show_cwd",
@@ -731,6 +741,13 @@ fn toggle_or_cycle_current(screen: &mut SettingsScreen) {
                     "auto_copy_enabled" => {
                         screen.auto_copy_enabled = new_value;
                         screen.settings_snapshot.auto_copy_on_highlight = new_value;
+                        let _ = screen.settings_snapshot.save_sync();
+                    }
+                    "mouse_capture" => {
+                        screen.mouse_capture = new_value;
+                        // Persist only the off state; on is the default, so clear the key.
+                        screen.settings_snapshot.config.mouse_capture =
+                            if new_value { None } else { Some(false) };
                         let _ = screen.settings_snapshot.save_sync();
                     }
                     "show_cwd" => {


### PR DESCRIPTION
## Summary

Claurst called crossterm `EnableMouseCapture` unconditionally on startup, which took the mouse away from the terminal and broke native click-drag text selection, copy/paste, and added scroll lag (#104). This makes mouse capture optional while keeping it on by default.

## Changes

- **`crates/core`**: new `Config.mouse_capture: Option<bool>` (serde key `mouseCapture`, `skip_serializing_if = None`) plus a `mouse_capture_enabled()` accessor that defaults to `true` when unset. Wired into `Settings::merge`.
- **`crates/tui` (`lib.rs`)**: `setup_terminal(mouse_capture: bool)` now gates `EnableMouseCapture`; the value is stored in a `MOUSE_CAPTURE_ACTIVE` atomic (mirroring the existing `KEYBOARD_ENHANCEMENT_ACTIVE` flag) so the restore path and panic hook only emit `DisableMouseCapture` when capture was actually on.
- **`crates/tui` (`app.rs`)**: `handle_mouse_event` early-returns when capture is disabled so no app-level handling interferes with the terminal.
- **`crates/cli` (`main.rs`)**: all three `setup_terminal` call sites pass the user's setting.
- **Settings screen**: new "Mouse capture" toggle (takes effect on next session).
- **Tests**: config default, serde round-trip, and the mouse-event gate (enabled vs. disabled).

## Behaviour

- Default is unchanged: mouse capture stays on, so scroll / right-click context menu / middle-click paste / drag text-selection keep working out of the box.
- Setting `"mouseCapture": false` (config or settings screen) releases the mouse to the terminal, restoring native selection and copy/paste with no scroll lag.
- Keyboard scrolling (PageUp/PageDown, etc.) is unaffected in both modes.

## Caveats

- When disabled, the app-level mouse features are intentionally given up: wheel scroll, right-click context menu, middle-click paste, click/drag text selection + auto-copy-on-highlight, and mouse clicks inside dialogs. Use the keyboard and your terminal's native selection instead.
- The settings-screen toggle persists immediately but applies to the terminal on the next session (consistent with other terminal-level settings).

## Testing

- `cargo test -p claurst-tui -p claurst-core --locked -- --test-threads=1` (matches CI): all pass.
- `cargo check -p claurst-tui -p claurst -p claurst-core`: clean.
- `lib.rs` CRLF line endings preserved; diff limited to the intended lines.

Closes #104
