### PR TITLE
fix(tools): route apply_patch/batch_edit/notebook_edit/cron writes through write_atomic

### DIFF
--- a/src-rust/crates/tools/src/apply_patch.rs
+++ b/src-rust/crates/tools/src/apply_patch.rs
@@ -427,7 +427,7 @@ impl Tool for ApplyPatchTool {
         // ----------------------------------------------------------------
 
         for (path, original_bytes, new_content) in &to_write {
-            if let Err(e) = tokio::fs::write(path, new_content).await {
+            if let Err(e) = crate::write_atomic(path, new_content.as_bytes()).await {
                 return ToolResult::error(format!(
                     "Failed to write {}: {}",
                     path.display(),

--- a/src-rust/crates/tools/src/apply_patch.rs
+++ b/src-rust/crates/tools/src/apply_patch.rs
@@ -554,4 +554,26 @@ mod tests {
         assert_eq!(after, "one\r\nTWO\r\nthree\r\n");
         assert_eq!(after.matches('\n').count(), after.matches("\r\n").count());
     }
+
+    /// #226: ApplyPatch writes through `write_atomic`. A successful patch must
+    /// leave the file with the right content and NO `.claurst-tmp-*` scratch
+    /// file lingering in the directory.
+    #[tokio::test]
+    async fn apply_patch_writes_atomically_no_tmp_left() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("foo.txt");
+        std::fs::write(&path, "hello\nworld\n").unwrap();
+
+        let ctx = crate::test_support::allow_all_context(dir.path().to_path_buf());
+        let patch = "--- a/foo.txt\n+++ b/foo.txt\n@@ -1,2 +1,2 @@\n hello\n-world\n+rust\n";
+        let res = ApplyPatchTool.execute(json!({ "patch": patch }), &ctx).await;
+        assert!(!res.is_error, "apply patch failed: {}", res.content);
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "hello\nrust\n");
+        let tmp_left = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .any(|e| e.file_name().to_string_lossy().contains(".claurst-tmp-"));
+        assert!(!tmp_left, "atomic write must not leave a temp file behind");
+    }
 }

--- a/src-rust/crates/tools/src/batch_edit.rs
+++ b/src-rust/crates/tools/src/batch_edit.rs
@@ -306,4 +306,41 @@ mod tests {
         assert_eq!(after, "ALPHA\r\nbeta\r\nGAMMA\r\n");
         assert_eq!(after.matches('\n').count(), after.matches("\r\n").count());
     }
+
+    /// #226: BatchEdit writes (and its rollback path) go through `write_atomic`.
+    /// A successful multi-file batch must land the right content in every file
+    /// and leave no `.claurst-tmp-*` scratch file behind. Because each file is
+    /// swapped in atomically via rename, a mid-write crash can never leave one
+    /// of these files partially written — so the rollback only ever has to
+    /// restore fully-written files, never repair a torn one.
+    #[tokio::test]
+    async fn batch_edit_writes_atomically_no_tmp_left() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a.txt");
+        let b = dir.path().join("b.txt");
+        std::fs::write(&a, "one\n").unwrap();
+        std::fs::write(&b, "two\n").unwrap();
+
+        let ctx = allow_all_context(dir.path().to_path_buf());
+        let res = BatchEditTool
+            .execute(
+                json!({
+                    "edits": [
+                        { "file_path": a.to_string_lossy(), "old_string": "one", "new_string": "ONE" },
+                        { "file_path": b.to_string_lossy(), "old_string": "two", "new_string": "TWO" }
+                    ]
+                }),
+                &ctx,
+            )
+            .await;
+        assert!(!res.is_error, "batch edit failed: {}", res.content);
+
+        assert_eq!(std::fs::read_to_string(&a).unwrap(), "ONE\n");
+        assert_eq!(std::fs::read_to_string(&b).unwrap(), "TWO\n");
+        let tmp_left = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .any(|e| e.file_name().to_string_lossy().contains(".claurst-tmp-"));
+        assert!(!tmp_left, "atomic write must not leave a temp file behind");
+    }
 }

--- a/src-rust/crates/tools/src/batch_edit.rs
+++ b/src-rust/crates/tools/src/batch_edit.rs
@@ -207,7 +207,7 @@ impl Tool for BatchEditTool {
 
         for (i, (path_str, original, new_content)) in unique_writings.iter().enumerate() {
             let path = std::path::Path::new(path_str);
-            match tokio::fs::write(path, new_content).await {
+            match crate::write_atomic(path, new_content.as_bytes()).await {
                 Ok(()) => {
                     ctx.record_file_change(
                         path.to_path_buf(),
@@ -223,7 +223,10 @@ impl Tool for BatchEditTool {
                     // rollback in reverse order to preserve original file state
                     for (rb_path, rb_original, rb_new_content) in unique_writings[0..i].iter().rev()
                     {
-                        if let Err(re) = tokio::fs::write(rb_path, rb_original).await {
+                        if let Err(re) =
+                            crate::write_atomic(std::path::Path::new(rb_path), rb_original.as_bytes())
+                                .await
+                        {
                             rollback_errors.push(format!("  rollback {}: {}", rb_path, re));
                         } else {
                             let rb_path = std::path::Path::new(rb_path);

--- a/src-rust/crates/tools/src/cron.rs
+++ b/src-rust/crates/tools/src/cron.rs
@@ -523,7 +523,9 @@ async fn persist_tasks_to_disk(store: &HashMap<String, CronTask>) -> Result<(), 
         .await
         .map_err(|e| e.to_string())?;
 
-    tokio::fs::write(&path, json).await.map_err(|e| e.to_string())?;
+    crate::write_atomic(&path, json.as_bytes())
+        .await
+        .map_err(|e| e.to_string())?;
 
     Ok(())
 }

--- a/src-rust/crates/tools/src/lib.rs
+++ b/src-rust/crates/tools/src/lib.rs
@@ -852,4 +852,59 @@ mod tests {
         assert!(!def.description.is_empty());
         assert!(def.input_schema.is_object());
     }
+
+    // ---- write_atomic tests -------------------------------------------------
+    //
+    // `write_atomic` is the single atomic-write path that ApplyPatch, BatchEdit,
+    // NotebookEdit and the cron store (#226) all route through. These tests pin
+    // its contract: it writes the exact bytes and never leaves a temp file
+    // behind on success — the guarantee that makes those tools crash-safe.
+
+    /// Count the `.claurst-tmp-*` scratch files left in `dir`.
+    fn count_atomic_tmp_files(dir: &std::path::Path) -> usize {
+        std::fs::read_dir(dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .contains(".claurst-tmp-")
+            })
+            .count()
+    }
+
+    #[tokio::test]
+    async fn write_atomic_writes_content_and_leaves_no_tmp() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out.txt");
+
+        // Fresh file.
+        write_atomic(&path, b"hello\nworld\n").await.unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "hello\nworld\n");
+        assert_eq!(count_atomic_tmp_files(dir.path()), 0, "no tmp after create");
+
+        // Overwrite an existing file (the crash-truncation scenario #226 fixes).
+        write_atomic(&path, b"replaced").await.unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "replaced");
+        assert_eq!(count_atomic_tmp_files(dir.path()), 0, "no tmp after overwrite");
+    }
+
+    /// The executable bit (and other permissions) must survive an atomic
+    /// overwrite, since we rename a fresh temp file over the destination.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_atomic_preserves_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("script.sh");
+
+        std::fs::write(&path, b"#!/bin/sh\n").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        write_atomic(&path, b"#!/bin/sh\necho hi\n").await.unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o755, "executable bit preserved");
+        assert_eq!(count_atomic_tmp_files(dir.path()), 0);
+    }
 }

--- a/src-rust/crates/tools/src/notebook_edit.rs
+++ b/src-rust/crates/tools/src/notebook_edit.rs
@@ -302,3 +302,63 @@ fn delete_cell(notebook: &mut Value, cell_id: &str) -> Result<String, String> {
 
     Ok(format!("Deleted cell '{}' (was at index {})", cell_id, idx))
 }
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::allow_all_context;
+
+    /// #226: NotebookEdit writes the updated notebook through `write_atomic`.
+    /// A successful edit must persist the new cell source and leave no
+    /// `.claurst-tmp-*` scratch file behind in the notebook's directory.
+    #[tokio::test]
+    async fn notebook_edit_writes_atomically_no_tmp_left() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nb.ipynb");
+        let notebook = json!({
+            "cells": [
+                {
+                    "cell_type": "code",
+                    "id": "c1",
+                    "metadata": {},
+                    "source": ["print('hi')\n"],
+                    "outputs": [],
+                    "execution_count": null
+                }
+            ],
+            "metadata": {},
+            "nbformat": 4,
+            "nbformat_minor": 5
+        });
+        std::fs::write(&path, serde_json::to_string_pretty(&notebook).unwrap()).unwrap();
+
+        let ctx = allow_all_context(dir.path().to_path_buf());
+        let res = NotebookEditTool
+            .execute(
+                json!({
+                    "notebook_path": path.to_string_lossy(),
+                    "cell_id": "cell-0",
+                    "new_source": "print('bye')",
+                    "edit_mode": "replace"
+                }),
+                &ctx,
+            )
+            .await;
+        assert!(!res.is_error, "notebook edit failed: {}", res.content);
+
+        let written: Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let src = &written["cells"][0]["source"];
+        assert_eq!(src, &json!(["print('bye')"]), "cell source updated");
+
+        let tmp_left = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .any(|e| e.file_name().to_string_lossy().contains(".claurst-tmp-"));
+        assert!(!tmp_left, "atomic write must not leave a temp file behind");
+    }
+}

--- a/src-rust/crates/tools/src/notebook_edit.rs
+++ b/src-rust/crates/tools/src/notebook_edit.rs
@@ -156,7 +156,7 @@ impl Tool for NotebookEditTool {
                     Ok(s) => s,
                     Err(e) => return ToolResult::error(format!("Failed to serialize notebook: {}", e)),
                 };
-                if let Err(e) = tokio::fs::write(&path, &updated).await {
+                if let Err(e) = crate::write_atomic(&path, updated.as_bytes()).await {
                     return ToolResult::error(format!("Failed to write notebook: {}", e));
                 }
                 ctx.record_file_change(


### PR DESCRIPTION
Fixes #226. These tools used plain `fs::write`, so a crash/disk-full mid-write truncated the file (and batch_edit's rollback could leave the mid-write file partial). All now use `write_atomic` (temp + rename); rollback writes are atomic too. 5 commits, +5 tests (assert content + no leftover tmp; perms preserved), `cargo test -p claurst-tools` = 103 passed. team_tool/web_fetch/todo_write (best-effort internal state, sync) deliberately left out of scope.

Closes #226