### PR TITLE
feat(release): publish SHA256SUMS and verify downloads in install.sh / install.ps1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,6 +239,20 @@ jobs:
           echo "Release assets:"
           ls -lh release/
 
+      # Generate SHA256 checksums covering every asset in release/ so the
+      # install scripts can verify download integrity (supply-chain
+      # protection).  We write SHA256SUMS to a temp path OUTSIDE release/
+      # first so it never hashes itself, then move it in.  Because the
+      # gh-release step publishes `files: release/*`, SHA256SUMS ships
+      # automatically alongside the archives.
+      - name: Generate SHA256SUMS
+        run: |
+          cd release
+          sha256sum * > "$RUNNER_TEMP/SHA256SUMS"
+          mv "$RUNNER_TEMP/SHA256SUMS" SHA256SUMS
+          echo "── SHA256SUMS ──────────────────────────────────────"
+          cat SHA256SUMS
+
       # Build release notes in two passes:
       #   1. Pull GitHub's auto-generated notes via the API — this gives us
       #      the "What's Changed" PR list with @author mentions, the

--- a/install.ps1
+++ b/install.ps1
@@ -136,6 +136,54 @@ function Download-And-Install($desiredVersion, $arch) {
         exit 1
     }
 
+    # ----- Verify checksum (supply-chain integrity) -----
+    # Fetch SHA256SUMS from the same release and verify the archive before we
+    # extract and run it.  Older releases may not ship SHA256SUMS: warn and
+    # continue so existing installs keep working.  If it IS present and the
+    # hash does NOT match, abort hard.
+    $sumsUrl = "https://github.com/$Repo/releases/download/v$desiredVersion/SHA256SUMS"
+    $sumsPath = Join-Path $tmpRoot 'SHA256SUMS'
+    $haveSums = $false
+    try {
+        $oldPref2 = $ProgressPreference
+        $ProgressPreference = 'SilentlyContinue'
+        Invoke-WebRequest -UseBasicParsing -Uri $sumsUrl -OutFile $sumsPath
+        $ProgressPreference = $oldPref2
+        $haveSums = $true
+    } catch {
+        Write-Warn "Could not fetch SHA256SUMS for v$desiredVersion - skipping checksum verification."
+    }
+
+    if ($haveSums) {
+        # SHA256SUMS lines look like "<hash>  <filename>" (two spaces). Split on
+        # whitespace into at most 2 parts and match on the bare archive name.
+        $expected = $null
+        foreach ($line in (Get-Content $sumsPath)) {
+            $parts = $line.Trim() -split '\s+', 2
+            if ($parts.Count -eq 2 -and $parts[1].Trim().TrimStart('*') -eq $archive) {
+                $expected = $parts[0].Trim()
+                break
+            }
+        }
+        if ([string]::IsNullOrEmpty($expected)) {
+            Write-Warn "No checksum listed for $archive in SHA256SUMS - skipping verification."
+        } else {
+            # Get-FileHash returns uppercase hex; sha256sum emits lowercase, so
+            # compare case-insensitively.
+            $actual = (Get-FileHash -Algorithm SHA256 -Path $zipPath).Hash
+            if ($actual -ieq $expected) {
+                Write-Muted "Checksum verified."
+            } else {
+                Write-Err "Checksum verification FAILED for $archive"
+                Write-Info "  expected: $expected"
+                Write-Info "  actual:   $actual"
+                Write-Info "The download may be corrupted or tampered with. Aborting."
+                Remove-Item -Recurse -Force $tmpRoot -ErrorAction SilentlyContinue
+                exit 1
+            }
+        }
+    }
+
     Write-Muted "Extracting..."
     try {
         Expand-Archive -Path $zipPath -DestinationPath $extractDir -Force

--- a/install.sh
+++ b/install.sh
@@ -208,6 +208,44 @@ download_and_install() {
         exit 1
     fi
 
+    # ----- Verify checksum (supply-chain integrity) -----
+    # Fetch SHA256SUMS from the same release and verify the archive before we
+    # extract and run it.  Older releases may not ship SHA256SUMS — in that
+    # case we warn and continue so existing installs keep working.  But if the
+    # file IS present and the hash does NOT match, we abort hard.
+    local sums_url="https://github.com/${REPO}/releases/download/v${specific_version}/SHA256SUMS"
+    if curl -fsSL -o "$tmp_dir/SHA256SUMS" "$sums_url" 2>/dev/null; then
+        # sha256sum emits "<hash>  <filename>" (two spaces); awk collapses the
+        # whitespace so $1=hash, $2=bare filename.  Match on the bare archive
+        # name (not the full temp path).
+        local expected actual
+        expected=$(awk -v f="$archive" '$2 == f {print $1}' "$tmp_dir/SHA256SUMS" | head -n 1)
+        if [[ -z "$expected" ]]; then
+            print_message warning "Warning: no checksum listed for ${archive} in SHA256SUMS - skipping verification."
+        else
+            if command -v sha256sum >/dev/null 2>&1; then
+                actual=$(sha256sum "$tmp_dir/$archive" | awk '{print $1}')
+            elif command -v shasum >/dev/null 2>&1; then
+                actual=$(shasum -a 256 "$tmp_dir/$archive" | awk '{print $1}')
+            else
+                actual=""
+            fi
+            if [[ -z "$actual" ]]; then
+                print_message warning "Warning: no sha256sum/shasum tool available - skipping checksum verification."
+            elif [[ "$actual" != "$expected" ]]; then
+                print_message error "Checksum verification FAILED for ${archive}"
+                print_message info "  expected: $expected"
+                print_message info "  actual:   $actual"
+                print_message info "The download may be corrupted or tampered with. Aborting."
+                exit 1
+            else
+                print_message info "${MUTED}Checksum verified.${NC}"
+            fi
+        fi
+    else
+        print_message warning "Warning: could not fetch SHA256SUMS for v${specific_version} - skipping checksum verification."
+    fi
+
     print_message info "${MUTED}Extracting...${NC}"
     tar -xzf "$tmp_dir/$archive" -C "$tmp_dir"
 


### PR DESCRIPTION
Fixes #205. Adds supply-chain integrity: release.yml generates `SHA256SUMS` over all release assets (written via $RUNNER_TEMP so it never hashes itself; auto-published via `files: release/*`), and both installers verify the downloaded archive before extracting — hard-fail on mismatch, warn-and-continue if SHA256SUMS is absent (older releases still install). `bash -n` + YAML validation + a tamper round-trip pass. 3 commits.

Closes #205