### PR TITLE
fix(security): pass restored shell env via child env, not bash -c argv

### DIFF
--- a/src-rust/crates/tools/src/bash.rs
+++ b/src-rust/crates/tools/src/bash.rs
@@ -185,9 +185,17 @@ fn extract_exports_from_command(command: &str) -> HashMap<String, String> {
 }
 
 /// Build the bash wrapper script that:
-/// 1. Restores saved cwd and env vars.
+/// 1. Restores the saved cwd.
 /// 2. Runs the user command.
 /// 3. Prints the sentinel + final pwd + `env` dump so we can persist state.
+///
+/// SECURITY (#211): restored env vars are deliberately NOT written into this
+/// script. The script is passed as an argv element to `bash -c "<script>"`, so
+/// anything embedded here (e.g. `export AWS_SECRET_ACCESS_KEY='…'`) would be
+/// visible to any local user via `ps auxww` / `/proc/<pid>/cmdline`. Restored
+/// vars are instead injected into the child's ENVIRONMENT via
+/// `Command::envs(&state.env_vars)` at spawn time, so their values never appear
+/// on a command line.
 ///
 /// On Windows we skip the wrapping (cmd.exe is a different shell).
 fn build_wrapper_script(
@@ -203,21 +211,9 @@ fn build_wrapper_script(
     // Escape the cwd for single-quote embedding
     let cwd_escaped: String = effective_cwd.to_string_lossy().replace('\'', "'\\''" );
 
-    // Build export lines for persisted env vars
-    let mut export_lines = String::new();
-    for (k, v) in &state.env_vars {
-        // Escape single quotes in value
-        let v_escaped: String = v.replace('\'', "'\\''");
-        export_lines.push_str(&format!("export {}='{}'\n", k, v_escaped));
-    }
-
-    // We use `env -0` + `awk` to safely dump env vars after the command
-    // finishes without being confused by multi-line values.
-    // If `env -0` is unavailable we fall back to a simpler printenv.
     format!(
         r#"set -e
 cd '{cwd}'
-{exports}
 set +e
 {user_cmd}
 __CC_EXIT_CODE=$?
@@ -227,7 +223,6 @@ env | grep -E '^[A-Za-z_][A-Za-z0-9_]*=' || true
 exit $__CC_EXIT_CODE
 "#,
         cwd = cwd_escaped,
-        exports = export_lines,
         user_cmd = command,
         sentinel = SHELL_STATE_SENTINEL,
     )
@@ -515,16 +510,21 @@ impl Tool for BashTool {
             return self.execute_windows(&params.command, ctx, &shell_state_arc, timeout_dur, timeout_ms).await;
         }
 
-        // Build a wrapper script that restores and then captures shell state.
-        let script = {
+        // Build a wrapper script that restores cwd + captures shell state, and
+        // clone the restored env vars so they can be injected into the child's
+        // ENVIRONMENT (never its argv) — see build_wrapper_script / #211.
+        let (script, restored_env) = {
             let state = shell_state_arc.lock();
-            build_wrapper_script(&params.command, &state, &ctx.working_dir)
+            let script = build_wrapper_script(&params.command, &state, &ctx.working_dir);
+            (script, state.env_vars.clone())
         };
 
         let child = match Command::new("bash")
             .arg("-c")
             .arg(&script)
             .current_dir(&ctx.working_dir)
+            // Restored shell vars reach the child via its environment, not argv (#211).
+            .envs(&restored_env)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .stdin(Stdio::null())
@@ -737,6 +737,47 @@ mod tests {
         let input: BashInput =
             serde_json::from_str(r#"{"command":"echo hi"}"#).unwrap();
         assert!(!input.run_in_background);
+    }
+
+    /// #211: restored env values (secrets) must never be baked into the wrapper
+    /// script. That script is passed as an argv element to `bash -c "<script>"`,
+    /// so any embedded `export KEY='value'` would be readable by any local user
+    /// via `ps auxww` / `/proc/<pid>/cmdline`. The values are instead delivered
+    /// to the child through `Command::envs(&state.env_vars)` (its environment).
+    #[test]
+    fn wrapper_script_never_embeds_restored_env_values() {
+        let mut state = ShellState::new();
+        state
+            .env_vars
+            .insert("SECRET".to_string(), "topsecret".to_string());
+        state
+            .env_vars
+            .insert("AWS_SECRET_ACCESS_KEY".to_string(), "aws-argv-leak".to_string());
+
+        let base = PathBuf::from("/tmp");
+        let script = build_wrapper_script("echo hi", &state, &base);
+
+        // Secret VALUES must not appear anywhere in the script string / argv.
+        assert!(
+            !script.contains("topsecret"),
+            "secret value leaked into wrapper script (argv):\n{script}"
+        );
+        assert!(
+            !script.contains("aws-argv-leak"),
+            "AWS secret leaked into wrapper script (argv):\n{script}"
+        );
+        // No re-exported lines for restored vars either.
+        assert!(
+            !script.contains("export SECRET="),
+            "restored var was re-exported into the script (argv):\n{script}"
+        );
+        assert!(
+            !script.contains("export AWS_SECRET_ACCESS_KEY="),
+            "restored var was re-exported into the script (argv):\n{script}"
+        );
+
+        // The env map the tool hands to `Command::envs` is where the value lives.
+        assert_eq!(state.env_vars.get("SECRET").map(String::as_str), Some("topsecret"));
     }
 
     /// Permission handler that allows everything — for exercising `execute`.

--- a/src-rust/crates/tools/src/pty_bash.rs
+++ b/src-rust/crates/tools/src/pty_bash.rs
@@ -104,21 +104,19 @@ fn extract_exports_from_command(command: &str) -> HashMap<String, String> {
     map
 }
 
+// SECURITY (#211): restored env vars are NEVER emitted into this script.
+// The script becomes an argv element (`bash -c "<script>"`), which is readable
+// by any local user via `ps auxww` / `/proc/<pid>/cmdline`. Instead the restored
+// vars are handed to the child through its ENVIRONMENT via `apply_restored_env`
+// (portable_pty `CommandBuilder::env`), so secret values never touch a command line.
 #[cfg(unix)]
 fn build_wrapper_script(command: &str, state: &ShellState, base_cwd: &PathBuf) -> String {
     let effective_cwd = state.cwd.as_ref().unwrap_or(base_cwd);
     let cwd_escaped: String = effective_cwd.to_string_lossy().replace('\'', "'\\''");
 
-    let mut export_lines = String::new();
-    for (k, v) in &state.env_vars {
-        let v_escaped: String = v.replace('\'', "'\\''");
-        export_lines.push_str(&format!("export {}='{}'\n", k, v_escaped));
-    }
-
     format!(
         r#"set -e
 cd '{cwd}'
-{exports}
 set +e
 {user_cmd}
 __CC_EXIT_CODE=$?
@@ -128,10 +126,21 @@ env | grep -E '^[A-Za-z_][A-Za-z0-9_]*=' || true
 exit $__CC_EXIT_CODE
 "#,
         cwd = cwd_escaped,
-        exports = export_lines,
         user_cmd = command,
         sentinel = SHELL_STATE_SENTINEL,
     )
+}
+
+/// Plumb the persisted shell env vars into the child process's environment
+/// (NOT its argv). Each var is set with `CommandBuilder::env`, so the child
+/// inherits it exactly as `export` would have — but the value never appears on
+/// any command line. This is the sole path through which restored values reach
+/// the child (#211).
+#[cfg(unix)]
+fn apply_restored_env(cmd: &mut portable_pty::CommandBuilder, env_vars: &HashMap<String, String>) {
+    for (k, v) in env_vars {
+        cmd.env(k, v);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -300,6 +309,7 @@ fn strip_ansi(s: &str) -> String {
 async fn run_in_pty(
     script: &str,
     working_dir: &str,
+    env_vars: &HashMap<String, String>,
     timeout: Duration,
 ) -> Result<(String, i32), String> {
     use portable_pty::{CommandBuilder, PtySize, native_pty_system};
@@ -319,6 +329,8 @@ async fn run_in_pty(
     let mut cmd = CommandBuilder::new("bash");
     cmd.args(["-c", script]);
     cmd.cwd(working_dir);
+    // Restored shell vars go through the child's ENVIRONMENT, never its argv (#211).
+    apply_restored_env(&mut cmd, env_vars);
 
     let mut child = pair
         .slave
@@ -584,17 +596,22 @@ impl Tool for PtyBashTool {
         // ── Unix PTY path ────────────────────────────────────────────────────
         #[cfg(unix)]
         {
-            // Build the wrapper script that restores + captures shell state.
-            let (script, working_dir_str) = {
+            // Build the wrapper script that restores cwd + captures shell state.
+            // Restored env vars are cloned out and later injected into the child's
+            // environment (never its argv) — see `apply_restored_env` (#211).
+            let (script, restored_env, working_dir_str) = {
                 let state = shell_state_arc.lock();
                 let script = build_wrapper_script(&params.command, &state, &ctx.working_dir);
+                let restored_env = state.env_vars.clone();
                 let wd = ctx.working_dir.to_string_lossy().into_owned();
-                (script, wd)
+                (script, restored_env, wd)
             };
 
-            let result =
-                tokio::time::timeout(timeout_dur, run_in_pty(&script, &working_dir_str, timeout_dur))
-                    .await;
+            let result = tokio::time::timeout(
+                timeout_dur,
+                run_in_pty(&script, &working_dir_str, &restored_env, timeout_dur),
+            )
+            .await;
 
             match result {
                 Ok(Ok((raw_output, exit_code))) => {
@@ -648,6 +665,77 @@ impl Tool for PtyBashTool {
                 Ok(Err(e)) => ToolResult::error(format!("PTY execution failed: {}", e)),
                 Err(_) => ToolResult::error(format!("Command timed out after {}ms", timeout_ms)),
             }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::ffi::OsStr;
+
+    /// #211: restored env values (secrets) must NOT be baked into the wrapper
+    /// script, because that script becomes an argv element of `bash -c`, which is
+    /// visible to any local user via `ps auxww` / `/proc/<pid>/cmdline`.
+    #[test]
+    fn wrapper_script_never_embeds_restored_env_values() {
+        let mut state = ShellState::new();
+        state
+            .env_vars
+            .insert("SECRET".to_string(), "topsecret".to_string());
+        state
+            .env_vars
+            .insert("AWS_SECRET_ACCESS_KEY".to_string(), "aws-argv-leak".to_string());
+
+        let base = PathBuf::from("/tmp");
+        let script = build_wrapper_script("echo hi", &state, &base);
+
+        // The secret VALUES must never appear in the script string / argv.
+        assert!(
+            !script.contains("topsecret"),
+            "secret value leaked into wrapper script (argv):\n{script}"
+        );
+        assert!(
+            !script.contains("aws-argv-leak"),
+            "AWS secret leaked into wrapper script (argv):\n{script}"
+        );
+        // And there must be no re-exported `export KEY=` lines for restored vars.
+        assert!(
+            !script.contains("export SECRET="),
+            "restored var was re-exported into the script (argv):\n{script}"
+        );
+        assert!(
+            !script.contains("export AWS_SECRET_ACCESS_KEY="),
+            "restored var was re-exported into the script (argv):\n{script}"
+        );
+    }
+
+    /// #211: the value IS delivered to the child — but through its environment
+    /// (`CommandBuilder::env`), which is not part of argv. This exercises the
+    /// env-plumbing function directly.
+    #[test]
+    fn restored_env_reaches_child_via_env_map_not_argv() {
+        use portable_pty::CommandBuilder;
+
+        let mut env_vars = HashMap::new();
+        env_vars.insert("SECRET".to_string(), "topsecret".to_string());
+
+        let mut cmd = CommandBuilder::new("bash");
+        cmd.args(["-c", "true"]);
+        apply_restored_env(&mut cmd, &env_vars);
+
+        // Value is present in the child's environment...
+        assert_eq!(cmd.get_env("SECRET"), Some(OsStr::new("topsecret")));
+        // ...and NOT in argv (only `bash -c true`).
+        for arg in cmd.get_argv() {
+            assert!(
+                !arg.to_string_lossy().contains("topsecret"),
+                "secret value leaked into CommandBuilder argv: {arg:?}"
+            );
         }
     }
 }


### PR DESCRIPTION
Fixes #211. The bash tool baked restored env vars into the `bash -c` script as `export KEY='value'`, leaking secret values (AWS keys, API tokens) into the child's argv (visible via `ps auxww` / `/proc/<pid>/cmdline`). Restored vars now reach the child via `CommandBuilder::env()` / `.envs()` so values never appear on a command line; `cwd` still round-trips.

Two commits: live `PtyBashTool` fix + tests, then the dead `bash.rs` copy kept consistent. `cargo test -p claurst-tools` = 85 passed.

Closes #211