### PR TITLE
fix(tools): preserve line endings on edit (was silent CRLF->LF rewrite)

### DIFF
--- a/src-rust/crates/tools/src/apply_patch.rs
+++ b/src-rust/crates/tools/src/apply_patch.rs
@@ -342,7 +342,13 @@ impl Tool for ApplyPatchTool {
                 String::new()
             };
 
-            // Split into lines (keep newlines for join later).
+            // Detect the file's dominant line ending BEFORE editing so we can
+            // rejoin with it instead of collapsing everything to LF (#225).
+            // `str::lines()` strips both `\n` and `\r\n`, so a CRLF file would
+            // otherwise be silently rewritten to LF throughout.
+            let eol = crate::line_endings::LineEnding::detect(&original_content);
+
+            // Split into lines (line endings are re-applied on join below).
             let mut lines: Vec<String> = original_content
                 .lines()
                 .map(|l| l.to_string())
@@ -378,10 +384,11 @@ impl Tool for ApplyPatchTool {
             let new_content = if lines.is_empty() {
                 String::new()
             } else {
-                // Re-join with newlines; preserve trailing newline if original had one.
-                let mut s = lines.join("\n");
+                // Re-join with the file's original line ending; preserve a
+                // trailing newline if the original had one.
+                let mut s = lines.join(eol.as_str());
                 if original_content.ends_with('\n') || original_content.is_empty() {
-                    s.push('\n');
+                    s.push_str(eol.as_str());
                 }
                 s
             };

--- a/src-rust/crates/tools/src/apply_patch.rs
+++ b/src-rust/crates/tools/src/apply_patch.rs
@@ -531,4 +531,27 @@ mod tests {
         assert_eq!(fps[0].path, "a.rs");
         assert_eq!(fps[1].path, "b.rs");
     }
+
+    /// #225: applying a patch to a CRLF file must keep CRLF, not collapse the
+    /// whole file to LF (str::lines() strips the `\r`).
+    #[tokio::test]
+    async fn apply_patch_crlf_file_preserves_crlf() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("file.txt");
+        let original = "one\r\ntwo\r\nthree\r\n";
+        std::fs::write(&path, original).unwrap();
+
+        let ctx = crate::test_support::allow_all_context(dir.path().to_path_buf());
+        // Patch content itself uses LF (as a real unified diff would); the
+        // target file's CRLF endings must survive the round-trip.
+        let patch = "--- a/file.txt\n+++ b/file.txt\n@@ -1,3 +1,3 @@\n one\n-two\n+TWO\n three\n";
+        let res = ApplyPatchTool
+            .execute(json!({ "patch": patch }), &ctx)
+            .await;
+        assert!(!res.is_error, "apply patch failed: {}", res.content);
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(after, "one\r\nTWO\r\nthree\r\n");
+        assert_eq!(after.matches('\n').count(), after.matches("\r\n").count());
+    }
 }

--- a/src-rust/crates/tools/src/batch_edit.rs
+++ b/src-rust/crates/tools/src/batch_edit.rs
@@ -134,12 +134,17 @@ impl Tool for BatchEditTool {
                 }
             };
 
-            // Normalize Windows CRLF line endings so matching behavior is stable
-            let content = original.replace("\r\n", "\n");
+            // Detect the current content's dominant line ending BEFORE editing
+            // so it survives the write (#225).  Match on an LF-normalized view
+            // but splice the replacement into the original bytes so untouched
+            // lines keep their exact endings.  `original` here is either the raw
+            // on-disk content or a previous edit's output (both real EOLs).
+            let eol = crate::line_endings::LineEnding::detect(&original);
+            let normalized = original.replace("\r\n", "\n");
             let old_string = edit.old_string.replace("\r\n", "\n");
             let new_string = edit.new_string.replace("\r\n", "\n");
 
-            let count = content.matches(&old_string).count();
+            let count = normalized.matches(&old_string).count();
             if count == 0 {
                 pre_check_errors.push(format!(
                     "Edit {}: old_string not found in {}",
@@ -158,7 +163,13 @@ impl Tool for BatchEditTool {
                 continue;
             }
 
-            let new_content = content.replacen(&old_string, &new_string, 1);
+            let (new_content, _replacements) = crate::line_endings::replace_preserving_eol(
+                &original,
+                &old_string,
+                &new_string,
+                eol,
+                false,
+            );
             prepared.push((path.display().to_string(), original, new_content.clone()));
             // update path_content so future edits see the new content
             path_content.insert(path.display().to_string(), new_content);

--- a/src-rust/crates/tools/src/batch_edit.rs
+++ b/src-rust/crates/tools/src/batch_edit.rs
@@ -270,3 +270,37 @@ impl Tool for BatchEditTool {
         }))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::allow_all_context;
+
+    /// #225: a multi-edit batch on a CRLF file keeps CRLF throughout; only the
+    /// edited lines change.
+    #[tokio::test]
+    async fn batch_edit_crlf_file_preserves_crlf() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("crlf.txt");
+        let original = "alpha\r\nbeta\r\ngamma\r\n";
+        std::fs::write(&path, original).unwrap();
+
+        let ctx = allow_all_context(dir.path().to_path_buf());
+        let res = BatchEditTool
+            .execute(
+                json!({
+                    "edits": [
+                        { "file_path": path.to_string_lossy(), "old_string": "alpha", "new_string": "ALPHA" },
+                        { "file_path": path.to_string_lossy(), "old_string": "gamma", "new_string": "GAMMA" }
+                    ]
+                }),
+                &ctx,
+            )
+            .await;
+        assert!(!res.is_error, "batch edit failed: {}", res.content);
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(after, "ALPHA\r\nbeta\r\nGAMMA\r\n");
+        assert_eq!(after.matches('\n').count(), after.matches("\r\n").count());
+    }
+}

--- a/src-rust/crates/tools/src/file_edit.rs
+++ b/src-rust/crates/tools/src/file_edit.rs
@@ -167,3 +167,63 @@ impl Tool for FileEditTool {
         }))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::allow_all_context;
+
+    /// #225: editing a CRLF file must keep CRLF; only the edited line changes.
+    #[tokio::test]
+    async fn edit_crlf_file_preserves_crlf() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("crlf.txt");
+        let original = "line one\r\nline two\r\nline three\r\n";
+        std::fs::write(&path, original).unwrap();
+
+        let ctx = allow_all_context(dir.path().to_path_buf());
+        let res = FileEditTool
+            .execute(
+                json!({
+                    "file_path": path.to_string_lossy(),
+                    "old_string": "line two",
+                    "new_string": "LINE TWO",
+                }),
+                &ctx,
+            )
+            .await;
+        assert!(!res.is_error, "edit failed: {}", res.content);
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        // Only the target changed; every other line kept its CRLF.
+        assert_eq!(after, "line one\r\nLINE TWO\r\nline three\r\n");
+        // No line ending was flipped to a bare LF.
+        assert_eq!(after.matches('\n').count(), after.matches("\r\n").count());
+    }
+
+    /// #225: an LF file must stay LF (no stray CR introduced).
+    #[tokio::test]
+    async fn edit_lf_file_stays_lf() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("lf.txt");
+        let original = "line one\nline two\nline three\n";
+        std::fs::write(&path, original).unwrap();
+
+        let ctx = allow_all_context(dir.path().to_path_buf());
+        let res = FileEditTool
+            .execute(
+                json!({
+                    "file_path": path.to_string_lossy(),
+                    "old_string": "line two",
+                    "new_string": "LINE TWO",
+                }),
+                &ctx,
+            )
+            .await;
+        assert!(!res.is_error, "edit failed: {}", res.content);
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(after, "line one\nLINE TWO\nline three\n");
+        assert!(!after.contains('\r'), "LF file gained a CR: {:?}", after);
+    }
+}

--- a/src-rust/crates/tools/src/file_edit.rs
+++ b/src-rust/crates/tools/src/file_edit.rs
@@ -96,14 +96,17 @@ impl Tool for FileEditTool {
             }
         };
 
-        // Normalize Windows CRLF line endings so matching behavior is stable
-        // across platforms and consistent with the TypeScript tool.
-        let content = content.replace("\r\n", "\n");
+        // Detect the file's original/dominant line ending BEFORE editing so we
+        // can re-apply it on write (#225).  Matching is done against an
+        // LF-normalized view so CRLF/LF differences never affect the match, but
+        // only the lines the edit actually changes are ever rewritten.
+        let eol = crate::line_endings::LineEnding::detect(&content);
+        let normalized = content.replace("\r\n", "\n");
         let old_string = params.old_string.replace("\r\n", "\n");
         let new_string = params.new_string.replace("\r\n", "\n");
 
         // Count occurrences
-        let count = content.matches(&old_string).count();
+        let count = normalized.matches(&old_string).count();
 
         if count == 0 {
             return ToolResult::error(format!(
@@ -123,13 +126,16 @@ impl Tool for FileEditTool {
             ));
         }
 
-        // Perform replacement
-        let new_content = if params.replace_all {
-            content.replace(&old_string, &new_string)
-        } else {
-            // Replace only the first occurrence
-            content.replacen(&old_string, &new_string, 1)
-        };
+        // Perform the replacement on the ORIGINAL bytes, preserving every
+        // untouched region's line endings and re-rendering inserted lines with
+        // the file's dominant line ending.
+        let (new_content, _replacements) = crate::line_endings::replace_preserving_eol(
+            &content,
+            &old_string,
+            &new_string,
+            eol,
+            params.replace_all,
+        );
 
         // Write back
         if let Err(e) = crate::write_atomic(&path, new_content.as_bytes()).await {

--- a/src-rust/crates/tools/src/lib.rs
+++ b/src-rust/crates/tools/src/lib.rs
@@ -26,6 +26,7 @@ pub mod exit_plan_mode;
 pub mod apply_patch;
 pub mod batch_edit;
 pub mod file_edit;
+pub mod line_endings;
 pub mod file_read;
 pub mod file_write;
 pub mod glob_tool;

--- a/src-rust/crates/tools/src/lib.rs
+++ b/src-rust/crates/tools/src/lib.rs
@@ -27,6 +27,8 @@ pub mod apply_patch;
 pub mod batch_edit;
 pub mod file_edit;
 pub mod line_endings;
+#[cfg(test)]
+pub(crate) mod test_support;
 pub mod file_read;
 pub mod file_write;
 pub mod glob_tool;

--- a/src-rust/crates/tools/src/line_endings.rs
+++ b/src-rust/crates/tools/src/line_endings.rs
@@ -1,0 +1,240 @@
+//! Line-ending detection and preservation for the file-editing tools.
+//!
+//! Issue #225: the edit tools normalized `\r\n` -> `\n` for matching and then
+//! wrote the LF-normalized content back, silently rewriting *every* line ending
+//! of a CRLF file to LF. That produces a massive spurious diff and corrupts
+//! files that must stay CRLF (this repo's own `crates/tui/src/lib.rs` is
+//! intentionally CRLF).
+//!
+//! These helpers let a tool match/replace on an LF-normalized view while
+//! writing back with the file's original line endings, so only the lines an
+//! edit actually changes ever differ.
+
+/// The dominant line ending of a text file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LineEnding {
+    /// Unix `\n`.
+    Lf,
+    /// Windows `\r\n`.
+    Crlf,
+}
+
+impl LineEnding {
+    /// Detect the dominant line ending of `content`.
+    ///
+    /// CRLF is reported only when it is the majority of the file's line
+    /// endings, so a predominantly-CRLF file stays CRLF and a predominantly-LF
+    /// file (or one with only a stray `\r\n`) stays LF. A file with no newline
+    /// at all defaults to [`LineEnding::Lf`].
+    pub fn detect(content: &str) -> LineEnding {
+        let crlf = content.matches("\r\n").count();
+        if crlf == 0 {
+            return LineEnding::Lf;
+        }
+        // Every `\r\n` contributes one `\n`, so bare LF endings are the total
+        // `\n` count minus the CRLF count.
+        let bare_lf = content.matches('\n').count() - crlf;
+        if crlf >= bare_lf {
+            LineEnding::Crlf
+        } else {
+            LineEnding::Lf
+        }
+    }
+
+    /// The byte sequence for this line ending.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            LineEnding::Lf => "\n",
+            LineEnding::Crlf => "\r\n",
+        }
+    }
+
+    /// Render LF-normalized `content` with this line ending.
+    ///
+    /// `content` must already use `\n` for every line ending (as produced by
+    /// replacing `\r\n` with `\n`). For [`LineEnding::Lf`] this is a no-op; for
+    /// [`LineEnding::Crlf`] every `\n` becomes `\r\n`.
+    pub fn apply(self, content: &str) -> String {
+        match self {
+            LineEnding::Lf => content.to_string(),
+            LineEnding::Crlf => content.replace('\n', "\r\n"),
+        }
+    }
+}
+
+/// Replace `old_norm` with `new_norm` inside `original`, preserving the exact
+/// bytes — and therefore the line endings — of every region that is NOT
+/// replaced.
+///
+/// Matching is line-ending agnostic: it runs against an LF-normalized view of
+/// `original`, so an `old_norm` that uses `\n` still matches a region stored
+/// with `\r\n`. `old_norm` and `new_norm` must already be LF-normalized; the
+/// replacement text is re-rendered with `eol` so inserted lines adopt the
+/// file's dominant line ending. Untouched regions keep their original bytes
+/// verbatim, which is what makes a mixed-EOL file safe to edit (nothing outside
+/// the replaced span is mass-converted).
+///
+/// Returns `(new_content, replacements_made)`. When `replace_all` is false only
+/// the first occurrence is replaced.
+pub(crate) fn replace_preserving_eol(
+    original: &str,
+    old_norm: &str,
+    new_norm: &str,
+    eol: LineEnding,
+    replace_all: bool,
+) -> (String, usize) {
+    let orig = original.as_bytes();
+
+    // Build an LF-normalized byte view of `original`, together with a map from
+    // each normalized-byte index to its starting offset in `original`. A `\r\n`
+    // collapses to a single `\n` that maps to the `\r`'s offset.
+    let mut norm: Vec<u8> = Vec::with_capacity(orig.len());
+    let mut map: Vec<usize> = Vec::with_capacity(orig.len() + 1);
+    let mut i = 0;
+    while i < orig.len() {
+        map.push(i);
+        if orig[i] == b'\r' && i + 1 < orig.len() && orig[i + 1] == b'\n' {
+            norm.push(b'\n');
+            i += 2;
+        } else {
+            norm.push(orig[i]);
+            i += 1;
+        }
+    }
+    map.push(orig.len()); // sentinel: index for a match that ends at EOF
+
+    let old_b = old_norm.as_bytes();
+    let new_rendered = eol.apply(new_norm);
+    let new_b = new_rendered.as_bytes();
+
+    let mut result: Vec<u8> = Vec::with_capacity(orig.len());
+    let mut copied = 0usize; // bytes of `orig` already emitted
+    let mut search_from = 0usize; // index into `norm`
+    let mut count = 0usize;
+
+    while let Some(rel) = find_subslice(&norm[search_from..], old_b) {
+        let start = search_from + rel; // norm index of match start
+        let end = start + old_b.len(); // norm index just past the match
+
+        // Map the normalized match span back onto original byte offsets. UTF-8
+        // is self-synchronizing, so a valid needle can only match on a char
+        // boundary — these offsets always land on boundaries.
+        let orig_start = map[start];
+        let orig_end = map[end];
+
+        result.extend_from_slice(&orig[copied..orig_start]);
+        result.extend_from_slice(new_b);
+        copied = orig_end;
+        count += 1;
+        search_from = end;
+
+        if !replace_all {
+            break;
+        }
+    }
+
+    result.extend_from_slice(&orig[copied..]);
+
+    // Safe: we only drop a `\r` that precedes a `\n` and splice in valid UTF-8.
+    // The lossy fallback is purely defensive and should be unreachable.
+    let new_content = match String::from_utf8(result) {
+        Ok(s) => s,
+        Err(e) => String::from_utf8_lossy(e.as_bytes()).into_owned(),
+    };
+    (new_content, count)
+}
+
+/// Return the index of the first occurrence of `needle` within `haystack`.
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() {
+        return Some(0);
+    }
+    if needle.len() > haystack.len() {
+        return None;
+    }
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_pure_lf() {
+        assert_eq!(LineEnding::detect("a\nb\nc\n"), LineEnding::Lf);
+        assert_eq!(LineEnding::detect("no newline at all"), LineEnding::Lf);
+        assert_eq!(LineEnding::detect(""), LineEnding::Lf);
+    }
+
+    #[test]
+    fn detect_pure_crlf() {
+        assert_eq!(LineEnding::detect("a\r\nb\r\nc\r\n"), LineEnding::Crlf);
+    }
+
+    #[test]
+    fn detect_mixed_uses_majority() {
+        // Majority CRLF (2 CRLF vs 1 bare LF) -> Crlf.
+        assert_eq!(LineEnding::detect("a\r\nb\r\nc\nd"), LineEnding::Crlf);
+        // Majority LF (1 CRLF vs 2 bare LF) -> Lf.
+        assert_eq!(LineEnding::detect("a\r\nb\nc\nd"), LineEnding::Lf);
+    }
+
+    #[test]
+    fn apply_roundtrips() {
+        assert_eq!(LineEnding::Lf.apply("a\nb\n"), "a\nb\n");
+        assert_eq!(LineEnding::Crlf.apply("a\nb\n"), "a\r\nb\r\n");
+    }
+
+    #[test]
+    fn replace_lf_stays_lf() {
+        let (out, n) =
+            replace_preserving_eol("a\nb\nc\n", "b", "B", LineEnding::Lf, false);
+        assert_eq!(out, "a\nB\nc\n");
+        assert_eq!(n, 1);
+    }
+
+    #[test]
+    fn replace_crlf_keeps_crlf_and_only_target_changes() {
+        // LF-normalized old_string matches a CRLF region; every other EOL stays.
+        let (out, n) =
+            replace_preserving_eol("a\r\nb\r\nc\r\n", "b", "B", LineEnding::Crlf, false);
+        assert_eq!(out, "a\r\nB\r\nc\r\n");
+        assert_eq!(n, 1);
+    }
+
+    #[test]
+    fn replace_crlf_multiline_new_text_gets_crlf() {
+        let (out, _) = replace_preserving_eol(
+            "one\r\ntwo\r\nthree\r\n",
+            "two",
+            "TWO\nEXTRA",
+            LineEnding::Crlf,
+            false,
+        );
+        assert_eq!(out, "one\r\nTWO\r\nEXTRA\r\nthree\r\n");
+    }
+
+    #[test]
+    fn replace_all_crlf() {
+        let (out, n) =
+            replace_preserving_eol("x\r\nx\r\nx\r\n", "x", "y", LineEnding::Crlf, true);
+        assert_eq!(out, "y\r\ny\r\ny\r\n");
+        assert_eq!(n, 3);
+    }
+
+    #[test]
+    fn mixed_file_leaves_untouched_eols_byte_identical() {
+        // A deliberately mixed file: CRLF, then LF, then CRLF. Editing the LF
+        // line must not flip the surrounding CRLF endings (and vice versa).
+        let original = "a\r\nb\nc\r\n";
+        let eol = LineEnding::detect(original); // Crlf is the majority (2 vs 1)
+        let (out, n) = replace_preserving_eol(original, "b", "B", eol, false);
+        // Only "b" -> "B"; the trailing `\n` after b and the CRLFs are intact.
+        assert_eq!(out, "a\r\nB\nc\r\n");
+        assert_eq!(n, 1);
+    }
+}

--- a/src-rust/crates/tools/src/test_support.rs
+++ b/src-rust/crates/tools/src/test_support.rs
@@ -1,0 +1,48 @@
+//! Test-only helpers for exercising a tool's `execute` against a permissive
+//! `ToolContext` rooted at a caller-supplied (usually temp) directory.
+
+use crate::ToolContext;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+/// Permission handler that approves everything, so `execute` runs unattended.
+pub(crate) struct AllowAllHandler;
+
+impl claurst_core::permissions::PermissionHandler for AllowAllHandler {
+    fn check_permission(
+        &self,
+        _request: &claurst_core::permissions::PermissionRequest,
+    ) -> claurst_core::permissions::PermissionDecision {
+        claurst_core::permissions::PermissionDecision::Allow
+    }
+
+    fn request_permission(
+        &self,
+        _request: &claurst_core::permissions::PermissionRequest,
+    ) -> claurst_core::permissions::PermissionDecision {
+        claurst_core::permissions::PermissionDecision::Allow
+    }
+}
+
+/// Build a permissive, non-interactive `ToolContext` rooted at `working_dir`.
+pub(crate) fn allow_all_context(working_dir: PathBuf) -> ToolContext {
+    ToolContext {
+        working_dir,
+        permission_mode: claurst_core::config::PermissionMode::Default,
+        permission_handler: Arc::new(AllowAllHandler),
+        cost_tracker: claurst_core::cost::CostTracker::new(),
+        session_id: "eol-test".to_string(),
+        file_history: Arc::new(parking_lot::Mutex::new(
+            claurst_core::file_history::FileHistory::new(),
+        )),
+        current_turn: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        non_interactive: true,
+        mcp_manager: None,
+        config: claurst_core::config::Config::default(),
+        managed_agent_config: None,
+        completion_notifier: None,
+        pending_permissions: None,
+        permission_manager: None,
+        user_question_tx: None,
+    }
+}


### PR DESCRIPTION
Fixes #225. Edit/BatchEdit/ApplyPatch normalized \r\n->\n and wrote LF back, converting every line ending in a CRLF file (massive spurious diff; breaks files that must stay CRLF like this repo's own tui/src/lib.rs). New `line_endings` helper detects the dominant EOL and `replace_preserving_eol` splices the replacement into the ORIGINAL bytes so untouched regions are byte-identical; only edited text is re-rendered with the file's EOL. 5 commits, +13 tests, `cargo test -p claurst-tools` = 98 passed.

Closes #225