### PR TITLE
fix(api): capture thinking/signature deltas & preserve block order in non-streaming aggregator

### DIFF
--- a/src-rust/crates/api/src/provider_types.rs
+++ b/src-rust/crates/api/src/provider_types.rs
@@ -462,3 +462,132 @@ pub enum ApiKeyHeader {
     /// A custom header name.
     Custom(String),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test for issue #217. The non-streaming aggregators used by
+    /// the Anthropic and MiniMax providers delegate to `StreamBlockAccumulator`.
+    /// It must (a) fold `ThinkingDelta`/`SignatureDelta` into the thinking block
+    /// rather than dropping them, and (b) preserve the model's interleave order
+    /// (thinking-first), instead of appending non-text blocks last.
+    #[test]
+    fn stream_block_accumulator_keeps_thinking_signature_and_order() {
+        let mut acc = StreamBlockAccumulator::new();
+
+        // Block 0: a signed thinking block, streamed as thinking-then-signature.
+        acc.on_event(&StreamEvent::ContentBlockStart {
+            index: 0,
+            content_block: ContentBlock::Thinking {
+                thinking: String::new(),
+                signature: String::new(),
+            },
+        });
+        acc.on_event(&StreamEvent::ThinkingDelta {
+            index: 0,
+            thinking: "Let me ".into(),
+        });
+        acc.on_event(&StreamEvent::ThinkingDelta {
+            index: 0,
+            thinking: "reason.".into(),
+        });
+        acc.on_event(&StreamEvent::SignatureDelta {
+            index: 0,
+            signature: "sig-".into(),
+        });
+        acc.on_event(&StreamEvent::SignatureDelta {
+            index: 0,
+            signature: "abc123".into(),
+        });
+        acc.on_event(&StreamEvent::ContentBlockStop { index: 0 });
+
+        // Block 1: visible text.
+        acc.on_event(&StreamEvent::ContentBlockStart {
+            index: 1,
+            content_block: ContentBlock::Text {
+                text: String::new(),
+            },
+        });
+        acc.on_event(&StreamEvent::TextDelta {
+            index: 1,
+            text: "Hello world".into(),
+        });
+        acc.on_event(&StreamEvent::ContentBlockStop { index: 1 });
+
+        // Block 2: a tool call, streamed as partial JSON.
+        acc.on_event(&StreamEvent::ContentBlockStart {
+            index: 2,
+            content_block: ContentBlock::ToolUse {
+                id: "tool_1".into(),
+                name: "get_weather".into(),
+                input: Value::Null,
+            },
+        });
+        acc.on_event(&StreamEvent::InputJsonDelta {
+            index: 2,
+            partial_json: r#"{"city":"#.into(),
+        });
+        acc.on_event(&StreamEvent::InputJsonDelta {
+            index: 2,
+            partial_json: r#""Paris"}"#.into(),
+        });
+        acc.on_event(&StreamEvent::ContentBlockStop { index: 2 });
+
+        let blocks = acc.finish();
+        assert_eq!(blocks.len(), 3, "all three blocks survive");
+
+        // Order preserved: thinking → text → tool_use. The old aggregator
+        // appended non-text blocks last (usize::MAX), so thinking would have
+        // landed *after* the text block.
+        match &blocks[0] {
+            ContentBlock::Thinking { thinking, signature } => {
+                assert_eq!(thinking, "Let me reason.", "thinking text captured");
+                assert_eq!(signature, "sig-abc123", "signature preserved verbatim");
+            }
+            other => panic!("expected Thinking block first, got {other:?}"),
+        }
+        match &blocks[1] {
+            ContentBlock::Text { text } => assert_eq!(text, "Hello world"),
+            other => panic!("expected Text block second, got {other:?}"),
+        }
+        match &blocks[2] {
+            ContentBlock::ToolUse { id, name, input } => {
+                assert_eq!(id, "tool_1");
+                assert_eq!(name, "get_weather");
+                assert_eq!(
+                    input.get("city").and_then(Value::as_str),
+                    Some("Paris"),
+                    "tool_use JSON assembled from partial deltas"
+                );
+            }
+            other => panic!("expected ToolUse block third, got {other:?}"),
+        }
+    }
+
+    /// The `ReasoningDelta` alias (used by some providers) must also land in the
+    /// thinking block rather than being dropped.
+    #[test]
+    fn stream_block_accumulator_folds_reasoning_delta_into_thinking() {
+        let mut acc = StreamBlockAccumulator::new();
+        acc.on_event(&StreamEvent::ContentBlockStart {
+            index: 0,
+            content_block: ContentBlock::Thinking {
+                thinking: String::new(),
+                signature: String::new(),
+            },
+        });
+        acc.on_event(&StreamEvent::ReasoningDelta {
+            index: 0,
+            reasoning: "scratch pad".into(),
+        });
+        acc.on_event(&StreamEvent::ContentBlockStop { index: 0 });
+
+        let blocks = acc.finish();
+        assert_eq!(blocks.len(), 1);
+        match &blocks[0] {
+            ContentBlock::Thinking { thinking, .. } => assert_eq!(thinking, "scratch pad"),
+            other => panic!("expected Thinking block, got {other:?}"),
+        }
+    }
+}

--- a/src-rust/crates/api/src/provider_types.rs
+++ b/src-rust/crates/api/src/provider_types.rs
@@ -191,6 +191,160 @@ pub enum StreamEvent {
 }
 
 // ---------------------------------------------------------------------------
+// StreamBlockAccumulator
+// ---------------------------------------------------------------------------
+
+/// Partial content-block state accumulated while draining a `StreamEvent`
+/// stream. Mirrors the streaming `StreamAccumulator` in `lib.rs`, but over the
+/// provider-level [`StreamEvent`]/[`ContentBlock`] types.
+enum PartialBlock {
+    Text(String),
+    Thinking {
+        thinking_buf: String,
+        signature_buf: String,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+        json_buf: String,
+    },
+    /// Any block that arrives fully-formed on `ContentBlockStart` and needs no
+    /// delta accumulation (e.g. `RedactedThinking`, images).
+    Passthrough(ContentBlock),
+}
+
+impl PartialBlock {
+    fn empty_thinking() -> Self {
+        PartialBlock::Thinking {
+            thinking_buf: String::new(),
+            signature_buf: String::new(),
+        }
+    }
+
+    fn from_start(block: ContentBlock) -> Self {
+        match block {
+            ContentBlock::Text { text } => PartialBlock::Text(text),
+            ContentBlock::Thinking { thinking, signature } => PartialBlock::Thinking {
+                thinking_buf: thinking,
+                signature_buf: signature,
+            },
+            ContentBlock::ToolUse { id, name, .. } => PartialBlock::ToolUse {
+                id,
+                name,
+                json_buf: String::new(),
+            },
+            other => PartialBlock::Passthrough(other),
+        }
+    }
+
+    fn finish(self) -> ContentBlock {
+        match self {
+            PartialBlock::Text(text) => ContentBlock::Text { text },
+            PartialBlock::Thinking {
+                thinking_buf,
+                signature_buf,
+            } => ContentBlock::Thinking {
+                thinking: thinking_buf,
+                signature: signature_buf,
+            },
+            PartialBlock::ToolUse { id, name, json_buf } => {
+                let input =
+                    serde_json::from_str(&json_buf).unwrap_or(Value::Object(Default::default()));
+                ContentBlock::ToolUse { id, name, input }
+            }
+            PartialBlock::Passthrough(block) => block,
+        }
+    }
+}
+
+/// Aggregates provider-level [`StreamEvent`] content-block events into ordered,
+/// finalized [`ContentBlock`]s. Shared by the non-streaming `create_message`
+/// aggregators (Anthropic, MiniMax, …) so that `ThinkingDelta` / `SignatureDelta`
+/// / `ReasoningDelta` are captured into their block (rather than dropped) and
+/// every block — text, thinking, tool_use, and anything else — keeps the stream
+/// index it was emitted at. `finish()` is a single index-ordered pass, so the
+/// model's interleave order (thinking-first / signed-thinking replay) survives.
+/// See issue #217.
+#[derive(Default)]
+pub(crate) struct StreamBlockAccumulator {
+    partials: std::collections::BTreeMap<usize, PartialBlock>,
+}
+
+impl StreamBlockAccumulator {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Feed one `StreamEvent`. Only content-block events mutate state; message
+    /// lifecycle events (`MessageStart`, `MessageDelta`, `MessageStop`,
+    /// `ContentBlockStop`, `Error`) are ignored so callers still handle those
+    /// (id / model / usage / stop_reason) themselves.
+    pub(crate) fn on_event(&mut self, event: &StreamEvent) {
+        match event {
+            StreamEvent::ContentBlockStart {
+                index,
+                content_block,
+            } => {
+                self.partials
+                    .insert(*index, PartialBlock::from_start(content_block.clone()));
+            }
+            StreamEvent::TextDelta { index, text } => {
+                if let Some(PartialBlock::Text(buf)) = self.partials.get_mut(index) {
+                    buf.push_str(text);
+                }
+            }
+            StreamEvent::ThinkingDelta { index, thinking } => {
+                if let PartialBlock::Thinking { thinking_buf, .. } = self
+                    .partials
+                    .entry(*index)
+                    .or_insert_with(PartialBlock::empty_thinking)
+                {
+                    thinking_buf.push_str(thinking);
+                }
+            }
+            StreamEvent::ReasoningDelta { index, reasoning } => {
+                // `ReasoningDelta` is an alias for thinking text used by some
+                // providers; fold it into the same thinking block.
+                if let PartialBlock::Thinking { thinking_buf, .. } = self
+                    .partials
+                    .entry(*index)
+                    .or_insert_with(PartialBlock::empty_thinking)
+                {
+                    thinking_buf.push_str(reasoning);
+                }
+            }
+            StreamEvent::SignatureDelta { index, signature } => {
+                if let PartialBlock::Thinking { signature_buf, .. } = self
+                    .partials
+                    .entry(*index)
+                    .or_insert_with(PartialBlock::empty_thinking)
+                {
+                    signature_buf.push_str(signature);
+                }
+            }
+            StreamEvent::InputJsonDelta {
+                index,
+                partial_json,
+            } => {
+                if let Some(PartialBlock::ToolUse { json_buf, .. }) = self.partials.get_mut(index) {
+                    json_buf.push_str(partial_json);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Consume the accumulator, producing finalized content blocks in the
+    /// stream-index order the model emitted them.
+    pub(crate) fn finish(self) -> Vec<ContentBlock> {
+        self.partials
+            .into_values()
+            .map(PartialBlock::finish)
+            .collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
 // ProviderCapabilities
 // ---------------------------------------------------------------------------
 

--- a/src-rust/crates/api/src/providers/anthropic.rs
+++ b/src-rust/crates/api/src/providers/anthropic.rs
@@ -19,7 +19,7 @@ use crate::provider::LlmProvider;
 use crate::provider_error::ProviderError;
 use crate::provider_types::{
     ProviderCapabilities, ProviderRequest, ProviderResponse, ProviderStatus, StopReason,
-    StreamEvent, SystemPromptStyle,
+    StreamBlockAccumulator, StreamEvent, SystemPromptStyle,
 };
 use crate::streaming::{AnthropicStreamEvent, ContentDelta, NullStreamHandler};
 use crate::types::{ApiMessage, ApiToolDefinition, CreateMessageRequest};
@@ -176,109 +176,62 @@ impl LlmProvider for AnthropicProvider {
 
         let mut id = String::from("unknown");
         let mut model = String::new();
-        let mut text_parts: Vec<(usize, String)> = Vec::new();
-        let mut content_blocks: Vec<ContentBlock> = Vec::new();
         let mut stop_reason = StopReason::EndTurn;
         let mut usage = UsageInfo::default();
 
-        // We need to track tool use blocks being assembled from partial JSON.
-        // Use a simple per-index buffer.
-        let mut tool_buffers: std::collections::HashMap<usize, (String, String, String)> =
-            std::collections::HashMap::new(); // index -> (id, name, json_buf)
+        // Accumulate every content block (text, thinking, tool_use, …) keyed by
+        // its stream index. Captures thinking/signature/reasoning deltas (which
+        // the previous `_ => {}` arm silently dropped) and preserves interleave
+        // order via a single ordered pass. See issue #217.
+        let mut blocks = StreamBlockAccumulator::new();
 
         use futures::StreamExt;
         while let Some(result) = stream.next().await {
             match result {
                 Err(e) => return Err(e),
-                Ok(evt) => match evt {
-                    StreamEvent::MessageStart {
-                        id: msg_id,
-                        model: msg_model,
-                        usage: msg_usage,
-                    } => {
-                        id = msg_id;
-                        model = msg_model;
-                        usage = msg_usage;
-                    }
-                    StreamEvent::ContentBlockStart {
-                        index,
-                        content_block,
-                    } => match content_block {
-                        ContentBlock::Text { text } => {
-                            text_parts.push((index, text));
-                        }
-                        ContentBlock::ToolUse {
-                            id: tool_id,
-                            name,
-                            input: _,
+                Ok(evt) => {
+                    // Content-block events feed the accumulator; message
+                    // lifecycle events update the local id/model/usage/stop.
+                    blocks.on_event(&evt);
+                    match evt {
+                        StreamEvent::MessageStart {
+                            id: msg_id,
+                            model: msg_model,
+                            usage: msg_usage,
                         } => {
-                            tool_buffers.insert(index, (tool_id, name, String::new()));
+                            id = msg_id;
+                            model = msg_model;
+                            usage = msg_usage;
                         }
-                        other => {
-                            content_blocks.push(other);
+                        StreamEvent::MessageDelta {
+                            stop_reason: sr,
+                            usage: delta_usage,
+                        } => {
+                            if let Some(r) = sr {
+                                stop_reason = r;
+                            }
+                            if let Some(u) = delta_usage {
+                                usage.output_tokens += u.output_tokens;
+                            }
                         }
-                    },
-                    StreamEvent::TextDelta { index, text } => {
-                        if let Some(entry) = text_parts.iter_mut().find(|(i, _)| *i == index) {
-                            entry.1.push_str(&text);
-                        }
-                    }
-                    StreamEvent::InputJsonDelta {
-                        index,
-                        partial_json,
-                    } => {
-                        if let Some((_, _, buf)) = tool_buffers.get_mut(&index) {
-                            buf.push_str(&partial_json);
-                        }
-                    }
-                    StreamEvent::ContentBlockStop { index } => {
-                        // Finalize any tool use block at this index.
-                        if let Some((tool_id, name, json_buf)) = tool_buffers.remove(&index) {
-                            let input = serde_json::from_str(&json_buf)
-                                .unwrap_or(serde_json::Value::Object(Default::default()));
-                            content_blocks.push(ContentBlock::ToolUse {
-                                id: tool_id,
-                                name,
-                                input,
+                        StreamEvent::MessageStop => break,
+                        StreamEvent::Error { error_type, message } => {
+                            return Err(ProviderError::StreamError {
+                                provider: self.id.clone(),
+                                message: format!("[{}] {}", error_type, message),
+                                partial_response: None,
                             });
                         }
+                        _ => {}
                     }
-                    StreamEvent::MessageDelta {
-                        stop_reason: sr,
-                        usage: delta_usage,
-                    } => {
-                        if let Some(r) = sr {
-                            stop_reason = r;
-                        }
-                        if let Some(u) = delta_usage {
-                            usage.output_tokens += u.output_tokens;
-                        }
-                    }
-                    StreamEvent::MessageStop => break,
-                    StreamEvent::Error { error_type, message } => {
-                        return Err(ProviderError::StreamError {
-                            provider: self.id.clone(),
-                            message: format!("[{}] {}", error_type, message),
-                            partial_response: None,
-                        });
-                    }
-                    _ => {}
-                },
+                }
             }
         }
 
-        // Assemble text blocks into content, sorted by index.
-        text_parts.sort_by_key(|(i, _)| *i);
-        let mut all_blocks: Vec<(usize, ContentBlock)> = text_parts
-            .into_iter()
-            .map(|(i, text)| (i, ContentBlock::Text { text }))
-            .collect();
-        // We don't have indices for the non-text blocks — just append them.
-        // In practice content blocks are already in-order from the stream.
-        for block in content_blocks {
-            all_blocks.push((usize::MAX, block));
-        }
-        let final_content: Vec<ContentBlock> = all_blocks.into_iter().map(|(_, b)| b).collect();
+        // Finalize every block in stream-index order — a single ordered pass
+        // that preserves interleave (thinking → text → tool_use, …). No block is
+        // appended out of band, so signed-thinking replay order is intact. #217.
+        let final_content: Vec<ContentBlock> = blocks.finish();
 
         Ok(ProviderResponse {
             id,

--- a/src-rust/crates/api/src/providers/minimax.rs
+++ b/src-rust/crates/api/src/providers/minimax.rs
@@ -15,7 +15,7 @@ use crate::provider::{LlmProvider, ModelInfo};
 use crate::provider_error::ProviderError;
 use crate::provider_types::{
     ProviderCapabilities, ProviderRequest, ProviderResponse, ProviderStatus, StopReason,
-    StreamEvent, SystemPromptStyle,
+    StreamBlockAccumulator, StreamEvent, SystemPromptStyle,
 };
 use crate::types::{ApiMessage, ApiToolDefinition, CreateMessageRequest};
 
@@ -217,103 +217,57 @@ impl LlmProvider for MinimaxProvider {
 
         let mut id = String::from("unknown");
         let mut model = String::new();
-        let mut text_parts: Vec<(usize, String)> = Vec::new();
-        let mut content_blocks: Vec<ContentBlock> = Vec::new();
         let mut stop_reason = StopReason::EndTurn;
         let mut usage = UsageInfo::default();
 
-        let mut tool_buffers: std::collections::HashMap<usize, (String, String, String)> =
-            std::collections::HashMap::new();
+        // Accumulate every content block keyed by its stream index — captures
+        // thinking/signature/reasoning deltas and preserves interleave order via
+        // a single ordered pass, instead of appending non-text blocks with
+        // usize::MAX. Same-class fix as the Anthropic aggregator. See issue #217.
+        let mut blocks = StreamBlockAccumulator::new();
 
         use futures::StreamExt;
         while let Some(result) = stream.next().await {
             match result {
                 Err(e) => return Err(e),
-                Ok(evt) => match evt {
-                    StreamEvent::MessageStart {
-                        id: msg_id,
-                        model: msg_model,
-                        usage: msg_usage,
-                    } => {
-                        id = msg_id;
-                        model = msg_model;
-                        usage = msg_usage;
-                    }
-                    StreamEvent::ContentBlockStart {
-                        index,
-                        content_block,
-                    } => match content_block {
-                        ContentBlock::Text { text } => {
-                            text_parts.push((index, text));
-                        }
-                        ContentBlock::ToolUse {
-                            id: tool_id,
-                            name,
-                            input: _,
+                Ok(evt) => {
+                    blocks.on_event(&evt);
+                    match evt {
+                        StreamEvent::MessageStart {
+                            id: msg_id,
+                            model: msg_model,
+                            usage: msg_usage,
                         } => {
-                            tool_buffers.insert(index, (tool_id, name, String::new()));
+                            id = msg_id;
+                            model = msg_model;
+                            usage = msg_usage;
                         }
-                        other => {
-                            content_blocks.push(other);
+                        StreamEvent::MessageDelta {
+                            stop_reason: sr,
+                            usage: delta_usage,
+                        } => {
+                            if let Some(r) = sr {
+                                stop_reason = r;
+                            }
+                            if let Some(u) = delta_usage {
+                                usage.output_tokens += u.output_tokens;
+                            }
                         }
-                    },
-                    StreamEvent::TextDelta { index, text } => {
-                        if let Some(entry) = text_parts.iter_mut().find(|(i, _)| *i == index) {
-                            entry.1.push_str(&text);
-                        }
-                    }
-                    StreamEvent::InputJsonDelta {
-                        index,
-                        partial_json,
-                    } => {
-                        if let Some((_, _, buf)) = tool_buffers.get_mut(&index) {
-                            buf.push_str(&partial_json);
-                        }
-                    }
-                    StreamEvent::ContentBlockStop { index } => {
-                        if let Some((tool_id, name, json_buf)) = tool_buffers.remove(&index) {
-                            let input = serde_json::from_str(&json_buf)
-                                .unwrap_or(serde_json::Value::Object(Default::default()));
-                            content_blocks.push(ContentBlock::ToolUse {
-                                id: tool_id,
-                                name,
-                                input,
+                        StreamEvent::MessageStop => break,
+                        StreamEvent::Error { error_type, message } => {
+                            return Err(ProviderError::StreamError {
+                                provider: self.id.clone(),
+                                message: format!("[{}] {}", error_type, message),
+                                partial_response: None,
                             });
                         }
+                        _ => {}
                     }
-                    StreamEvent::MessageDelta {
-                        stop_reason: sr,
-                        usage: delta_usage,
-                    } => {
-                        if let Some(r) = sr {
-                            stop_reason = r;
-                        }
-                        if let Some(u) = delta_usage {
-                            usage.output_tokens += u.output_tokens;
-                        }
-                    }
-                    StreamEvent::MessageStop => break,
-                    StreamEvent::Error { error_type, message } => {
-                        return Err(ProviderError::StreamError {
-                            provider: self.id.clone(),
-                            message: format!("[{}] {}", error_type, message),
-                            partial_response: None,
-                        });
-                    }
-                    _ => {}
-                },
+                }
             }
         }
 
-        text_parts.sort_by_key(|(i, _)| *i);
-        let mut all_blocks: Vec<(usize, ContentBlock)> = text_parts
-            .into_iter()
-            .map(|(i, text)| (i, ContentBlock::Text { text }))
-            .collect();
-        for block in content_blocks {
-            all_blocks.push((usize::MAX, block));
-        }
-        let final_content: Vec<ContentBlock> = all_blocks.into_iter().map(|(_, b)| b).collect();
+        let final_content: Vec<ContentBlock> = blocks.finish();
 
         Ok(ProviderResponse {
             id,


### PR DESCRIPTION
Fixes #217. Reconfirmed **live** (the non-streaming `LlmProvider::create_message` is hit from web_fetch, the free-provider fallback, commands, and away_summary). The Anthropic aggregator dropped `ThinkingDelta`/`SignatureDelta`/`ReasoningDelta` (`_ => {}`) and appended non-text blocks with `usize::MAX`, emptying thinking blocks and destroying interleave order (breaks signed-thinking replay). Added a shared index-keyed `StreamBlockAccumulator`; both Anthropic and MiniMax (same-class bug) now use it. 3 commits + tests, `cargo test --workspace` green.

Closes #217