### PR TITLE
fix(tui): char-boundary/UTF-8 panics that crash the TUI

### DIFF
--- a/src-rust/crates/tui/src/messages/mod.rs
+++ b/src-rust/crates/tui/src/messages/mod.rs
@@ -1452,9 +1452,14 @@ fn truncate_user_prompt_text(text: &str) -> String {
         return text.to_string();
     }
 
-    let head = &text[..TRUNCATE_USER_PROMPT_HEAD_CHARS.min(text.len())];
-    let tail_start = text.len().saturating_sub(TRUNCATE_USER_PROMPT_TAIL_CHARS);
-    let tail = &text[tail_start..];
+    // The *_CHARS constants count characters, not bytes. Slice by chars so a
+    // multibyte codepoint straddling the cut never panics (#221).
+    let head: String = text.chars().take(TRUNCATE_USER_PROMPT_HEAD_CHARS).collect();
+    let tail: String = {
+        let total_chars = text.chars().count();
+        let skip = total_chars.saturating_sub(TRUNCATE_USER_PROMPT_TAIL_CHARS);
+        text.chars().skip(skip).collect()
+    };
     let hidden_lines = text
         .chars()
         .take(TRUNCATE_USER_PROMPT_HEAD_CHARS)
@@ -2637,5 +2642,20 @@ mod tests {
         let a_text: Vec<_> = a.iter().map(|l| line_text(l)).collect();
         let b_text: Vec<_> = b.iter().map(|l| line_text(l)).collect();
         assert_eq!(a_text, b_text);
+    }
+
+    #[test]
+    fn truncate_user_prompt_text_handles_multibyte_over_limit() {
+        // >10K chars of a 3-byte codepoint. Pre-fix, the *_CHARS constants were
+        // used as BYTE offsets, slicing mid-codepoint (2500 % 3 == 1) (#221).
+        let text = "\u{2705}".repeat(11_000); // ✅ (3 bytes), 11K chars > 10K limit
+        let out = truncate_user_prompt_text(&text);
+        assert!(out.starts_with('\u{2705}'));
+        assert!(out.contains("lines"));
+        assert!(out.chars().count() < text.chars().count());
+
+        // Mixed multibyte content around both cut points must also be safe.
+        let mixed = "😀é✅ん".repeat(3_000);
+        let _ = truncate_user_prompt_text(&mixed); // no panic == pass
     }
 }

--- a/src-rust/crates/tui/src/overlays.rs
+++ b/src-rust/crates/tui/src/overlays.rs
@@ -1232,6 +1232,80 @@ impl MessageSelectorOverlay {
     }
 }
 
+/// Truncate `s` to at most `max_width` display columns, cutting on char
+/// boundaries and appending an ellipsis when truncated.
+///
+/// Byte-slicing here panics when a multibyte char straddles the cut, and a raw
+/// `usize` width subtraction underflow-panics on narrow terminals (#221).
+fn truncate_to_width(s: &str, max_width: usize) -> String {
+    if UnicodeWidthStr::width(s) <= max_width {
+        return s.to_string();
+    }
+    if max_width == 0 {
+        return String::new();
+    }
+    if max_width == 1 {
+        return "\u{2026}".to_string();
+    }
+    let mut out = String::new();
+    let mut width = 0usize;
+    for ch in s.chars() {
+        let cw = UnicodeWidthStr::width(ch.encode_utf8(&mut [0u8; 4]));
+        // Reserve one column for the trailing ellipsis.
+        if width + cw > max_width - 1 {
+            break;
+        }
+        out.push(ch);
+        width += cw;
+    }
+    out.push('\u{2026}');
+    out
+}
+
+/// Find the first case-insensitive occurrence of `needle_lc` (already
+/// lowercased) inside `haystack`, returning the byte range **in the original**
+/// `haystack`.
+///
+/// Never indexes one string with another string's byte offsets, so it is safe
+/// for lossy / length-changing lowercase mappings such as `İ` (U+0130 → "i̇"),
+/// `K` (U+212A → "k"), and `ẞ`/`ß` (#221). Both returned offsets are guaranteed
+/// char boundaries of `haystack`.
+fn case_insensitive_find(haystack: &str, needle_lc: &str) -> Option<(usize, usize)> {
+    if needle_lc.is_empty() {
+        return None;
+    }
+    for (start, _) in haystack.char_indices() {
+        let mut hay_chars = haystack[start..].chars();
+        let mut need_chars = needle_lc.chars();
+        // Lowercase expansion of one haystack char may yield several chars.
+        let mut pending: std::collections::VecDeque<char> = std::collections::VecDeque::new();
+        let mut end = start;
+        let mut matched = true;
+        'need: while let Some(nc) = need_chars.next() {
+            while pending.is_empty() {
+                match hay_chars.next() {
+                    Some(hc) => {
+                        end += hc.len_utf8();
+                        pending.extend(hc.to_lowercase());
+                    }
+                    None => {
+                        matched = false;
+                        break 'need;
+                    }
+                }
+            }
+            if pending.pop_front() != Some(nc) {
+                matched = false;
+                break 'need;
+            }
+        }
+        if matched {
+            return Some((start, end));
+        }
+    }
+    None
+}
+
 /// Render the message selector overlay.
 pub fn render_message_selector(frame: &mut Frame, overlay: &MessageSelectorOverlay, area: Rect) {
     if !overlay.visible {
@@ -1275,12 +1349,10 @@ pub fn render_message_selector(frame: &mut Frame, overlay: &MessageSelectorOverl
 
             let tool_tag = if msg.has_tool_use { " [tool]" } else { "" };
 
-            let preview_max = dialog_width as usize - 20;
-            let preview = if UnicodeWidthStr::width(msg.preview.as_str()) > preview_max {
-                format!("{}…", &msg.preview[..preview_max.saturating_sub(1)])
-            } else {
-                msg.preview.clone()
-            };
+            // saturating_sub avoids an underflow panic on narrow terminals, and
+            // truncate_to_width cuts on char boundaries by display width (#221).
+            let preview_max = (dialog_width as usize).saturating_sub(20);
+            let preview = truncate_to_width(&msg.preview, preview_max);
 
             let prefix = if is_selected { "  \u{25BA} " } else { "    " };
             let idx_style = if is_selected {
@@ -1763,13 +1835,14 @@ pub fn render_global_search(state: &GlobalSearchState, area: ratatui::layout::Re
                 let text_trimmed = result.text.trim();
                 let query_lc = state.query.to_lowercase();
                 let text_spans: Vec<Span<'static>> = if !query_lc.is_empty() {
-                    let text_lc = text_trimmed.to_lowercase();
-                    if let Some(pos) = text_lc.find(query_lc.as_str()) {
-                        let before: String = text_trimmed.chars().take(
-                            text_trimmed[..pos].chars().count()
-                        ).collect();
-                        let matched: String = text_trimmed[pos..pos + query_lc.len()].to_string();
-                        let after: String = text_trimmed[pos + query_lc.len()..].chars().take(30).collect();
+                    // Match case-insensitively but slice the ORIGINAL string on
+                    // its own char boundaries. to_lowercase() is not length- or
+                    // boundary-preserving (İ, K U+212A, ß), so indexing the
+                    // original with the lowercased copy's offsets panics (#221).
+                    if let Some((start, end)) = case_insensitive_find(text_trimmed, &query_lc) {
+                        let before: String = text_trimmed[..start].to_string();
+                        let matched: String = text_trimmed[start..end].to_string();
+                        let after: String = text_trimmed[end..].chars().take(30).collect();
                         vec![
                             Span::styled(before, style),
                             Span::styled(matched, style.bg(Color::Rgb(60, 50, 0)).fg(Color::Yellow)),
@@ -2099,5 +2172,83 @@ mod tests {
         flow.reject_confirm();
         assert_eq!(flow.step, RewindStep::Selecting);
         assert!(flow.visible);
+    }
+
+    // --- #221: char-boundary / width-underflow safety ------------------
+
+    #[test]
+    fn truncate_to_width_is_char_safe_and_no_underflow() {
+        // CJK (width-2) chars: byte slicing would panic mid-codepoint, and the
+        // widths 0/1 exercise the underflow-prone branches (#221).
+        let s = "\u{4f60}\u{597d}\u{4e16}\u{754c}"; // 你好世界
+        for w in 0..=10usize {
+            let out = truncate_to_width(s, w);
+            assert!(UnicodeWidthStr::width(out.as_str()) <= w.max(1));
+        }
+        assert_eq!(truncate_to_width("hi", 10), "hi");
+    }
+
+    #[test]
+    fn case_insensitive_find_handles_lossy_lowercase() {
+        // İ (U+0130) -> "i̇" (2 chars); K (U+212A) -> "k"; ẞ (U+1E9E) -> "ß".
+        // Indexing the original with the lowercased copy's offsets panics.
+        let cases = [
+            ("\u{0130}", "i"),          // İ
+            ("\u{212A}", "k"),          // K (Kelvin sign)
+            ("\u{1E9E}", "\u{00df}"),   // ẞ matched by ß
+            ("abc\u{0130}def", "i"),    // match in the middle
+        ];
+        for (hay, needle_lc) in cases {
+            let (start, end) = case_insensitive_find(hay, needle_lc)
+                .unwrap_or_else(|| panic!("expected a match in {hay:?}"));
+            assert!(hay.is_char_boundary(start));
+            assert!(hay.is_char_boundary(end));
+            // All three slices used by the highlighter must be panic-free.
+            let _ = &hay[..start];
+            let _ = &hay[start..end];
+            let _ = &hay[end..];
+        }
+        assert!(case_insensitive_find("hello", "z").is_none());
+    }
+
+    #[test]
+    fn render_global_search_ci_highlight_no_panic() {
+        // Original text carries İ / K / ẞ; query "i" matches case-insensitively.
+        // Pre-fix, the slice used the lowercased copy's offset and panicked.
+        let state = GlobalSearchState {
+            visible: true,
+            query: "i".to_string(),
+            results: vec![SearchResult {
+                file: "a.txt".to_string(),
+                line: 1,
+                col: 1,
+                text: "\u{0130}stanbul \u{212A}elvin \u{1E9E}harp".to_string(),
+                context_before: vec![],
+                context_after: vec![],
+            }],
+            selected: 0,
+            total_matches: 1,
+            searching: false,
+        };
+        let area = Rect { x: 0, y: 0, width: 60, height: 20 };
+        let mut buf = Buffer::empty(area);
+        render_global_search(&state, area, &mut buf); // no panic == pass
+    }
+
+    #[test]
+    fn render_message_selector_cjk_narrow_terminal_no_panic() {
+        use ratatui::{backend::TestBackend, Terminal};
+        // width 23 -> dialog_width 19 -> preview_max = 19 - 20 underflowed
+        // (panic) pre-fix, and byte-slicing the CJK preview panicked too (#221).
+        let overlay = MessageSelectorOverlay::open(vec![SelectorMessage {
+            idx: 0,
+            role: "user".to_string(),
+            preview: "\u{4f60}\u{597d}\u{4e16}\u{754c}".repeat(8), // long CJK
+            has_tool_use: false,
+        }]);
+        let mut terminal = Terminal::new(TestBackend::new(23, 20)).unwrap();
+        terminal
+            .draw(|frame| render_message_selector(frame, &overlay, frame.area()))
+            .unwrap(); // no panic == pass
     }
 }

--- a/src-rust/crates/tui/src/prompt_input.rs
+++ b/src-rust/crates/tui/src/prompt_input.rs
@@ -1317,6 +1317,20 @@ fn home_dir() -> Option<String> {
 /// in `paste_contents` for retrieval at submit time.  This mirrors opencode's
 /// behaviour and prevents the input box from flooding with multi-hundred-line
 /// pastes.  Single-line short strings are inserted verbatim.
+/// Normalize `\r\n` and lone `\r` into `\n`.
+///
+/// The prompt buffer must never contain a bare carriage return: the renderer
+/// splits logical lines on `\n` and advances the cursor's byte offset assuming
+/// a single-byte separator, so a `\r` (or CRLF pair) desyncs that accounting
+/// and can slice mid-codepoint (#221).
+fn normalize_newlines(s: &str) -> String {
+    if s.contains('\r') {
+        s.replace("\r\n", "\n").replace('\r', "\n")
+    } else {
+        s.to_string()
+    }
+}
+
 pub fn handle_paste(
     content: &str,
     paste_counter: &mut u32,
@@ -1693,6 +1707,10 @@ impl PromptInputState {
         if let Some(stored_content) = stored {
             self.paste_contents.insert(self.paste_counter, stored_content);
         }
+        // Normalize CRLF / lone CR into LF before inserting. A stray '\r' in
+        // the buffer desyncs the render cursor's byte accounting (which assumes
+        // a 1-byte '\n' separator) and can slice mid-codepoint (#221).
+        let text = normalize_newlines(&text);
         for c in text.chars() {
             self.text.insert(self.cursor, c);
             self.cursor += c.len_utf8();
@@ -2964,17 +2982,12 @@ pub fn render_prompt_input(
     // Text rows start 1 row below the top separator.
     let text_start_y = area.y + 1;
 
-    // Split into logical lines; guarantee at least one.
-    let logical_lines: Vec<String> = {
-        let collected: Vec<String> = display_text.lines().map(|l| l.to_string()).collect();
-        if display_text.ends_with('\n') || collected.is_empty() {
-            let mut v = collected;
-            v.push(String::new());
-            v
-        } else {
-            collected
-        }
-    };
+    // Split into logical lines on '\n'. Using `split` (not `.lines()`, which
+    // strips '\r') keeps the byte accounting below in sync with the buffer:
+    // each logical line is separated by exactly one '\n' byte, and text ending
+    // in '\n' naturally yields a trailing empty line. `split` always yields at
+    // least one element, so there is always >= 1 logical line (#221).
+    let logical_lines: Vec<String> = display_text.split('\n').map(|l| l.to_string()).collect();
 
     let text_style = if state.text.is_empty() && !focused {
         Style::default().fg(Color::DarkGray)
@@ -3007,8 +3020,14 @@ pub fn render_prompt_input(
             // The +1 accounts for the '\n' between logical lines (last line has no trailing \n).
             let line_end_byte = byte_idx + line_bytes;
             if state.cursor <= line_end_byte {
-                let intra_byte = state.cursor - byte_idx;
-                let display_col = UnicodeWidthStr::width(&line_text[..intra_byte.min(line_bytes)]);
+                // Clamp the cursor into this line, then walk back to a char
+                // boundary so a multibyte codepoint straddling the cut never
+                // panics the slice (#221).
+                let mut intra_byte = (state.cursor - byte_idx).min(line_bytes);
+                while intra_byte > 0 && !line_text.is_char_boundary(intra_byte) {
+                    intra_byte -= 1;
+                }
+                let display_col = UnicodeWidthStr::width(&line_text[..intra_byte]);
                 found = Some((li, display_col));
                 break 'outer;
             }
@@ -4512,5 +4531,36 @@ mod tests {
         s.accept_suggestion();
         assert_eq!(s.text, "@src/main.rs more text");
         assert_eq!(s.cursor, "@src/main.rs".len());
+    }
+
+    // ---- #221: CRLF + multibyte paste/render safety --------------------
+
+    #[test]
+    fn paste_normalizes_crlf_and_lone_cr() {
+        // A stray '\r' must never enter the buffer: it desyncs the renderer's
+        // cursor byte accounting (which assumes a 1-byte separator) (#221).
+        let mut s = PromptInputState::new();
+        s.paste("x\r\né");
+        assert_eq!(s.text, "x\né");
+        assert!(!s.text.contains('\r'));
+        assert!(s.text.is_char_boundary(s.cursor));
+
+        let mut s2 = PromptInputState::new();
+        s2.paste("a\rb");
+        assert_eq!(s2.text, "a\nb");
+    }
+
+    #[test]
+    fn render_crlf_multibyte_cursor_midcodepoint_no_panic() {
+        // Seed a buffer with CRLF + a 2-byte char and place the cursor where the
+        // pre-fix accounting mapped mid-codepoint (`&"é"[..1]`) and panicked.
+        let mut s = PromptInputState::new();
+        s.text = "x\r\né".to_string();
+        s.cursor = 3; // byte offset of the start of 'é' (a valid boundary)
+
+        let area = Rect { x: 0, y: 0, width: 12, height: 4 };
+        let mut buf = Buffer::empty(area);
+        // Reaching the end of this call without panicking is the assertion.
+        render_prompt_input(&s, area, &mut buf, true, InputMode::Default, Color::Blue, false);
     }
 }

--- a/src-rust/crates/tui/src/render.rs
+++ b/src-rust/crates/tui/src/render.rs
@@ -2740,13 +2740,11 @@ fn render_legacy_history_search(
                 .map(String::as_str)
                 .unwrap_or("");
 
-            let truncated = if UnicodeWidthStr::width(entry) > (dialog_width as usize - 6) {
-                let mut s = entry.to_string();
-                s.truncate(dialog_width as usize - 9);
-                format!("{}\u{2026}", s)
-            } else {
-                entry.to_string()
-            };
+            // truncate_end is width-aware, cuts on char boundaries, and appends
+            // its own ellipsis. The old code did `String::truncate` on a raw
+            // byte index (panics mid-codepoint) after a `usize` subtraction that
+            // could underflow-panic on a narrow terminal (#221).
+            let truncated = truncate_end(entry, (dialog_width as usize).saturating_sub(6));
 
             let (prefix, style) = if is_selected {
                 (
@@ -3184,5 +3182,26 @@ mod tool_block_tests {
         assert!(joined.contains("[ ] Wire adapter"), "pending marker: {joined:?}");
         // The raw result-preview string must NOT leak into the checklist view.
         assert!(!joined.contains("Todo list updated"), "preview suppressed: {joined:?}");
+    }
+
+    #[test]
+    fn legacy_history_search_narrow_multibyte_no_panic() {
+        use crate::app::{App, HistorySearch};
+        use claurst_core::config::Config;
+        use claurst_core::cost::CostTracker;
+        use ratatui::{backend::TestBackend, Terminal};
+
+        let mut app = App::new(Config::default(), CostTracker::new());
+        app.prompt_input.history = vec!["\u{4f60}\u{597d}\u{4e16}\u{754c}".repeat(6)]; // wide CJK
+        let mut hs = HistorySearch::new();
+        hs.matches = vec![0];
+
+        // width 10 -> dialog_width 6 -> `dialog_width - 9` underflow-panicked
+        // pre-fix, and `String::truncate` on a byte index sliced the CJK entry
+        // mid-codepoint (#221). No panic == pass.
+        let mut terminal = Terminal::new(TestBackend::new(10, 12)).unwrap();
+        terminal
+            .draw(|frame| render_legacy_history_search(frame, &hs, &app, frame.area()))
+            .unwrap();
     }
 }


### PR DESCRIPTION
Fixes #221. Five byte-slice sites panicked on multibyte text or underflowed on narrow terminals, taking down the whole TUI:
- CRLF+multibyte paste desynced the prompt cursor (mid-codepoint slice)
- `truncate_user_prompt_text` used char-count constants as byte offsets
- global search highlighted by indexing the original string with `to_lowercase()` offsets (not length-preserving)
- /rewind preview + legacy history-search truncated by byte and underflowed widths

All fixed to slice on char boundaries with `saturating_sub`. 8 regression tests (each panics pre-fix). `cargo test -p claurst-tui` = 596 passed / 0 failed. 4 sequential commits (one per file).

Closes #221