### PR TITLE
fix: make background-agent cancel actually stop the task (not just relabel it)

### DIFF
--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -4139,6 +4139,7 @@ pub mod tasks {
     use once_cell::sync::Lazy;
     use serde::{Deserialize, Serialize};
     use std::sync::Arc;
+    use tokio_util::sync::CancellationToken;
     use uuid::Uuid;
 
     /// Current status of a background task.
@@ -4178,6 +4179,11 @@ pub mod tasks {
         pub output: Vec<String>,
         /// OS process ID, if applicable.
         pub pid: Option<u32>,
+        /// Cancellation token for the task's in-process work loop. Signalling it
+        /// stops the running loop (e.g. a background sub-agent). Not persisted —
+        /// it holds no meaningful state across (de)serialization.
+        #[serde(skip)]
+        pub cancel_token: Option<CancellationToken>,
     }
 
     impl BackgroundTask {
@@ -4191,6 +4197,7 @@ pub mod tasks {
                 completed_at: None,
                 output: Vec::new(),
                 pid: None,
+                cancel_token: None,
             }
         }
 
@@ -4256,8 +4263,25 @@ pub mod tasks {
             self.update_status(id, TaskStatus::Completed);
         }
 
-        /// Mark a task as `Cancelled`.  No-op if unknown or already terminal.
+        /// Attach a cancellation token to a task so it can later be signalled by
+        /// [`TaskRegistry::cancel`].  No-op if the ID is unknown.
+        pub fn set_cancel_token(&self, id: &str, token: CancellationToken) {
+            if let Some(mut entry) = self.tasks.get_mut(id) {
+                entry.cancel_token = Some(token);
+            }
+        }
+
+        /// Mark a task as `Cancelled` and signal its cancellation token (if any)
+        /// so the running work loop actually stops.  No-op if unknown or already
+        /// terminal.
         pub fn cancel(&self, id: &str) {
+            // Clone the token out from under the shard guard, then signal it once
+            // the guard has been dropped — never hold a DashMap lock across other
+            // registry operations (or any `.await`).
+            let token = self.tasks.get(id).and_then(|e| e.cancel_token.clone());
+            if let Some(token) = token {
+                token.cancel();
+            }
             self.update_status(id, TaskStatus::Cancelled);
         }
 

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -4939,4 +4939,80 @@ mod tests {
                 "Preset {} executor_model must be provider/model", preset.name);
         }
     }
+
+    // ---- Background task cancellation (issue #219) --------------------------
+
+    /// Cancelling a task must signal the cancellation token attached to it, not
+    /// merely relabel its status. Without this, a "cancelled" background agent
+    /// keeps running and editing files.
+    #[test]
+    fn registry_cancel_signals_attached_token() {
+        use tokio_util::sync::CancellationToken;
+
+        let registry = tasks::TaskRegistry::new();
+        let id = registry.register(tasks::BackgroundTask::new("cancellable task"));
+
+        let token = CancellationToken::new();
+        registry.set_cancel_token(&id, token.clone());
+        assert!(!token.is_cancelled());
+
+        registry.cancel(&id);
+
+        assert!(
+            token.is_cancelled(),
+            "cancel() must signal the attached cancellation token"
+        );
+        assert_eq!(
+            registry.get(&id).unwrap().status,
+            tasks::TaskStatus::Cancelled
+        );
+    }
+
+    /// A running work loop that holds the registered token (as the background
+    /// sub-agent's `run_query_loop` does) must actually stop when the task is
+    /// cancelled through the registry.
+    #[tokio::test]
+    async fn spawned_loop_observes_registry_cancellation() {
+        use std::time::Duration;
+        use tokio_util::sync::CancellationToken;
+
+        let registry = tasks::TaskRegistry::new();
+        let mut task = tasks::BackgroundTask::new("bg loop");
+        let id = task.id.clone();
+        let token = CancellationToken::new();
+        // Attach at registration, exactly as the background spawn does.
+        task.cancel_token = Some(token.clone());
+        registry.register(task);
+
+        // Stand-in for run_query_loop: keep "working" until the shared token is
+        // signalled, mirroring the real loop's between-turn cancellation check.
+        let loop_token = token.clone();
+        let handle = tokio::spawn(async move {
+            loop {
+                if loop_token.is_cancelled() {
+                    return "cancelled";
+                }
+                tokio::select! {
+                    _ = loop_token.cancelled() => return "cancelled",
+                    _ = tokio::time::sleep(Duration::from_millis(5)) => {}
+                }
+            }
+        });
+
+        // Let the loop start spinning, then cancel via the registry.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        registry.cancel(&id);
+
+        let reason = tokio::time::timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("loop must stop promptly after cancellation")
+            .expect("loop task must not panic");
+
+        assert_eq!(reason, "cancelled");
+        assert!(token.is_cancelled());
+        assert_eq!(
+            registry.get(&id).unwrap().status,
+            tasks::TaskStatus::Cancelled
+        );
+    }
 }

--- a/src-rust/crates/query/src/agent_tool.rs
+++ b/src-rust/crates/query/src/agent_tool.rs
@@ -377,6 +377,12 @@ impl Tool for AgentTool {
                 params.description
             ));
             task.id = agent_id.clone();
+            // Cancellation token shared between the registry and the spawned
+            // sub-agent loop: signalling it via TaskRegistry::cancel (e.g. from a
+            // monitor cancel) actually stops the loop instead of only relabeling
+            // the task (issue #219).
+            let cancel = CancellationToken::new();
+            task.cancel_token = Some(cancel.clone());
             let _ = claurst_core::tasks::global_registry().register(task);
 
             // Re-create the tool list inside the closure so it is owned and Send.
@@ -394,7 +400,6 @@ impl Tool for AgentTool {
             let agent_id_bg = agent_id.clone();
 
             tokio::spawn(async move {
-                let cancel = CancellationToken::new();
                 let mut messages = vec![Message::user(prompt_bg)];
                 let outcome = run_query_loop(
                     client_bg.as_ref(),

--- a/src-rust/crates/tools/src/monitor_tool.rs
+++ b/src-rust/crates/tools/src/monitor_tool.rs
@@ -158,7 +158,12 @@ impl Tool for MonitorTool {
                                         .output();
                                 }
                             }
-                            global_registry().update_status(&id, TaskStatus::Cancelled);
+                            // Signal the task's cancellation token (if any) and
+                            // mark it Cancelled. For an in-process background
+                            // agent this is what actually stops the running loop
+                            // (issue #219); the pid-kill above covers external
+                            // OS child processes.
+                            global_registry().cancel(&id);
                             ToolResult::success(format!("Task {} cancelled.", id))
                         } else {
                             ToolResult::error(format!(


### PR DESCRIPTION
Fixes #219. `TaskRegistry::cancel` only set status=Cancelled; the background sub-agent's `CancellationToken` was created *inside* the spawn closure so nothing could signal it. Now the token is created before the spawn, stored on the registry entry, and `cancel(id)` clones it out from under the DashMap guard and calls `token.cancel()`. The monitor-tool Cancel action routes through `registry.cancel()`, and the loop already observes the token at turn boundaries / streaming / tool-exec. 3 commits + 2 tests (incl. a spawned-loop-observes-cancel tokio test). `cargo test -p claurst-core` = 451 passed.

Closes #219