### PR TITLE
fix(tui): improve shortcut handling on non-English keyboard layouts

### DIFF
--- a/src-rust/crates/core/src/voice.rs
+++ b/src-rust/crates/core/src/voice.rs
@@ -587,6 +587,8 @@ mod tests {
 
     #[test]
     fn test_no_tokens_requires_oauth() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var(KILL_SWITCH_ENV);
         let result = check_voice_availability(None);
         assert_eq!(result, VoiceAvailability::RequiresOAuth);
         assert!(!result.is_available());
@@ -595,6 +597,8 @@ mod tests {
 
     #[test]
     fn test_available_with_all_scopes() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var(KILL_SWITCH_ENV);
         let tokens = tokens_with_scopes(vec!["user:inference", "user:profile"]);
         let result = check_voice_availability(Some(&tokens));
         assert_eq!(result, VoiceAvailability::Available);
@@ -604,6 +608,8 @@ mod tests {
 
     #[test]
     fn test_missing_one_scope() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var(KILL_SWITCH_ENV);
         let tokens = tokens_with_scopes(vec!["user:inference"]);
         let result = check_voice_availability(Some(&tokens));
         assert!(matches!(result, VoiceAvailability::MissingScopes { .. }));
@@ -624,6 +630,8 @@ mod tests {
 
     #[test]
     fn test_empty_scopes_missing() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var(KILL_SWITCH_ENV);
         let tokens = tokens_with_scopes(vec![]);
         let result = check_voice_availability(Some(&tokens));
         assert!(
@@ -662,6 +670,8 @@ mod tests {
 
     #[test]
     fn test_extra_scopes_still_available() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var(KILL_SWITCH_ENV);
         let tokens = tokens_with_scopes(vec![
             "user:inference",
             "user:profile",

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -675,6 +675,44 @@ fn key_event_to_keystroke(key: &KeyEvent) -> Option<ParsedKeystroke> {
     })
 }
 
+/// Rewrite a Ctrl-modified keystroke that carries a non-ASCII character to the
+/// Latin letter at the same physical QWERTY position.
+///
+/// A few core shortcuts — most importantly Ctrl+C (interrupt / exit) and Ctrl+D
+/// (exit) — are matched directly against `KeyEvent::code` in `handle_key_event`
+/// rather than going through the keybinding table (they are intentionally absent
+/// from `default_bindings`, see `NON_REBINDABLE`). On a non-Latin layout
+/// (Ukrainian / Russian JCUKEN, …) the reported character is the Cyrillic glyph
+/// at that physical key — e.g. Ctrl+С arrives as `Char('с')` — so the literal
+/// `KeyCode::Char('c')` arms never fire and the shortcut is dead.
+///
+/// Normalizing once at the top of `handle_key_event` lets every downstream
+/// `key.code` comparison (and the keybinding layer, idempotently) see the Latin
+/// letter, mirroring what `key_event_to_keystroke` already does for bound keys.
+///
+/// Restricted to **pure Ctrl (Ctrl without Alt)** on purpose: Ctrl+<letter>
+/// never produces literal text, so rewriting it cannot corrupt text entry,
+/// whereas Alt / AltGr (reported as Ctrl+Alt) is used to compose characters on
+/// some layouts and must be left untouched. Characters with no known
+/// position mapping (or that map to a non-ASCII result) are returned unchanged.
+fn normalize_layout_shortcut_key(key: KeyEvent) -> KeyEvent {
+    if let KeyCode::Char(c) = key.code {
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        let alt = key.modifiers.contains(KeyModifiers::ALT);
+        if ctrl && !alt && !c.is_ascii() {
+            if let Some(latin) = layout_to_latin(c).chars().next() {
+                if latin.is_ascii() {
+                    return KeyEvent {
+                        code: KeyCode::Char(latin),
+                        ..key
+                    };
+                }
+            }
+        }
+    }
+    key
+}
+
 // ---------------------------------------------------------------------------
 // Focus target
 // ---------------------------------------------------------------------------
@@ -2935,6 +2973,13 @@ impl App {
     /// Process a keyboard event. Returns `true` when the input should be
     /// submitted (Enter pressed with no blocking dialog).
     pub fn handle_key_event(&mut self, key: KeyEvent) -> bool {
+        // Make Ctrl shortcuts layout-independent before any handler runs: on
+        // non-Latin layouts (Ukrainian / Russian, …) a Ctrl combo reports the
+        // Cyrillic glyph at the physical key, which would otherwise miss the
+        // literal `KeyCode::Char(..)` arms below — including Ctrl+C / Ctrl+D,
+        // which are matched here rather than via the keybinding table (issue #47).
+        let key = normalize_layout_shortcut_key(key);
+
         // Dismiss error modal with Esc
         if key.code == KeyCode::Esc && self.notifications.current_is_error() {
             self.dismiss_error_notifications();
@@ -6948,5 +6993,195 @@ mod tests {
 
         assert!(app.permission_request.is_none());
         assert!(!app.bash_command_allowed_by_prefix("npm test"));
+    }
+
+    // ---- issue #47: shortcuts on non-English (Cyrillic) keyboard layouts ----
+
+    #[test]
+    fn test_layout_to_latin_maps_cyrillic_shortcut_positions() {
+        // Letters used by core Ctrl/Alt shortcuts must resolve to the Latin key
+        // at the same physical QWERTY position on the Russian/Ukrainian JCUKEN
+        // layout. (left = Cyrillic glyph reported by the terminal, right = Latin)
+        assert_eq!(layout_to_latin('с'), "c"); // Ctrl+C  (interrupt / exit)
+        assert_eq!(layout_to_latin('в'), "d"); // Ctrl+D  (exit)
+        assert_eq!(layout_to_latin('к'), "r"); // Ctrl+R  (history search)
+        assert_eq!(layout_to_latin('и'), "b"); // Ctrl+B  (create branch)
+        assert_eq!(layout_to_latin('з'), "p"); // Ctrl+P  (global search)
+        assert_eq!(layout_to_latin('е'), "t"); // Ctrl+T  (tasks overlay)
+        assert_eq!(layout_to_latin('т'), "n"); // n
+        assert_eq!(layout_to_latin('о'), "j"); // Ctrl+J  (newline fallback)
+        assert_eq!(layout_to_latin('г'), "u"); // Ctrl+U  (kill to start)
+        assert_eq!(layout_to_latin('ц'), "w"); // Ctrl+W  (kill word)
+        assert_eq!(layout_to_latin('л'), "k"); // Ctrl+K  (command palette)
+        assert_eq!(layout_to_latin('а'), "f"); // Alt+F   (word forward)
+        assert_eq!(layout_to_latin('н'), "y"); // Ctrl+Y  (yank)
+    }
+
+    #[test]
+    fn test_layout_to_latin_covers_full_qwerty_letter_row() {
+        // Every Latin letter position should be reachable from some Cyrillic key,
+        // so every Ctrl/Alt+<letter> binding works regardless of layout.
+        let cyrillic = "йцукенгшщзфывапролдячсмить";
+        let mut latin: Vec<char> = cyrillic
+            .chars()
+            .filter_map(|c| layout_to_latin(c).chars().next())
+            .filter(|c| c.is_ascii_alphabetic())
+            .collect();
+        latin.sort_unstable();
+        latin.dedup();
+        assert_eq!(latin.len(), 26, "all 26 Latin letters must be covered");
+    }
+
+    #[test]
+    fn test_layout_to_latin_uppercase_cyrillic_folds_to_lowercase_latin() {
+        // Shift+Ctrl on a Cyrillic layout reports the uppercase glyph.
+        assert_eq!(layout_to_latin('С'), "c");
+        assert_eq!(layout_to_latin('В'), "d");
+    }
+
+    #[test]
+    fn test_layout_to_latin_passes_through_unknown_chars() {
+        // Plain ASCII and unmapped characters are returned unchanged (lowercased).
+        assert_eq!(layout_to_latin('c'), "c");
+        assert_eq!(layout_to_latin('A'), "a");
+    }
+
+    #[test]
+    fn test_key_event_to_keystroke_maps_ctrl_cyrillic_to_latin() {
+        // Ctrl+С (Cyrillic) on a non-Latin layout must resolve to the Latin "c".
+        let ks = key_event_to_keystroke(&press_key(
+            KeyCode::Char('с'),
+            KeyModifiers::CONTROL,
+        ))
+        .expect("keystroke");
+        assert_eq!(ks.key, "c");
+        assert!(ks.ctrl);
+
+        // Ctrl+О (Cyrillic, the physical J key) → "j" so Ctrl+J newline works.
+        let ks = key_event_to_keystroke(&press_key(
+            KeyCode::Char('о'),
+            KeyModifiers::CONTROL,
+        ))
+        .expect("keystroke");
+        assert_eq!(ks.key, "j");
+    }
+
+    #[test]
+    fn test_key_event_to_keystroke_keeps_plain_cyrillic_for_text_entry() {
+        // Without a modifier the character must NOT be Latinized — it is literal
+        // text the user is typing.
+        let ks = key_event_to_keystroke(&press_key(KeyCode::Char('с'), KeyModifiers::NONE))
+            .expect("keystroke");
+        assert_eq!(ks.key, "с");
+        assert!(!ks.ctrl && !ks.alt);
+    }
+
+    #[test]
+    fn test_normalize_layout_shortcut_key_rewrites_pure_ctrl() {
+        // Pure Ctrl + Cyrillic → Latin letter at the same physical position.
+        let out = normalize_layout_shortcut_key(press_key(
+            KeyCode::Char('с'),
+            KeyModifiers::CONTROL,
+        ));
+        assert_eq!(out.code, KeyCode::Char('c'));
+        assert!(out.modifiers.contains(KeyModifiers::CONTROL));
+    }
+
+    #[test]
+    fn test_normalize_layout_shortcut_key_leaves_plain_and_altgr_untouched() {
+        // No modifier: literal text entry — must stay Cyrillic.
+        let out = normalize_layout_shortcut_key(press_key(KeyCode::Char('с'), KeyModifiers::NONE));
+        assert_eq!(out.code, KeyCode::Char('с'));
+
+        // Ctrl+Alt (AltGr) can compose characters on some layouts — leave it.
+        let out = normalize_layout_shortcut_key(press_key(
+            KeyCode::Char('с'),
+            KeyModifiers::CONTROL | KeyModifiers::ALT,
+        ));
+        assert_eq!(out.code, KeyCode::Char('с'));
+
+        // Plain Alt is also left alone (avoid disturbing Option/meta composition).
+        let out = normalize_layout_shortcut_key(press_key(KeyCode::Char('с'), KeyModifiers::ALT));
+        assert_eq!(out.code, KeyCode::Char('с'));
+    }
+
+    #[test]
+    fn test_normalize_layout_shortcut_key_passes_ascii_through() {
+        // ASCII Ctrl combos (English layout) are unchanged — no regression.
+        let out = normalize_layout_shortcut_key(press_key(KeyCode::Char('c'), KeyModifiers::CONTROL));
+        assert_eq!(out.code, KeyCode::Char('c'));
+    }
+
+    #[test]
+    fn test_ctrl_cyrillic_o_inserts_newline_like_ctrl_j() {
+        // On a Cyrillic layout the physical Ctrl+J key reports Ctrl+О; it must
+        // still insert a newline so multi-line composing works (issue #47).
+        let mut app = make_app();
+        app.prompt_input.text = "ab".to_string();
+        app.prompt_input.cursor = app.prompt_input.text.len();
+        app.refresh_prompt_input();
+
+        app.handle_key_event(press_key(KeyCode::Char('о'), KeyModifiers::CONTROL));
+
+        assert_eq!(app.prompt_input.text, "ab\n");
+    }
+
+    #[test]
+    fn test_ctrl_j_inserts_newline_on_english_layout() {
+        // Regression guard: the English Ctrl+J path still inserts a newline.
+        let mut app = make_app();
+        app.prompt_input.text = "ab".to_string();
+        app.prompt_input.cursor = app.prompt_input.text.len();
+        app.refresh_prompt_input();
+
+        app.handle_key_event(press_key(KeyCode::Char('j'), KeyModifiers::CONTROL));
+
+        assert_eq!(app.prompt_input.text, "ab\n");
+    }
+
+    #[test]
+    fn test_raw_newline_char_inserts_newline() {
+        // A bare LF (0x0A) arriving as Char('\n') — e.g. Shift+Enter on a
+        // terminal without the kitty protocol — must add a newline, not be
+        // dropped.
+        let mut app = make_app();
+        app.prompt_input.text = "ab".to_string();
+        app.prompt_input.cursor = app.prompt_input.text.len();
+        app.refresh_prompt_input();
+
+        app.handle_key_event(press_key(KeyCode::Char('\n'), KeyModifiers::NONE));
+
+        assert_eq!(app.prompt_input.text, "ab\n");
+    }
+
+    #[test]
+    fn test_ctrl_cyrillic_c_triggers_exit_confirmation_on_cyrillic_layout() {
+        // Ctrl+С (Cyrillic) on an empty prompt must arm the two-press exit
+        // confirmation exactly like the English Ctrl+C (issue #47 — "Ctrl combos
+        // don't work").
+        let mut app = make_app();
+        assert!(app.prompt_input.is_empty());
+
+        app.handle_key_event(press_key(KeyCode::Char('с'), KeyModifiers::CONTROL));
+        assert!(
+            app.last_exit_key_warning.is_some(),
+            "first Ctrl+С should arm the exit confirmation"
+        );
+        assert!(!app.should_exit);
+
+        // Second press within the timeout exits.
+        app.handle_key_event(press_key(KeyCode::Char('с'), KeyModifiers::CONTROL));
+        assert!(app.should_exit, "second Ctrl+С should exit");
+    }
+
+    #[test]
+    fn test_ctrl_c_still_triggers_exit_confirmation_on_english_layout() {
+        // Regression guard: the English Ctrl+C exit confirmation is unchanged.
+        let mut app = make_app();
+        app.handle_key_event(press_key(KeyCode::Char('c'), KeyModifiers::CONTROL));
+        assert!(app.last_exit_key_warning.is_some());
+        assert!(!app.should_exit);
+        app.handle_key_event(press_key(KeyCode::Char('c'), KeyModifiers::CONTROL));
+        assert!(app.should_exit);
     }
 }


### PR DESCRIPTION
## Summary

Improves keyboard-shortcut robustness on non-English (Ukrainian/Russian) layouts. Refs #47.

I cannot test on a physical Cyrillic keyboard, so this PR makes conservative, well-tested robustness improvements and asks the reporter to verify.

## What already worked (no change needed)

- `layout_to_latin` (`crates/tui/src/app.rs`) already maps the full Russian/Ukrainian JCUKEN letter row to the Latin letter at the same physical QWERTY position. All 26 Latin positions are covered, so **every bound Ctrl/Alt+letter shortcut already works on Cyrillic** via the keybinding layer: `key_event_to_keystroke` applies `layout_to_latin` whenever Ctrl/Alt is held and the char is non-ASCII.
- **Ctrl+J -> newline** therefore already worked on Cyrillic (physical J = Cyrillic `о`, mapped to `j`), and **Shift+Enter -> newline** works on terminals that speak the kitty protocol (Enter is layout-independent). A bare LF (`Char('\n')`) also already inserts a newline via the text-entry path.
- **ESC** is `KeyCode::Esc`, which is layout-independent in crossterm; there is no code-level layout bug, so it is left unchanged. If ESC still misbehaves it is a terminal/kitty-disambiguation interaction, not layout.
- The recent #183 work (gating US-QWERTY shift normalization on `kitty_keyboard_active`) is unrelated to layout mapping and is left intact.

## The real gap this fixes

A handful of shortcuts are matched **directly against `KeyEvent::code`** in `handle_key_event` instead of going through the keybinding table. Most importantly **Ctrl+C (interrupt/exit)** and **Ctrl+D (exit)** are intentionally absent from `default_bindings` (`NON_REBINDABLE`) and compared against the literal Latin char. On a Cyrillic layout the reported char is the Cyrillic glyph (e.g. Ctrl+`с` for C, Ctrl+`в` for D), so those arms never fired and the shortcuts were dead. The same affected the other directly-matched combos: Ctrl+P, Ctrl+T, Ctrl+R, Ctrl+Y, Ctrl+V.

Fix: normalize a **pure-Ctrl (no Alt)** non-ASCII keystroke to the Latin letter at the same physical position once at the top of `handle_key_event`, via a new `normalize_layout_shortcut_key` helper that reuses `layout_to_latin`. This mirrors what the keybinding layer already does for bound keys.

Why pure-Ctrl only: Ctrl+`<letter>` never produces literal text, so rewriting it cannot corrupt typing. Alt / AltGr (reported as Ctrl+Alt) is deliberately excluded so character composition on other layouts is untouched. English-layout behavior is unchanged (ASCII passes through).

## Tests

Added unit tests in `crates/tui/src/app.rs`:
- `layout_to_latin` coverage for the Cyrillic positions used by core shortcuts, full-26-letter coverage, uppercase folding, and ASCII pass-through.
- `key_event_to_keystroke` maps Ctrl+Cyrillic to the Latin key, and keeps plain (unmodified) Cyrillic as literal text.
- `normalize_layout_shortcut_key` rewrites pure-Ctrl, leaves plain/Alt/AltGr/ASCII untouched.
- Integration: Ctrl+`о` inserts a newline like Ctrl+J; Ctrl+`с` arms and then triggers the two-press exit; English Ctrl+J / Ctrl+C regression guards; bare LF inserts a newline.

Also fixed a pre-existing flaky env-var race in the voice-availability tests (readers of `CLAURST_VOICE_DISABLED` now take `ENV_LOCK`) so the test gate is deterministic.

`cargo test -p claurst-tui -p claurst-core` passes (verified across multiple parallel runs); `cargo check -p claurst-tui -p claurst-core` is clean.

## Needs reporter verification

On a Cyrillic (Ukrainian/Russian) layout, please confirm: Ctrl+C / Ctrl+D, other Ctrl combos, and newline insertion (Shift+Enter and/or Ctrl+J). If ESC still fails, please share your terminal so we can investigate the kitty/disambiguation angle separately, since ESC is layout-independent at the code level.
