### PR TITLE
feat(api): configurable request timeout + bounded stream idle timeout

### DIFF
--- a/src-rust/crates/api/src/lib.rs
+++ b/src-rust/crates/api/src/lib.rs
@@ -97,6 +97,57 @@ pub use providers::{
     ollama, lm_studio, deepseek, groq, xai, openrouter, mistral, opencode_zen,
 };
 
+// ---------------------------------------------------------------------------
+// Request timeout configuration (issue #175)
+// ---------------------------------------------------------------------------
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Default total request timeout in seconds when the user has not configured
+/// one. Kept in sync with [`claurst_core::config::DEFAULT_REQUEST_TIMEOUT_SECS`].
+pub use claurst_core::config::DEFAULT_REQUEST_TIMEOUT_SECS;
+
+/// Process-wide total request timeout (seconds) applied to provider HTTP
+/// clients that are constructed lazily without access to the user `Config`
+/// (OpenAI, OpenAI-compatible, Cohere, MiniMax, Copilot, Azure, Bedrock, …).
+///
+/// Set once at startup from the resolved configuration via
+/// [`set_request_timeout_secs`]; defaults to [`DEFAULT_REQUEST_TIMEOUT_SECS`].
+/// A process-wide value is used because providers are built in many places via
+/// builder chains that do not thread the user `Config` through.
+static REQUEST_TIMEOUT_SECS: AtomicU64 = AtomicU64::new(DEFAULT_REQUEST_TIMEOUT_SECS);
+
+/// Override the process-wide request timeout. A value of `0` resets to
+/// [`DEFAULT_REQUEST_TIMEOUT_SECS`]. Idempotent; safe to call multiple times.
+pub fn set_request_timeout_secs(secs: u64) {
+    let value = if secs == 0 { DEFAULT_REQUEST_TIMEOUT_SECS } else { secs };
+    REQUEST_TIMEOUT_SECS.store(value, Ordering::Relaxed);
+}
+
+/// Current process-wide request timeout in seconds.
+pub fn request_timeout_secs() -> u64 {
+    REQUEST_TIMEOUT_SECS.load(Ordering::Relaxed)
+}
+
+/// Current process-wide request timeout as a [`Duration`].
+pub fn request_timeout() -> Duration {
+    Duration::from_secs(request_timeout_secs())
+}
+
+/// Per-chunk idle timeout used to bound infinite mid-stream stalls (issue #185).
+///
+/// An OpenAI-compatible provider can begin a streamed tool call and then pause
+/// indefinitely before sending the tool arguments. The streaming loops wrap
+/// each `byte_stream.next()` in `tokio::time::timeout(stream_idle_timeout(), …)`
+/// so such stalls surface as a stream error instead of hanging forever.
+///
+/// The value is GENEROUS and never smaller than the configured request timeout,
+/// so legitimately slow-but-progressing local models (whose chunks reset the
+/// timer) are never cut off — the goal is only to bound true infinite stalls.
+pub fn stream_idle_timeout() -> Duration {
+    request_timeout().max(Duration::from_secs(DEFAULT_REQUEST_TIMEOUT_SECS))
+}
+
 // Composite "Free" provider — stacks many free-tier upstreams behind one
 // `free/auto` model id.
 pub use providers::{FreeEntry, FreeProvider, FreeUpstream, FREE_CATALOG};
@@ -446,7 +497,9 @@ pub mod client {
                 max_retries: 5,
                 initial_retry_delay: Duration::from_secs(1),
                 max_retry_delay: Duration::from_secs(60),
-                request_timeout: Duration::from_secs(600),
+                // Honour the process-wide configured timeout (issue #175);
+                // falls back to DEFAULT_REQUEST_TIMEOUT_SECS when unset.
+                request_timeout: crate::request_timeout(),
                 use_bearer_auth: false,
                 provider: Provider::Anthropic,
             }
@@ -975,7 +1028,10 @@ pub mod client {
                         .header("x-stainless-runtime-version", "v22.0.0")
                         .header("x-stainless-package-version", "0.94.0")
                         .header("x-stainless-retry-count", (attempts - 1).to_string())
-                        .header("x-stainless-timeout", "600")
+                        .header(
+                            "x-stainless-timeout",
+                            self.config.request_timeout.as_secs().to_string(),
+                        )
                         .header("x-claude-code-session-id", &session_id)
                         .header("x-client-request-id", uuid::Uuid::new_v4().to_string())
                         .header("Authorization", format!("Bearer {}", &self.config.api_key));
@@ -1514,5 +1570,66 @@ mod tests {
         let (msg, _usage, stop) = acc.finish();
         assert_eq!(msg.get_text(), Some("Hello world!"));
         assert_eq!(stop.as_deref(), Some("end_turn"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Request timeout (#175) + stream idle timeout (#185)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn request_timeout_threads_through_to_client_config() {
+        // Reset to the default and confirm the generous 600s fallback.
+        set_request_timeout_secs(0);
+        assert_eq!(request_timeout_secs(), DEFAULT_REQUEST_TIMEOUT_SECS);
+        assert_eq!(request_timeout(), Duration::from_secs(600));
+
+        // An override threads through request_timeout() and ClientConfig::default.
+        set_request_timeout_secs(1800);
+        assert_eq!(request_timeout_secs(), 1800);
+        assert_eq!(
+            client::ClientConfig::default().request_timeout,
+            Duration::from_secs(1800)
+        );
+        // Idle timeout is generous and never smaller than the request timeout.
+        assert!(stream_idle_timeout() >= request_timeout());
+        assert_eq!(stream_idle_timeout(), Duration::from_secs(1800));
+
+        // A short request timeout still keeps a generous idle floor (#185:
+        // bound stalls without cutting off slow-but-progressing streams).
+        set_request_timeout_secs(60);
+        assert_eq!(
+            stream_idle_timeout(),
+            Duration::from_secs(DEFAULT_REQUEST_TIMEOUT_SECS)
+        );
+
+        // Restore the default so we do not leak state into other tests.
+        set_request_timeout_secs(0);
+    }
+
+    #[tokio::test]
+    async fn stalled_stream_elapses_instead_of_hanging() {
+        use futures::StreamExt;
+
+        // A byte stream that never yields models a provider that begins a
+        // streamed response and then pauses indefinitely (issue #185).
+        let mut stalled =
+            futures::stream::pending::<Result<bytes::Bytes, std::io::Error>>();
+
+        // The exact construct used by the streaming loops: wrapping the chunk
+        // read in tokio::time::timeout must elapse rather than hang forever.
+        // A short duration keeps the test fast; production uses the generous
+        // stream_idle_timeout() value asserted below.
+        let result =
+            tokio::time::timeout(Duration::from_millis(50), stalled.next()).await;
+        assert!(
+            result.is_err(),
+            "a stalled stream must hit the idle timeout, not hang"
+        );
+
+        // Invariants that hold for any configured value: the production idle
+        // timeout is finite, never below the request timeout, and never below
+        // the generous default floor.
+        assert!(stream_idle_timeout() >= request_timeout());
+        assert!(stream_idle_timeout() >= Duration::from_secs(DEFAULT_REQUEST_TIMEOUT_SECS));
     }
 }

--- a/src-rust/crates/api/src/providers/azure.rs
+++ b/src-rust/crates/api/src/providers/azure.rs
@@ -43,7 +43,7 @@ pub struct AzureProvider {
 impl AzureProvider {
     pub fn new(resource_name: String, api_key: String) -> Self {
         let http_client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(600))
+            .timeout(crate::request_timeout())
             .build()
             .expect("failed to build reqwest client");
 

--- a/src-rust/crates/api/src/providers/bedrock.rs
+++ b/src-rust/crates/api/src/providers/bedrock.rs
@@ -55,7 +55,7 @@ impl BedrockProvider {
             .unwrap_or_else(|_| "us-east-1".to_string());
 
         let http_client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(600))
+            .timeout(crate::request_timeout())
             .build()
             .expect("failed to build reqwest client");
 

--- a/src-rust/crates/api/src/providers/codex.rs
+++ b/src-rust/crates/api/src/providers/codex.rs
@@ -53,7 +53,7 @@ pub struct CodexProvider {
 impl CodexProvider {
     pub fn new(tokens: CodexTokens) -> Self {
         let http_client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(600))
+            .timeout(crate::request_timeout())
             .build()
             .expect("failed to build reqwest client");
 

--- a/src-rust/crates/api/src/providers/cohere.rs
+++ b/src-rust/crates/api/src/providers/cohere.rs
@@ -42,7 +42,7 @@ impl CohereProvider {
     /// Create a new CohereProvider with the given API key.
     pub fn new(api_key: String) -> Self {
         let http_client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(600))
+            .timeout(crate::request_timeout())
             .build()
             .expect("failed to build reqwest client");
 

--- a/src-rust/crates/api/src/providers/copilot.rs
+++ b/src-rust/crates/api/src/providers/copilot.rs
@@ -51,7 +51,7 @@ pub struct CopilotProvider {
 impl CopilotProvider {
     pub fn new(token: String) -> Self {
         let http_client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(600))
+            .timeout(crate::request_timeout())
             .build()
             .expect("failed to build reqwest client");
 

--- a/src-rust/crates/api/src/providers/minimax.rs
+++ b/src-rust/crates/api/src/providers/minimax.rs
@@ -36,7 +36,7 @@ impl MinimaxProvider {
         headers.insert("X-Api-Key", header::HeaderValue::from_str(&api_key).expect("unable to parse api key for http header"));
         let http_client = Client::builder()
             .default_headers(headers)
-            .timeout(std::time::Duration::from_secs(600))
+            .timeout(crate::request_timeout())
             .build()
             .expect("MinimaxProvider: failed to build HTTP client");
 

--- a/src-rust/crates/api/src/providers/openai.rs
+++ b/src-rust/crates/api/src/providers/openai.rs
@@ -51,7 +51,7 @@ pub struct OpenAiProvider {
 impl OpenAiProvider {
     pub fn new(api_key: String) -> Self {
         let http_client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(600))
+            .timeout(crate::request_timeout())
             .build()
             .expect("failed to build reqwest client");
 
@@ -730,7 +730,34 @@ impl LlmProvider for OpenAiProvider {
                 (String, String, String),
             > = std::collections::HashMap::new();
 
-            while let Some(chunk_result) = byte_stream.next().await {
+            // Bound infinite mid-stream stalls (issue #185): wrap each chunk
+            // read in a generous idle timeout so a provider that pauses
+            // indefinitely surfaces an error instead of hanging. Each chunk
+            // resets the timer, so slow-but-progressing models are never cut off.
+            let idle_timeout = crate::stream_idle_timeout();
+            loop {
+                let chunk_result = match tokio::time::timeout(
+                    idle_timeout,
+                    byte_stream.next(),
+                )
+                .await
+                {
+                    Ok(Some(chunk_result)) => chunk_result,
+                    // Stream ended normally.
+                    Ok(None) => break,
+                    // No bytes for `idle_timeout` — provider stalled mid-stream.
+                    Err(_) => {
+                        yield Err(ProviderError::StreamError {
+                            provider: provider_id.clone(),
+                            message: format!(
+                                "Stream stalled: no data received for {}s; aborting to avoid hanging",
+                                idle_timeout.as_secs()
+                            ),
+                            partial_response: None,
+                        });
+                        return;
+                    }
+                };
                 let chunk = match chunk_result {
                     Ok(c) => c,
                     Err(e) => {

--- a/src-rust/crates/api/src/providers/openai_compat.rs
+++ b/src-rust/crates/api/src/providers/openai_compat.rs
@@ -114,7 +114,7 @@ impl OpenAiCompatProvider {
         base_url: impl Into<String>,
     ) -> Self {
         let http_client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(600))
+            .timeout(crate::request_timeout())
             .build()
             .expect("failed to build reqwest client");
 
@@ -851,7 +851,36 @@ impl LlmProvider for OpenAiCompatProvider {
                 (String, String, String),
             > = std::collections::HashMap::new();
 
-            while let Some(chunk_result) = byte_stream.next().await {
+            // Bound infinite mid-stream stalls (issue #185): some
+            // OpenAI-compatible providers begin a streamed tool call and then
+            // pause indefinitely before sending the arguments. Wrap each chunk
+            // read in a generous idle timeout so a stall surfaces as an error
+            // instead of hanging forever. Each chunk resets the timer, so
+            // slow-but-progressing local models are never cut off.
+            let idle_timeout = crate::stream_idle_timeout();
+            loop {
+                let chunk_result = match tokio::time::timeout(
+                    idle_timeout,
+                    byte_stream.next(),
+                )
+                .await
+                {
+                    Ok(Some(chunk_result)) => chunk_result,
+                    // Stream ended normally.
+                    Ok(None) => break,
+                    // No bytes for `idle_timeout` — provider stalled mid-stream.
+                    Err(_) => {
+                        yield Err(ProviderError::StreamError {
+                            provider: provider_id.clone(),
+                            message: format!(
+                                "Stream stalled: no data received for {}s; aborting to avoid hanging",
+                                idle_timeout.as_secs()
+                            ),
+                            partial_response: None,
+                        });
+                        return;
+                    }
+                };
                 let chunk = match chunk_result {
                     Ok(c) => c,
                     Err(e) => {

--- a/src-rust/crates/api/src/registry.rs
+++ b/src-rust/crates/api/src/registry.rs
@@ -364,6 +364,12 @@ impl ProviderRegistry {
         config: &claurst_core::config::Config,
         anthropic_config: ClientConfig,
     ) -> Self {
+        // Apply the user-configured request timeout (issue #175) before any
+        // provider HTTP clients are built, so they all honour it. Uses the
+        // active provider's resolved value (per-provider override or global).
+        crate::set_request_timeout_secs(
+            config.resolve_request_timeout_secs(config.selected_provider_id()),
+        );
         let mut registry = Self::from_environment_with_auth_store(anthropic_config);
         let active_provider = config.selected_provider_id();
 

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -595,6 +595,9 @@ async fn main() -> anyhow::Result<()> {
         (String::new(), false)
     };
 
+    // Apply the user-configured request timeout (issue #175) before building any
+    // client so the Anthropic client and all providers honour it.
+    claurst_api::set_request_timeout_secs(config.resolve_request_timeout_secs_active());
     let client_config = claurst_api::client::ClientConfig {
         api_key: api_key.clone(),
         api_base: config.resolve_anthropic_api_base(),
@@ -1230,6 +1233,8 @@ async fn refresh_provider_runtime_state(
         .resolve_anthropic_auth_async()
         .await
         .unwrap_or((String::new(), false));
+    // Apply the user-configured request timeout (issue #175) before rebuilding.
+    claurst_api::set_request_timeout_secs(config.resolve_request_timeout_secs_active());
     let client_config = claurst_api::client::ClientConfig {
         api_key,
         api_base: config.resolve_anthropic_api_base(),

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -651,6 +651,11 @@ pub mod config {
         100  // 100 KB
     }
 
+    /// Default total request timeout (seconds) when the user has not configured
+    /// one. Generous so slow local models (CPU inference, large MoE) that can
+    /// take several minutes to first token are not cut off prematurely.
+    pub const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 600;
+
     /// Definition of a named agent with per-agent model, permissions,
     /// temperature, and system prompt.
     pub fn api_key_env_vars_for_provider(provider_id: &str) -> &'static [&'static str] {
@@ -900,6 +905,17 @@ pub mod config {
         /// Provider-specific options (passed through to provider implementation)
         #[serde(default)]
         pub options: HashMap<String, serde_json::Value>,
+        /// Total request timeout in seconds for this provider's HTTP client.
+        /// Overrides the global [`Config::request_timeout_secs`] when set.
+        /// Useful for slow local models (CPU inference, large MoE) that can take
+        /// several minutes to first token. `None` falls back to the global value.
+        #[serde(
+            default,
+            rename = "requestTimeoutSecs",
+            alias = "request_timeout_secs",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub request_timeout_secs: Option<u64>,
     }
 
     impl Default for ProviderConfig {
@@ -911,6 +927,7 @@ pub mod config {
                 models_whitelist: Vec::new(),
                 models_blacklist: Vec::new(),
                 options: HashMap::new(),
+                request_timeout_secs: None,
             }
         }
     }
@@ -995,6 +1012,18 @@ pub mod config {
         /// Note: @include in CLAUDE.md/AGENTS.md always injects regardless of this limit.
         #[serde(default = "default_file_injection_max_size", rename = "fileInjectionMaxSize")]
         pub file_injection_max_size: usize,
+        /// Total request timeout in seconds applied to provider HTTP clients.
+        /// Slow local models (CPU inference, large MoE) can take several minutes
+        /// to first token; raise this to avoid premature cut-off. `None` (or 0)
+        /// uses [`DEFAULT_REQUEST_TIMEOUT_SECS`]. Per-provider overrides live on
+        /// [`ProviderConfig::request_timeout_secs`].
+        #[serde(
+            default,
+            rename = "requestTimeoutSecs",
+            alias = "request_timeout_secs",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub request_timeout_secs: Option<u64>,
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -1468,6 +1497,25 @@ pub mod config {
             self.resolve_provider_api_base(self.selected_provider_id())
                 .unwrap_or_else(|| self.resolve_anthropic_api_base())
         }
+
+        /// Resolve the total request timeout (in seconds) for `provider_id`.
+        ///
+        /// Precedence: per-provider [`ProviderConfig::request_timeout_secs`] >
+        /// global [`Config::request_timeout_secs`] > [`DEFAULT_REQUEST_TIMEOUT_SECS`].
+        /// Zero values are treated as unset.
+        pub fn resolve_request_timeout_secs(&self, provider_id: &str) -> u64 {
+            self.provider_configs
+                .get(provider_id)
+                .and_then(|provider| provider.request_timeout_secs)
+                .filter(|&secs| secs > 0)
+                .or_else(|| self.request_timeout_secs.filter(|&secs| secs > 0))
+                .unwrap_or(DEFAULT_REQUEST_TIMEOUT_SECS)
+        }
+
+        /// Resolve the request timeout for the active provider.
+        pub fn resolve_request_timeout_secs_active(&self) -> u64 {
+            self.resolve_request_timeout_secs(self.selected_provider_id())
+        }
     }
 
     impl Settings {
@@ -1684,6 +1732,7 @@ pub mod config {
                 file_autocomplete_show_hidden_files: over.config.file_autocomplete_show_hidden_files || base.config.file_autocomplete_show_hidden_files,
                 file_injection_enabled: over.config.file_injection_enabled || base.config.file_injection_enabled,
                 file_injection_max_size: if over.config.file_injection_max_size != 0 { over.config.file_injection_max_size } else { base.config.file_injection_max_size },
+                request_timeout_secs: over.config.request_timeout_secs.or(base.config.request_timeout_secs),
             };
             Self {
                 config: merged_config,
@@ -1792,6 +1841,92 @@ pub mod config {
             }
         }
         result
+    }
+
+    #[cfg(test)]
+    mod request_timeout_tests {
+        use super::*;
+
+        #[test]
+        fn defaults_to_600_when_unset() {
+            let config = Config::default();
+            assert_eq!(config.request_timeout_secs, None);
+            assert_eq!(
+                config.resolve_request_timeout_secs("openai"),
+                DEFAULT_REQUEST_TIMEOUT_SECS
+            );
+            assert_eq!(DEFAULT_REQUEST_TIMEOUT_SECS, 600);
+        }
+
+        #[test]
+        fn global_request_timeout_serde_roundtrips_with_camelcase_key() {
+            let mut config = Config::default();
+            config.request_timeout_secs = Some(1800);
+            // Serialises with the documented camelCase key.
+            let json = serde_json::to_string(&config).expect("serialise");
+            assert!(
+                json.contains("\"requestTimeoutSecs\":1800"),
+                "expected camelCase key in: {json}"
+            );
+            // Round-trips back and threads through the resolver.
+            let parsed: Config = serde_json::from_str(&json).expect("deserialise");
+            assert_eq!(parsed.request_timeout_secs, Some(1800));
+            assert_eq!(parsed.resolve_request_timeout_secs("ollama"), 1800);
+        }
+
+        #[test]
+        fn snake_case_alias_also_parses() {
+            // Patch a fully-serialised config to use the snake_case alias and
+            // confirm it still deserialises (back-compat with snake_case keys).
+            let mut value =
+                serde_json::to_value(Config::default()).expect("to_value");
+            let obj = value.as_object_mut().unwrap();
+            obj.remove("requestTimeoutSecs");
+            obj.insert(
+                "request_timeout_secs".to_string(),
+                serde_json::json!(900),
+            );
+            let parsed: Config =
+                serde_json::from_value(value).expect("alias should parse");
+            assert_eq!(parsed.request_timeout_secs, Some(900));
+        }
+
+        #[test]
+        fn per_provider_override_wins_over_global() {
+            let mut config = Config::default();
+            config.request_timeout_secs = Some(1200);
+            let mut provider = ProviderConfig::default();
+            provider.request_timeout_secs = Some(3600);
+            config
+                .provider_configs
+                .insert("ollama".to_string(), provider);
+            // Per-provider override applies to ollama.
+            assert_eq!(config.resolve_request_timeout_secs("ollama"), 3600);
+            // Other providers fall back to the global value.
+            assert_eq!(config.resolve_request_timeout_secs("openai"), 1200);
+        }
+
+        #[test]
+        fn effective_config_merges_top_level_provider_timeout() {
+            let mut settings = Settings::default();
+            settings.config.request_timeout_secs = Some(1200);
+            let mut provider = ProviderConfig::default();
+            provider.request_timeout_secs = Some(3600);
+            settings.providers.insert("ollama".to_string(), provider);
+            let config = settings.effective_config();
+            assert_eq!(config.resolve_request_timeout_secs("ollama"), 3600);
+            assert_eq!(config.resolve_request_timeout_secs("openai"), 1200);
+        }
+
+        #[test]
+        fn zero_is_treated_as_unset() {
+            let mut config = Config::default();
+            config.request_timeout_secs = Some(0);
+            assert_eq!(
+                config.resolve_request_timeout_secs("openai"),
+                DEFAULT_REQUEST_TIMEOUT_SECS
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes two issues that share the request-timeout plumbing, so they are addressed together.

### #175 — user-configurable request timeout
Slow local models (CPU inference, large MoE) can take several minutes to first token. The request timeout was hardcoded to 600s in `ClientConfig::default`, in every provider HTTP-client builder, and in the `x-stainless-timeout` header, so such models were cut off.

- New `requestTimeoutSecs` field on `Config` (global) and `ProviderConfig` (per-provider override), with a `request_timeout_secs` snake_case alias for back-compat.
- `Config::resolve_request_timeout_secs(provider_id)` resolves per-provider override → global → `DEFAULT_REQUEST_TIMEOUT_SECS` (600). Zero is treated as unset.
- The resolved value is applied process-wide via `claurst_api::set_request_timeout_secs` (called from `ProviderRegistry::from_config` and the CLI startup paths before any client is built) and consumed by `claurst_api::request_timeout()`.
- Every provider client builder now uses `crate::request_timeout()` instead of a hardcoded 600s: OpenAI, OpenAI-compatible, Cohere, MiniMax, Copilot, Codex, Azure, Bedrock, plus `ClientConfig::default` (Anthropic) and the `x-stainless-timeout` header.

Default behavior is unchanged (600s) when the setting is absent.

### #185 — hang when a stream stalls mid-tool-call
An OpenAI-compatible provider can begin a streamed tool call and then pause indefinitely before sending the tool arguments. The per-chunk read (`while let Some(chunk) = byte_stream.next().await`) had no idle bound; the total client timeout does not reliably interrupt an idle gap and the query-loop stall timer resets on every event, so Claurst could hang.

- Both the `openai_compat` and `openai` streaming loops now wrap each `byte_stream.next()` in `tokio::time::timeout(stream_idle_timeout(), ...)`. On elapse they emit a `StreamError` instead of hanging.
- `stream_idle_timeout()` is generous and never smaller than the configured request timeout (`max(request_timeout, 600s)`). Each arriving chunk resets the timer, so legitimately slow-but-progressing local models are never cut off — the bound only catches true infinite stalls.

## Tests
- `claurst-core`: config parsing (camelCase + snake_case alias), serde round-trip, per-provider-over-global precedence, `effective_config` merge, and zero-as-unset.
- `claurst-api`: timeout-helper threading into `ClientConfig`/`stream_idle_timeout`, and a test that a stalled byte-stream elapses under `tokio::time::timeout` rather than hanging.
- `cargo test -p claurst-api -p claurst-core` green; `cargo check -p claurst-api -p claurst-core -p claurst` clean.

## Notes
- A process-wide timeout value is used because providers are constructed lazily in many places via builder chains that do not thread the user `Config`; it is set once at startup from the resolved config.

Closes #175
Closes #185
