### PR TITLE
fix(security): central permission backstop in execute_tool; gate worktree post_create_command

### DIFF
--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -2824,6 +2824,169 @@ mod tests {
             "messages must be replaced with the compacted result on success"
         );
     }
+
+    // ---- Central permission backstop (issue #210) ---------------------------
+    //
+    // These tests pin the `execute_tool` backstop contract:
+    //  (a) a non-self-gating tool at a gated level is DENIED (never executes)
+    //      when the handler denies;
+    //  (b) a self-gating tool is NOT gated centrally (no double-prompt) — its
+    //      execute() runs even though the handler would deny;
+    //  (c) a ReadOnly / None tool is never gated centrally.
+
+    use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
+
+    /// Permission handler that denies everything (returns `Ask`, which in a
+    /// non-interactive context surfaces as a hard denial).
+    struct DenyAllHandler;
+    impl claurst_core::permissions::PermissionHandler for DenyAllHandler {
+        fn check_permission(
+            &self,
+            _request: &claurst_core::permissions::PermissionRequest,
+        ) -> claurst_core::permissions::PermissionDecision {
+            claurst_core::permissions::PermissionDecision::Ask {
+                reason: "denied by test handler".to_string(),
+            }
+        }
+        fn request_permission(
+            &self,
+            request: &claurst_core::permissions::PermissionRequest,
+        ) -> claurst_core::permissions::PermissionDecision {
+            self.check_permission(request)
+        }
+    }
+
+    /// A configurable mock tool that records whether its `execute()` ran.
+    struct MockTool {
+        name: &'static str,
+        level: PermissionLevel,
+        self_gates: bool,
+        ran: Arc<AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl Tool for MockTool {
+        fn name(&self) -> &str { self.name }
+        fn description(&self) -> &str { "mock tool for backstop tests" }
+        fn permission_level(&self) -> PermissionLevel { self.level }
+        fn self_gates(&self) -> bool { self.self_gates }
+        fn input_schema(&self) -> Value { serde_json::json!({"type": "object"}) }
+        async fn execute(&self, _input: Value, _ctx: &ToolContext) -> ToolResult {
+            self.ran.store(true, AtomicOrdering::SeqCst);
+            ToolResult::success("mock ran")
+        }
+    }
+
+    fn deny_all_context() -> ToolContext {
+        ToolContext {
+            working_dir: std::path::PathBuf::from("/workspace"),
+            permission_mode: claurst_core::config::PermissionMode::Default,
+            permission_handler: Arc::new(DenyAllHandler),
+            cost_tracker: claurst_core::cost::CostTracker::new(),
+            session_id: "backstop-test".to_string(),
+            file_history: Arc::new(parking_lot::Mutex::new(
+                claurst_core::file_history::FileHistory::new(),
+            )),
+            current_turn: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            non_interactive: true,
+            mcp_manager: None,
+            config: claurst_core::config::Config::default(),
+            managed_agent_config: None,
+            completion_notifier: None,
+            pending_permissions: None,
+            permission_manager: None,
+            user_question_tx: None,
+        }
+    }
+
+    /// (a) A tool that does NOT self-gate and requires a gated level (Execute)
+    /// is blocked by the central backstop when the handler denies — and its
+    /// `execute()` never runs.
+    #[tokio::test]
+    async fn backstop_denies_non_self_gating_gated_tool() {
+        let ran = Arc::new(AtomicBool::new(false));
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(MockTool {
+            name: "MockExec",
+            level: PermissionLevel::Execute,
+            self_gates: false,
+            ran: ran.clone(),
+        })];
+        let ctx = deny_all_context();
+
+        let result = execute_tool("MockExec", &serde_json::json!({}), &tools, &ctx).await;
+
+        assert!(result.is_error, "central backstop must block a denied tool");
+        assert!(
+            !ran.load(AtomicOrdering::SeqCst),
+            "execute() must NOT run when the backstop denies"
+        );
+    }
+
+    /// (b) A self-gating tool is NOT gated by the central backstop (no double
+    /// prompt): even with a deny-all handler, its `execute()` still runs
+    /// because the central gate is skipped for self-gaters.
+    #[tokio::test]
+    async fn backstop_skips_self_gating_tool() {
+        let ran = Arc::new(AtomicBool::new(false));
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(MockTool {
+            name: "MockSelfGated",
+            level: PermissionLevel::Execute,
+            self_gates: true,
+            ran: ran.clone(),
+        })];
+        let ctx = deny_all_context();
+
+        let result = execute_tool("MockSelfGated", &serde_json::json!({}), &tools, &ctx).await;
+
+        assert!(
+            !result.is_error,
+            "self-gating tool must not be blocked by the central backstop"
+        );
+        assert_eq!(result.content, "mock ran");
+        assert!(
+            ran.load(AtomicOrdering::SeqCst),
+            "self-gating tool's execute() must run (central gate skipped)"
+        );
+    }
+
+    /// (c) ReadOnly and None tools are never gated centrally, so they run even
+    /// under a deny-all handler.
+    #[tokio::test]
+    async fn backstop_skips_read_only_and_none_tools() {
+        for level in [PermissionLevel::ReadOnly, PermissionLevel::None] {
+            let ran = Arc::new(AtomicBool::new(false));
+            let tools: Vec<Box<dyn Tool>> = vec![Box::new(MockTool {
+                name: "MockSafe",
+                level,
+                self_gates: false,
+                ran: ran.clone(),
+            })];
+            let ctx = deny_all_context();
+
+            let result = execute_tool("MockSafe", &serde_json::json!({}), &tools, &ctx).await;
+
+            assert!(
+                !result.is_error,
+                "{:?} tool must not be gated centrally",
+                level
+            );
+            assert!(
+                ran.load(AtomicOrdering::SeqCst),
+                "{:?} tool's execute() must run",
+                level
+            );
+        }
+    }
+
+    #[test]
+    fn backstop_permission_level_gating_matrix() {
+        assert!(!permission_level_is_gated(PermissionLevel::None));
+        assert!(!permission_level_is_gated(PermissionLevel::ReadOnly));
+        assert!(permission_level_is_gated(PermissionLevel::Write));
+        assert!(permission_level_is_gated(PermissionLevel::Execute));
+        assert!(permission_level_is_gated(PermissionLevel::Dangerous));
+        assert!(permission_level_is_gated(PermissionLevel::Forbidden));
+    }
 }
 
 /// Stream handler that forwards events to an unbounded channel.

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -48,7 +48,7 @@ use claurst_core::config::Config;
 use claurst_core::cost::CostTracker;
 use claurst_core::error::ClaudeError;
 use claurst_core::types::{ContentBlock, Message, ToolResultContent, UsageInfo};
-use claurst_tools::{Tool, ToolContext, ToolResult};
+use claurst_tools::{PermissionLevel, Tool, ToolContext, ToolResult};
 use serde_json::Value;
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -2246,6 +2246,28 @@ fn parse_tool_args(json_str: &str) -> Result<Value, serde_json::Error> {
     serde_json::from_str(trimmed)
 }
 
+/// Whether a `PermissionLevel` must be gated by the central backstop.
+///
+/// Only `None` and `ReadOnly` are exempt; every other level (`Write`,
+/// `Execute`, `Dangerous`, `Forbidden`) represents a side-effecting action that
+/// the backstop must confirm before it runs.
+fn permission_level_is_gated(level: PermissionLevel) -> bool {
+    !matches!(level, PermissionLevel::None | PermissionLevel::ReadOnly)
+}
+
+/// Synthesize a human-readable permission description for a tool that does not
+/// gate itself, surfacing the tool name and a truncated preview of its input so
+/// the user can see what is about to run.
+fn synthesize_permission_description(name: &str, input: &Value) -> String {
+    let rendered = serde_json::to_string(input).unwrap_or_default();
+    let preview: String = rendered.chars().take(200).collect();
+    if preview.is_empty() || preview == "{}" || preview == "null" {
+        format!("Run tool '{}'", name)
+    } else {
+        format!("Run tool '{}' with input: {}", name, preview)
+    }
+}
+
 /// Execute a single tool invocation.
 async fn execute_tool(
     name: &str,
@@ -2258,6 +2280,20 @@ async fn execute_tool(
     match tool {
         Some(tool) => {
             debug!(tool = name, "Executing tool");
+            // Central permission backstop (issue #210): if a tool does not gate
+            // itself (`self_gates() == false`) and requires a gated permission
+            // level, prompt here BEFORE executing. On denial, return a blocked
+            // result WITHOUT running the tool. Tools that already prompt
+            // internally opt out via `self_gates() == true` (no double-prompt),
+            // and read-only / no-permission tools are skipped. This makes a tool
+            // that forgets to gate itself secure by default.
+            if !tool.self_gates() && permission_level_is_gated(tool.permission_level()) {
+                let description = synthesize_permission_description(name, input);
+                if let Err(e) = ctx.check_permission(name, &description, false) {
+                    warn!(tool = name, "Tool blocked by central permission backstop");
+                    return ToolResult::error(e.to_string());
+                }
+            }
             tool.execute(input.clone(), ctx).await
         }
         None => {

--- a/src-rust/crates/tools/src/apply_patch.rs
+++ b/src-rust/crates/tools/src/apply_patch.rs
@@ -248,6 +248,9 @@ fn find_context_position(
 
 #[async_trait]
 impl Tool for ApplyPatchTool {
+    // Gates itself: calls `ctx.check_permission` in `execute()` (#210).
+    fn self_gates(&self) -> bool { true }
+
     fn name(&self) -> &str {
         claurst_core::constants::TOOL_NAME_APPLY_PATCH
     }

--- a/src-rust/crates/tools/src/batch_edit.rs
+++ b/src-rust/crates/tools/src/batch_edit.rs
@@ -30,6 +30,9 @@ struct BatchEditInput {
 
 #[async_trait]
 impl Tool for BatchEditTool {
+    // Gates itself: calls `ctx.check_permission` in `execute()` (#210).
+    fn self_gates(&self) -> bool { true }
+
     fn name(&self) -> &str {
         claurst_core::constants::TOOL_NAME_BATCH_EDIT
     }

--- a/src-rust/crates/tools/src/computer_use.rs
+++ b/src-rust/crates/tools/src/computer_use.rs
@@ -61,6 +61,9 @@ pub struct ComputerUseTool;
 
 #[async_trait]
 impl Tool for ComputerUseTool {
+    // Gates itself: calls `ctx.check_permission` in `execute()` (#210).
+    fn self_gates(&self) -> bool { true }
+
     fn name(&self) -> &str {
         "computer"
     }

--- a/src-rust/crates/tools/src/cron.rs
+++ b/src-rust/crates/tools/src/cron.rs
@@ -260,6 +260,9 @@ fn default_true() -> bool { true }
 
 #[async_trait]
 impl Tool for CronCreateTool {
+    // Gates itself: calls `ctx.check_permission` in `execute()` (#210).
+    fn self_gates(&self) -> bool { true }
+
     fn name(&self) -> &str { "CronCreate" }
 
     fn description(&self) -> &str {

--- a/src-rust/crates/tools/src/file_edit.rs
+++ b/src-rust/crates/tools/src/file_edit.rs
@@ -20,6 +20,9 @@ struct FileEditInput {
 
 #[async_trait]
 impl Tool for FileEditTool {
+    // Gates itself: calls `ctx.check_permission_for_path` in `execute()` (#210).
+    fn self_gates(&self) -> bool { true }
+
     fn name(&self) -> &str {
         claurst_core::constants::TOOL_NAME_FILE_EDIT
     }

--- a/src-rust/crates/tools/src/file_read.rs
+++ b/src-rust/crates/tools/src/file_read.rs
@@ -19,6 +19,9 @@ struct FileReadInput {
 
 #[async_trait]
 impl Tool for FileReadTool {
+    // Gates itself: calls `ctx.check_permission_for_path` in `execute()` (#210).
+    fn self_gates(&self) -> bool { true }
+
     fn name(&self) -> &str {
         claurst_core::constants::TOOL_NAME_FILE_READ
     }

--- a/src-rust/crates/tools/src/file_write.rs
+++ b/src-rust/crates/tools/src/file_write.rs
@@ -16,6 +16,9 @@ struct FileWriteInput {
 
 #[async_trait]
 impl Tool for FileWriteTool {
+    // Gates itself: calls `ctx.check_permission` in `execute()` (#210).
+    fn self_gates(&self) -> bool { true }
+
     fn name(&self) -> &str {
         claurst_core::constants::TOOL_NAME_FILE_WRITE
     }

--- a/src-rust/crates/tools/src/glob_tool.rs
+++ b/src-rust/crates/tools/src/glob_tool.rs
@@ -18,6 +18,9 @@ struct GlobInput {
 
 #[async_trait]
 impl Tool for GlobTool {
+    // Gates itself: calls `ctx.check_permission_for_path` in `execute()` (#210).
+    fn self_gates(&self) -> bool { true }
+
     fn name(&self) -> &str {
         claurst_core::constants::TOOL_NAME_GLOB
     }

--- a/src-rust/crates/tools/src/grep_tool.rs
+++ b/src-rust/crates/tools/src/grep_tool.rs
@@ -67,6 +67,9 @@ fn extensions_for_type(t: &str) -> Vec<&'static str> {
 
 #[async_trait]
 impl Tool for GrepTool {
+    // Gates itself: calls `ctx.check_permission_for_path` in `execute()` (#210).
+    fn self_gates(&self) -> bool { true }
+
     fn name(&self) -> &str {
         claurst_core::constants::TOOL_NAME_GREP
     }

--- a/src-rust/crates/tools/src/lib.rs
+++ b/src-rust/crates/tools/src/lib.rs
@@ -507,6 +507,19 @@ pub trait Tool: Send + Sync {
     /// The permission level the tool requires.
     fn permission_level(&self) -> PermissionLevel;
 
+    /// Whether this tool performs its own permission gating inside `execute()`.
+    ///
+    /// - `false` (default): the central backstop in `execute_tool` is
+    ///   responsible for gating this tool. Secure by default — a tool that
+    ///   forgets to call `ctx.check_permission*` is still caught by the backstop
+    ///   whenever its `permission_level()` is a gated level.
+    /// - `true`: the tool already prompts for permission internally (it calls
+    ///   `ctx.check_permission*` in `execute()`), so the central gate must NOT
+    ///   also prompt — this prevents double-prompting.
+    fn self_gates(&self) -> bool {
+        false
+    }
+
     /// JSON Schema describing the tool's input parameters.
     fn input_schema(&self) -> Value;
 

--- a/src-rust/crates/tools/src/lsp_tool.rs
+++ b/src-rust/crates/tools/src/lsp_tool.rs
@@ -11,6 +11,9 @@ pub struct LspTool;
 
 #[async_trait]
 impl Tool for LspTool {
+    // Gates itself: calls `ctx.check_permission_for_path` in `execute()` (#210).
+    fn self_gates(&self) -> bool { true }
+
     fn name(&self) -> &str {
         "LSP"
     }

--- a/src-rust/crates/tools/src/mcp_auth_tool.rs
+++ b/src-rust/crates/tools/src/mcp_auth_tool.rs
@@ -24,6 +24,9 @@ struct McpAuthInput {
 
 #[async_trait]
 impl Tool for McpAuthTool {
+    // Gates itself: calls `ctx.check_permission` in `execute()` (#210).
+    fn self_gates(&self) -> bool { true }
+
     fn name(&self) -> &str {
         "mcp__auth"
     }

--- a/src-rust/crates/tools/src/mcp_resources.rs
+++ b/src-rust/crates/tools/src/mcp_resources.rs
@@ -25,6 +25,9 @@ struct ListMcpResourcesInput {
 
 #[async_trait]
 impl Tool for ListMcpResourcesTool {
+    // Gates itself: calls `ctx.check_permission` in `execute()` (#210).
+    fn self_gates(&self) -> bool { true }
+
     fn name(&self) -> &str { "ListMcpResources" }
 
     fn description(&self) -> &str {
@@ -106,6 +109,9 @@ struct ReadMcpResourceInput {
 
 #[async_trait]
 impl Tool for ReadMcpResourceTool {
+    // Gates itself: calls `ctx.check_permission` in `execute()` (#210).
+    fn self_gates(&self) -> bool { true }
+
     fn name(&self) -> &str { "ReadMcpResource" }
 
     fn description(&self) -> &str {

--- a/src-rust/crates/tools/src/notebook_edit.rs
+++ b/src-rust/crates/tools/src/notebook_edit.rs
@@ -38,6 +38,9 @@ fn default_edit_mode() -> String {
 
 #[async_trait]
 impl Tool for NotebookEditTool {
+    // Gates itself: calls `ctx.check_permission` in `execute()` (#210).
+    fn self_gates(&self) -> bool { true }
+
     fn name(&self) -> &str {
         claurst_core::constants::TOOL_NAME_NOTEBOOK_EDIT
     }

--- a/src-rust/crates/tools/src/powershell.rs
+++ b/src-rust/crates/tools/src/powershell.rs
@@ -77,6 +77,9 @@ fn risk_explanation(level: PsRiskLevel, command: &str) -> String {
 
 #[async_trait]
 impl Tool for PowerShellTool {
+    // Gates itself: calls `ctx.check_permission*` in `execute()` (#210).
+    fn self_gates(&self) -> bool { true }
+
     fn name(&self) -> &str { "PowerShell" }
 
     fn description(&self) -> &str {

--- a/src-rust/crates/tools/src/pty_bash.rs
+++ b/src-rust/crates/tools/src/pty_bash.rs
@@ -659,6 +659,9 @@ fn truncate_output(mut output: String, exit_code: i32) -> ToolResult {
 
 #[async_trait]
 impl Tool for PtyBashTool {
+    // Gates itself: calls `ctx.check_permission*` in `execute()` (#210).
+    fn self_gates(&self) -> bool { true }
+
     fn name(&self) -> &str {
         claurst_core::constants::TOOL_NAME_BASH
     }

--- a/src-rust/crates/tools/src/repl_tool.rs
+++ b/src-rust/crates/tools/src/repl_tool.rs
@@ -202,6 +202,9 @@ struct ReplInput {
 
 #[async_trait]
 impl Tool for ReplTool {
+    // Gates itself: calls `ctx.check_permission` in `execute()` (#210).
+    fn self_gates(&self) -> bool { true }
+
     fn name(&self) -> &str {
         "REPL"
     }

--- a/src-rust/crates/tools/src/skill_tool.rs
+++ b/src-rust/crates/tools/src/skill_tool.rs
@@ -30,6 +30,9 @@ struct SkillInput {
 
 #[async_trait]
 impl Tool for SkillTool {
+    // Gates itself: calls `ctx.check_permission_for_path` in `execute()` (#210).
+    fn self_gates(&self) -> bool { true }
+
     fn name(&self) -> &str { "Skill" }
 
     fn description(&self) -> &str {

--- a/src-rust/crates/tools/src/web_fetch.rs
+++ b/src-rust/crates/tools/src/web_fetch.rs
@@ -266,6 +266,9 @@ fn strip_html(html: &str) -> String {
 
 #[async_trait]
 impl Tool for WebFetchTool {
+    // Gates itself: calls `ctx.check_permission` in `execute()` (#210).
+    fn self_gates(&self) -> bool { true }
+
     fn name(&self) -> &str {
         claurst_core::constants::TOOL_NAME_WEB_FETCH
     }

--- a/src-rust/crates/tools/src/worktree.rs
+++ b/src-rust/crates/tools/src/worktree.rs
@@ -464,3 +464,99 @@ async fn run_git(cwd: &std::path::Path, args: &[&str]) -> Result<String, String>
         Err(String::from_utf8_lossy(&output.stderr).to_string())
     }
 }
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::allow_all_context;
+    use claurst_core::permissions::{PermissionDecision, PermissionHandler, PermissionRequest};
+
+    /// Handler that allows worktree creation but denies (via `Ask`) any request
+    /// whose description mentions the post-create command.
+    struct DenyPostCreateHandler;
+    impl PermissionHandler for DenyPostCreateHandler {
+        fn check_permission(&self, request: &PermissionRequest) -> PermissionDecision {
+            if request.description.contains("post-create command") {
+                PermissionDecision::Ask { reason: "denied in test".to_string() }
+            } else {
+                PermissionDecision::Allow
+            }
+        }
+        fn request_permission(&self, request: &PermissionRequest) -> PermissionDecision {
+            self.check_permission(request)
+        }
+    }
+
+    async fn init_git_repo(dir: &std::path::Path) {
+        run_git(dir, &["init"]).await.expect("git init");
+        run_git(dir, &["config", "user.email", "t@example.com"]).await.expect("git config email");
+        run_git(dir, &["config", "user.name", "Test"]).await.expect("git config name");
+        std::fs::write(dir.join("README.md"), b"hi").unwrap();
+        run_git(dir, &["add", "."]).await.expect("git add");
+        run_git(dir, &["commit", "-m", "init"]).await.expect("git commit");
+    }
+
+    async fn reset_session() {
+        *WORKTREE_SESSION.write().await = None;
+    }
+
+    /// A Critical-classified post_create_command is BLOCKED and never executed,
+    /// while the worktree itself is still created.
+    #[tokio::test]
+    async fn worktree_post_create_critical_command_is_blocked() {
+        reset_session().await;
+        let tmp = tempfile::tempdir().unwrap();
+        init_git_repo(tmp.path()).await;
+
+        // `dd if=…` is classified Critical, yet writing /dev/null → marker is a
+        // harmless no-op if it ever ran — so this test is regression-safe.
+        let marker = tmp.path().join("critical_ran");
+        let cmd = format!("dd if=/dev/null of={}", marker.display());
+
+        let ctx = allow_all_context(tmp.path().to_path_buf());
+        let result = EnterWorktreeTool
+            .execute(json!({ "post_create_command": cmd }), &ctx)
+            .await;
+
+        assert!(!result.is_error, "worktree creation should still succeed");
+        assert!(
+            result.content.contains("BLOCKED"),
+            "Critical post-create command must be reported as blocked: {}",
+            result.content
+        );
+        assert!(!marker.exists(), "Critical post-create command must NOT run");
+        reset_session().await;
+    }
+
+    /// A (non-Critical) post_create_command is not executed when permission is
+    /// denied; the worktree is still created.
+    #[tokio::test]
+    async fn worktree_post_create_command_denied_is_not_run() {
+        reset_session().await;
+        let tmp = tempfile::tempdir().unwrap();
+        init_git_repo(tmp.path()).await;
+
+        let marker = tmp.path().join("denied_ran");
+        let cmd = format!("touch {}", marker.display());
+
+        let mut ctx = allow_all_context(tmp.path().to_path_buf());
+        ctx.permission_handler = Arc::new(DenyPostCreateHandler);
+
+        let result = EnterWorktreeTool
+            .execute(json!({ "post_create_command": cmd }), &ctx)
+            .await;
+
+        assert!(!result.is_error, "worktree creation should still succeed");
+        assert!(
+            result.content.contains("was not run"),
+            "denied post-create command must be reported as not run: {}",
+            result.content
+        );
+        assert!(!marker.exists(), "denied post-create command must NOT run");
+        reset_session().await;
+    }
+}

--- a/src-rust/crates/tools/src/worktree.rs
+++ b/src-rust/crates/tools/src/worktree.rs
@@ -207,35 +207,57 @@ impl Tool for EnterWorktreeTool {
                     original_head,
                 });
 
-                // Run optional post-create command in the new worktree directory
+                // Run optional post-create command in the new worktree directory.
+                //
+                // Security (#210): the post_create_command is model-supplied and
+                // was previously run via raw `sh -c` behind only the generic
+                // "create a git worktree" prompt — the command itself was never
+                // gated or surfaced. Gate it specifically here: classify it,
+                // hard-block Critical-risk commands, and prompt with the ACTUAL
+                // command text so the user sees exactly what will run.
                 let post_create_output = if let Some(cmd) = params.post_create_command {
-                    let shell_result = if cfg!(target_os = "windows") {
-                        tokio::process::Command::new("cmd")
-                            .args(["/C", &cmd])
-                            .current_dir(&worktree_path)
-                            .output()
-                            .await
+                    let risk = claurst_core::bash_classifier::classify_bash_command(&cmd);
+                    if risk == claurst_core::bash_classifier::BashRiskLevel::Critical {
+                        format!(
+                            "\nPost-create command '{}' was BLOCKED: classified as Critical risk \
+                             and never executed. Re-create the worktree without it, or run a safer command.",
+                            cmd
+                        )
+                    } else if let Err(e) = ctx.check_permission(
+                        self.name(),
+                        &format!("Run post-create command in the new worktree: {}", cmd),
+                        false,
+                    ) {
+                        format!("\nPost-create command '{}' was not run: {}", cmd, e)
                     } else {
-                        tokio::process::Command::new("sh")
-                            .args(["-c", &cmd])
-                            .current_dir(&worktree_path)
-                            .output()
-                            .await
-                    };
-                    match shell_result {
-                        Ok(out) if out.status.success() => {
-                            let stdout = String::from_utf8_lossy(&out.stdout);
-                            format!("\nPost-create command '{}' completed successfully.{}",
-                                cmd,
-                                if stdout.trim().is_empty() { String::new() } else { format!("\nOutput: {}", stdout.trim()) }
-                            )
+                        let shell_result = if cfg!(target_os = "windows") {
+                            tokio::process::Command::new("cmd")
+                                .args(["/C", &cmd])
+                                .current_dir(&worktree_path)
+                                .output()
+                                .await
+                        } else {
+                            tokio::process::Command::new("sh")
+                                .args(["-c", &cmd])
+                                .current_dir(&worktree_path)
+                                .output()
+                                .await
+                        };
+                        match shell_result {
+                            Ok(out) if out.status.success() => {
+                                let stdout = String::from_utf8_lossy(&out.stdout);
+                                format!("\nPost-create command '{}' completed successfully.{}",
+                                    cmd,
+                                    if stdout.trim().is_empty() { String::new() } else { format!("\nOutput: {}", stdout.trim()) }
+                                )
+                            }
+                            Ok(out) => {
+                                let stderr = String::from_utf8_lossy(&out.stderr);
+                                format!("\nPost-create command '{}' exited with error.\nStderr: {}",
+                                    cmd, stderr.trim())
+                            }
+                            Err(e) => format!("\nCould not run post-create command '{}': {}", cmd, e),
                         }
-                        Ok(out) => {
-                            let stderr = String::from_utf8_lossy(&out.stderr);
-                            format!("\nPost-create command '{}' exited with error.\nStderr: {}",
-                                cmd, stderr.trim())
-                        }
-                        Err(e) => format!("\nCould not run post-create command '{}': {}", cmd, e),
                     }
                 } else {
                     String::new()

--- a/src-rust/crates/tools/src/worktree.rs
+++ b/src-rust/crates/tools/src/worktree.rs
@@ -55,6 +55,10 @@ struct EnterWorktreeInput {
 
 #[async_trait]
 impl Tool for EnterWorktreeTool {
+    // Gates itself: prompts for worktree creation AND for the post_create_command
+    // in `execute()` (#210). The central backstop must not also prompt.
+    fn self_gates(&self) -> bool { true }
+
     fn name(&self) -> &str { "EnterWorktree" }
 
     fn description(&self) -> &str {


### PR DESCRIPTION
Fixes #210. Tool gating was per-tool with no central check, so a tool that forgot to gate ran unprompted. Adds `Tool::self_gates()` (self-gaters opt out) and a backstop in `execute_tool` that gates any non-self-gating tool above ReadOnly — catching previously-ungated ConfigTool/TaskStop/TeamCreate/TeamDelete/ExitWorktree without double-prompting existing self-gaters (AgentTool is None, so subagent spawning is unaffected). Worktree `post_create_command` now classifies (hard-blocks Critical), surfaces the command text, and gates it. 4 commits + tests, tools+query green.

Closes #210