### PR TITLE
fix(query): don't execute tools from a failed provider stream; error on malformed tool args

### DIFF
--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -1368,10 +1368,31 @@ pub async fn run_query_loop(
                     // Reconstruct tool-use blocks (sorted by index for determinism).
                     let mut tc_indices: Vec<usize> = tool_call_blocks.keys().cloned().collect();
                     tc_indices.sort();
+                    // Tool calls whose accumulated JSON arguments failed to
+                    // parse. We still emit a tool_use block (so the assistant
+                    // message stays well-formed and every tool_use has a
+                    // matching tool_result), but we must NOT execute the tool
+                    // with empty/garbage input — instead we surface a tool
+                    // error to the model so it can retry (issue #215).
+                    let mut malformed_tool_calls: std::collections::HashSet<String> =
+                        std::collections::HashSet::new();
                     for idx in tc_indices {
                         if let Some((id, name, json_str)) = tool_call_blocks.remove(&idx) {
-                            let input: serde_json::Value = serde_json::from_str(&json_str)
-                                .unwrap_or(serde_json::json!({}));
+                            let input = match parse_tool_args(&json_str) {
+                                Ok(v) => v,
+                                Err(e) => {
+                                    warn!(
+                                        provider = %provider_id_str,
+                                        tool = %name,
+                                        tool_id = %id,
+                                        error = %e,
+                                        "Tool-call arguments failed to parse (truncated/malformed JSON); surfacing a tool error instead of executing with empty args"
+                                    );
+                                    malformed_tool_calls.insert(id.clone());
+                                    // Placeholder input — this call is never executed.
+                                    serde_json::json!({})
+                                }
+                            };
                             content_blocks.push(ContentBlock::ToolUse { id, name, input });
                         }
                     }
@@ -1418,7 +1439,17 @@ pub async fn run_query_loop(
                                     input_json: tool_input.to_string(),
                                 });
                             }
-                            let result = execute_tool(&*tool_name, &tool_input, tools, &tool_ctx).await;
+                            let result = if malformed_tool_calls.contains(&tool_id) {
+                                // Never execute a tool whose arguments could not
+                                // be parsed — return an error the model can see
+                                // and recover from (issue #215).
+                                ToolResult::error(format!(
+                                    "Tool call '{}' was not executed: its arguments were malformed or truncated JSON. Retry the tool call with complete, valid JSON arguments.",
+                                    tool_name
+                                ))
+                            } else {
+                                execute_tool(&*tool_name, &tool_input, tools, &tool_ctx).await
+                            };
                             if let Some(ref tx) = event_tx {
                                 let _ = tx.send(QueryEvent::ToolEnd {
                                     tool_name: tool_name.clone(),
@@ -2181,6 +2212,23 @@ pub async fn run_query_loop(
             }
         }
     }
+}
+
+/// Parse the accumulated JSON arguments of a streamed tool call.
+///
+/// Providers stream a tool call's arguments as a sequence of partial-JSON
+/// deltas which we concatenate into a single buffer. A well-behaved
+/// no-argument call yields an empty (or whitespace-only) buffer, which we
+/// map to an empty object. Any *non-empty* buffer that fails to parse is
+/// returned as an error rather than being silently replaced with `{}` — a
+/// truncated stream must never cause a tool (e.g. Edit/Write) to run with
+/// empty arguments (issue #215).
+fn parse_tool_args(json_str: &str) -> Result<Value, serde_json::Error> {
+    let trimmed = json_str.trim();
+    if trimmed.is_empty() {
+        return Ok(serde_json::json!({}));
+    }
+    serde_json::from_str(trimmed)
 }
 
 /// Execute a single tool invocation.

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -1214,6 +1214,10 @@ pub async fn run_query_loop(
                     let provider_stall = tokio::time::sleep(provider_stall_timeout);
                     tokio::pin!(provider_stall);
                     let mut provider_stream_stalled = false;
+                    // Set when the stream yields a mid-stream `Err`. The
+                    // accumulated text/tool-calls are then incomplete and MUST
+                    // NOT be assembled into a "completed" turn (issue #215).
+                    let mut provider_stream_error: Option<String> = None;
 
                     loop {
                         tokio::select! {
@@ -1230,6 +1234,7 @@ pub async fn run_query_loop(
                                     None => break,
                                     Some(Err(e)) => {
                                         error!(provider = %provider_id_str, error = %e, "Provider stream error");
+                                        provider_stream_error = Some(e.to_string());
                                         break;
                                     }
                                     Some(Ok(evt)) => {
@@ -1302,6 +1307,44 @@ pub async fn run_query_loop(
                         }
                         turn -= 1;
                         continue;
+                    }
+
+                    // A mid-stream error means the accumulated text and
+                    // tool-call JSON are incomplete/untrustworthy. Do NOT fall
+                    // through to assemble and execute tools from a truncated
+                    // stream (issue #215 — an Edit/Write could otherwise run
+                    // with empty `{}` args). Mirror the Anthropic branch's
+                    // retry semantics: retry the turn if retries remain,
+                    // otherwise surface the failure as a QueryOutcome::Error.
+                    if let Some(err) = provider_stream_error {
+                        if retries_left > 0 {
+                            retries_left -= 1;
+                            warn!(
+                                provider = %provider_id_str,
+                                model = %model_id_str,
+                                retries_left,
+                                error = %err,
+                                "Provider stream error — retrying turn"
+                            );
+                            if let Some(ref tx) = event_tx {
+                                let _ = tx.send(QueryEvent::Status(format!(
+                                    "Stream error — retrying ({} left)…",
+                                    retries_left + 1
+                                )));
+                            }
+                            turn -= 1;
+                            continue;
+                        }
+                        error!(
+                            provider = %provider_id_str,
+                            model = %model_id_str,
+                            error = %err,
+                            "Provider stream error — retries exhausted; aborting turn"
+                        );
+                        return QueryOutcome::Error(ClaudeError::Api(format!(
+                            "Provider '{}' stream error (model '{}'): {}",
+                            provider_id_str, model_id_str, err
+                        )));
                     }
 
                     // Build the content blocks from accumulated stream data.

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -2423,6 +2423,61 @@ mod tests {
         }
     }
 
+    // ---- parse_tool_args tests (issue #215) ---------------------------------
+
+    #[test]
+    fn test_parse_tool_args_valid_object() {
+        // A complete JSON object parses to the same value.
+        let v = parse_tool_args("{\"a\":1}").expect("valid JSON should parse");
+        assert_eq!(v, serde_json::json!({ "a": 1 }));
+
+        let v = parse_tool_args("{\"path\": \"/tmp/x\", \"content\": \"hi\"}")
+            .expect("valid JSON should parse");
+        assert_eq!(v["path"], "/tmp/x");
+        assert_eq!(v["content"], "hi");
+    }
+
+    #[test]
+    fn test_parse_tool_args_empty_is_empty_object() {
+        // No-argument tool calls arrive as an empty (or whitespace-only)
+        // buffer and must map to `{}` so the happy path still works.
+        assert_eq!(parse_tool_args("").unwrap(), serde_json::json!({}));
+        assert_eq!(parse_tool_args("   ").unwrap(), serde_json::json!({}));
+        assert_eq!(parse_tool_args("\n\t ").unwrap(), serde_json::json!({}));
+    }
+
+    #[test]
+    fn test_parse_tool_args_truncated_is_error_not_empty_object() {
+        // The core of issue #215: a truncated/malformed stream must surface
+        // an error, NOT silently become `{}` (which would run Edit/Write with
+        // empty arguments).
+        assert!(
+            parse_tool_args("{\"a\":").is_err(),
+            "truncated JSON must be an error"
+        );
+        assert!(
+            parse_tool_args("{\"path\": \"/etc/passwd").is_err(),
+            "truncated string value must be an error"
+        );
+        assert!(
+            parse_tool_args("{not json}").is_err(),
+            "invalid JSON must be an error"
+        );
+
+        // Regression guard: the failing cases must never resolve to `{}`.
+        for bad in ["{\"a\":", "{\"path\": \"/etc/passwd", "{not json}"] {
+            let resolved = parse_tool_args(bad).unwrap_or(serde_json::json!({}));
+            // The OLD buggy behavior turned these into `{}`; assert we now
+            // *detect* the error rather than relying on that fallback.
+            assert!(
+                parse_tool_args(bad).is_err(),
+                "expected error for {:?}, but got {}",
+                bad,
+                resolved
+            );
+        }
+    }
+
     // ---- build_system_prompt tests ------------------------------------------
 
     #[test]


### PR DESCRIPTION
Fixes #215. The provider streaming branch swallowed mid-stream errors and assembled the partial turn as complete, dispatching tools from truncated JSON via `unwrap_or(json!({}))` (e.g. Edit/Write with empty args). Now a mid-stream error retries (via the shared retries_left, matching the Anthropic branch) or returns `QueryOutcome::Error`. Unparseable tool args return a recoverable `ToolResult::error` while still emitting the `tool_use` block (keeps tool_use<->tool_result pairing). 3 commits + tests, `cargo test -p claurst-query` = 93 passed.

Closes #215