### PR TITLE
fix(tui): bound memory growth (evict paste bodies, clamp scroll_offset)

### DIFF
--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -1094,6 +1094,11 @@ pub struct App {
     pub total_message_lines: Cell<usize>,
     /// Scroll offset from the last render frame (used for selection validation).
     pub last_render_scroll_offset: Cell<u16>,
+    /// Maximum `scroll_offset` (lines above the bottom) from the last render.
+    /// Written by the renderer, which is the only place the full content height
+    /// is known; read back on the next scroll event to clamp `scroll_offset` so
+    /// scrolling up past the top can't inflate it unboundedly (#223).
+    pub last_max_scroll: Cell<usize>,
 
     // ---- Text selection state --------------------------------------------
     /// Selection drag anchor (col, row) — set on mouse-down.
@@ -1474,6 +1479,7 @@ impl App {
             message_row_map: RefCell::new(std::collections::HashMap::new()),
             total_message_lines: Cell::new(0),
             last_render_scroll_offset: Cell::new(0),
+            last_max_scroll: Cell::new(0),
             selection_anchor: None,
             selection_focus: None,
             selection_text: RefCell::new(String::new()),
@@ -2678,6 +2684,22 @@ impl App {
         }
         self.refresh_prompt_input();
         input
+    }
+
+    /// Scroll the transcript up by `amount` lines and disable auto-follow.
+    ///
+    /// `scroll_offset` counts lines above the bottom (0 = pinned to the newest
+    /// content). It is clamped to `last_max_scroll` — the maximum meaningful
+    /// offset from the last render — so scrolling up past the top of the
+    /// transcript can't inflate it unboundedly. Without the clamp, an over-scroll
+    /// would leave `scroll_offset` far above `max_scroll`, and the user would
+    /// have to press Down that many times before the view moved (#223).
+    fn scroll_up_by(&mut self, amount: usize) {
+        self.scroll_offset = self
+            .scroll_offset
+            .saturating_add(amount)
+            .min(self.last_max_scroll.get());
+        self.auto_scroll = false;
     }
 
     /// Compute the number of lines to scroll per wheel/trackpad event.
@@ -4450,8 +4472,7 @@ impl App {
             // ---- Message boundary navigation (Alt+Up/Alt+Down) ----------
             KeyCode::Up if key.modifiers.contains(KeyModifiers::ALT) => {
                 // Jump up by ~20 lines (approximate message boundary).
-                self.scroll_offset = self.scroll_offset.saturating_add(20);
-                self.auto_scroll = false;
+                self.scroll_up_by(20);
             }
             KeyCode::Down if key.modifiers.contains(KeyModifiers::ALT) => {
                 // Jump down by ~20 lines (approximate message boundary).
@@ -4499,9 +4520,8 @@ impl App {
 
             // ---- Scroll ------------------------------------------------
             KeyCode::PageUp => {
-                self.scroll_offset = self.scroll_offset.saturating_add(10);
-                // Scrolling up disables auto-follow.
-                self.auto_scroll = false;
+                // Scrolling up disables auto-follow (handled by scroll_up_by).
+                self.scroll_up_by(10);
             }
             KeyCode::PageDown => {
                 let new_off = self.scroll_offset.saturating_sub(10);
@@ -5011,8 +5031,7 @@ impl App {
                 false
             }
             "scrollUp" => {
-                self.scroll_offset = self.scroll_offset.saturating_add(10);
-                self.auto_scroll = false;
+                self.scroll_up_by(10);
                 false
             }
             "scrollDown" => {
@@ -5113,8 +5132,7 @@ impl App {
             }
             "previousMessage" => {
                 // Alt+←: Navigate to previous message in transcript
-                self.scroll_offset = self.scroll_offset.saturating_add(5);
-                self.auto_scroll = false;
+                self.scroll_up_by(5);
                 false
             }
             "nextMessage" => {
@@ -5847,8 +5865,7 @@ impl App {
                 // Don't consume Ctrl+Scroll — let the terminal handle zoom.
                 if !mouse_event.modifiers.contains(KeyModifiers::CONTROL) {
                     let step = self.scroll_step();
-                    self.scroll_offset = self.scroll_offset.saturating_add(step);
-                    self.auto_scroll = false;
+                    self.scroll_up_by(step);
                 }
             }
             MouseEventKind::ScrollDown => {

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -6656,12 +6656,59 @@ mod tests {
     #[test]
     fn mouse_events_processed_when_capture_enabled() {
         // Default config leaves mouse capture on, so a scroll wheel event
-        // should move the scroll offset.
+        // should move the scroll offset — provided there is content to scroll
+        // over (a render must have established a non-zero max_scroll).
         let mut app = make_app();
         assert!(app.config.mouse_capture_enabled());
         assert_eq!(app.scroll_offset, 0);
+        app.last_max_scroll.set(50);
         app.handle_mouse_event(scroll_up_event());
         assert!(app.scroll_offset > 0, "scroll should advance when capture is on");
+        assert!(app.scroll_offset <= 50, "scroll stays within max_scroll");
+    }
+
+    // ---- scroll_offset clamping (issue #223) ----
+
+    #[test]
+    fn scroll_up_offset_clamped_to_max_scroll() {
+        let mut app = make_app();
+        // A render established that the transcript is 5 lines taller than the
+        // viewport, so scroll_offset can meaningfully range over 0..=5.
+        app.last_max_scroll.set(5);
+
+        // Scroll up far past the top, many times.
+        for _ in 0..50 {
+            app.scroll_up_by(10);
+        }
+
+        // Without the clamp scroll_offset would be 500; it must stay at
+        // max_scroll so the offset can't inflate unboundedly (#223).
+        assert_eq!(
+            app.scroll_offset, 5,
+            "scroll_offset must not inflate past max_scroll"
+        );
+        assert!(!app.auto_scroll, "scrolling up disables auto-follow");
+
+        // Because it was clamped, a single Down step moves the view
+        // immediately instead of burning through hundreds of wasted presses.
+        let before = app.scroll_offset;
+        app.scroll_offset = app.scroll_offset.saturating_sub(1);
+        assert!(
+            app.scroll_offset < before,
+            "a single Down moves the view once scroll_offset is clamped"
+        );
+    }
+
+    #[test]
+    fn scroll_up_no_op_when_nothing_to_scroll() {
+        // When content fits the viewport (max_scroll == 0) scrolling up is a
+        // no-op rather than silently inflating scroll_offset.
+        let mut app = make_app();
+        app.last_max_scroll.set(0);
+        for _ in 0..20 {
+            app.scroll_up_by(10);
+        }
+        assert_eq!(app.scroll_offset, 0, "no scroll room means no offset growth");
     }
 
     #[test]

--- a/src-rust/crates/tui/src/lib.rs
+++ b/src-rust/crates/tui/src/lib.rs
@@ -1028,6 +1028,9 @@ mod tests {
     #[test]
     fn test_page_scroll() {
         let mut app = make_app();
+        // A render must have established a scrollable range; otherwise a
+        // scroll-up is correctly a no-op (offset is clamped to max_scroll, #223).
+        app.last_max_scroll.set(100);
         app.handle_key_event(key(KeyCode::PageUp));
         assert_eq!(app.scroll_offset, 10);
         app.handle_key_event(key(KeyCode::PageDown));

--- a/src-rust/crates/tui/src/prompt_input.rs
+++ b/src-rust/crates/tui/src/prompt_input.rs
@@ -2587,6 +2587,14 @@ impl PromptInputState {
         self.visual_anchor = None;
         self.vim_command_buf.clear();
         self.vim_search_buf.clear();
+        // #223: emptying the buffer removes every `[Pasted ~N lines #M]`
+        // placeholder along with it, so the paste bodies stored in
+        // `paste_contents` are now unreachable. Drop them to bound memory —
+        // otherwise every large block ever pasted is retained for the App's
+        // lifetime. `clear()` is the funnel for submit (`take()`), cancel, and
+        // reset, so eviction only ever fires once a placeholder has left the
+        // buffer, never while one is still live (so expansion is never broken).
+        self.paste_contents.clear();
     }
 
     /// Take the current text, clearing the input.

--- a/src-rust/crates/tui/src/prompt_input.rs
+++ b/src-rust/crates/tui/src/prompt_input.rs
@@ -3568,6 +3568,53 @@ mod tests {
         assert_eq!(counter, 2);
     }
 
+    #[test]
+    fn paste_contents_evicted_on_submit() {
+        // #223: every large paste stored its body in `paste_contents` but the
+        // map was never pruned, so it grew for the App's lifetime. Submitting
+        // (take → clear) must reclaim the stored bodies.
+        let mut s = PromptInputState::new();
+        let block_a = "alpha line\n".repeat(50);
+        let block_b = "beta line\n".repeat(60);
+        let block_c = "gamma line\n".repeat(70);
+
+        s.paste(&block_a);
+        s.paste(" and then "); // small — inlined, no counter bump, not stored
+        s.paste(&block_b);
+        s.paste(&block_c);
+
+        // Three large pastes were stored, keyed by the incrementing counter.
+        assert_eq!(s.paste_contents.len(), 3, "each large paste should be stored");
+
+        // Before eviction the submitted text still expands correctly: every
+        // placeholder in the buffer maps back to its original body.
+        assert!(s.text.contains("#1]") && s.text.contains("#2]") && s.text.contains("#3]"));
+        assert_eq!(s.paste_contents.get(&1), Some(&block_a));
+        assert_eq!(s.paste_contents.get(&2), Some(&block_b));
+        assert_eq!(s.paste_contents.get(&3), Some(&block_c));
+
+        // Submit. The taken text keeps its placeholders (expansion is not
+        // broken), but the stored bodies are reclaimed.
+        let taken = s.take();
+        assert!(taken.contains("[Pasted ~"), "placeholders survive the take");
+        assert!(s.paste_contents.is_empty(), "paste_contents must be emptied on submit (#223)");
+        assert!(s.text.is_empty());
+
+        // A fresh paste after submit starts clean and bounded.
+        s.paste(&block_a);
+        assert_eq!(s.paste_contents.len(), 1);
+    }
+
+    #[test]
+    fn paste_contents_evicted_on_cancel() {
+        // Discarding the buffer (Esc / clear) must also reclaim stored pastes.
+        let mut s = PromptInputState::new();
+        s.paste(&"discard me\n".repeat(40));
+        assert_eq!(s.paste_contents.len(), 1);
+        s.clear();
+        assert!(s.paste_contents.is_empty(), "clear() must reclaim stored pastes (#223)");
+    }
+
     // ---- compute_typeahead ---------------------------------------------
 
     // Helper constants for tests

--- a/src-rust/crates/tui/src/render.rs
+++ b/src-rust/crates/tui/src/render.rs
@@ -1116,6 +1116,11 @@ fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
     let content_height = lines.len() as u16;
     let visible_height = msg_area.height;  // no borders, full height available
     let max_scroll = content_height.saturating_sub(visible_height) as usize;
+    // Publish the max meaningful scroll offset so the next scroll event can
+    // clamp `scroll_offset` against it (the content height is only known here,
+    // at render time). Prevents unbounded inflation when scrolling past the top
+    // (#223).
+    app.last_max_scroll.set(max_scroll);
     // scroll_offset counts lines above the bottom (0 = at bottom).
     // ratatui scroll() takes an absolute top-row index, so convert:
     //   top_row = max_scroll - scroll_offset  (clamped to [0, max_scroll])


### PR DESCRIPTION
Fixes #223. `paste_contents` was write-only (inserted on paste, never read) yet retained for the App's lifetime — now reclaimed in `clear()` (the single funnel for submit/cancel/reset), which can't break a live placeholder since the buffer is empty there. `scroll_offset` was `saturating_add`'d and only clamped at render against `&App`, never written back — now clamped to a published `last_max_scroll` at all 5 scroll-up sites. 3 commits, +4 tests, `cargo test -p claurst-tui` = 604 passed.

Closes #223