### PR TITLE
fix(query): preserve conversation across failed compaction (was mem::take-wiped)

### DIFF
--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -715,6 +715,33 @@ const MAX_TOKENS_RECOVERY_MSG: &str =
 
 // Spinner verbs are imported from claurst_core::spinner
 
+/// Apply the outcome of a reactive-compact / context-collapse call to the live
+/// message list, preserving the conversation when compaction fails.
+///
+/// Fixes #213: the reactive paths used to `std::mem::take(messages)` before
+/// calling `compact::reactive_compact` / `compact::context_collapse`. That left
+/// `*messages` empty, and on ANY failure (API error, `Cancelled`, empty
+/// summary) the drained messages were never restored — silently destroying the
+/// live conversation. Here we only overwrite `*messages` when compaction
+/// returns `Ok`; on `Err` the original messages are left completely untouched,
+/// so a failed compaction can never wipe the session.
+///
+/// Returns `Ok(tokens_freed)` on success, or the original error on failure.
+fn apply_compact_result<E>(
+    messages: &mut Vec<Message>,
+    outcome: Result<compact::CompactResult, E>,
+) -> Result<u64, E> {
+    match outcome {
+        Ok(result) => {
+            let tokens_freed = result.tokens_freed;
+            *messages = result.messages;
+            Ok(tokens_freed)
+        }
+        // Failure: leave `*messages` untouched so the conversation survives.
+        Err(e) => Err(e),
+    }
+}
+
 /// Run the agentic query loop.
 ///
 /// This sends the conversation to the API, handles tool calls in a loop, and
@@ -1656,51 +1683,43 @@ pub async fn run_query_loop(
                         "Compacting context... (emergency collapse)".to_string(),
                     ));
                 }
-                match compact::context_collapse(
-                    std::mem::take(messages),
-                    client,
-                    config,
-                )
-                .await
-                {
-                    Ok(result) => {
-                        *messages = result.messages;
-                        info!(
-                            tokens_freed = result.tokens_freed,
-                            "Context-collapse complete"
-                        );
+                // Pass a clone so the live conversation survives a failed
+                // compaction; `*messages` is only overwritten on success (#213).
+                let outcome =
+                    compact::context_collapse(messages.clone(), client, config).await;
+                match apply_compact_result(messages, outcome) {
+                    Ok(tokens_freed) => {
+                        info!(tokens_freed, "Context-collapse complete");
                     }
                     Err(e) => {
-                        warn!(error = %e, "Context-collapse failed");
-                        // Put messages back on failure (mem::take drained them).
-                        // We can't recover them here — re-run auto-compact as fallback.
+                        // `*messages` is left untouched — the conversation is intact.
+                        warn!(error = %e, "Context-collapse failed; conversation preserved");
                     }
                 }
             } else if compact::should_compact(usage.input_tokens, context_limit) {
                 if let Some(ref tx) = event_tx {
                     let _ = tx.send(QueryEvent::Status("Compacting context...".to_string()));
                 }
-                match compact::reactive_compact(
-                    std::mem::take(messages),
+                // Pass a clone so the live conversation survives a failed
+                // compaction; `*messages` is only overwritten on success (#213).
+                let outcome = compact::reactive_compact(
+                    messages.clone(),
                     client,
                     config,
                     cancel_token.clone(),
                     &[],
                 )
-                .await
-                {
-                    Ok(result) => {
-                        *messages = result.messages;
-                        info!(
-                            tokens_freed = result.tokens_freed,
-                            "Reactive compact complete"
-                        );
+                .await;
+                match apply_compact_result(messages, outcome) {
+                    Ok(tokens_freed) => {
+                        info!(tokens_freed, "Reactive compact complete");
                     }
+                    // `*messages` is left untouched on both failure arms below.
                     Err(claurst_core::error::ClaudeError::Cancelled) => {
-                        warn!("Reactive compact was cancelled");
+                        warn!("Reactive compact was cancelled; conversation preserved");
                     }
                     Err(e) => {
-                        warn!(error = %e, "Reactive compact failed");
+                        warn!(error = %e, "Reactive compact failed; conversation preserved");
                     }
                 }
             }

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -2541,6 +2541,92 @@ mod tests {
         assert!(is_openaiish_provider("alibaba"));
         assert!(is_openaiish_provider("qwen"));
     }
+
+    // ---- apply_compact_result / #213 data-loss guard ------------------------
+
+    fn sample_conversation() -> Vec<Message> {
+        vec![
+            Message::user("initial user request"),
+            Message::assistant("assistant reply with important context"),
+            Message::user("follow-up question"),
+            Message::assistant("second assistant reply"),
+        ]
+    }
+
+    fn texts(messages: &[Message]) -> Vec<String> {
+        messages.iter().map(|m| m.get_all_text()).collect()
+    }
+
+    #[test]
+    fn failed_compaction_preserves_messages() {
+        // Regression test for #213: a failed compaction must NOT wipe the
+        // conversation. Previously the reactive path drained `messages` with
+        // std::mem::take and never restored them on error.
+        let mut messages = sample_conversation();
+        let before = texts(&messages);
+
+        // Simulate a failed reactive_compact / context_collapse (API error,
+        // Cancelled, empty summary all map to Err here).
+        let outcome: Result<compact::CompactResult, ClaudeError> =
+            Err(ClaudeError::Cancelled);
+        let result = apply_compact_result(&mut messages, outcome);
+
+        assert!(result.is_err(), "helper must surface the compaction error");
+        assert_eq!(
+            messages.len(),
+            before.len(),
+            "messages must not be emptied on failed compaction"
+        );
+        assert_eq!(
+            texts(&messages),
+            before,
+            "message contents must be identical after failed compaction"
+        );
+    }
+
+    #[test]
+    fn failed_compaction_with_generic_error_preserves_messages() {
+        // The helper is generic over the error type; any Err leaves messages
+        // untouched.
+        let mut messages = sample_conversation();
+        let before = texts(&messages);
+
+        let outcome: Result<compact::CompactResult, &str> = Err("empty summary");
+        let result = apply_compact_result(&mut messages, outcome);
+
+        assert_eq!(result, Err("empty summary"));
+        assert_eq!(texts(&messages), before);
+    }
+
+    #[test]
+    fn successful_compaction_replaces_messages() {
+        // On success the compacted result replaces the live messages and the
+        // freed-token count is returned.
+        let mut messages = sample_conversation();
+        let compacted = vec![
+            Message::user("[summary of earlier conversation]"),
+            Message::user("follow-up question"),
+        ];
+        let expected = texts(&compacted);
+
+        let outcome: Result<compact::CompactResult, ClaudeError> = Ok(compact::CompactResult {
+            messages: compacted,
+            summary: "[summary of earlier conversation]".to_string(),
+            tokens_freed: 4_096,
+        });
+        let result = apply_compact_result(&mut messages, outcome);
+
+        assert_eq!(
+            result.unwrap(),
+            4_096,
+            "tokens_freed must be surfaced on success"
+        );
+        assert_eq!(
+            texts(&messages),
+            expected,
+            "messages must be replaced with the compacted result on success"
+        );
+    }
 }
 
 /// Stream handler that forwards events to an unbounded channel.


### PR DESCRIPTION
Fixes #213. reactive-compact / context-collapse called the compaction fns with `std::mem::take(messages)`, emptying the live conversation; on any failure (empty summary, API error, cancel) it was never restored — session destroyed. Now passes `messages.clone()` and applies the result only on `Ok` via a new `apply_compact_result` helper; every failure path leaves messages untouched. 2 commits + 3 tests, `cargo test -p claurst-query` = 90 passed.

Closes #213