### PR TITLE
feat(tui): Shift+Enter inserts a newline; Enter submits

### DIFF
--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -1698,7 +1698,7 @@ async fn run_interactive(
         render::render_app, restore_terminal, setup_terminal, App,
         device_auth_dialog::DeviceAuthEvent,
     };
-    use crossterm::event::{self, Event, KeyCode};
+    use crossterm::event::{self, Event, KeyCode, KeyModifiers};
     use std::time::Duration;
     use tokio::sync::mpsc;
     use tokio_util::sync::CancellationToken;
@@ -2125,7 +2125,17 @@ async fn run_interactive(
                     // Enter => submit input (but NOT when ANY dialog/overlay is open —
                     // dialogs handle their own Enter in handle_key_event).
                     let any_dialog_open = app.any_modal_open();
-                    if key.code == KeyCode::Enter && app.is_streaming && !any_dialog_open {
+                    // Only a bare Enter submits/queues. A *modified* Enter
+                    // (Shift/Alt/Ctrl+Enter) means "insert a newline" and must
+                    // fall through to app.handle_key_event below, which inserts
+                    // it into the prompt buffer. Ctrl+J (a non-Enter key) is the
+                    // other newline escape and never reaches these branches.
+                    // (issue #224 — Shift+Enter inserts a newline; Enter submits.)
+                    let plain_enter = key.code == KeyCode::Enter
+                        && !key.modifiers.contains(KeyModifiers::SHIFT)
+                        && !key.modifiers.contains(KeyModifiers::ALT)
+                        && !key.modifiers.contains(KeyModifiers::CONTROL);
+                    if plain_enter && app.is_streaming && !any_dialog_open {
                         // Queue the message: it will auto-submit once the
                         // current turn finishes (issue #149).
                         let input = app.take_input();
@@ -2141,7 +2151,7 @@ async fn run_interactive(
                         }
                         continue;
                     }
-                    if key.code == KeyCode::Enter && !app.is_streaming && !any_dialog_open {
+                    if plain_enter && !app.is_streaming && !any_dialog_open {
                         // If a file-ref suggestion is active, accept it instead of submitting.
                         if !app.prompt_input.suggestions.is_empty()
                             && app.prompt_input.suggestion_index.is_some()

--- a/src-rust/crates/core/src/keybindings.rs
+++ b/src-rust/crates/core/src/keybindings.rs
@@ -184,6 +184,10 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         // fallback is not needed there. Keep it as a compatibility belt-and-braces
         // for terminals that do not support the protocol.
         ("ctrl+j", "newline", KeyContext::Chat),
+        // Alt+Enter is the other conventional newline escape (many terminals,
+        // e.g. legacy iTerm2 / xterm modifyOtherKeys, send Alt+Enter as
+        // \x1b\r). Kept as an additional fallback alongside Shift+Enter/Ctrl+J.
+        ("alt+enter", "newline", KeyContext::Chat),
 
         // Line start/end navigation
         ("home", "goLineStart", KeyContext::Chat),
@@ -840,6 +844,31 @@ mod tests {
         });
         assert!(ctrl_j.is_some(), "ctrl+j binding not found");
         assert_eq!(ctrl_j.unwrap().action.as_deref(), Some("newline"));
+    }
+
+    #[test]
+    fn test_shift_enter_and_alt_enter_map_to_newline() {
+        // The multi-line composing fallbacks (#224): Shift+Enter (kitty),
+        // plus Alt+Enter and Ctrl+J for terminals that can't distinguish
+        // Shift+Enter from a bare Enter.
+        let bindings = default_bindings();
+        let find = |ctrl: bool, alt: bool, shift: bool, key: &str| {
+            bindings
+                .iter()
+                .find(|b| {
+                    b.chord.len() == 1
+                        && b.chord[0].ctrl == ctrl
+                        && b.chord[0].alt == alt
+                        && b.chord[0].shift == shift
+                        && b.chord[0].key == key
+                        && b.context == KeyContext::Chat
+                })
+                .and_then(|b| b.action.as_deref())
+        };
+        assert_eq!(find(false, false, true, "enter"), Some("newline"), "shift+enter");
+        assert_eq!(find(false, true, false, "enter"), Some("newline"), "alt+enter");
+        // And a bare Enter still submits.
+        assert_eq!(find(false, false, false, "enter"), Some("submit"), "enter");
     }
 
     #[test]

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -4436,9 +4436,13 @@ impl App {
             }
 
             // ---- Submit ------------------------------------------------
-            // Shift+Enter / Alt+Enter / Ctrl+Enter insert a literal newline
-            // so users can compose multi-line prompts before sending
-            // (issue #149 follow-up).
+            // Fallback newline insertion for when the keybinding layer doesn't
+            // claim a modified Enter (e.g. Ctrl+Enter, or Shift/Alt+Enter after
+            // the user unbinds them): Shift+Enter / Alt+Enter / Ctrl+Enter
+            // insert a literal newline so users can compose multi-line prompts
+            // before sending (issue #149 / #224). The authoritative bindings
+            // live in claurst_core::keybindings (shift+enter, alt+enter, ctrl+j
+            // → newline; enter → submit) and are handled above at the resolver.
             KeyCode::Enter
                 if !self.is_streaming
                     && (key.modifiers.contains(KeyModifiers::SHIFT)
@@ -6887,6 +6891,87 @@ mod tests {
 
         assert!(should_submit);
         assert_eq!(app.prompt_input.text, "/theme");
+    }
+
+    // ---- Shift+Enter newline vs Enter submit (issue #224) ----
+
+    /// Feed some text then a modified Enter and return (submitted?, buffer).
+    fn type_then_modified_enter(mods: KeyModifiers) -> (bool, String) {
+        let mut app = make_app();
+        for c in "hi".chars() {
+            app.handle_key_event(press_key(KeyCode::Char(c), KeyModifiers::NONE));
+        }
+        let submitted = app.handle_key_event(press_key(KeyCode::Enter, mods));
+        (submitted, app.prompt_input.text.clone())
+    }
+
+    #[test]
+    fn shift_enter_inserts_newline_not_submit() {
+        // On kitty-capable terminals Shift+Enter arrives as Enter+SHIFT and must
+        // insert a literal newline, leaving the prompt multi-line and unsent.
+        let (submitted, text) = type_then_modified_enter(KeyModifiers::SHIFT);
+        assert!(!submitted, "Shift+Enter must not submit");
+        assert_eq!(text, "hi\n", "Shift+Enter should append a newline");
+        assert!(text.contains('\n'), "buffer should now be multi-line");
+    }
+
+    #[test]
+    fn alt_enter_inserts_newline_fallback() {
+        // Alt+Enter is a fallback for terminals that can't report Shift+Enter.
+        let (submitted, text) = type_then_modified_enter(KeyModifiers::ALT);
+        assert!(!submitted, "Alt+Enter must not submit");
+        assert_eq!(text, "hi\n");
+    }
+
+    #[test]
+    fn ctrl_enter_inserts_newline_fallback() {
+        // Ctrl+Enter is the Windows-Terminal-style fallback for newline.
+        let (submitted, text) = type_then_modified_enter(KeyModifiers::CONTROL);
+        assert!(!submitted, "Ctrl+Enter must not submit");
+        assert_eq!(text, "hi\n");
+    }
+
+    #[test]
+    fn ctrl_j_inserts_newline_fallback() {
+        // Ctrl+J (Char('j') + CONTROL) is the conventional legacy newline escape
+        // (pi binds insert-newline to shift+enter + ctrl+j). It must insert a
+        // newline, not the literal character 'j'.
+        let mut app = make_app();
+        for c in "hi".chars() {
+            app.handle_key_event(press_key(KeyCode::Char(c), KeyModifiers::NONE));
+        }
+        let submitted = app.handle_key_event(press_key(KeyCode::Char('j'), KeyModifiers::CONTROL));
+        assert!(!submitted, "Ctrl+J must not submit");
+        assert_eq!(app.prompt_input.text, "hi\n", "Ctrl+J should insert a newline, not 'j'");
+    }
+
+    #[test]
+    fn bare_enter_submits_without_newline() {
+        // A plain Enter (no modifiers) submits and leaves the buffer untouched.
+        let mut app = make_app();
+        for c in "hi".chars() {
+            app.handle_key_event(press_key(KeyCode::Char(c), KeyModifiers::NONE));
+        }
+        let submitted = app.handle_key_event(press_key(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(submitted, "bare Enter should submit");
+        assert_eq!(app.prompt_input.text, "hi", "bare Enter must not insert a newline");
+        assert!(!app.prompt_input.text.contains('\n'));
+    }
+
+    #[test]
+    fn shift_enter_newline_composes_multiline_prompt() {
+        // Compose two lines with Shift+Enter between them, then submit with a
+        // bare Enter; the buffer keeps both lines and only the bare Enter sends.
+        let mut app = make_app();
+        for c in "line1".chars() {
+            app.handle_key_event(press_key(KeyCode::Char(c), KeyModifiers::NONE));
+        }
+        assert!(!app.handle_key_event(press_key(KeyCode::Enter, KeyModifiers::SHIFT)));
+        for c in "line2".chars() {
+            app.handle_key_event(press_key(KeyCode::Char(c), KeyModifiers::NONE));
+        }
+        assert_eq!(app.prompt_input.text, "line1\nline2");
+        assert!(app.handle_key_event(press_key(KeyCode::Enter, KeyModifiers::NONE)));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #224. The core keybinding resolver already mapped shift+enter/ctrl+j -> newline, but the CLI event loop intercepted *every* Enter and submitted before the resolver ran. Fixed by gating the CLI's Enter interception to plain (unmodified) Enter, so modified Enter falls through to the resolver; added alt+enter to defaults. Newline: Shift+Enter (kitty), Alt+Enter, Ctrl+J, Ctrl+Enter; submit: bare Enter. Confirmed against pi. 2 commits + tests, `cargo test --workspace` clean.

Closes #224