### PR TITLE
fix(security): gate REPL and CronCreate tools behind permission checks

### DIFF
--- a/src-rust/crates/tools/src/cron.rs
+++ b/src-rust/crates/tools/src/cron.rs
@@ -272,7 +272,10 @@ impl Tool for CronCreateTool {
          Use durable=true to persist across sessions."
     }
 
-    fn permission_level(&self) -> PermissionLevel { PermissionLevel::None }
+    // Creating a scheduled task installs a durable/session prompt that later runs
+    // an agent unattended, so it is an arbitrary-execution primitive and must be
+    // gated (issue #209) — not `None`.
+    fn permission_level(&self) -> PermissionLevel { PermissionLevel::Execute }
 
     fn input_schema(&self) -> Value {
         json!({
@@ -299,7 +302,7 @@ impl Tool for CronCreateTool {
         })
     }
 
-    async fn execute(&self, input: Value, _ctx: &ToolContext) -> ToolResult {
+    async fn execute(&self, input: Value, ctx: &ToolContext) -> ToolResult {
         let params: CronCreateInput = match serde_json::from_value(input) {
             Ok(p) => p,
             Err(e) => return ToolResult::error(format!("Invalid input: {}", e)),
@@ -310,6 +313,22 @@ impl Tool for CronCreateTool {
                 "Invalid cron expression '{}'. Expected 5 fields: M H DoM Mon DoW.",
                 params.cron
             ));
+        }
+
+        // ── Security gate (issue #209) ───────────────────────────────────────
+        // Installing a scheduled task persists a prompt that will later run an
+        // agent unattended (and, when durable, across sessions). Gate it BEFORE
+        // persisting so the user sees exactly what durable task is being
+        // installed. `is_read_only = false` treats it as arbitrary execution.
+        let prompt_preview: String = params.prompt.chars().take(120).collect();
+        let reason = format!(
+            "Install {} scheduled task ({}) that will run prompt: {}",
+            if params.durable { "durable" } else { "session" },
+            cron_to_human(&params.cron),
+            prompt_preview
+        );
+        if let Err(e) = ctx.check_permission(self.name(), &reason, false) {
+            return ToolResult::error(e.to_string());
         }
 
         // Ensure persistent tasks are loaded from disk before we check the count.
@@ -507,4 +526,79 @@ async fn persist_tasks_to_disk(store: &HashMap<String, CronTask>) -> Result<(), 
     tokio::fs::write(&path, json).await.map_err(|e| e.to_string())?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+
+    /// Handler that always asks; with `non_interactive = true` this denies.
+    struct DenyHandler;
+    impl claurst_core::permissions::PermissionHandler for DenyHandler {
+        fn check_permission(
+            &self,
+            _request: &claurst_core::permissions::PermissionRequest,
+        ) -> claurst_core::permissions::PermissionDecision {
+            claurst_core::permissions::PermissionDecision::Ask {
+                reason: "denied in test".to_string(),
+            }
+        }
+        fn request_permission(
+            &self,
+            request: &claurst_core::permissions::PermissionRequest,
+        ) -> claurst_core::permissions::PermissionDecision {
+            self.check_permission(request)
+        }
+    }
+
+    fn deny_ctx() -> ToolContext {
+        ToolContext {
+            working_dir: std::env::temp_dir(),
+            permission_mode: claurst_core::config::PermissionMode::Default,
+            permission_handler: Arc::new(DenyHandler),
+            cost_tracker: claurst_core::cost::CostTracker::new(),
+            session_id: "cron-deny-test".to_string(),
+            file_history: Arc::new(parking_lot::Mutex::new(
+                claurst_core::file_history::FileHistory::new(),
+            )),
+            current_turn: Arc::new(AtomicUsize::new(0)),
+            non_interactive: true,
+            mcp_manager: None,
+            config: claurst_core::config::Config::default(),
+            managed_agent_config: None,
+            completion_notifier: None,
+            pending_permissions: None,
+            permission_manager: None,
+            user_question_tx: None,
+        }
+    }
+
+    #[test]
+    fn cron_create_requires_execute_permission_level() {
+        assert_eq!(CronCreateTool.permission_level(), PermissionLevel::Execute);
+    }
+
+    #[tokio::test]
+    async fn cron_create_denied_permission_does_not_persist() {
+        // Unique marker so we can assert the task never made it into the store.
+        let marker = "CRON_209_UNIQUE_MARKER_do_not_run";
+        let ctx = deny_ctx();
+        let result = CronCreateTool
+            .execute(
+                json!({ "cron": "*/5 * * * *", "prompt": marker, "durable": true }),
+                &ctx,
+            )
+            .await;
+
+        assert!(result.is_error, "denied CronCreate must return an error");
+
+        // The gate runs before any store mutation, so no task with our marker
+        // should exist in the global store.
+        let store = CRON_STORE.read().await;
+        assert!(
+            !store.values().any(|t| t.prompt == marker),
+            "denied CronCreate must not persist the task"
+        );
+    }
 }

--- a/src-rust/crates/tools/src/repl_tool.rs
+++ b/src-rust/crates/tools/src/repl_tool.rs
@@ -14,6 +14,7 @@
 
 use crate::{PermissionLevel, Tool, ToolContext, ToolResult};
 use async_trait::async_trait;
+use claurst_core::bash_classifier::{classify_bash_command, BashRiskLevel};
 use dashmap::DashMap;
 use once_cell::sync::Lazy;
 use serde::Deserialize;
@@ -41,6 +42,13 @@ struct ReplSession {
 }
 
 /// Key: (session_id, language)
+///
+// TODO(#209): interpreter processes are intentionally kept alive across tool
+// calls and are only removed here when they die or on the next call. There is
+// currently no session-end teardown hook wired into the app that could kill
+// leftover interpreters for a finished session, so we do not attempt it here.
+// When such a hook exists, drain REPL_SESSIONS for the ending session_id and
+// kill each child. The security gate above is the priority for #209.
 static REPL_SESSIONS: Lazy<Arc<DashMap<(String, String), Arc<Mutex<ReplSession>>>>> =
     Lazy::new(|| Arc::new(DashMap::new()));
 
@@ -238,6 +246,31 @@ impl Tool for ReplTool {
             .unwrap_or("bash")
             .to_lowercase();
 
+        // ── Security gate (issue #209) ───────────────────────────────────────
+        // REPL executes arbitrary, model-supplied code in a live interpreter, so
+        // it must pass the same permission gate as the Bash tool BEFORE any
+        // interpreter is spawned or any code is run.  `execute_tool` does not gate
+        // on our behalf, so we gate here.  `is_read_only = false` ensures the
+        // action is treated as arbitrary execution (never auto-approved in
+        // Default/Plan/AcceptEdits modes).
+        let preview: String = params.code.chars().take(80).collect::<String>().replace('\n', " ");
+        let reason = format!("REPL ({}): {}", language, preview);
+        if let Err(e) = ctx.check_permission(self.name(), &reason, false) {
+            return ToolResult::error(e.to_string());
+        }
+
+        // For shell languages, additionally block Critical-risk commands
+        // unconditionally — exactly like the PTY Bash tool does.
+        if matches!(language.as_str(), "bash" | "sh" | "")
+            && classify_bash_command(&params.code) == BashRiskLevel::Critical
+        {
+            return ToolResult::error(format!(
+                "Command blocked: classified as Critical risk by the bash security classifier.\n\
+                 Refusing to execute REPL code: {}",
+                preview
+            ));
+        }
+
         debug!(
             session = %ctx.session_id,
             language = %language,
@@ -258,5 +291,120 @@ impl Tool for ReplTool {
                 ToolResult::error(format!("REPL error: {}", e))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::Arc;
+
+    /// Handler that always asks; combined with `non_interactive = true` this
+    /// resolves to a permission denial (mirrors `AskPermissionHandler` in lib.rs).
+    struct DenyHandler;
+    impl claurst_core::permissions::PermissionHandler for DenyHandler {
+        fn check_permission(
+            &self,
+            _request: &claurst_core::permissions::PermissionRequest,
+        ) -> claurst_core::permissions::PermissionDecision {
+            claurst_core::permissions::PermissionDecision::Ask {
+                reason: "denied in test".to_string(),
+            }
+        }
+        fn request_permission(
+            &self,
+            request: &claurst_core::permissions::PermissionRequest,
+        ) -> claurst_core::permissions::PermissionDecision {
+            self.check_permission(request)
+        }
+    }
+
+    /// Handler that allows everything — used to exercise the Critical-block path.
+    struct AllowHandler;
+    impl claurst_core::permissions::PermissionHandler for AllowHandler {
+        fn check_permission(
+            &self,
+            _request: &claurst_core::permissions::PermissionRequest,
+        ) -> claurst_core::permissions::PermissionDecision {
+            claurst_core::permissions::PermissionDecision::Allow
+        }
+        fn request_permission(
+            &self,
+            _request: &claurst_core::permissions::PermissionRequest,
+        ) -> claurst_core::permissions::PermissionDecision {
+            claurst_core::permissions::PermissionDecision::Allow
+        }
+    }
+
+    fn ctx_with(
+        handler: Arc<dyn claurst_core::permissions::PermissionHandler>,
+        session_id: &str,
+    ) -> ToolContext {
+        ToolContext {
+            working_dir: std::env::temp_dir(),
+            permission_mode: claurst_core::config::PermissionMode::Default,
+            permission_handler: handler,
+            cost_tracker: claurst_core::cost::CostTracker::new(),
+            session_id: session_id.to_string(),
+            file_history: Arc::new(parking_lot::Mutex::new(
+                claurst_core::file_history::FileHistory::new(),
+            )),
+            current_turn: Arc::new(AtomicUsize::new(0)),
+            non_interactive: true,
+            mcp_manager: None,
+            config: claurst_core::config::Config::default(),
+            managed_agent_config: None,
+            completion_notifier: None,
+            pending_permissions: None,
+            permission_manager: None,
+            user_question_tx: None,
+        }
+    }
+
+    #[test]
+    fn repl_requires_execute_permission_level() {
+        assert_eq!(ReplTool.permission_level(), PermissionLevel::Execute);
+    }
+
+    #[tokio::test]
+    async fn repl_denied_permission_blocks_execution() {
+        let ctx = ctx_with(Arc::new(DenyHandler), "repl-deny-test");
+        let result = ReplTool
+            .execute(
+                json!({ "language": "python", "code": "print('should not run')" }),
+                &ctx,
+            )
+            .await;
+
+        assert!(result.is_error, "denied REPL must return an error result");
+        // No interpreter should have been spawned for this session/language.
+        assert!(
+            REPL_SESSIONS
+                .get(&("repl-deny-test".to_string(), "python".to_string()))
+                .is_none(),
+            "no REPL session must be spawned when permission is denied"
+        );
+    }
+
+    #[tokio::test]
+    async fn repl_blocks_critical_bash_even_when_allowed() {
+        let ctx = ctx_with(Arc::new(AllowHandler), "repl-critical-test");
+        let result = ReplTool
+            .execute(json!({ "language": "bash", "code": "rm -rf /" }), &ctx)
+            .await;
+
+        assert!(result.is_error, "Critical bash must be blocked");
+        assert!(
+            result.content.contains("Critical"),
+            "block message should mention the Critical classification, got: {}",
+            result.content
+        );
+        assert!(
+            REPL_SESSIONS
+                .get(&("repl-critical-test".to_string(), "bash".to_string()))
+                .is_none(),
+            "no bash REPL session must be spawned for a Critical command"
+        );
     }
 }


### PR DESCRIPTION
Fixes #209. Both tools executed with no gate (per-tool gating; `execute_tool` doesn't gate). REPL now calls `check_permission` before spawning an interpreter and blocks `Critical` shell commands; CronCreate is `Execute`-level and gated before persisting. 5 tests added, `cargo test --workspace` green.

Closes #209