### PR TITLE
fix(query): make in-flight tools & sub-agents cancellable (cancellation tree)

### DIFF
--- a/src-rust/crates/acp/src/prompt.rs
+++ b/src-rust/crates/acp/src/prompt.rs
@@ -67,6 +67,10 @@ pub async fn handle(
         pending_permissions: Some(session.pending_permissions.clone()),
         permission_manager: Some(runtime.permission_manager.clone()),
         user_question_tx: None,
+        // Bind to this turn's cancel token so the parallel tool executor and any
+        // sub-agents observe cancellation (issue #218). `run_query_loop` also
+        // rebinds this to the token it is driven by.
+        cancel_token: cancel.clone(),
     };
 
     // Spawn the permission drainer for this turn.

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -731,6 +731,9 @@ async fn main() -> anyhow::Result<()> {
         pending_permissions: Some(pending_permissions.clone()),
         permission_manager: Some(permission_manager.clone()),
         user_question_tx: if is_non_interactive { None } else { Some(user_question_tx) },
+        // Placeholder token; `run_query_loop` rebinds it to the loop's actual
+        // cancel token so the parallel tool executor honours Ctrl-C (issue #218).
+        cancel_token: tokio_util::sync::CancellationToken::new(),
     };
 
     // Hourly shadow-snapshot GC loop: only runs when snapshot is explicitly enabled.

--- a/src-rust/crates/query/src/agent_tool.rs
+++ b/src-rust/crates/query/src/agent_tool.rs
@@ -25,7 +25,6 @@ use serde_json::{json, Value};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
-use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use crate::{run_query_loop, QueryConfig, QueryOutcome};
@@ -380,8 +379,10 @@ impl Tool for AgentTool {
             // Cancellation token shared between the registry and the spawned
             // sub-agent loop: signalling it via TaskRegistry::cancel (e.g. from a
             // monitor cancel) actually stops the loop instead of only relabeling
-            // the task (issue #219).
-            let cancel = CancellationToken::new();
+            // the task (issue #219). Derive it as a CHILD of the parent's token
+            // so cancelling the parent query also cancels this sub-agent, while
+            // the registry can still cancel this sub-agent independently (#218).
+            let cancel = ctx.cancel_token.child_token();
             task.cancel_token = Some(cancel.clone());
             let _ = claurst_core::tasks::global_registry().register(task);
 
@@ -465,7 +466,9 @@ impl Tool for AgentTool {
         // Synchronous mode: run the sub-agent loop and wait for completion.
         // -----------------------------------------------------------------------
         let mut messages = vec![Message::user(params.prompt)];
-        let cancel = CancellationToken::new();
+        // Derive the sub-agent's token as a CHILD of the parent's so a parent
+        // cancel propagates into this sub-agent's own run_query_loop (issue #218).
+        let cancel = ctx.cancel_token.child_token();
 
         let outcome = run_query_loop(
             client.as_ref(),
@@ -635,7 +638,9 @@ pub fn init_team_swarm_runner() {
                     ..Default::default()
                 };
 
-                let cancel = tokio_util::sync::CancellationToken::new();
+                // Child of the parent's token so a parent cancel propagates into
+                // this team sub-agent as well (issue #218).
+                let cancel = ctx.cancel_token.child_token();
                 let mut messages = vec![claurst_core::types::Message::user(prompt)];
                 let outcome = crate::run_query_loop(
                     client.as_ref(),

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -2149,23 +2149,14 @@ pub async fn run_query_loop(
                     })
                     .collect();
 
-                // Run all tool futures concurrently; join_all preserves order.
-                // But race the batch against the loop's cancel token (issue #218):
-                // on cancellation we abandon any in-flight tools promptly instead
-                // of blocking until the slowest one finishes, and synthesize a
-                // cancelled ToolResult for EVERY tool so each tool_use still gets a
-                // matching tool_result and the message history stays well-formed.
-                let mut batch_cancelled = false;
-                let exec_results: Vec<ToolResult> = tokio::select! {
-                    results = futures::future::join_all(exec_futures) => results,
-                    _ = tool_ctx.cancel_token.cancelled() => {
-                        batch_cancelled = true;
-                        prepared
-                            .iter()
-                            .map(|_| ToolResult::error(TOOL_CANCELLED_MSG))
-                            .collect()
-                    }
-                };
+                // Run all tool futures concurrently, but race the batch against the
+                // loop's cancel token (issue #218): on cancellation the in-flight
+                // tools are abandoned promptly instead of blocking until the
+                // slowest one finishes, and a cancelled ToolResult is synthesized
+                // for EVERY tool so each tool_use still gets a matching tool_result
+                // and the message history stays well-formed.
+                let (exec_results, batch_cancelled) =
+                    run_tool_batch(exec_futures, &tool_ctx.cancel_token).await;
 
                 // Phase 3: post-hooks, event emission, and result block assembly.
                 // When the batch was cancelled we skip the awaiting PostToolUse
@@ -2341,6 +2332,34 @@ async fn execute_tool(
         None => {
             warn!(tool = name, "Unknown tool requested");
             ToolResult::error(format!("Unknown tool: {}", name))
+        }
+    }
+}
+
+/// Run a batch of tool-execution futures concurrently, abandoning them promptly
+/// if `cancel_token` fires (issue #218).
+///
+/// Returns exactly one `ToolResult` per input future, in order, plus a bool that
+/// is `true` iff the batch was cancelled before every tool finished. On the
+/// happy path (no cancellation) this is `join_all` and the results are the real
+/// tool outputs. On cancellation the in-flight futures are dropped (abandoned)
+/// and every position is filled with a synthetic cancelled `ToolResult` so the
+/// caller can still answer every `tool_use` and keep the message history valid.
+async fn run_tool_batch<F>(
+    exec_futures: Vec<F>,
+    cancel_token: &tokio_util::sync::CancellationToken,
+) -> (Vec<ToolResult>, bool)
+where
+    F: std::future::Future<Output = ToolResult>,
+{
+    let count = exec_futures.len();
+    tokio::select! {
+        results = futures::future::join_all(exec_futures) => (results, false),
+        _ = cancel_token.cancelled() => {
+            let cancelled = (0..count)
+                .map(|_| ToolResult::error(TOOL_CANCELLED_MSG))
+                .collect();
+            (cancelled, true)
         }
     }
 }
@@ -3029,6 +3048,93 @@ mod tests {
         assert!(permission_level_is_gated(PermissionLevel::Execute));
         assert!(permission_level_is_gated(PermissionLevel::Dangerous));
         assert!(permission_level_is_gated(PermissionLevel::Forbidden));
+    }
+
+    // ---- Issue #218: cancellation plumbing ---------------------------------
+
+    /// (a) The parallel tool executor (`run_tool_batch`, the exact code the query
+    /// loop runs) must abandon a long-running tool the moment the cancel token
+    /// fires: with a tool future that never completes and a pre-cancelled token,
+    /// the batch returns promptly instead of blocking, reports cancellation, and
+    /// still yields one cancelled `ToolResult` per tool so every `tool_use` can
+    /// be answered and the message history stays valid.
+    #[tokio::test]
+    async fn executor_abandons_in_flight_tools_on_cancel() {
+        use std::future::Future;
+        use std::pin::Pin;
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        cancel.cancel(); // pre-cancelled
+
+        // Two tool futures: one that never completes (a long-running tool) and
+        // one that would succeed. Boxed so they share a concrete type.
+        let never: Pin<Box<dyn Future<Output = ToolResult> + Send>> =
+            Box::pin(std::future::pending());
+        let quick: Pin<Box<dyn Future<Output = ToolResult> + Send>> =
+            Box::pin(async { ToolResult::success("done") });
+
+        // If the executor blocked on the never-completing tool this would time
+        // out; it must return promptly instead.
+        let (results, cancelled) = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            run_tool_batch(vec![never, quick], &cancel),
+        )
+        .await
+        .expect("executor must return promptly, not block on the pending tool");
+
+        assert!(cancelled, "batch must report that it was cancelled");
+        assert_eq!(
+            results.len(),
+            2,
+            "every tool_use must still receive a tool_result"
+        );
+        assert!(
+            results.iter().all(|r| r.is_error),
+            "cancelled tool results are errors"
+        );
+        assert!(
+            results[0].content.contains("cancelled"),
+            "cancelled result should say so, got: {}",
+            results[0].content
+        );
+    }
+
+    /// The happy path is unchanged: with a live (never-cancelled) token the batch
+    /// runs the futures to completion and returns their real results in order.
+    #[tokio::test]
+    async fn executor_runs_to_completion_without_cancel() {
+        let cancel = tokio_util::sync::CancellationToken::new();
+        // `std::future::ready` gives both futures the same concrete type so they
+        // share a Vec (mirroring the Either-unified futures the real loop builds).
+        let f1 = std::future::ready(ToolResult::success("a"));
+        let f2 = std::future::ready(ToolResult::error("b"));
+
+        let (results, cancelled) = run_tool_batch(vec![f1, f2], &cancel).await;
+
+        assert!(!cancelled, "no cancellation should have occurred");
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].content, "a");
+        assert!(!results[0].is_error);
+        assert_eq!(results[1].content, "b");
+        assert!(results[1].is_error);
+    }
+
+    /// (b) A sub-agent receives a CHILD of the parent's cancel token — exactly
+    /// how `AgentTool` derives it from `ctx.cancel_token` — so cancelling the
+    /// parent query propagates into the sub-agent. `ToolContext` now exposes the
+    /// token, and cancelling it must flip the child.
+    #[test]
+    fn subagent_child_token_propagates_parent_cancel() {
+        let ctx = deny_all_context();
+        // AgentTool spawns each sub-agent with a token derived exactly this way.
+        let child = ctx.cancel_token.child_token();
+
+        assert!(!child.is_cancelled(), "child starts live");
+        ctx.cancel_token.cancel();
+        assert!(
+            child.is_cancelled(),
+            "cancelling the parent's token must cancel the sub-agent's child token"
+        );
     }
 }
 

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -764,6 +764,15 @@ pub async fn run_query_loop(
     cancel_token: tokio_util::sync::CancellationToken,
     mut pending_messages: Option<&mut Vec<String>>,
 ) -> QueryOutcome {
+    // Rebind the tool context to carry the loop's actual cancel token so the
+    // parallel tool executor — and any tools or sub-agents that read
+    // `ctx.cancel_token` — observe the same cancellation signal that drives this
+    // loop (issue #218). Callers construct the context with a placeholder token;
+    // making the loop authoritative here means a parent cancel reaches tools.
+    let mut loop_ctx = tool_ctx.clone();
+    loop_ctx.cancel_token = cancel_token.clone();
+    let tool_ctx = &loop_ctx;
+
     let mut turn = 0u32;
     let mut compact_state = compact::AutoCompactState::default();
     // Tracks how many consecutive max_tokens recoveries we've attempted so
@@ -2896,6 +2905,7 @@ mod tests {
             pending_permissions: None,
             permission_manager: None,
             user_question_tx: None,
+            cancel_token: tokio_util::sync::CancellationToken::new(),
         }
     }
 

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -715,6 +715,12 @@ const MAX_TOKENS_RECOVERY_MSG: &str =
      you were doing. Pick up mid-thought if that is where the cut happened. \
      Break remaining work into smaller pieces.";
 
+/// Content stored in the synthetic `tool_result` for a tool that was abandoned
+/// mid-flight because the query loop was cancelled (issue #218). Every
+/// outstanding `tool_use` still receives a matching `tool_result` carrying this
+/// text so the message history stays well-formed.
+const TOOL_CANCELLED_MSG: &str = "Tool execution was cancelled by the user before it completed.";
+
 // Spinner verbs are imported from claurst_core::spinner
 
 /// Apply the outcome of a reactive-compact / context-collapse call to the live
@@ -2144,36 +2150,56 @@ pub async fn run_query_loop(
                     .collect();
 
                 // Run all tool futures concurrently; join_all preserves order.
-                let exec_results: Vec<ToolResult> =
-                    futures::future::join_all(exec_futures).await;
+                // But race the batch against the loop's cancel token (issue #218):
+                // on cancellation we abandon any in-flight tools promptly instead
+                // of blocking until the slowest one finishes, and synthesize a
+                // cancelled ToolResult for EVERY tool so each tool_use still gets a
+                // matching tool_result and the message history stays well-formed.
+                let mut batch_cancelled = false;
+                let exec_results: Vec<ToolResult> = tokio::select! {
+                    results = futures::future::join_all(exec_futures) => results,
+                    _ = tool_ctx.cancel_token.cancelled() => {
+                        batch_cancelled = true;
+                        prepared
+                            .iter()
+                            .map(|_| ToolResult::error(TOOL_CANCELLED_MSG))
+                            .collect()
+                    }
+                };
 
                 // Phase 3: post-hooks, event emission, and result block assembly.
+                // When the batch was cancelled we skip the awaiting PostToolUse
+                // hooks (they run external commands and would defeat the point of
+                // returning promptly) but still emit ToolEnd + build every result
+                // block so the conversation and TUI stay consistent.
                 let mut result_blocks: Vec<ContentBlock> =
                     Vec::with_capacity(prepared.len());
                 for (p, result) in prepared.iter().zip(exec_results.into_iter()) {
-                    let hooks = &tool_ctx.config.hooks;
-                    let post_ctx = claurst_core::hooks::HookContext {
-                        event: "PostToolUse".to_string(),
-                        tool_name: Some(p.name.clone()),
-                        tool_input: Some(p.input.clone()),
-                        tool_output: Some(result.content.clone()),
-                        is_error: Some(result.is_error),
-                        session_id: Some(tool_ctx.session_id.clone()),
-                    };
-                    claurst_core::hooks::run_hooks(
-                        hooks,
-                        claurst_core::config::HookEvent::PostToolUse,
-                        &post_ctx,
-                        &tool_ctx.working_dir,
-                    )
-                    .await;
+                    if !batch_cancelled {
+                        let hooks = &tool_ctx.config.hooks;
+                        let post_ctx = claurst_core::hooks::HookContext {
+                            event: "PostToolUse".to_string(),
+                            tool_name: Some(p.name.clone()),
+                            tool_input: Some(p.input.clone()),
+                            tool_output: Some(result.content.clone()),
+                            is_error: Some(result.is_error),
+                            session_id: Some(tool_ctx.session_id.clone()),
+                        };
+                        claurst_core::hooks::run_hooks(
+                            hooks,
+                            claurst_core::config::HookEvent::PostToolUse,
+                            &post_ctx,
+                            &tool_ctx.working_dir,
+                        )
+                        .await;
 
-                    claurst_plugins::run_global_post_tool_hook(
-                        &p.name,
-                        &p.input,
-                        &result.content,
-                        result.is_error,
-                    );
+                        claurst_plugins::run_global_post_tool_hook(
+                            &p.name,
+                            &p.input,
+                            &result.content,
+                            result.is_error,
+                        );
+                    }
 
                     if let Some(ref tx) = event_tx {
                         let _ = tx.send(QueryEvent::ToolEnd {
@@ -2191,8 +2217,15 @@ pub async fn run_query_loop(
                     });
                 }
 
-                // Append tool results as a user message
+                // Append tool results as a user message so the history remains
+                // valid (every tool_use is answered) even on cancellation.
                 messages.push(Message::user_blocks(result_blocks));
+
+                // If the batch was abandoned due to cancellation, stop the loop
+                // now rather than sending the (cancelled) results back to the model.
+                if batch_cancelled {
+                    return QueryOutcome::Cancelled;
+                }
 
                 // Continue the loop to send results back to the model
                 continue;

--- a/src-rust/crates/tools/src/cron.rs
+++ b/src-rust/crates/tools/src/cron.rs
@@ -576,6 +576,7 @@ mod tests {
             pending_permissions: None,
             permission_manager: None,
             user_question_tx: None,
+            cancel_token: tokio_util::sync::CancellationToken::new(),
         }
     }
 

--- a/src-rust/crates/tools/src/lib.rs
+++ b/src-rust/crates/tools/src/lib.rs
@@ -303,6 +303,12 @@ pub struct ToolContext {
     /// Channel for the `AskUserQuestion` tool to send questions to the TUI and
     /// receive the user's typed answer.  `None` in headless / non-interactive mode.
     pub user_question_tx: Option<tokio::sync::mpsc::UnboundedSender<UserQuestionEvent>>,
+    /// Cancellation token for the owning query loop (issue #218). The parallel
+    /// tool executor selects on this to abandon in-flight tools when the user
+    /// cancels, and long-running tools may observe it to bail out early. Defaults
+    /// to a fresh disconnected token; `run_query_loop` rebinds it to the loop's
+    /// actual token so cancellation propagates into tools and sub-agents.
+    pub cancel_token: tokio_util::sync::CancellationToken,
 }
 
 impl ToolContext {
@@ -647,6 +653,7 @@ mod tests {
             pending_permissions: None,
             permission_manager: None,
             user_question_tx: None,
+            cancel_token: tokio_util::sync::CancellationToken::new(),
         }
     }
 

--- a/src-rust/crates/tools/src/monitor_tool.rs
+++ b/src-rust/crates/tools/src/monitor_tool.rs
@@ -276,6 +276,7 @@ mod tests {
             pending_permissions: None,
             permission_manager: None,
             user_question_tx: None,
+            cancel_token: tokio_util::sync::CancellationToken::new(),
         }
     }
 }

--- a/src-rust/crates/tools/src/pty_bash.rs
+++ b/src-rust/crates/tools/src/pty_bash.rs
@@ -952,6 +952,7 @@ mod tests {
             pending_permissions: None,
             permission_manager: None,
             user_question_tx: None,
+            cancel_token: tokio_util::sync::CancellationToken::new(),
         }
     }
 

--- a/src-rust/crates/tools/src/repl_tool.rs
+++ b/src-rust/crates/tools/src/repl_tool.rs
@@ -362,6 +362,7 @@ mod tests {
             pending_permissions: None,
             permission_manager: None,
             user_question_tx: None,
+            cancel_token: tokio_util::sync::CancellationToken::new(),
         }
     }
 

--- a/src-rust/crates/tools/src/test_support.rs
+++ b/src-rust/crates/tools/src/test_support.rs
@@ -44,5 +44,6 @@ pub(crate) fn allow_all_context(working_dir: PathBuf) -> ToolContext {
         pending_permissions: None,
         permission_manager: None,
         user_question_tx: None,
+        cancel_token: tokio_util::sync::CancellationToken::new(),
     }
 }


### PR DESCRIPTION
Fixes #218. `ToolContext` gains a `cancel_token` (the loop rebinds it to its real token); the parallel tool executor is now `run_tool_batch` — `select!` between `join_all` and `cancelled()`, abandoning in-flight tools promptly on Ctrl-C while still synthesizing a cancelled `ToolResult` for every `tool_use` (history stays valid) and returning `QueryOutcome::Cancelled`. Sub-agents (sync/background/team-swarm) now derive `child_token()` so parent cancel propagates, preserving #219's registry registration. 4 commits + 3 tests, query 105 / tools 101 / `cargo check --workspace` green.

Closes #218