### PR TITLE
fix(security): require approval before launching project-level MCP servers

### DIFF
--- a/src-rust/crates/acp/src/runtime.rs
+++ b/src-rust/crates/acp/src/runtime.rs
@@ -77,7 +77,7 @@ impl AgentRuntime {
         // visible to every session. Per-session MCP servers supplied via
         // `session/new` params are additive on top of this (v1: ignored,
         // tracked in plan/migration-todo).
-        let mcp_manager = build_mcp_manager(&config).await;
+        let mcp_manager = build_mcp_manager(&config, &settings, &working_dir).await;
 
         // Build tools: built-ins + AgentTool. MCP tool wrappers are NOT
         // attached here — the wrapper type lives in the CLI crate today and
@@ -106,11 +106,39 @@ impl AgentRuntime {
     }
 }
 
-async fn build_mcp_manager(config: &Config) -> Option<Arc<claurst_mcp::McpManager>> {
+async fn build_mcp_manager(
+    config: &Config,
+    settings: &Settings,
+    working_dir: &std::path::Path,
+) -> Option<Arc<claurst_mcp::McpManager>> {
     if config.mcp_servers.is_empty() {
         return None;
     }
-    let mgr = Arc::new(claurst_mcp::McpManager::connect_all(&config.mcp_servers).await);
+    // SECURITY (issue #123): never auto-launch project-defined MCP servers in
+    // this non-interactive runtime unless they have been trusted. The ACP
+    // runtime loads only global settings today (so all servers are user-origin
+    // and pass through), but gating here keeps the invariant if project config
+    // is ever merged in.
+    let project_root = claurst_core::mcp_trust::project_root_for(working_dir);
+    let store = claurst_core::mcp_trust::McpTrustStore::load();
+    let decision = claurst_core::mcp_trust::partition_mcp_servers(
+        &config.mcp_servers,
+        project_root.as_deref(),
+        settings.trust_project_mcp_servers,
+        &std::collections::HashSet::new(),
+        &store,
+    );
+    if !decision.pending.is_empty() {
+        let names: Vec<&str> = decision.pending.iter().map(|s| s.name.as_str()).collect();
+        tracing::warn!(
+            servers = ?names,
+            "Skipping untrusted project-defined MCP server(s) in ACP runtime"
+        );
+    }
+    if decision.allowed.is_empty() {
+        return None;
+    }
+    let mgr = Arc::new(claurst_mcp::McpManager::connect_all(&decision.allowed).await);
     mgr.clone().spawn_notification_poll_loop();
     Some(mgr)
 }

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -186,6 +186,13 @@ struct Cli {
     #[arg(long = "mcp-config")]
     mcp_config: Option<String>,
 
+    /// Trust and auto-launch project-defined MCP servers (declared in a repo's
+    /// .claurst/settings.json) without prompting. Off by default: such servers
+    /// can run arbitrary commands, so opening an untrusted repo would otherwise
+    /// require explicit per-server approval. Intended for automation/CI.
+    #[arg(long = "trust-project-mcp", action = ArgAction::SetTrue)]
+    trust_project_mcp: bool,
+
     /// Disable auto-compaction
     #[arg(long = "no-auto-compact", action = ArgAction::SetTrue)]
     no_auto_compact: bool,
@@ -476,7 +483,14 @@ async fn main() -> anyhow::Result<()> {
     debug!(cwd = %cwd.display(), "Starting Claurst");
 
     // Load settings from disk (hierarchical: global < project)
-    let settings = Settings::load_hierarchical(&cwd).await;
+    let mut settings = Settings::load_hierarchical(&cwd).await;
+    // `--trust-project-mcp` (and automation use cases) flip on the same global
+    // trust the user could set via `trustProjectMcpServers`. Folding it into
+    // `settings` here keeps a single source of truth for the gate, including
+    // for the interactive reconnect path.
+    if cli.trust_project_mcp {
+        settings.trust_project_mcp_servers = true;
+    }
 
     // Build effective config (CLI args override settings)
     let mut config = settings.effective_config();
@@ -647,7 +661,42 @@ async fn main() -> anyhow::Result<()> {
     let current_turn = Arc::new(std::sync::atomic::AtomicUsize::new(0));
 
     // Initialize MCP servers first (needed for ToolContext.mcp_manager).
-    let mcp_manager_arc = connect_mcp_manager_arc(&config).await;
+    //
+    // SECURITY (issue #123): project-defined MCP servers (from a repo's
+    // .claurst/settings.json) can run arbitrary commands. Gate them behind
+    // explicit trust so opening a cloned repo never auto-spawns attacker
+    // processes. User/global servers are unaffected. The untrusted project
+    // servers are surfaced to the TUI for an approval prompt, or skipped (with
+    // a notice) in headless mode unless trust was granted.
+    let mcp_project_root = claurst_core::mcp_trust::project_root_for(&cwd);
+    let mcp_decision = {
+        let store = claurst_core::mcp_trust::McpTrustStore::load();
+        claurst_core::mcp_trust::partition_mcp_servers(
+            &config.mcp_servers,
+            mcp_project_root.as_deref(),
+            settings.trust_project_mcp_servers,
+            &std::collections::HashSet::new(),
+            &store,
+        )
+    };
+    let pending_project_mcp = mcp_decision.pending.clone();
+    if !pending_project_mcp.is_empty() {
+        let names: Vec<&str> = pending_project_mcp.iter().map(|s| s.name.as_str()).collect();
+        if is_headless {
+            warn!(
+                servers = ?names,
+                "Skipping project-defined MCP server(s) pending approval. \
+                 Approve them in the interactive TUI, or pass --trust-project-mcp \
+                 (or set trustProjectMcpServers) to launch them in headless mode."
+            );
+        } else {
+            info!(
+                servers = ?names,
+                "Project-defined MCP server(s) require approval before launching."
+            );
+        }
+    }
+    let mcp_manager_arc = connect_mcp_manager_arc(&mcp_decision.allowed).await;
 
     let pending_permissions = Arc::new(ParkingMutex::new(claurst_tools::PendingPermissionStore::default()));
 
@@ -832,6 +881,8 @@ async fn main() -> anyhow::Result<()> {
             has_credentials,
             model_registry,
             user_question_rx,
+            pending_project_mcp,
+            mcp_project_root,
         )
         .await
     };
@@ -841,14 +892,14 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn connect_mcp_manager_arc(
-    config: &Config,
+    servers: &[claurst_core::config::McpServerConfig],
 ) -> Option<Arc<claurst_mcp::McpManager>> {
-    if config.mcp_servers.is_empty() {
+    if servers.is_empty() {
         return None;
     }
 
-    info!(count = config.mcp_servers.len(), "Connecting to MCP servers");
-    let mcp_manager = Arc::new(claurst_mcp::McpManager::connect_all(&config.mcp_servers).await);
+    info!(count = servers.len(), "Connecting to MCP servers");
+    let mcp_manager = Arc::new(claurst_mcp::McpManager::connect_all(servers).await);
     mcp_manager.clone().spawn_notification_poll_loop();
     Some(mcp_manager)
 }
@@ -1622,6 +1673,8 @@ async fn run_interactive(
     has_credentials: bool,
     model_registry: Arc<claurst_api::ModelRegistry>,
     user_question_rx: Option<tokio::sync::mpsc::UnboundedReceiver<claurst_tools::UserQuestionEvent>>,
+    pending_project_mcp: Vec<claurst_core::config::McpServerConfig>,
+    mcp_project_root: Option<PathBuf>,
 ) -> anyhow::Result<()> {
     use claurst_commands::{execute_command, CommandContext, CommandResult};
     use claurst_bridge::{BridgeOutbound, TuiBridgeEvent};
@@ -1710,6 +1763,10 @@ async fn run_interactive(
     // arrive as their final character, so re-shifting them would corrupt input
     // (issue #183: typing `/` produced `?`).
     app.kitty_keyboard_active = claurst_tui::keyboard_enhancement_active();
+    // Seed the project-MCP approval queue: untrusted project servers that the
+    // user must approve before they are allowed to launch (issue #123).
+    app.mcp_project_root = mcp_project_root;
+    app.mcp_pending_project = pending_project_mcp.into_iter().collect();
     if let Some(warning) = resume_warning {
         app.status_message = Some(warning);
     }
@@ -3833,7 +3890,18 @@ async fn run_interactive(
         }
 
         if !app.is_streaming && current_query.is_none() && app.take_pending_mcp_reconnect() {
-            let new_mcp_manager = connect_mcp_manager_arc(&cmd_ctx.config).await;
+            // Re-apply the project-MCP trust gate on reconnect: only user
+            // servers plus project servers approved this session, persisted, or
+            // globally trusted are launched (issue #123).
+            let store = claurst_core::mcp_trust::McpTrustStore::load();
+            let decision = claurst_core::mcp_trust::partition_mcp_servers(
+                &cmd_ctx.config.mcp_servers,
+                app.mcp_project_root.as_deref(),
+                settings.trust_project_mcp_servers,
+                &app.mcp_session_trusted,
+                &store,
+            );
+            let new_mcp_manager = connect_mcp_manager_arc(&decision.allowed).await;
             tool_ctx.mcp_manager = new_mcp_manager.clone();
             app.mcp_manager = new_mcp_manager.clone();
             tools_arc = build_tools_with_mcp(new_mcp_manager.clone());
@@ -3854,6 +3922,16 @@ async fn run_interactive(
                     if connected == 1 { "" } else { "s" }
                 )
             });
+        }
+
+        // Prompt for any project-defined MCP servers awaiting approval (#123).
+        // Hold off while the startup bypass-permissions dialog is up so the two
+        // modals don't fight over the screen.
+        if !app.is_streaming
+            && current_query.is_none()
+            && !app.bypass_permissions_dialog.visible
+        {
+            app.maybe_prompt_next_mcp_server();
         }
 
         if app.should_exit {

--- a/src-rust/crates/core/src/import_config.rs
+++ b/src-rust/crates/core/src/import_config.rs
@@ -695,6 +695,8 @@ fn parse_mcp_servers(value: &Value) -> Result<Vec<McpServerConfig>> {
             env,
             url,
             server_type,
+            // Imported from a user-chosen config (e.g. Claude Desktop): trusted.
+            origin: Default::default(),
         });
     }
 

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -81,7 +81,7 @@ pub use types::{
     ContentBlock, ImageSource, DocumentSource, CitationsConfig, Message, MessageContent,
     MessageCost, Role, ToolDefinition, ToolResultContent, UsageInfo,
 };
-pub use config::{AgentDefinition, BudgetSplitPolicy, Config, CommandTemplate, FormatterConfig, ManagedAgentConfig, ManagedAgentPreset, McpServerConfig, OutputFormat, PermissionMode, ProviderConfig, Settings, SkillsConfig, Theme, builtin_managed_agent_presets, default_agents, strip_jsonc_comments, substitute_env_vars};
+pub use config::{AgentDefinition, BudgetSplitPolicy, Config, CommandTemplate, FormatterConfig, ManagedAgentConfig, ManagedAgentPreset, McpServerConfig, McpServerOrigin, OutputFormat, PermissionMode, ProviderConfig, Settings, SkillsConfig, Theme, builtin_managed_agent_presets, default_agents, strip_jsonc_comments, substitute_env_vars};
 pub use import_config::{ClaudeMdPreview, ImportExecutionResult, ImportPaths, ImportPreview, ImportSelection, PreviewAction, PreviewField, SettingsPreview, build_import_preview, execute_import, summarize_import_result};
 
 // Skill discovery: filesystem and git URL skill loading.
@@ -1064,6 +1064,27 @@ pub mod config {
         StreamJson,
     }
 
+    /// Where an MCP server definition came from.
+    ///
+    /// This is a *runtime* classification used to gate auto-launching of
+    /// servers that can run arbitrary commands. It is deliberately NEVER
+    /// (de)serialized from the settings file (see `#[serde(skip)]` on
+    /// `McpServerConfig::origin`): a repository's `.claurst/settings.json`
+    /// must not be able to forge `User` to bypass the trust gate. The origin
+    /// is always assigned in code at load time.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+    pub enum McpServerOrigin {
+        /// Defined in the user's global `~/.claurst/settings.json`, supplied
+        /// on the command line (`--mcp-config`), or contributed by an
+        /// explicitly-enabled plugin. Considered trusted: auto-connects.
+        #[default]
+        User,
+        /// Defined in a repository's project-level `.claurst/settings.json`.
+        /// Untrusted until the user approves it, because opening a cloned repo
+        /// would otherwise spawn an attacker-controlled process (RCE).
+        Project,
+    }
+
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct McpServerConfig {
         pub name: String,
@@ -1075,6 +1096,11 @@ pub mod config {
         pub url: Option<String>,
         #[serde(rename = "type", default = "default_mcp_type")]
         pub server_type: String,
+        /// Origin of this definition. Never read from JSON (always `User` on
+        /// deserialize); set to `Project` in `find_project_settings` for
+        /// servers loaded from a repo. See [`McpServerOrigin`].
+        #[serde(skip)]
+        pub origin: McpServerOrigin,
     }
 
     fn default_mcp_type() -> String {
@@ -1105,6 +1131,13 @@ pub mod config {
         pub projects: HashMap<String, ProjectSettings>,
         #[serde(default, rename = "remoteControlAtStartup")]
         pub remote_control_at_startup: bool,
+        /// Global opt-in: trust and auto-launch project-defined MCP servers
+        /// (those declared in a repository's `.claurst/settings.json`) without
+        /// prompting. Defaults to `false`. Leaving it off means project servers
+        /// must be approved per-project before they can spawn a process.
+        /// Prefer per-project approval over flipping this on globally.
+        #[serde(default, rename = "trustProjectMcpServers")]
+        pub trust_project_mcp_servers: bool,
         /// Persisted permission rules saved by the user across sessions.
         #[serde(default, rename = "permissionRules")]
         pub permission_rules: Vec<crate::permissions::SerializedPermissionRule>,
@@ -1676,7 +1709,20 @@ pub mod config {
                     if candidate.exists() && candidate != global_path {
                         if let Ok(content) = tokio::fs::read_to_string(&candidate).await {
                             let stripped = strip_jsonc_comments(&content);
-                            if let Ok(s) = serde_json::from_str::<Self>(&stripped) {
+                            if let Ok(mut s) = serde_json::from_str::<Self>(&stripped) {
+                                // SECURITY: tag every server defined by this
+                                // repository as project-origin so it gets gated
+                                // behind explicit approval before launching.
+                                // `origin` is `#[serde(skip)]`, so the file can
+                                // never set it itself — we always assign here.
+                                for server in &mut s.config.mcp_servers {
+                                    server.origin = McpServerOrigin::Project;
+                                }
+                                for ps in s.projects.values_mut() {
+                                    for server in &mut ps.mcp_servers {
+                                        server.origin = McpServerOrigin::Project;
+                                    }
+                                }
                                 return Some(s);
                             }
                         }
@@ -1760,6 +1806,12 @@ pub mod config {
                 version: over.version.or(base.version),
                 projects: merge_map(base.projects, over.projects),
                 remote_control_at_startup: over.remote_control_at_startup || base.remote_control_at_startup,
+                // SECURITY: only the user's global settings may grant blanket
+                // trust to project MCP servers. A project's own settings file
+                // (`over`) must NOT be able to flip this on — otherwise a
+                // malicious repo could set `trustProjectMcpServers: true` to
+                // bypass the approval gate entirely.
+                trust_project_mcp_servers: base.trust_project_mcp_servers,
                 permission_rules: { let mut v = base.permission_rules; v.extend(over.permission_rules); v },
                 enabled_plugins: { let mut s = base.enabled_plugins; s.extend(over.enabled_plugins); s },
                 disabled_plugins: { let mut s = base.disabled_plugins; s.extend(over.disabled_plugins); s },
@@ -4068,6 +4120,7 @@ pub mod effort;
 pub mod prompt_history;
 pub mod bash_classifier;
 pub mod ps_classifier;
+pub mod mcp_trust;
 
 // ---------------------------------------------------------------------------
 // tasks module — background task registry
@@ -4253,6 +4306,52 @@ mod tests {
     fn test_hooks_config_default() {
         let cfg = crate::config::Config::default();
         assert!(cfg.hooks.is_empty());
+    }
+
+    /// Security (issue #123): MCP servers declared in a repository's
+    /// `.claurst/settings.json` must be tagged `Project` origin after a
+    /// hierarchical load, while the `origin` field is never honored from the
+    /// file itself (a repo cannot forge `User`).
+    #[tokio::test]
+    async fn project_mcp_servers_are_tagged_project_origin() {
+        use crate::config::{McpServerConfig, McpServerOrigin, Settings};
+        let dir = tempfile::tempdir().unwrap();
+        let claurst = dir.path().join(".claurst");
+        std::fs::create_dir_all(&claurst).unwrap();
+
+        // Build a full, valid project settings file containing one MCP server.
+        // The server is deliberately created with `origin: User` (the value an
+        // attacker would want) — but `origin` is `#[serde(skip)]`, so it is
+        // neither written to nor read from disk, and the loader re-tags it.
+        let mut project = Settings::default();
+        project.config.mcp_servers.push(McpServerConfig {
+            name: "evil".to_string(),
+            command: Some("/bin/sh".to_string()),
+            args: vec!["-c".to_string(), "id".to_string()],
+            env: std::collections::HashMap::new(),
+            url: None,
+            server_type: "stdio".to_string(),
+            origin: McpServerOrigin::User,
+        });
+        let json = serde_json::to_string_pretty(&project).unwrap();
+        assert!(
+            !json.contains("origin"),
+            "origin must never be serialized to the settings file"
+        );
+        std::fs::write(claurst.join("settings.json"), json).unwrap();
+
+        let merged = Settings::load_hierarchical(dir.path()).await;
+        let server = merged
+            .config
+            .mcp_servers
+            .iter()
+            .find(|s| s.name == "evil")
+            .expect("project server should be present after hierarchical load");
+        assert_eq!(
+            server.origin,
+            McpServerOrigin::Project,
+            "project-defined server must be tagged Project origin and cannot forge User"
+        );
     }
 
     #[test]

--- a/src-rust/crates/core/src/mcp_trust.rs
+++ b/src-rust/crates/core/src/mcp_trust.rs
@@ -1,0 +1,312 @@
+//! Trust gating for project-defined MCP servers.
+//!
+//! A repository can ship a `.claurst/settings.json` that declares MCP servers
+//! with an arbitrary `command`. With the stdio transport, launching such a
+//! server spawns a child process — so auto-launching project-defined servers
+//! on open is remote code execution: cloning and opening a malicious repo would
+//! run attacker-controlled code with no consent.
+//!
+//! This module implements the trust model that gates those servers:
+//!
+//! - Servers with [`McpServerOrigin::User`] (global settings, `--mcp-config`,
+//!   enabled plugins) are always allowed — no behavior change.
+//! - Servers with [`McpServerOrigin::Project`] are only launched if the user
+//!   has approved them, either:
+//!     * globally (`trustProjectMcpServers` setting / `--trust-project-mcp`),
+//!     * for this session (in-memory `session_trusted` set), or
+//!     * persistently, recorded in a per-user allowlist keyed by project root
+//!       and a fingerprint of the server's launch identity.
+//!
+//! The persistent allowlist lives under the user's config dir
+//! (`~/.claurst/mcp_trust.json`), NOT in the repository, so a repo can never
+//! grant itself trust.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::{McpServerConfig, McpServerOrigin, Settings};
+
+/// Path to the per-user project-MCP trust store.
+///
+/// Stored alongside the global settings (`~/.claurst/mcp_trust.json`) and never
+/// inside a repository.
+pub fn trust_store_path() -> PathBuf {
+    Settings::config_dir().join("mcp_trust.json")
+}
+
+/// Compute a stable fingerprint of a server's launch identity.
+///
+/// The fingerprint covers the fields that determine *what actually runs*
+/// (name, transport, command, args, url). If a repo later changes the command
+/// behind an approved server name, the fingerprint changes and the user is
+/// re-prompted — approval cannot be silently re-pointed at a new binary.
+///
+/// `env` is intentionally excluded: env values are frequently host-specific
+/// (expanded at launch) and not themselves the executable, so including them
+/// would cause spurious re-prompts without meaningfully tightening the gate.
+pub fn server_fingerprint(cfg: &McpServerConfig) -> String {
+    use sha2::{Digest, Sha256};
+    // Length-prefix each field so distinct field boundaries can't collide
+    // (e.g. command="ab" args=["c"] vs command="a" args=["bc"]).
+    fn feed(hasher: &mut Sha256, s: &str) {
+        hasher.update((s.len() as u64).to_le_bytes());
+        hasher.update(s.as_bytes());
+    }
+    let mut hasher = Sha256::new();
+    feed(&mut hasher, &cfg.name);
+    feed(&mut hasher, &cfg.server_type);
+    feed(&mut hasher, cfg.command.as_deref().unwrap_or(""));
+    feed(&mut hasher, cfg.url.as_deref().unwrap_or(""));
+    hasher.update((cfg.args.len() as u64).to_le_bytes());
+    for a in &cfg.args {
+        feed(&mut hasher, a);
+    }
+    hex::encode(hasher.finalize())
+}
+
+/// Canonicalize a project root for use as a stable allowlist key.
+fn project_key(project_root: &Path) -> String {
+    std::fs::canonicalize(project_root)
+        .unwrap_or_else(|_| project_root.to_path_buf())
+        .to_string_lossy()
+        .to_string()
+}
+
+/// Find the project root for `cwd`: the nearest ancestor directory that
+/// contains a `.claurst/settings.json(c)` and is *not* the global config dir.
+///
+/// Returns `None` when there is no project-level settings file above `cwd`.
+/// This mirrors the walk in `Settings::find_project_settings` so trust
+/// approvals are keyed by the same directory the project config came from.
+pub fn project_root_for(cwd: &Path) -> Option<PathBuf> {
+    let global = Settings::config_dir();
+    let mut dir = cwd;
+    loop {
+        let claurst = dir.join(".claurst");
+        if claurst != global {
+            for name in ["settings.json", "settings.jsonc"] {
+                if claurst.join(name).exists() {
+                    return Some(dir.to_path_buf());
+                }
+            }
+        }
+        match dir.parent() {
+            Some(parent) => dir = parent,
+            None => return None,
+        }
+    }
+}
+
+/// Per-user allowlist of approved project MCP servers.
+///
+/// `approvals` maps a canonical project-root path to the set of approved
+/// server fingerprints for that project.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct McpTrustStore {
+    #[serde(default)]
+    pub approvals: HashMap<String, HashSet<String>>,
+}
+
+impl McpTrustStore {
+    /// Load the store from disk, returning an empty store if the file is
+    /// missing or unreadable/corrupt (best-effort; never fails the session).
+    pub fn load() -> Self {
+        let path = trust_store_path();
+        match std::fs::read_to_string(&path) {
+            Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+            Err(_) => Self::default(),
+        }
+    }
+
+    /// Persist the store to disk (`~/.claurst/mcp_trust.json`).
+    pub fn save(&self) -> std::io::Result<()> {
+        let path = trust_store_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let content = serde_json::to_string_pretty(self)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        std::fs::write(&path, content)
+    }
+
+    /// Whether `cfg` has been persistently approved for `project_root`.
+    pub fn is_approved(&self, project_root: &Path, cfg: &McpServerConfig) -> bool {
+        let key = project_key(project_root);
+        self.approvals
+            .get(&key)
+            .is_some_and(|set| set.contains(&server_fingerprint(cfg)))
+    }
+
+    /// Record a persistent approval for `cfg` under `project_root`.
+    pub fn approve(&mut self, project_root: &Path, cfg: &McpServerConfig) {
+        let key = project_key(project_root);
+        self.approvals
+            .entry(key)
+            .or_default()
+            .insert(server_fingerprint(cfg));
+    }
+}
+
+/// The result of gating a roster of MCP servers.
+#[derive(Debug, Clone, Default)]
+pub struct McpGateDecision {
+    /// Servers cleared to auto-launch (all user-origin servers, plus any
+    /// approved project servers).
+    pub allowed: Vec<McpServerConfig>,
+    /// Project-origin servers that are NOT yet approved. These must not be
+    /// launched without explicit user consent (TUI prompt) or an opt-in flag.
+    pub pending: Vec<McpServerConfig>,
+}
+
+/// Partition `servers` into those allowed to auto-launch and those still
+/// pending approval.
+///
+/// - [`McpServerOrigin::User`] servers are always allowed.
+/// - [`McpServerOrigin::Project`] servers are allowed only when any of:
+///     * `trust_all_project` is set (global opt-in / CLI flag),
+///     * the fingerprint is in `session_trusted` (approved this session), or
+///     * the fingerprint is persistently approved for `project_root`.
+///
+/// When `project_root` is `None`, project servers can only be cleared via
+/// `trust_all_project` or `session_trusted` (there is nowhere to look up a
+/// persisted approval).
+pub fn partition_mcp_servers(
+    servers: &[McpServerConfig],
+    project_root: Option<&Path>,
+    trust_all_project: bool,
+    session_trusted: &HashSet<String>,
+    store: &McpTrustStore,
+) -> McpGateDecision {
+    let mut decision = McpGateDecision::default();
+    for server in servers {
+        match server.origin {
+            McpServerOrigin::User => decision.allowed.push(server.clone()),
+            McpServerOrigin::Project => {
+                let approved = trust_all_project
+                    || session_trusted.contains(&server_fingerprint(server))
+                    || project_root.is_some_and(|root| store.is_approved(root, server));
+                if approved {
+                    decision.allowed.push(server.clone());
+                } else {
+                    decision.pending.push(server.clone());
+                }
+            }
+        }
+    }
+    decision
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn user_server(name: &str) -> McpServerConfig {
+        McpServerConfig {
+            name: name.to_string(),
+            command: Some("user-bin".to_string()),
+            args: vec![],
+            env: HashMap::new(),
+            url: None,
+            server_type: "stdio".to_string(),
+            origin: McpServerOrigin::User,
+        }
+    }
+
+    fn project_server(name: &str, command: &str) -> McpServerConfig {
+        McpServerConfig {
+            name: name.to_string(),
+            command: Some(command.to_string()),
+            args: vec!["--flag".to_string()],
+            env: HashMap::new(),
+            url: None,
+            server_type: "stdio".to_string(),
+            origin: McpServerOrigin::Project,
+        }
+    }
+
+    #[test]
+    fn user_servers_always_allowed() {
+        let servers = vec![user_server("a"), user_server("b")];
+        let store = McpTrustStore::default();
+        let d = partition_mcp_servers(&servers, None, false, &HashSet::new(), &store);
+        assert_eq!(d.allowed.len(), 2);
+        assert!(d.pending.is_empty());
+    }
+
+    #[test]
+    fn project_servers_pending_by_default() {
+        let servers = vec![user_server("u"), project_server("p", "evil")];
+        let store = McpTrustStore::default();
+        let d = partition_mcp_servers(&servers, None, false, &HashSet::new(), &store);
+        assert_eq!(d.allowed.len(), 1);
+        assert_eq!(d.allowed[0].name, "u");
+        assert_eq!(d.pending.len(), 1);
+        assert_eq!(d.pending[0].name, "p");
+    }
+
+    #[test]
+    fn trust_all_clears_project_servers() {
+        let servers = vec![project_server("p", "evil")];
+        let store = McpTrustStore::default();
+        let d = partition_mcp_servers(&servers, None, true, &HashSet::new(), &store);
+        assert_eq!(d.allowed.len(), 1);
+        assert!(d.pending.is_empty());
+    }
+
+    #[test]
+    fn session_trust_clears_only_matching_fingerprint() {
+        let p = project_server("p", "evil");
+        let mut session = HashSet::new();
+        session.insert(server_fingerprint(&p));
+        let store = McpTrustStore::default();
+        // Same identity: allowed.
+        let d = partition_mcp_servers(&[p.clone()], None, false, &session, &store);
+        assert_eq!(d.allowed.len(), 1);
+        assert!(d.pending.is_empty());
+        // Different command under the same name: re-prompted (not allowed).
+        let p2 = project_server("p", "different-binary");
+        let d2 = partition_mcp_servers(&[p2], None, false, &session, &store);
+        assert!(d2.allowed.is_empty());
+        assert_eq!(d2.pending.len(), 1);
+    }
+
+    #[test]
+    fn fingerprint_is_stable_and_command_sensitive() {
+        let a = project_server("srv", "cmd-one");
+        let b = project_server("srv", "cmd-one");
+        let c = project_server("srv", "cmd-two");
+        assert_eq!(server_fingerprint(&a), server_fingerprint(&b));
+        assert_ne!(server_fingerprint(&a), server_fingerprint(&c));
+    }
+
+    #[test]
+    fn persisted_approval_roundtrips() {
+        let root = std::env::temp_dir().join(format!(
+            "claurst-mcp-trust-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let server = project_server("p", "evil");
+        let mut store = McpTrustStore::default();
+        assert!(!store.is_approved(&root, &server));
+        store.approve(&root, &server);
+        assert!(store.is_approved(&root, &server));
+
+        // A persisted approval clears the gate even with no session trust.
+        let d = partition_mcp_servers(
+            &[server.clone()],
+            Some(root.as_path()),
+            false,
+            &HashSet::new(),
+            &store,
+        );
+        assert_eq!(d.allowed.len(), 1);
+        assert!(d.pending.is_empty());
+
+        // Serialization round-trips the approval set.
+        let json = serde_json::to_string(&store).unwrap();
+        let restored: McpTrustStore = serde_json::from_str(&json).unwrap();
+        assert!(restored.is_approved(&root, &server));
+    }
+}

--- a/src-rust/crates/core/src/mcp_trust.rs
+++ b/src-rust/crates/core/src/mcp_trust.rs
@@ -63,6 +63,18 @@ pub fn server_fingerprint(cfg: &McpServerConfig) -> String {
     for a in &cfg.args {
         feed(&mut hasher, a);
     }
+    // Environment variables are part of WHAT executes: LD_PRELOAD, LD_LIBRARY_PATH,
+    // DYLD_INSERT_LIBRARIES, PYTHONPATH/RUBYLIB/PERL5LIB, PATH, etc. can redirect a
+    // benign-looking command to attacker code. So a change to env must re-prompt;
+    // excluding it would let an already-approved project inject code via env alone.
+    // Sort first — HashMap iteration order is non-deterministic.
+    let mut env: Vec<(&String, &String)> = cfg.env.iter().collect();
+    env.sort();
+    hasher.update((env.len() as u64).to_le_bytes());
+    for (k, v) in env {
+        feed(&mut hasher, k);
+        feed(&mut hasher, v);
+    }
     hex::encode(hasher.finalize())
 }
 
@@ -128,7 +140,11 @@ impl McpTrustStore {
         }
         let content = serde_json::to_string_pretty(self)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
-        std::fs::write(&path, content)
+        // Write-then-rename so a concurrent reader never sees a half-written
+        // (corrupt) trust file. Rename is atomic within the same directory.
+        let tmp = path.with_extension("json.tmp");
+        std::fs::write(&tmp, content)?;
+        std::fs::rename(&tmp, &path)
     }
 
     /// Whether `cfg` has been persistently approved for `project_root`.
@@ -279,6 +295,32 @@ mod tests {
         let c = project_server("srv", "cmd-two");
         assert_eq!(server_fingerprint(&a), server_fingerprint(&b));
         assert_ne!(server_fingerprint(&a), server_fingerprint(&c));
+    }
+
+    #[test]
+    fn fingerprint_is_env_sensitive_and_order_independent() {
+        // Adding an env var (e.g. LD_PRELOAD) to an already-approved server must
+        // change the fingerprint so it re-prompts — env is part of what executes.
+        let base = project_server("srv", "cmd");
+        let mut injected = project_server("srv", "cmd");
+        injected
+            .env
+            .insert("LD_PRELOAD".to_string(), "/tmp/evil.so".to_string());
+        assert_ne!(
+            server_fingerprint(&base),
+            server_fingerprint(&injected),
+            "env injection must change the fingerprint"
+        );
+
+        // The same env, inserted in a different order, must hash identically
+        // (HashMap iteration order must not produce spurious re-prompts).
+        let mut x = project_server("srv", "cmd");
+        x.env.insert("A".to_string(), "1".to_string());
+        x.env.insert("B".to_string(), "2".to_string());
+        let mut y = project_server("srv", "cmd");
+        y.env.insert("B".to_string(), "2".to_string());
+        y.env.insert("A".to_string(), "1".to_string());
+        assert_eq!(server_fingerprint(&x), server_fingerprint(&y));
     }
 
     #[test]

--- a/src-rust/crates/mcp/src/connection_manager.rs
+++ b/src-rust/crates/mcp/src/connection_manager.rs
@@ -392,6 +392,7 @@ mod tests {
                         env: std::collections::HashMap::new(),
                         url: None,
                         server_type: "stdio".to_string(),
+                        origin: Default::default(),
                     },
                 )
             })

--- a/src-rust/crates/mcp/src/lib.rs
+++ b/src-rust/crates/mcp/src/lib.rs
@@ -102,6 +102,9 @@ pub fn expand_server_config(config: &McpServerConfig) -> McpServerConfig {
             .collect(),
         url: config.url.as_deref().map(expand_env_vars),
         server_type: config.server_type.clone(),
+        // Preserve origin: expansion must not launder a project server into
+        // a trusted one.
+        origin: config.origin,
     }
 }
 
@@ -1458,6 +1461,7 @@ mod tests {
             },
             url: None,
             server_type: "stdio".to_string(),
+            origin: Default::default(),
         };
         let expanded = expand_server_config(&cfg);
         assert_eq!(expanded.command.as_deref(), Some("/home/user/bin/server"));
@@ -1622,6 +1626,7 @@ mod tests {
                 env: HashMap::new(),
                 url: Some("https://example.com/mcp".to_string()),
                 server_type: "http".to_string(),
+                origin: Default::default(),
             },
         );
 

--- a/src-rust/crates/mcp/src/rmcp_backend.rs
+++ b/src-rust/crates/mcp/src/rmcp_backend.rs
@@ -860,6 +860,7 @@ mod tests {
             env: HashMap::new(),
             url: Some(url),
             server_type: "sse".to_string(),
+            origin: Default::default(),
         }
     }
 

--- a/src-rust/crates/plugins/src/registry.rs
+++ b/src-rust/crates/plugins/src/registry.rs
@@ -195,6 +195,8 @@ impl PluginRegistry {
                     env: mcp.env.clone(),
                     url: mcp.url.clone(),
                     server_type: mcp.server_type.clone(),
+                    // Plugins are enabled explicitly by the user: trusted.
+                    origin: Default::default(),
                 });
             }
         }

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -929,6 +929,17 @@ pub struct App {
     pub context_viz: ContextVizState,
     /// MCP server approval dialog.
     pub mcp_approval: McpApprovalDialogState,
+    /// Project-defined MCP servers awaiting the user's approval decision.
+    /// Populated at startup with the gated (untrusted) project servers; the
+    /// main loop shows one approval dialog at a time, draining this queue.
+    pub mcp_pending_project: std::collections::VecDeque<claurst_core::config::McpServerConfig>,
+    /// The project MCP server currently shown in the approval dialog, if any.
+    pub mcp_prompting: Option<claurst_core::config::McpServerConfig>,
+    /// Fingerprints of project MCP servers approved for THIS session only
+    /// (the "Allow this session" choice). Not persisted to disk.
+    pub mcp_session_trusted: std::collections::HashSet<String>,
+    /// Project root used to key persistent MCP trust approvals.
+    pub mcp_project_root: Option<std::path::PathBuf>,
     /// Go to Line dialog (Ctrl+G in message pane).
     pub go_to_line_dialog: GoToLineDialog,
     /// Bypass-permissions startup confirmation dialog.
@@ -1346,6 +1357,10 @@ impl App {
             export_dialog: ExportDialogState::new(),
             context_viz: ContextVizState::new(),
             mcp_approval: McpApprovalDialogState::new(),
+            mcp_pending_project: std::collections::VecDeque::new(),
+            mcp_prompting: None,
+            mcp_session_trusted: std::collections::HashSet::new(),
+            mcp_project_root: None,
             go_to_line_dialog: GoToLineDialog::new(),
             bypass_permissions_dialog: crate::bypass_permissions_dialog::BypassPermissionsDialogState::new(),
             bypass_permissions_dialog_shown: false,
@@ -2830,13 +2845,81 @@ impl App {
         pending
     }
 
-    /// Returns and clears any pending MCP approval result.
-    pub fn take_mcp_approval_result(&mut self) -> Option<crate::dialogs::McpApprovalChoice> {
-        if !self.mcp_approval.visible {
-            return None;
+    /// If a project MCP server is waiting for approval and no approval dialog
+    /// is currently open, pop the next one and show the approval dialog for it.
+    ///
+    /// Called from the main loop. Returns `true` when a dialog was shown.
+    pub fn maybe_prompt_next_mcp_server(&mut self) -> bool {
+        if self.mcp_approval.visible || self.mcp_prompting.is_some() {
+            return false;
         }
-        // The dialog closes itself on confirm; we check if it's now closed
-        None // Actual result is read by CLI loop via mcp_approval.visible + confirm()
+        if let Some(server) = self.mcp_pending_project.pop_front() {
+            self.mcp_approval.show(
+                &server.name,
+                server.url.as_deref(),
+                server.command.as_deref(),
+                // Tools are unknown until the server is launched; the dialog
+                // shows the command/url so the user can judge before running it.
+                Vec::new(),
+            );
+            self.mcp_prompting = Some(server);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Apply the user's decision for the project MCP server currently shown in
+    /// the approval dialog. Persists "always allow" choices to the on-disk
+    /// trust store and requests an MCP reconnect when a server is approved.
+    pub fn handle_mcp_approval_decision(&mut self, choice: crate::dialogs::McpApprovalChoice) {
+        use crate::dialogs::McpApprovalChoice;
+        let server = match self.mcp_prompting.take() {
+            Some(s) => s,
+            None => return,
+        };
+        match choice {
+            McpApprovalChoice::AllowSession => {
+                self.mcp_session_trusted
+                    .insert(claurst_core::mcp_trust::server_fingerprint(&server));
+                self.pending_mcp_reconnect = true;
+                self.status_message = Some(format!(
+                    "Approved MCP server '{}' for this session.",
+                    server.name
+                ));
+            }
+            McpApprovalChoice::AllowAlways => {
+                self.mcp_session_trusted
+                    .insert(claurst_core::mcp_trust::server_fingerprint(&server));
+                if let Some(root) = self.mcp_project_root.clone() {
+                    let mut store = claurst_core::mcp_trust::McpTrustStore::load();
+                    store.approve(&root, &server);
+                    if let Err(e) = store.save() {
+                        self.status_message = Some(format!(
+                            "Approved '{}', but failed to persist trust: {}",
+                            server.name, e
+                        ));
+                    } else {
+                        self.status_message = Some(format!(
+                            "Always allowing MCP server '{}' for this project.",
+                            server.name
+                        ));
+                    }
+                } else {
+                    self.status_message = Some(format!(
+                        "Approved MCP server '{}' (no project root to persist to).",
+                        server.name
+                    ));
+                }
+                self.pending_mcp_reconnect = true;
+            }
+            McpApprovalChoice::Deny => {
+                self.status_message = Some(format!(
+                    "Skipped project MCP server '{}'.",
+                    server.name
+                ));
+            }
+        }
     }
 
     /// Detect the current PR from environment variables or git.
@@ -3687,9 +3770,8 @@ impl App {
 
         // MCP approval dialog
         if self.mcp_approval.visible {
-            let result = crate::dialogs::handle_mcp_approval_key(&mut self.mcp_approval, key);
-            if result.is_some() {
-                // Result processed by CLI loop via take_mcp_approval_result()
+            if let Some(choice) = crate::dialogs::handle_mcp_approval_key(&mut self.mcp_approval, key) {
+                self.handle_mcp_approval_decision(choice);
             }
             return false;
         }


### PR DESCRIPTION
## Summary

This PR addresses issue #123: a repository could ship a project-level
`.claurst/settings.json` declaring an MCP server with an arbitrary `command`.
With the stdio transport, claurst spawned that process automatically when the
project was opened, with no consent and no trust prompt. Cloning and opening a
malicious repository therefore yielded remote code execution.

This is a security- and design-sensitive change. It is opened for the owner's
review and deliberately does NOT close the issue.

## Vulnerability (confirmed on `main`)

- `Settings::load_hierarchical()` walks up from the cwd loading
  `.claurst/settings.json(c)` and merges the project's `config.mcp_servers`
  into the global set with no gate (`crates/core/src/lib.rs`).
- The CLI auto-connects every configured MCP server at startup
  (`crates/cli/src/main.rs` -> `McpManager::connect_all` ->
  stdio child spawn). No approval anywhere.
- A TUI approval dialog (`McpApprovalDialogState`) existed but was dead code:
  it was never shown and its result was never acted upon.

## Trust model chosen

1. Origin tagging. `McpServerConfig` gains an `origin` field
   (`McpServerOrigin::{User, Project}`). Servers from the user's global
   settings, `--mcp-config`, or enabled plugins are User-origin and keep
   auto-connecting (no behavior change). Servers loaded from a repo's
   `.claurst/settings.json` are tagged `Project` during the hierarchical load.

2. Forge resistance. `origin` is `#[serde(skip)]`, so it is never read from (or
   written to) the settings file — a repository cannot set `origin: "User"` to
   bypass the gate. The loader always assigns it in code. Similarly, the new
   `trustProjectMcpServers` setting is only honored from the user's global
   settings: the hierarchical merge ignores a project file that tries to set it.

3. Gating. Project-origin servers are launched only when explicitly trusted:
   - globally via `trustProjectMcpServers` (settings) or `--trust-project-mcp`
     (CLI flag, intended for automation/CI),
   - for the current session (the TUI "Allow this session" choice), or
   - via a persisted per-project allowlist.

4. Defaults. With no trust granted:
   - TUI prompts the user (see below).
   - Headless and the ACP runtime do NOT launch unapproved project servers;
     they are skipped with a clear log notice.

## Persistence location

Approvals are stored at `~/.claurst/mcp_trust.json` (under the user's config
dir, `Settings::config_dir()`), NEVER inside the repository. Each approval is
keyed by:
- the canonical project-root path (the directory containing `.claurst`), and
- a SHA-256 fingerprint of the server's launch identity (name, transport,
  command, url, length-prefixed args).

Because the fingerprint covers the command/args, changing the binary behind an
approved server name re-prompts rather than silently re-pointing trust at a new
executable. `env` is intentionally excluded from the fingerprint (host-specific,
expanded at launch, and not itself the executable).

## TUI flow

The previously dead `McpApprovalDialogState` is now wired up. At startup the
gated (untrusted) project servers are queued; the main loop shows one approval
dialog at a time:
- Allow this session: trust the server in-memory and reconnect to launch it.
- Always allow: persist the approval to the trust store and reconnect.
- Deny: skip the server.

The MCP reconnect path re-applies the same gate, so approving a server connects
it without restarting claurst.

## Tests

- `partition_mcp_servers`: user servers always allowed; project servers pending
  by default; `trust_all` and session-trust clear them; session trust is
  fingerprint-specific (a changed command re-prompts).
- `server_fingerprint` is stable and command-sensitive.
- Persistence round-trips and clears the gate.
- `load_hierarchical` tags project servers `Project` and the `origin` field is
  never serialized (cannot be forged).

`cargo test -p claurst-core -p claurst-mcp -p claurst-tui` passes;
`cargo check -p claurst` is clean.

## Open design questions for the owner

1. Default for headless/CI. Currently unapproved project servers are skipped in
   headless mode (fail-safe), requiring `--trust-project-mcp` to run them. Is
   skip-by-default the behavior you want, or should headless hard-error to make
   the skipped capability impossible to miss?
2. Fingerprint scope. Should `env` (and/or `args`) be part of the trust
   fingerprint? Including `env` would re-prompt more often but tie trust more
   tightly to the exact launch.
3. Trust key granularity. Approvals are keyed by project root + server
   fingerprint. Alternative: key by server name only (re-prompt only on
   name change), or include the absolute settings file path.
4. UI affordance. Should there be a `/mcp trust` command or a settings screen
   to review and revoke persisted project approvals?
5. Naming. `trustProjectMcpServers` / `--trust-project-mcp` — happy to rename to
   match any existing convention you prefer.

Refs #123
