### PR TITLE
test: make HOME/filesystem-dependent tests hermetic for sandboxed builds

### DIFF
--- a/src-rust/Cargo.lock
+++ b/src-rust/Cargo.lock
@@ -915,6 +915,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",

--- a/src-rust/crates/core/src/session_storage.rs
+++ b/src-rust/crates/core/src/session_storage.rs
@@ -230,8 +230,15 @@ pub fn projects_dir() -> PathBuf {
 /// to produce a stable, platform-safe directory name that is fully reversible
 /// (unlike the TS `sanitizePath` which just replaces chars with hyphens).
 pub fn transcript_dir(project_root: &Path) -> PathBuf {
+    transcript_dir_in(&crate::config::Settings::config_dir(), project_root)
+}
+
+/// Like [`transcript_dir`] but rooted at an explicit config directory instead
+/// of the detected `~/.claurst`. Lets tests stage transcripts in a tempdir
+/// without writing under HOME (unwritable in sandboxed builds).
+pub fn transcript_dir_in(config_dir: &Path, project_root: &Path) -> PathBuf {
     let encoded = URL_SAFE_NO_PAD.encode(project_root.to_string_lossy().as_bytes());
-    projects_dir().join(encoded)
+    config_dir.join("projects").join(encoded)
 }
 
 /// Returns the full path to a session's JSONL transcript file.
@@ -365,7 +372,16 @@ pub async fn load_transcript(path: &Path) -> crate::Result<Vec<TranscriptEntry>>
 /// For each file, a cheap tail-read extracts the `last-prompt` and
 /// `custom-title` metadata without loading the full transcript.
 pub async fn list_sessions(project_root: &Path) -> crate::Result<Vec<SessionSummary>> {
-    let dir = transcript_dir(project_root);
+    list_sessions_in(&crate::config::Settings::config_dir(), project_root).await
+}
+
+/// Like [`list_sessions`] but rooted at an explicit config directory. See
+/// [`transcript_dir_in`].
+pub async fn list_sessions_in(
+    config_dir: &Path,
+    project_root: &Path,
+) -> crate::Result<Vec<SessionSummary>> {
+    let dir = transcript_dir_in(config_dir, project_root);
 
     let mut dir_entries = match tokio::fs::read_dir(&dir).await {
         Ok(d) => d,
@@ -691,7 +707,7 @@ mod tests {
         let project_root = tmp.path().join("myproject");
         tokio::fs::create_dir_all(&project_root).await.unwrap();
 
-        let tdir = transcript_dir(&project_root);
+        let tdir = transcript_dir_in(tmp.path(), &project_root);
         tokio::fs::create_dir_all(&tdir).await.unwrap();
 
         for id in ["aaaa", "bbbb"] {
@@ -704,7 +720,7 @@ mod tests {
             tokio::time::sleep(std::time::Duration::from_millis(5)).await;
         }
 
-        let sessions = list_sessions(&project_root).await.unwrap();
+        let sessions = list_sessions_in(tmp.path(), &project_root).await.unwrap();
         assert_eq!(sessions.len(), 2);
         // Newest first.
         assert_eq!(sessions[0].session_id, "bbbb");

--- a/src-rust/crates/core/src/snapshot/shadow.rs
+++ b/src-rust/crates/core/src/snapshot/shadow.rs
@@ -33,15 +33,23 @@ impl ShadowSnapshot {
     /// Create a `ShadowSnapshot` for `working_dir`, or return `None` when
     /// git is not on PATH or the directory is not inside a git repository.
     pub fn for_session(working_dir: &Path) -> Option<Self> {
+        let data_root = dirs::data_dir()?.join("claurst").join("snapshot");
+        Self::for_session_in(working_dir, &data_root)
+    }
+
+    /// Like [`for_session`] but roots the shadow gitdir under an explicit
+    /// `data_root` instead of the user's data directory. Lets tests (and
+    /// sandboxed builds with no writable HOME) stage a hermetic snapshot
+    /// store in a tempdir rather than writing under `~/.claurst`.
+    pub fn for_session_in(working_dir: &Path, data_root: &Path) -> Option<Self> {
         if which::which("git").is_err() {
             warn!("snapshot: git not on PATH, disabled");
             return None;
         }
         let repo_root = find_repo_root(working_dir)?;
-        let data_dir = dirs::data_dir()?.join("claurst").join("snapshot");
         let project_hash = path_hash(&repo_root);
         let worktree_hash = path_hash(working_dir);
-        let gitdir = data_dir.join(project_hash).join(worktree_hash);
+        let gitdir = data_root.join(project_hash).join(worktree_hash);
         Some(Self {
             gitdir,
             worktree: working_dir.to_path_buf(),

--- a/src-rust/crates/core/tests/snapshot_tests.rs
+++ b/src-rust/crates/core/tests/snapshot_tests.rs
@@ -53,8 +53,20 @@ async fn git(dir: &Path, args: &[&str]) {
         .ok();
 }
 
+/// A process-wide tempdir that backs every shadow snapshot store in this test
+/// binary. Routing snapshots here keeps the tests hermetic: sandboxed builds
+/// (e.g. Nix) run with no HOME and disallow writes outside the build tree, so
+/// the real `dirs::data_dir()` location is unwritable. Each test uses a
+/// distinct repo tempdir, so the per-project/worktree hashes never collide.
+fn shadow_data_root() -> &'static Path {
+    use std::sync::OnceLock;
+    static ROOT: OnceLock<TempDir> = OnceLock::new();
+    ROOT.get_or_init(|| tempfile::tempdir().expect("shadow data tempdir"))
+        .path()
+}
+
 fn snap_or_skip(dir: &Path) -> ShadowSnapshot {
-    match ShadowSnapshot::for_session(dir) {
+    match ShadowSnapshot::for_session_in(dir, shadow_data_root()) {
         Some(s) => s,
         None => {
             eprintln!("git not available or not a repo; skipping test");

--- a/src-rust/crates/mcp/Cargo.toml
+++ b/src-rust/crates/mcp/Cargo.toml
@@ -29,3 +29,6 @@ chrono = { workspace = true }
 open = { workspace = true }
 urlencoding = { workspace = true }
 rmcp = { version = "1.4.0", default-features = false, features = ["client", "auth", "transport-child-process", "transport-streamable-http-client-reqwest", "reqwest-tls-no-provider"] }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/src-rust/crates/mcp/src/lib.rs
+++ b/src-rust/crates/mcp/src/lib.rs
@@ -1605,6 +1605,13 @@ mod tests {
 
     #[test]
     fn test_auth_state_uses_token_expiry_datetime() {
+        // Redirect the on-disk token store into a tempdir so this test never
+        // touches (or requires a writable) ~/.claurst. Sandboxed builds run
+        // with no HOME and disallow writes outside the build tree.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prev = std::env::var_os("CLAURST_MCP_TOKENS_DIR");
+        std::env::set_var("CLAURST_MCP_TOKENS_DIR", tmp.path());
+
         let mut mgr = McpManager::new();
         mgr.server_configs.insert(
             "remote".to_string(),
@@ -1640,6 +1647,11 @@ mod tests {
         }
 
         oauth::remove_mcp_token("remote").ok();
+
+        match prev {
+            Some(v) => std::env::set_var("CLAURST_MCP_TOKENS_DIR", v),
+            None => std::env::remove_var("CLAURST_MCP_TOKENS_DIR"),
+        }
     }
 }
 

--- a/src-rust/crates/mcp/src/oauth.rs
+++ b/src-rust/crates/mcp/src/oauth.rs
@@ -38,12 +38,24 @@ impl McpToken {
     }
 }
 
-/// Path to the token store for a given MCP server.
-fn token_path(server_name: &str) -> PathBuf {
+/// Directory holding the MCP OAuth token store.
+///
+/// Defaults to `~/.claurst/mcp-tokens`, but can be redirected with the
+/// `CLAURST_MCP_TOKENS_DIR` environment variable. The override lets tests run
+/// hermetically (and lets packagers/sandboxes relocate the store) without
+/// writing to the real HOME, which is unwritable in sandboxed builds.
+fn token_store_dir() -> PathBuf {
+    if let Some(dir) = std::env::var_os("CLAURST_MCP_TOKENS_DIR") {
+        return PathBuf::from(dir);
+    }
     dirs::home_dir()
         .unwrap_or_default()
         .join(".claurst/mcp-tokens")
-        .join(format!("{}.json", server_name))
+}
+
+/// Path to the token store for a given MCP server.
+fn token_path(server_name: &str) -> PathBuf {
+    token_store_dir().join(format!("{}.json", server_name))
 }
 
 /// Persist an MCP OAuth token to disk.

--- a/src-rust/crates/tools/src/todo_write.rs
+++ b/src-rust/crates/tools/src/todo_write.rs
@@ -4,7 +4,7 @@ use crate::{PermissionLevel, Tool, ToolContext, ToolResult};
 use async_trait::async_trait;
 use serde::Deserialize;
 use serde_json::{json, Value};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tracing::debug;
 
 // ---------------------------------------------------------------------------
@@ -13,17 +13,27 @@ use tracing::debug;
 
 /// Returns the path to the persisted todo list for `session_id`.
 pub fn todos_path(session_id: &str) -> PathBuf {
+    todos_dir().join(format!("{}.json", session_id))
+}
+
+/// Directory holding persisted todo lists (`~/.claurst/todos`).
+fn todos_dir() -> PathBuf {
     dirs::home_dir()
         .unwrap_or_default()
         .join(".claurst")
         .join("todos")
-        .join(format!("{}.json", session_id))
 }
 
 /// Load the persisted todo list for `session_id`. Returns an empty vec if the
 /// file does not exist or cannot be parsed.
 pub fn load_todos(session_id: &str) -> Vec<Value> {
-    let path = todos_path(session_id);
+    load_todos_in(&todos_dir(), session_id)
+}
+
+/// Like [`load_todos`] but reads from an explicit todos directory. Lets tests
+/// run hermetically without depending on a writable HOME.
+pub fn load_todos_in(dir: &Path, session_id: &str) -> Vec<Value> {
+    let path = dir.join(format!("{}.json", session_id));
     std::fs::read_to_string(&path)
         .ok()
         .and_then(|s| serde_json::from_str::<Vec<Value>>(&s).ok())
@@ -32,7 +42,13 @@ pub fn load_todos(session_id: &str) -> Vec<Value> {
 
 /// Persist `todos` to `~/.claurst/todos/<session_id>.json`.
 pub fn save_todos(session_id: &str, todos: &[Value]) {
-    let path = todos_path(session_id);
+    save_todos_in(&todos_dir(), session_id, todos);
+}
+
+/// Like [`save_todos`] but writes into an explicit todos directory. Lets tests
+/// run hermetically without depending on a writable HOME.
+pub fn save_todos_in(dir: &Path, session_id: &str, todos: &[Value]) {
+    let path = dir.join(format!("{}.json", session_id));
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
@@ -378,13 +394,13 @@ mod tests {
             json!({"id": "1", "content": "Task one", "status": "pending"}),
             json!({"id": "2", "content": "Task two", "status": "completed"}),
         ];
-        save_todos(&session_id, &todos);
-        let loaded = load_todos(&session_id);
+        let dir = tempfile::tempdir().expect("tempdir");
+        save_todos_in(dir.path(), &session_id, &todos);
+        let loaded = load_todos_in(dir.path(), &session_id);
         assert_eq!(loaded.len(), 2);
         assert_eq!(loaded[0]["id"].as_str(), Some("1"));
         assert_eq!(loaded[1]["status"].as_str(), Some("completed"));
-        // Clean up.
-        let _ = std::fs::remove_file(todos_path(&session_id));
+        // tempdir cleans up automatically.
     }
 
     // --- Status parsing ------------------------------------------------------

--- a/src-rust/crates/tui/src/osc8.rs
+++ b/src-rust/crates/tui/src/osc8.rs
@@ -51,9 +51,16 @@ pub struct UrlHit {
 }
 
 fn enabled() -> bool {
-    match std::env::var("CLAURST_NO_HYPERLINKS").as_deref() {
-        Ok(v) => !matches!(v.trim(), "1" | "true" | "yes" | "on"),
-        Err(_) => true,
+    enabled_for(std::env::var("CLAURST_NO_HYPERLINKS").ok().as_deref())
+}
+
+/// Pure decision split out from [`enabled`] so it can be unit-tested without
+/// mutating the process-global env var (which races with the URL-scan tests
+/// running in parallel and made them flaky).
+fn enabled_for(value: Option<&str>) -> bool {
+    match value {
+        Some(v) => !matches!(v.trim(), "1" | "true" | "yes" | "on"),
+        None => true,
     }
 }
 
@@ -306,22 +313,13 @@ mod tests {
 
     #[test]
     fn enabled_respects_env_var() {
-        // Save & restore the env var around the asserts so other tests don't
-        // observe stray state. (No #[serial] crate available here.)
-        let prev = std::env::var("CLAURST_NO_HYPERLINKS").ok();
-
-        std::env::remove_var("CLAURST_NO_HYPERLINKS");
-        assert!(enabled());
-
-        std::env::set_var("CLAURST_NO_HYPERLINKS", "1");
-        assert!(!enabled());
-
-        std::env::set_var("CLAURST_NO_HYPERLINKS", "0");
-        assert!(enabled());
-
-        match prev {
-            Some(v) => std::env::set_var("CLAURST_NO_HYPERLINKS", v),
-            None => std::env::remove_var("CLAURST_NO_HYPERLINKS"),
-        }
+        // Test the pure decision directly — no env mutation, so this can't
+        // race with the URL-scan tests running in parallel.
+        assert!(enabled_for(None));
+        assert!(!enabled_for(Some("1")));
+        assert!(!enabled_for(Some("true")));
+        assert!(!enabled_for(Some(" on ")));
+        assert!(enabled_for(Some("0")));
+        assert!(enabled_for(Some("")));
     }
 }


### PR DESCRIPTION
## Summary

Issue #176 reported ~10 test failures when building for Nix. This PR addresses the still-real subset: tests that performed I/O against the user's home/data directory at its real, detected location, which fails in a sandbox with no writable HOME and writes restricted to the build tree.

The named "test/implementation mismatch" failures the reporter listed are already fixed on `main` and pass locally:
- keybindings: `test_default_bindings_omit_ctrl_c_and_ctrl_d` (ctrl+c is intentionally omitted from `default_bindings()` and handled directly).
- onboarding: the default-page tests assert `ProviderSetup`/`Welcome` based on credentials.
- the render-snapshot tests all pass.

## What changed

Made the genuinely sandbox-fragile tests hermetic via explicit path injection (mirroring the existing `build_import_preview_with_paths` pattern), so they pass with no writable HOME and without writing outside a tempdir:

- **`session_storage`**: added `transcript_dir_in` / `list_sessions_in`; the public helpers delegate to them. The test stages transcripts in a tempdir.
- **`snapshot`**: added `ShadowSnapshot::for_session_in(working_dir, data_root)`; `for_session` delegates. The snapshot integration tests back the shadow store with a process-wide tempdir (each test uses a distinct repo tempdir, so per-project/worktree hashes never collide).
- **`mcp` / `oauth`**: `token_path` now honors `CLAURST_MCP_TOKENS_DIR` (default unchanged: `~/.claurst/mcp-tokens`). This lets the auth-state test — and packagers/sandboxes — relocate the token store off HOME.
- **`tools` / `todo_write`**: added `save_todos_in` / `load_todos_in`; the roundtrip test uses a tempdir.

Also fixed a pre-existing flaky test surfaced during investigation: `osc8::enabled_respects_env_var` mutated the process-global `CLAURST_NO_HYPERLINKS` var, racing with the URL-scan tests that run in parallel (it intermittently turned hyperlink scanning off mid-run). The decision is now a pure `enabled_for()` tested directly with no env mutation.

## Verification

- `cargo test --workspace` is green.
- Hermeticity verified by running the full suite with a read-only HOME (real `CARGO_HOME`/`RUSTUP_HOME`): **1428 passed, 0 failed** — previously 21 failed (session_storage 1, snapshot 18, mcp oauth 1, todo_write 1).

No version bump. No production behavior change except the additive `CLAURST_MCP_TOKENS_DIR` override.

Closes #176
