### PR TITLE
refactor(api): shared SSE byte-decoder (fixes UTF-8 chunk corruption) + registry-driven picker + protocol scaffold

### DIFF
--- a/src-rust/crates/api/src/lib.rs
+++ b/src-rust/crates/api/src/lib.rs
@@ -65,7 +65,7 @@ pub use provider_error::ProviderError;
 // Phase 1B re-exports — provider abstraction traits.
 pub use provider::{LlmProvider, ModelInfo};
 pub use auth::{AuthProvider, LoginFlow};
-pub use stream_parser::{StreamParser, SseStreamParser, JsonLinesStreamParser};
+pub use stream_parser::{SseByteDecoder, StreamParser, SseStreamParser, JsonLinesStreamParser};
 pub use transform::MessageTransformer;
 
 // Phase 1C re-exports — provider registry.
@@ -1112,30 +1112,16 @@ pub mod client {
             use sse_parser::SseLineParser;
 
             let mut parser = SseLineParser::new();
+            // Shared byte-buffering decoder (#228): buffers raw bytes and only
+            // decodes complete lines, so a multibyte codepoint split across a
+            // network chunk boundary is never corrupted.
+            let mut decoder = crate::SseByteDecoder::new();
             let mut byte_stream = resp.bytes_stream();
-            let mut leftover = String::new();
 
             while let Some(chunk_result) = byte_stream.next().await {
                 let chunk = chunk_result.map_err(|e| ClaudeError::Api(format!("HTTP error: {e}")))?;
-                let text = String::from_utf8_lossy(&chunk);
 
-                // Prepend any leftover from the previous chunk
-                let combined = if leftover.is_empty() {
-                    text.to_string()
-                } else {
-                    let mut s = std::mem::take(&mut leftover);
-                    s.push_str(&text);
-                    s
-                };
-
-                // Split into lines.  If the chunk doesn't end with a newline
-                // the last piece is an incomplete line – stash it.
-                let mut lines: Vec<&str> = combined.split('\n').collect();
-                if !combined.ends_with('\n') {
-                    leftover = lines.pop().unwrap_or("").to_string();
-                }
-
-                for line in lines {
+                for line in decoder.push(&chunk) {
                     let line = line.trim_end_matches('\r');
                     if let Some(frame) = parser.feed_line(line) {
                         if let Some(event) =

--- a/src-rust/crates/api/src/lib.rs
+++ b/src-rust/crates/api/src/lib.rs
@@ -36,6 +36,10 @@ pub mod auth;
 pub mod stream_parser;
 pub mod transform;
 
+// Wire-format protocol layer (#228): request-building + stream decoding owned
+// once per wire format, shared across the providers that speak it.
+pub mod protocol;
+
 // Provider registry (Phase 1C).
 pub mod registry;
 
@@ -67,6 +71,9 @@ pub use provider::{LlmProvider, ModelInfo};
 pub use auth::{AuthProvider, LoginFlow};
 pub use stream_parser::{SseByteDecoder, StreamParser, SseStreamParser, JsonLinesStreamParser};
 pub use transform::MessageTransformer;
+
+// #228 protocol layer re-exports.
+pub use protocol::{LineStreamDecoder, OpenAiChatDecoder};
 
 // Phase 1C re-exports — provider registry.
 pub use registry::ProviderRegistry;
@@ -1103,6 +1110,17 @@ pub mod client {
             }
         }
 
+        // TODO(#228): this SSE loop + `frame_to_event` below are the decode half
+        // of the **AnthropicMessages** wire protocol. They should be hoisted into
+        // a sans-IO `protocol::anthropic_messages` decoder (mirroring
+        // `protocol::openai_chat::OpenAiChatDecoder`) and shared with
+        // `providers::anthropic::AnthropicProvider`, collapsing the two Anthropic
+        // stacks. Remaining step / risk: this path decodes into the Anthropic-typed
+        // `AnthropicStreamEvent` consumed by `StreamHandler`/`StreamAccumulator`
+        // and the TUI, whereas the protocol decoders emit the provider-agnostic
+        // `provider_types::StreamEvent`; unifying requires either a decoder generic
+        // over its output event or migrating those consumers. Deferred to keep the
+        // TUI and all tests green.
         /// Read an SSE byte stream, parse frames, and emit `AnthropicStreamEvent`s.
         async fn process_sse_stream(
             resp: wreq::Response,

--- a/src-rust/crates/api/src/protocol/mod.rs
+++ b/src-rust/crates/api/src/protocol/mod.rs
@@ -1,0 +1,46 @@
+// protocol — wire-format protocol layer (#228).
+//
+// A *protocol* owns the request-building and response/stream-decoding logic for
+// one on-the-wire format, independent of which vendor/endpoint speaks it. This
+// mirrors opencode's `packages/llm` protocol/route split, where a single
+// `anthropic-messages` / `openai-chat` / `openai-responses` / … implementation
+// is shared by every provider that talks that format, and providers collapse to
+// config (endpoint + auth + which protocol + model source).
+//
+// Status (#228): this module currently owns the **stream decoding** half of the
+// OpenAI-Chat protocol — the sans-IO [`openai_chat::OpenAiChatDecoder`], factored
+// out verbatim from `providers/openai_compat.rs` (the adapter that already backs
+// ~35 OpenAI-compatible vendors). Request-building and the other wire formats
+// (`AnthropicMessages`, `OpenAiResponses`, `Gemini`, `BedrockConverse`) are not
+// yet hoisted here — see the `TODO(#228)` markers in the respective provider
+// files. Decoders are kept sans-IO on purpose: they turn already-decoded text
+// lines into provider-agnostic [`StreamEvent`]s with no network access, which
+// makes them unit-testable without a live endpoint and lets every transport
+// (wreq/reqwest, live or replayed) reuse them.
+
+use crate::provider_types::StreamEvent;
+
+pub mod openai_chat;
+
+pub use openai_chat::OpenAiChatDecoder;
+
+/// Sans-IO decoder that turns individual already-UTF-8-decoded SSE / JSON-Lines
+/// **text lines** (as produced by [`crate::SseByteDecoder`]) into a stream of
+/// provider-agnostic [`StreamEvent`]s.
+///
+/// One implementation exists per wire format (protocol). Because the decode
+/// logic never touches the network, a provider's streaming loop shrinks to:
+/// read a chunk → `byte_decoder.push(&chunk)` → `feed_line` each line → yield
+/// the events; and the format's decoding can be tested in isolation.
+pub trait LineStreamDecoder: Send {
+    /// Feed one complete line (trailing `\n` already stripped; `\r` may remain).
+    /// Any resulting events are appended to `out`.
+    ///
+    /// Returns `true` when the wire format signals the stream is finished (e.g.
+    /// an OpenAI `data: [DONE]` sentinel) and the caller should stop reading.
+    fn feed_line(&mut self, line: &str, out: &mut Vec<StreamEvent>) -> bool;
+
+    /// Called once the underlying byte stream ends. Appends any trailing events
+    /// (e.g. a synthesized `MessageStop`) to `out`.
+    fn finish(&mut self, out: &mut Vec<StreamEvent>);
+}

--- a/src-rust/crates/api/src/protocol/openai_chat.rs
+++ b/src-rust/crates/api/src/protocol/openai_chat.rs
@@ -1,0 +1,493 @@
+// protocol::openai_chat — the OpenAI Chat Completions streaming wire format.
+//
+// `OpenAiChatDecoder` is the sans-IO decoder for the `chat/completions` SSE
+// stream shared by OpenAI and the ~35 OpenAI-compatible vendors behind
+// `providers/openai_compat.rs`. The logic here is a verbatim extraction of that
+// adapter's former inline stream loop (#228): identical event ordering, tool-call
+// block indexing, reasoning/thinking handling and finish/usage semantics — only
+// now it is a reusable, unit-testable state machine instead of being welded into
+// an `async_stream::stream!` block.
+
+use std::collections::HashMap;
+
+use claurst_core::types::{ContentBlock, UsageInfo};
+use serde_json::{json, Value};
+use tracing::debug;
+
+use crate::protocol::LineStreamDecoder;
+use crate::providers::openai::OpenAiProvider;
+use crate::provider_types::StreamEvent;
+
+/// Dedicated index for the Thinking content block emitted when a provider
+/// streams a `reasoning_content` field (DeepSeek V4, etc.). Chosen to avoid
+/// colliding with text (index 0) or tool calls (1 + tc_index).
+const THINKING_BLOCK_INDEX: usize = usize::MAX - 100;
+
+/// Streaming decoder for the OpenAI Chat Completions SSE format.
+///
+/// Construct with [`OpenAiChatDecoder::new`], feed each SSE line via
+/// [`feed_line`](Self::feed_line), and after the byte stream ends call
+/// [`finish`](Self::finish) to flush a trailing `MessageStop`.
+pub struct OpenAiChatDecoder {
+    /// Provider-specific reasoning field name (e.g. DeepSeek's
+    /// `reasoning_content`), checked before the common fallbacks.
+    reasoning_field: Option<String>,
+    message_started: bool,
+    message_id: String,
+    model_name: String,
+    thinking_open: bool,
+    /// Keyed by content-block index → (tool_call_id, name, accumulated_args).
+    tool_call_buffers: HashMap<usize, (String, String, String)>,
+}
+
+impl OpenAiChatDecoder {
+    pub fn new(reasoning_field: Option<String>) -> Self {
+        Self {
+            reasoning_field,
+            message_started: false,
+            message_id: String::from("unknown"),
+            model_name: String::new(),
+            thinking_open: false,
+            tool_call_buffers: HashMap::new(),
+        }
+    }
+
+    /// Feed one SSE line. See [`LineStreamDecoder::feed_line`].
+    pub fn feed_line(&mut self, line: &str, out: &mut Vec<StreamEvent>) -> bool {
+        let line = line.trim_end_matches('\r').trim();
+
+        if line.is_empty() || line.starts_with(':') {
+            return false;
+        }
+
+        let data = match line.strip_prefix("data:") {
+            Some(rest) => rest.trim(),
+            None => return false,
+        };
+
+        if data == "[DONE]" {
+            out.push(StreamEvent::MessageStop);
+            return true;
+        }
+
+        let chunk_json: Value = match serde_json::from_str(data) {
+            Ok(v) => v,
+            Err(e) => {
+                debug!("Failed to parse SSE chunk: {}: {}", e, data);
+                return false;
+            }
+        };
+
+        if !self.message_started {
+            if let Some(id) = chunk_json.get("id").and_then(|v| v.as_str()) {
+                self.message_id = id.to_string();
+            }
+            if let Some(m) = chunk_json.get("model").and_then(|v| v.as_str()) {
+                self.model_name = m.to_string();
+            }
+            out.push(StreamEvent::MessageStart {
+                id: self.message_id.clone(),
+                model: self.model_name.clone(),
+                usage: UsageInfo::default(),
+            });
+            out.push(StreamEvent::ContentBlockStart {
+                index: 0,
+                content_block: ContentBlock::Text { text: String::new() },
+            });
+            self.message_started = true;
+        }
+
+        let choices = match chunk_json.get("choices").and_then(|c| c.as_array()) {
+            Some(c) => c,
+            None => {
+                if let Some(usage_val) = chunk_json.get("usage") {
+                    let usage = OpenAiProvider::parse_usage_pub(Some(usage_val));
+                    out.push(StreamEvent::MessageDelta {
+                        stop_reason: None,
+                        usage: Some(usage),
+                    });
+                }
+                return false;
+            }
+        };
+
+        let choice = match choices.first() {
+            Some(c) => c,
+            None => return false,
+        };
+
+        let delta = match choice.get("delta") {
+            Some(d) => d,
+            None => return false,
+        };
+
+        // Reasoning / thinking extraction.
+        // Check the provider-specific field first (e.g. DeepSeek's
+        // "reasoning_content"), then fall back to common field names used by
+        // other providers (Copilot "reasoning_text", generic "reasoning", etc.).
+        // This allows reasoning traces to show for any provider that emits them
+        // without needing explicit per-provider configuration.
+        {
+            const COMMON_REASONING_FIELDS: &[&str] = &[
+                "reasoning_content", // DeepSeek
+                "reasoning_text",    // GitHub Copilot
+                "reasoning",         // Generic / future
+            ];
+            let fields_to_check: Vec<&str> = if let Some(ref f) = self.reasoning_field {
+                // Provider-specific field first, then common ones.
+                let mut v = vec![f.as_str()];
+                for common in COMMON_REASONING_FIELDS {
+                    if *common != f.as_str() {
+                        v.push(common);
+                    }
+                }
+                v
+            } else {
+                COMMON_REASONING_FIELDS.to_vec()
+            };
+            for field in &fields_to_check {
+                if let Some(reasoning) = delta.get(*field).and_then(|v| v.as_str()) {
+                    if !reasoning.is_empty() {
+                        // Open a dedicated Thinking block on first reasoning
+                        // delta so the accumulator has a partial to append into
+                        // (see StreamAccumulator::on_event). Without this start
+                        // event the reasoning deltas would be dropped and the
+                        // completed assistant message would not carry any
+                        // ContentBlock::Thinking — which is what DeepSeek V4
+                        // thinking mode requires the client to echo back on
+                        // subsequent turns.
+                        if !self.thinking_open {
+                            out.push(StreamEvent::ContentBlockStart {
+                                index: THINKING_BLOCK_INDEX,
+                                content_block: ContentBlock::Thinking {
+                                    thinking: String::new(),
+                                    signature: String::new(),
+                                },
+                            });
+                            self.thinking_open = true;
+                        }
+                        out.push(StreamEvent::ReasoningDelta {
+                            index: THINKING_BLOCK_INDEX,
+                            reasoning: reasoning.to_string(),
+                        });
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Text content delta.
+        if let Some(content) = delta.get("content").and_then(|c| c.as_str()) {
+            if !content.is_empty() {
+                // Close any open thinking block before visible text starts
+                // streaming, so the blocks land in order in the final message:
+                // [Thinking, Text, ToolUse...].
+                if self.thinking_open {
+                    out.push(StreamEvent::ContentBlockStop {
+                        index: THINKING_BLOCK_INDEX,
+                    });
+                    self.thinking_open = false;
+                }
+                out.push(StreamEvent::TextDelta {
+                    index: 0,
+                    text: content.to_string(),
+                });
+            }
+        }
+
+        // Tool call deltas.
+        if let Some(tool_calls) = delta.get("tool_calls").and_then(|t| t.as_array()) {
+            // Close any open thinking block before tool calls start (same
+            // ordering guarantee as for text above).
+            if self.thinking_open {
+                out.push(StreamEvent::ContentBlockStop {
+                    index: THINKING_BLOCK_INDEX,
+                });
+                self.thinking_open = false;
+            }
+            for tc in tool_calls {
+                let tc_index = tc.get("index").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+                if let Some(tc_id) = tc.get("id").and_then(|v| v.as_str()) {
+                    let name = tc
+                        .get("function")
+                        .and_then(|f| f.get("name"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let block_index = 1 + tc_index;
+                    self.tool_call_buffers.insert(
+                        block_index,
+                        (tc_id.to_string(), name.clone(), String::new()),
+                    );
+                    out.push(StreamEvent::ContentBlockStart {
+                        index: block_index,
+                        content_block: ContentBlock::ToolUse {
+                            id: tc_id.to_string(),
+                            name,
+                            input: json!({}),
+                        },
+                    });
+                }
+                if let Some(args_frag) = tc
+                    .get("function")
+                    .and_then(|f| f.get("arguments"))
+                    .and_then(|v| v.as_str())
+                {
+                    if !args_frag.is_empty() {
+                        let block_index = 1 + tc_index;
+                        if let Some((_, _, buf)) = self.tool_call_buffers.get_mut(&block_index) {
+                            buf.push_str(args_frag);
+                        }
+                        out.push(StreamEvent::InputJsonDelta {
+                            index: block_index,
+                            partial_json: args_frag.to_string(),
+                        });
+                    }
+                }
+            }
+        }
+
+        // finish_reason.
+        if let Some(finish_reason) = choice.get("finish_reason").and_then(|v| v.as_str()) {
+            if !finish_reason.is_empty() && finish_reason != "null" {
+                // Flush any still-open thinking block first so it is finalized
+                // into the assistant message.
+                if self.thinking_open {
+                    out.push(StreamEvent::ContentBlockStop {
+                        index: THINKING_BLOCK_INDEX,
+                    });
+                    self.thinking_open = false;
+                }
+                out.push(StreamEvent::ContentBlockStop { index: 0 });
+                let mut tc_indices: Vec<usize> = self.tool_call_buffers.keys().cloned().collect();
+                tc_indices.sort();
+                for idx in tc_indices {
+                    out.push(StreamEvent::ContentBlockStop { index: idx });
+                }
+
+                let stop_reason = OpenAiProvider::map_finish_reason_pub(finish_reason);
+                let usage_val = chunk_json.get("usage");
+                let usage = usage_val.map(|u| OpenAiProvider::parse_usage_pub(Some(u)));
+
+                out.push(StreamEvent::MessageDelta {
+                    stop_reason: Some(stop_reason),
+                    usage,
+                });
+            }
+        }
+
+        false
+    }
+
+    /// Flush a trailing `MessageStop` if the stream produced any content but
+    /// ended without an explicit `[DONE]` sentinel.
+    pub fn finish(&mut self, out: &mut Vec<StreamEvent>) {
+        if self.message_started {
+            out.push(StreamEvent::MessageStop);
+        }
+    }
+}
+
+impl LineStreamDecoder for OpenAiChatDecoder {
+    fn feed_line(&mut self, line: &str, out: &mut Vec<StreamEvent>) -> bool {
+        OpenAiChatDecoder::feed_line(self, line, out)
+    }
+
+    fn finish(&mut self, out: &mut Vec<StreamEvent>) {
+        OpenAiChatDecoder::finish(self, out)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Feed a slice of lines and return every event produced (excluding the
+    /// stop signal, which is asserted separately where it matters).
+    fn drain(decoder: &mut OpenAiChatDecoder, lines: &[&str]) -> (Vec<StreamEvent>, bool) {
+        let mut out = Vec::new();
+        let mut done = false;
+        for l in lines {
+            if decoder.feed_line(l, &mut out) {
+                done = true;
+                break;
+            }
+        }
+        (out, done)
+    }
+
+    #[test]
+    fn text_stream_emits_start_delta_finish() {
+        let mut d = OpenAiChatDecoder::new(None);
+        let (events, done) = drain(
+            &mut d,
+            &[
+                r#"data: {"id":"chatcmpl-1","model":"gpt-x","choices":[{"delta":{"content":"Hello"}}]}"#,
+                r#"data: {"choices":[{"delta":{"content":" world"}}]}"#,
+                r#"data: {"choices":[{"delta":{},"finish_reason":"stop"}]}"#,
+            ],
+        );
+        assert!(!done, "no [DONE] fed yet");
+
+        // MessageStart carries the id/model; a text block opens at index 0.
+        assert!(matches!(
+            &events[0],
+            StreamEvent::MessageStart { id, model, .. } if id == "chatcmpl-1" && model == "gpt-x"
+        ));
+        assert!(matches!(
+            &events[1],
+            StreamEvent::ContentBlockStart { index: 0, content_block: ContentBlock::Text { .. } }
+        ));
+
+        let text: String = events
+            .iter()
+            .filter_map(|e| match e {
+                StreamEvent::TextDelta { index: 0, text } => Some(text.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(text, "Hello world");
+
+        // finish_reason closes block 0 and emits a MessageDelta.
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, StreamEvent::ContentBlockStop { index: 0 })));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, StreamEvent::MessageDelta { stop_reason: Some(_), .. })));
+
+        // finish() flushes MessageStop since content was produced.
+        let mut tail = Vec::new();
+        d.finish(&mut tail);
+        assert!(matches!(tail.as_slice(), [StreamEvent::MessageStop]));
+    }
+
+    #[test]
+    fn done_sentinel_stops_and_emits_message_stop() {
+        let mut d = OpenAiChatDecoder::new(None);
+        let (events, done) = drain(
+            &mut d,
+            &[
+                r#"data: {"id":"c","model":"m","choices":[{"delta":{"content":"hi"}}]}"#,
+                "data: [DONE]",
+            ],
+        );
+        assert!(done, "[DONE] must stop the stream");
+        assert!(matches!(events.last(), Some(StreamEvent::MessageStop)));
+    }
+
+    #[test]
+    fn tool_call_arguments_assemble_across_lines() {
+        let mut d = OpenAiChatDecoder::new(None);
+        let (events, _done) = drain(
+            &mut d,
+            &[
+                r#"data: {"id":"c","model":"m","choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"get_weather","arguments":""}}]}}]}"#,
+                r#"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"city\":"}}]}}]}"#,
+                r#"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"Paris\"}"}}]}}]}"#,
+                r#"data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}"#,
+            ],
+        );
+
+        // The tool block opens at index 1 (1 + tc_index) with id + name.
+        assert!(events.iter().any(|e| matches!(
+            e,
+            StreamEvent::ContentBlockStart {
+                index: 1,
+                content_block: ContentBlock::ToolUse { id, name, .. }
+            } if id == "call_1" && name == "get_weather"
+        )));
+
+        // The streamed argument fragments concatenate into valid JSON.
+        let args: String = events
+            .iter()
+            .filter_map(|e| match e {
+                StreamEvent::InputJsonDelta { index: 1, partial_json } => Some(partial_json.clone()),
+                _ => None,
+            })
+            .collect();
+        let parsed: Value = serde_json::from_str(&args).expect("assembled tool args must be valid JSON");
+        assert_eq!(parsed["city"], "Paris");
+
+        // finish closes text block 0 and the tool block 1.
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, StreamEvent::ContentBlockStop { index: 1 })));
+    }
+
+    #[test]
+    fn reasoning_opens_thinking_block_then_text_closes_it() {
+        let mut d = OpenAiChatDecoder::new(None);
+        let (events, _done) = drain(
+            &mut d,
+            &[
+                r#"data: {"id":"c","model":"m","choices":[{"delta":{"reasoning_content":"pondering"}}]}"#,
+                r#"data: {"choices":[{"delta":{"content":"answer"}}]}"#,
+            ],
+        );
+
+        // A Thinking block opens at THINKING_BLOCK_INDEX and receives the delta.
+        assert!(events.iter().any(|e| matches!(
+            e,
+            StreamEvent::ContentBlockStart {
+                index,
+                content_block: ContentBlock::Thinking { .. }
+            } if *index == THINKING_BLOCK_INDEX
+        )));
+        assert!(events.iter().any(|e| matches!(
+            e,
+            StreamEvent::ReasoningDelta { index, reasoning } if *index == THINKING_BLOCK_INDEX && reasoning == "pondering"
+        )));
+        // Visible text closes the thinking block first, preserving block order.
+        let stop_pos = events
+            .iter()
+            .position(|e| matches!(e, StreamEvent::ContentBlockStop { index } if *index == THINKING_BLOCK_INDEX));
+        let text_pos = events
+            .iter()
+            .position(|e| matches!(e, StreamEvent::TextDelta { index: 0, .. }));
+        assert!(stop_pos.is_some() && text_pos.is_some());
+        assert!(stop_pos < text_pos, "thinking block must close before text");
+    }
+
+    /// A provider-specific reasoning field (DeepSeek-style) is honoured.
+    #[test]
+    fn custom_reasoning_field_is_checked_first() {
+        let mut d = OpenAiChatDecoder::new(Some("thinking_blob".to_string()));
+        let (events, _done) = drain(
+            &mut d,
+            &[r#"data: {"id":"c","model":"m","choices":[{"delta":{"thinking_blob":"hmm"}}]}"#],
+        );
+        assert!(events.iter().any(|e| matches!(
+            e,
+            StreamEvent::ReasoningDelta { reasoning, .. } if reasoning == "hmm"
+        )));
+    }
+
+    /// A usage-only chunk with no `choices` yields a usage MessageDelta and does
+    /// not terminate the stream.
+    #[test]
+    fn usage_only_chunk_yields_message_delta() {
+        let mut d = OpenAiChatDecoder::new(None);
+        // Prime message_started so the usage-only branch is reached the same way
+        // it is in a real stream.
+        let mut out = Vec::new();
+        d.feed_line(
+            r#"data: {"id":"c","model":"m","choices":[{"delta":{"content":"x"}}]}"#,
+            &mut out,
+        );
+        out.clear();
+        let stop = d.feed_line(
+            r#"data: {"usage":{"prompt_tokens":10,"completion_tokens":5}}"#,
+            &mut out,
+        );
+        assert!(!stop);
+        assert!(matches!(
+            out.as_slice(),
+            [StreamEvent::MessageDelta { stop_reason: None, usage: Some(_) }]
+        ));
+    }
+}

--- a/src-rust/crates/api/src/providers/anthropic.rs
+++ b/src-rust/crates/api/src/providers/anthropic.rs
@@ -242,6 +242,14 @@ impl LlmProvider for AnthropicProvider {
         })
     }
 
+    // TODO(#228): `AnthropicProvider` is a thin adapter over the legacy
+    // `AnthropicClient` (crate::client, in lib.rs): it delegates SSE decoding to
+    // `client.create_message_stream` and then maps the Anthropic-typed
+    // `AnthropicStreamEvent`s to `StreamEvent` via `map_stream_event`. These are
+    // the two Anthropic stacks #228 wants collapsed under one `AnthropicMessages`
+    // protocol (see the matching TODO on `AnthropicClient::process_sse_stream`).
+    // Not done in this pass because `AnthropicClient` is a public type the TUI and
+    // other crates depend on directly — deferring keeps everything green.
     async fn create_message_stream(
         &self,
         request: ProviderRequest,

--- a/src-rust/crates/api/src/providers/azure.rs
+++ b/src-rust/crates/api/src/providers/azure.rs
@@ -239,6 +239,11 @@ impl LlmProvider for AzureProvider {
         let resp = self.do_streaming(&request).await?;
         let provider_id = self.id.clone();
 
+        // TODO(#228): Azure OpenAI speaks the OpenAI-Chat wire format but does no
+        // reasoning extraction at all. Migrate to
+        // `protocol::openai_chat::OpenAiChatDecoder` once it can be configured to
+        // skip reasoning (the current decoder always extracts it) so the switch
+        // stays behavior-preserving.
         let s = stream! {
             use futures::StreamExt;
 

--- a/src-rust/crates/api/src/providers/azure.rs
+++ b/src-rust/crates/api/src/providers/azure.rs
@@ -243,7 +243,9 @@ impl LlmProvider for AzureProvider {
             use futures::StreamExt;
 
             let mut byte_stream = resp.bytes_stream();
-            let mut leftover = String::new();
+            // Shared byte-buffering decoder (#228): complete lines only, so a
+            // multibyte codepoint straddling a chunk boundary is never corrupted.
+            let mut decoder = crate::SseByteDecoder::new();
 
             let mut message_started = false;
             let mut message_id = String::from("unknown");
@@ -266,21 +268,7 @@ impl LlmProvider for AzureProvider {
                     }
                 };
 
-                let text = String::from_utf8_lossy(&chunk);
-                let combined = if leftover.is_empty() {
-                    text.to_string()
-                } else {
-                    let mut s = std::mem::take(&mut leftover);
-                    s.push_str(&text);
-                    s
-                };
-
-                let mut lines: Vec<&str> = combined.split('\n').collect();
-                if !combined.ends_with('\n') {
-                    leftover = lines.pop().unwrap_or("").to_string();
-                }
-
-                for line in lines {
+                for line in decoder.push(&chunk) {
                     let line = line.trim_end_matches('\r').trim();
 
                     if line.is_empty() || line.starts_with(':') {

--- a/src-rust/crates/api/src/providers/bedrock.rs
+++ b/src-rust/crates/api/src/providers/bedrock.rs
@@ -658,6 +658,11 @@ impl LlmProvider for BedrockProvider {
         let resp = self.send_streaming(&request).await?;
         let provider_id = self.id.clone();
 
+        // TODO(#228): this AWS event-stream framing + Converse event decode is the
+        // **BedrockConverse** wire protocol; it should move into a
+        // `protocol::bedrock_converse` decoder (its binary framing means it does
+        // not share the SSE byte-line decoder the other protocols use).
+        //
         // Bedrock Converse streaming uses the AWS event-stream binary framing
         // (`vnd.amazon.eventstream`). Each message on the wire is:
         //

--- a/src-rust/crates/api/src/providers/cohere.rs
+++ b/src-rust/crates/api/src/providers/cohere.rs
@@ -386,6 +386,9 @@ impl LlmProvider for CohereProvider {
         let provider_id = self.id.clone();
         let model_name = request.model.clone();
 
+        // TODO(#228): Cohere streams newline-delimited Cohere-shaped JSON (not the
+        // OpenAI `data:` SSE format), so it wants its own `protocol` decoder rather
+        // than `OpenAiChatDecoder`.
         let s = stream! {
             use futures::StreamExt;
 

--- a/src-rust/crates/api/src/providers/cohere.rs
+++ b/src-rust/crates/api/src/providers/cohere.rs
@@ -390,7 +390,9 @@ impl LlmProvider for CohereProvider {
             use futures::StreamExt;
 
             let mut byte_stream = resp.bytes_stream();
-            let mut leftover = String::new();
+            // Shared byte-buffering decoder (#228): complete lines only, so a
+            // multibyte codepoint straddling a chunk boundary is never corrupted.
+            let mut decoder = crate::SseByteDecoder::new();
 
             let mut message_started = false;
             let mut tool_call_buffers: std::collections::HashMap<
@@ -412,21 +414,7 @@ impl LlmProvider for CohereProvider {
                     }
                 };
 
-                let text = String::from_utf8_lossy(&chunk);
-                let combined = if leftover.is_empty() {
-                    text.to_string()
-                } else {
-                    let mut s = std::mem::take(&mut leftover);
-                    s.push_str(&text);
-                    s
-                };
-
-                let mut lines: Vec<&str> = combined.split('\n').collect();
-                if !combined.ends_with('\n') {
-                    leftover = lines.pop().unwrap_or("").to_string();
-                }
-
-                for line in lines {
+                for line in decoder.push(&chunk) {
                     let line = line.trim_end_matches('\r').trim();
                     if line.is_empty() {
                         continue;

--- a/src-rust/crates/api/src/providers/copilot.rs
+++ b/src-rust/crates/api/src/providers/copilot.rs
@@ -900,6 +900,11 @@ impl LlmProvider for CopilotProvider {
         let resp = self.do_streaming(&request).await?;
         let provider_id = self.id.clone();
 
+        // TODO(#228): Copilot speaks the OpenAI-Chat wire format and could reuse
+        // `protocol::openai_chat::OpenAiChatDecoder`, except it surfaces reasoning
+        // as `ReasoningDelta { index: 0 }` (no dedicated Thinking block). Migrate
+        // once that decoder gains a "simple reasoning" mode; keeping this loop is
+        // behavior-preserving until then.
         let s = stream! {
             use futures::StreamExt;
 

--- a/src-rust/crates/api/src/providers/copilot.rs
+++ b/src-rust/crates/api/src/providers/copilot.rs
@@ -904,7 +904,9 @@ impl LlmProvider for CopilotProvider {
             use futures::StreamExt;
 
             let mut byte_stream = resp.bytes_stream();
-            let mut leftover = String::new();
+            // Shared byte-buffering decoder (#228): complete lines only, so a
+            // multibyte codepoint straddling a chunk boundary is never corrupted.
+            let mut decoder = crate::SseByteDecoder::new();
 
             let mut message_started = false;
             let mut message_id = String::from("unknown");
@@ -927,21 +929,7 @@ impl LlmProvider for CopilotProvider {
                     }
                 };
 
-                let text = String::from_utf8_lossy(&chunk);
-                let combined = if leftover.is_empty() {
-                    text.to_string()
-                } else {
-                    let mut s = std::mem::take(&mut leftover);
-                    s.push_str(&text);
-                    s
-                };
-
-                let mut lines: Vec<&str> = combined.split('\n').collect();
-                if !combined.ends_with('\n') {
-                    leftover = lines.pop().unwrap_or("").to_string();
-                }
-
-                for line in lines {
+                for line in decoder.push(&chunk) {
                     let line = line.trim_end_matches('\r').trim();
 
                     if line.is_empty() || line.starts_with(':') {

--- a/src-rust/crates/api/src/providers/google.rs
+++ b/src-rust/crates/api/src/providers/google.rs
@@ -701,7 +701,11 @@ impl LlmProvider for GoogleProvider {
                 std::collections::HashMap::new();
             let mut emitted_message_start = false;
             let message_id = format!("gemini-{}", uuid_v4_simple());
-            let mut line_buf = String::new();
+            // Shared byte-buffering decoder (#228): buffers raw bytes and only
+            // decodes complete lines. Previously a non-UTF8 chunk — which is
+            // exactly what a multibyte codepoint split across a chunk boundary
+            // looks like — was skipped entirely, dropping data.
+            let mut decoder = crate::SseByteDecoder::new();
             let mut tool_name_counts: std::collections::HashMap<String, usize> =
                 std::collections::HashMap::new();
 
@@ -718,20 +722,9 @@ impl LlmProvider for GoogleProvider {
                     }
                 };
 
-                let chunk_str = match std::str::from_utf8(&chunk) {
-                    Ok(s) => s,
-                    Err(_) => {
-                        warn!("Google SSE: non-UTF8 chunk, skipping");
-                        continue;
-                    }
-                };
-
-                line_buf.push_str(chunk_str);
-
                 // Process complete lines.
-                while let Some(newline_pos) = line_buf.find('\n') {
-                    let line = line_buf[..newline_pos].trim_end_matches('\r').to_string();
-                    line_buf = line_buf[newline_pos + 1..].to_string();
+                for line in decoder.push(&chunk) {
+                    let line = line.trim_end_matches('\r');
 
                     if let Some(data) = line.strip_prefix("data: ") {
                         let data = data.trim();

--- a/src-rust/crates/api/src/providers/google.rs
+++ b/src-rust/crates/api/src/providers/google.rs
@@ -693,6 +693,9 @@ impl LlmProvider for GoogleProvider {
         let model_clone = model.clone();
         let byte_stream = resp.bytes_stream();
 
+        // TODO(#228): Gemini has its own SSE JSON shape (candidates/parts); this
+        // decode belongs in a `protocol::gemini` decoder, alongside the
+        // OpenAI-Chat and AnthropicMessages protocols.
         let stream = async_stream::stream! {
             let mut byte_stream = byte_stream;
             let text_block_index: usize = 0;

--- a/src-rust/crates/api/src/providers/minimax.rs
+++ b/src-rust/crates/api/src/providers/minimax.rs
@@ -326,6 +326,9 @@ impl LlmProvider for MinimaxProvider {
         }
 
         let provider_id_inner = provider_id.clone();
+        // TODO(#228): MiniMax streams the **Anthropic** messages wire format
+        // (decoded via `map_anthropic_event`), so it belongs to the future
+        // `AnthropicMessages` protocol — not `OpenAiChatDecoder`.
         let s = stream! {
             let byte_stream = resp.bytes_stream();
             // Shared byte-buffering decoder (#228): complete lines only, so a

--- a/src-rust/crates/api/src/providers/minimax.rs
+++ b/src-rust/crates/api/src/providers/minimax.rs
@@ -328,7 +328,9 @@ impl LlmProvider for MinimaxProvider {
         let provider_id_inner = provider_id.clone();
         let s = stream! {
             let byte_stream = resp.bytes_stream();
-            let mut leftover = String::new();
+            // Shared byte-buffering decoder (#228): complete lines only, so a
+            // multibyte codepoint straddling a chunk boundary is never corrupted.
+            let mut decoder = crate::SseByteDecoder::new();
 
             use futures::StreamExt;
             let mut stream = std::pin::pin!(byte_stream);
@@ -336,21 +338,7 @@ impl LlmProvider for MinimaxProvider {
             while let Some(chunk_result) = stream.next().await {
                 match chunk_result {
                     Ok(chunk) => {
-                        let text = String::from_utf8_lossy(&chunk);
-                        let combined = if leftover.is_empty() {
-                            text.to_string()
-                        } else {
-                            let mut s = std::mem::take(&mut leftover);
-                            s.push_str(&text);
-                            s
-                        };
-
-                        let mut lines: Vec<&str> = combined.split('\n').collect();
-                        if !combined.ends_with('\n') {
-                            leftover = lines.pop().unwrap_or("").to_string();
-                        }
-
-                        for line in lines {
+                        for line in decoder.push(&chunk) {
                             let line = line.trim_end_matches('\r').trim();
                             if line.is_empty() {
                                 continue;

--- a/src-rust/crates/api/src/providers/openai_compat.rs
+++ b/src-rust/crates/api/src/providers/openai_compat.rs
@@ -851,7 +851,9 @@ impl LlmProvider for OpenAiCompatProvider {
             use futures::StreamExt;
 
             let mut byte_stream = resp.bytes_stream();
-            let mut leftover = String::new();
+            // Shared byte-buffering decoder (#228): complete lines only, so a
+            // multibyte codepoint straddling a chunk boundary is never corrupted.
+            let mut decoder = crate::SseByteDecoder::new();
 
             let mut message_started = false;
             let mut message_id = String::from("unknown");
@@ -909,21 +911,7 @@ impl LlmProvider for OpenAiCompatProvider {
                     }
                 };
 
-                let text = String::from_utf8_lossy(&chunk);
-                let combined = if leftover.is_empty() {
-                    text.to_string()
-                } else {
-                    let mut s = std::mem::take(&mut leftover);
-                    s.push_str(&text);
-                    s
-                };
-
-                let mut lines: Vec<&str> = combined.split('\n').collect();
-                if !combined.ends_with('\n') {
-                    leftover = lines.pop().unwrap_or("").to_string();
-                }
-
-                for line in lines {
+                for line in decoder.push(&chunk) {
                     let line = line.trim_end_matches('\r').trim();
 
                     if line.is_empty() || line.starts_with(':') {

--- a/src-rust/crates/api/src/providers/openai_compat.rs
+++ b/src-rust/crates/api/src/providers/openai_compat.rs
@@ -9,10 +9,9 @@ use std::pin::Pin;
 use async_stream::stream;
 use async_trait::async_trait;
 use claurst_core::provider_id::{ModelId, ProviderId};
-use claurst_core::types::{ContentBlock, UsageInfo};
+use claurst_core::types::ContentBlock;
 use futures::Stream;
 use serde_json::{json, Value};
-use tracing::debug;
 
 use crate::error_handling::parse_error_response;
 use crate::provider::{LlmProvider, ModelInfo};
@@ -851,23 +850,13 @@ impl LlmProvider for OpenAiCompatProvider {
             use futures::StreamExt;
 
             let mut byte_stream = resp.bytes_stream();
-            // Shared byte-buffering decoder (#228): complete lines only, so a
-            // multibyte codepoint straddling a chunk boundary is never corrupted.
-            let mut decoder = crate::SseByteDecoder::new();
-
-            let mut message_started = false;
-            let mut message_id = String::from("unknown");
-            let mut model_name = String::new();
-            // Dedicated index for the Thinking content block emitted when a
-            // provider streams a `reasoning_content` field (DeepSeek V4, etc.).
-            // Chosen to avoid colliding with text (index 0) or tool calls
-            // (1 + tc_index).
-            const THINKING_BLOCK_INDEX: usize = usize::MAX - 100;
-            let mut thinking_open = false;
-            let mut tool_call_buffers: std::collections::HashMap<
-                usize,
-                (String, String, String),
-            > = std::collections::HashMap::new();
+            // Byte-buffering line decoder (#228): complete UTF-8 lines only, so
+            // a multibyte codepoint straddling a chunk boundary is never lost.
+            let mut byte_decoder = crate::SseByteDecoder::new();
+            // Sans-IO OpenAI-Chat protocol decoder (#228): owns all message /
+            // reasoning / tool-call / finish-reason decoding for this wire
+            // format (extracted from this loop into `protocol::openai_chat`).
+            let mut chat_decoder = crate::OpenAiChatDecoder::new(reasoning_field);
 
             // Bound infinite mid-stream stalls (issue #185): some
             // OpenAI-compatible providers begin a streamed tool call and then
@@ -911,251 +900,24 @@ impl LlmProvider for OpenAiCompatProvider {
                     }
                 };
 
-                for line in decoder.push(&chunk) {
-                    let line = line.trim_end_matches('\r').trim();
-
-                    if line.is_empty() || line.starts_with(':') {
-                        continue;
+                for line in byte_decoder.push(&chunk) {
+                    let mut events = Vec::new();
+                    let stop = chat_decoder.feed_line(&line, &mut events);
+                    for event in events {
+                        yield Ok(event);
                     }
-
-                    let data = if let Some(rest) = line.strip_prefix("data:") {
-                        rest.trim()
-                    } else {
-                        continue;
-                    };
-
-                    if data == "[DONE]" {
-                        yield Ok(StreamEvent::MessageStop);
+                    if stop {
                         return;
-                    }
-
-                    let chunk_json: Value = match serde_json::from_str(data) {
-                        Ok(v) => v,
-                        Err(e) => {
-                            debug!("Failed to parse SSE chunk: {}: {}", e, data);
-                            continue;
-                        }
-                    };
-
-                    if !message_started {
-                        if let Some(id) = chunk_json.get("id").and_then(|v| v.as_str()) {
-                            message_id = id.to_string();
-                        }
-                        if let Some(m) = chunk_json.get("model").and_then(|v| v.as_str()) {
-                            model_name = m.to_string();
-                        }
-                        yield Ok(StreamEvent::MessageStart {
-                            id: message_id.clone(),
-                            model: model_name.clone(),
-                            usage: UsageInfo::default(),
-                        });
-                        yield Ok(StreamEvent::ContentBlockStart {
-                            index: 0,
-                            content_block: ContentBlock::Text { text: String::new() },
-                        });
-                        message_started = true;
-                    }
-
-                    let choices = match chunk_json.get("choices").and_then(|c| c.as_array()) {
-                        Some(c) => c,
-                        None => {
-                            if let Some(usage_val) = chunk_json.get("usage") {
-                                let usage = OpenAiProvider::parse_usage_pub(Some(usage_val));
-                                yield Ok(StreamEvent::MessageDelta {
-                                    stop_reason: None,
-                                    usage: Some(usage),
-                                });
-                            }
-                            continue;
-                        }
-                    };
-
-                    let choice = match choices.first() {
-                        Some(c) => c,
-                        None => continue,
-                    };
-
-                    let delta = match choice.get("delta") {
-                        Some(d) => d,
-                        None => continue,
-                    };
-
-                    // Reasoning / thinking extraction.
-                    // Check the provider-specific field first (e.g. DeepSeek's
-                    // "reasoning_content"), then fall back to common field names
-                    // used by other providers (Copilot "reasoning_text", generic
-                    // "reasoning", etc.).  This allows reasoning traces to show
-                    // for any provider that emits them without needing explicit
-                    // per-provider configuration.
-                    {
-                        const COMMON_REASONING_FIELDS: &[&str] = &[
-                            "reasoning_content",  // DeepSeek
-                            "reasoning_text",     // GitHub Copilot
-                            "reasoning",          // Generic / future
-                        ];
-                        let fields_to_check: Vec<&str> = if let Some(ref f) = reasoning_field {
-                            // Provider-specific field first, then common ones
-                            let mut v = vec![f.as_str()];
-                            for common in COMMON_REASONING_FIELDS {
-                                if *common != f.as_str() {
-                                    v.push(common);
-                                }
-                            }
-                            v
-                        } else {
-                            COMMON_REASONING_FIELDS.to_vec()
-                        };
-                        for field in &fields_to_check {
-                            if let Some(reasoning) = delta.get(*field).and_then(|v| v.as_str()) {
-                                if !reasoning.is_empty() {
-                                    // Open a dedicated Thinking block on first
-                                    // reasoning delta so the accumulator has a
-                                    // partial to append into (see
-                                    // StreamAccumulator::on_event).  Without
-                                    // this start event the reasoning deltas
-                                    // would be dropped and the completed
-                                    // assistant message would not carry any
-                                    // ContentBlock::Thinking — which is what
-                                    // DeepSeek V4 thinking mode requires the
-                                    // client to echo back on subsequent turns.
-                                    if !thinking_open {
-                                        yield Ok(StreamEvent::ContentBlockStart {
-                                            index: THINKING_BLOCK_INDEX,
-                                            content_block: ContentBlock::Thinking {
-                                                thinking: String::new(),
-                                                signature: String::new(),
-                                            },
-                                        });
-                                        thinking_open = true;
-                                    }
-                                    yield Ok(StreamEvent::ReasoningDelta {
-                                        index: THINKING_BLOCK_INDEX,
-                                        reasoning: reasoning.to_string(),
-                                    });
-                                    break;
-                                }
-                            }
-                        }
-                    }
-
-                    // Text content delta
-                    if let Some(content) = delta.get("content").and_then(|c| c.as_str()) {
-                        if !content.is_empty() {
-                            // Close any open thinking block before visible text
-                            // starts streaming, so the blocks land in order in
-                            // the final message: [Thinking, Text, ToolUse...].
-                            if thinking_open {
-                                yield Ok(StreamEvent::ContentBlockStop {
-                                    index: THINKING_BLOCK_INDEX,
-                                });
-                                thinking_open = false;
-                            }
-                            yield Ok(StreamEvent::TextDelta {
-                                index: 0,
-                                text: content.to_string(),
-                            });
-                        }
-                    }
-
-                    // Tool call deltas
-                    if let Some(tool_calls) =
-                        delta.get("tool_calls").and_then(|t| t.as_array())
-                    {
-                        // Close any open thinking block before tool calls
-                        // start (same ordering guarantee as for text above).
-                        if thinking_open {
-                            yield Ok(StreamEvent::ContentBlockStop {
-                                index: THINKING_BLOCK_INDEX,
-                            });
-                            thinking_open = false;
-                        }
-                        for tc in tool_calls {
-                            let tc_index = tc
-                                .get("index")
-                                .and_then(|v| v.as_u64())
-                                .unwrap_or(0) as usize;
-                            if let Some(tc_id) =
-                                tc.get("id").and_then(|v| v.as_str())
-                            {
-                                let name = tc
-                                    .get("function")
-                                    .and_then(|f| f.get("name"))
-                                    .and_then(|v| v.as_str())
-                                    .unwrap_or("")
-                                    .to_string();
-                                let block_index = 1 + tc_index;
-                                tool_call_buffers.insert(
-                                    block_index,
-                                    (tc_id.to_string(), name.clone(), String::new()),
-                                );
-                                yield Ok(StreamEvent::ContentBlockStart {
-                                    index: block_index,
-                                    content_block: ContentBlock::ToolUse {
-                                        id: tc_id.to_string(),
-                                        name,
-                                        input: json!({}),
-                                    },
-                                });
-                            }
-                            if let Some(args_frag) = tc
-                                .get("function")
-                                .and_then(|f| f.get("arguments"))
-                                .and_then(|v| v.as_str())
-                            {
-                                if !args_frag.is_empty() {
-                                    let block_index = 1 + tc_index;
-                                    if let Some((_, _, buf)) =
-                                        tool_call_buffers.get_mut(&block_index)
-                                    {
-                                        buf.push_str(args_frag);
-                                    }
-                                    yield Ok(StreamEvent::InputJsonDelta {
-                                        index: block_index,
-                                        partial_json: args_frag.to_string(),
-                                    });
-                                }
-                            }
-                        }
-                    }
-
-                    // finish_reason
-                    if let Some(finish_reason) =
-                        choice.get("finish_reason").and_then(|v| v.as_str())
-                    {
-                        if !finish_reason.is_empty() && finish_reason != "null" {
-                            // Flush any still-open thinking block first so it
-                            // is finalized into the assistant message.
-                            if thinking_open {
-                                yield Ok(StreamEvent::ContentBlockStop {
-                                    index: THINKING_BLOCK_INDEX,
-                                });
-                                thinking_open = false;
-                            }
-                            yield Ok(StreamEvent::ContentBlockStop { index: 0 });
-                            let mut tc_indices: Vec<usize> =
-                                tool_call_buffers.keys().cloned().collect();
-                            tc_indices.sort();
-                            for idx in tc_indices {
-                                yield Ok(StreamEvent::ContentBlockStop { index: idx });
-                            }
-
-                            let stop_reason =
-                                OpenAiProvider::map_finish_reason_pub(finish_reason);
-
-                            let usage_val = chunk_json.get("usage");
-                            let usage = usage_val.map(|u| OpenAiProvider::parse_usage_pub(Some(u)));
-
-                            yield Ok(StreamEvent::MessageDelta {
-                                stop_reason: Some(stop_reason),
-                                usage,
-                            });
-                        }
                     }
                 }
             }
 
-            if message_started {
-                yield Ok(StreamEvent::MessageStop);
+            // Byte stream ended: flush a trailing MessageStop if content began
+            // but no explicit `[DONE]` sentinel arrived.
+            let mut tail = Vec::new();
+            chat_decoder.finish(&mut tail);
+            for event in tail {
+                yield Ok(event);
             }
         };
 

--- a/src-rust/crates/api/src/stream_parser.rs
+++ b/src-rust/crates/api/src/stream_parser.rs
@@ -13,6 +13,81 @@ use crate::provider_error::ProviderError;
 use crate::provider_types::StreamEvent;
 
 // ---------------------------------------------------------------------------
+// SseByteDecoder — shared byte-buffering line decoder (#228)
+// ---------------------------------------------------------------------------
+
+/// Byte-buffering line decoder shared by every provider SSE / JSON-Lines loop.
+///
+/// Historically each provider decoded raw network chunks with
+/// `String::from_utf8_lossy(&chunk)` *per chunk* and stitched the resulting
+/// strings together with a `leftover: String`. That corrupts (or, for Google,
+/// silently drops) any multibyte UTF-8 codepoint whose bytes straddle a network
+/// chunk boundary — including bytes inside tool-call JSON — because the trailing
+/// partial codepoint of one chunk is replaced with U+FFFD before it can be
+/// joined to the continuation bytes in the next chunk.
+///
+/// This decoder buffers the *raw bytes* instead. On each [`push`](Self::push)
+/// it appends the chunk, splits on the **last** `\n` byte, decodes only the
+/// complete prefix (which — because `\n` (0x0A) can never appear inside a
+/// multibyte UTF-8 sequence — always ends on a codepoint boundary) and retains
+/// any trailing partial bytes (an incomplete line and/or an incomplete
+/// codepoint) for the next call. Complete lines are therefore always decoded
+/// from whole codepoints.
+#[derive(Debug, Default)]
+pub struct SseByteDecoder {
+    buf: Vec<u8>,
+}
+
+impl SseByteDecoder {
+    pub fn new() -> Self {
+        Self { buf: Vec::new() }
+    }
+
+    /// Feed one raw network chunk. Returns every complete line that is now
+    /// available (each without its trailing `\n`, `\r` preserved). Trailing
+    /// bytes after the last `\n` — a partial line and/or a partial multibyte
+    /// codepoint — are buffered until a subsequent call completes them.
+    pub fn push(&mut self, chunk: &[u8]) -> Vec<String> {
+        self.buf.extend_from_slice(chunk);
+
+        // Everything up to and including the last '\n' forms complete lines.
+        let Some(last_nl) = self.buf.iter().rposition(|&b| b == b'\n') else {
+            // No newline yet — hold the whole buffer (may end mid-codepoint).
+            return Vec::new();
+        };
+
+        // Retain the bytes *after* the last '\n' (the partial tail); take the
+        // complete prefix for decoding. `\n` is ASCII so the prefix always ends
+        // on a UTF-8 codepoint boundary and lossy decoding cannot split a char.
+        let tail = self.buf.split_off(last_nl + 1);
+        let complete = std::mem::replace(&mut self.buf, tail);
+
+        let decoded = String::from_utf8_lossy(&complete);
+        let mut lines: Vec<String> = decoded.split('\n').map(str::to_string).collect();
+        // The prefix ends with '\n', so `split` yields a trailing empty piece
+        // that is an artifact of the split, not a real (blank) SSE line — drop
+        // exactly that one. Genuine blank lines between the newlines survive.
+        lines.pop();
+        lines
+    }
+
+    /// Return any bytes buffered but not yet terminated by a `\n`, decoding
+    /// them lossily and clearing the buffer.
+    ///
+    /// Providers historically discarded an unterminated trailing line at EOF
+    /// (it lived in `leftover` and was dropped), so the SSE loops do **not**
+    /// call this — it exists for callers that want the final partial line.
+    pub fn flush(&mut self) -> Option<String> {
+        if self.buf.is_empty() {
+            return None;
+        }
+        let s = String::from_utf8_lossy(&self.buf).into_owned();
+        self.buf.clear();
+        Some(s)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // StreamParser
 // ---------------------------------------------------------------------------
 
@@ -115,5 +190,127 @@ impl StreamParser for JsonLinesStreamParser {
             status: None,
             body: None,
         })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::SseByteDecoder;
+
+    /// Feed a full SSE payload as a single chunk and collect the lines.
+    #[test]
+    fn single_chunk_splits_into_lines() {
+        let mut d = SseByteDecoder::new();
+        let lines = d.push(b"event: message_start\ndata: {\"a\":1}\n\n");
+        assert_eq!(lines, vec!["event: message_start", "data: {\"a\":1}", ""]);
+        // Nothing buffered — everything ended on a newline.
+        assert_eq!(d.flush(), None);
+    }
+
+    /// A partial trailing line (no newline yet) is held back until completed.
+    #[test]
+    fn partial_line_is_buffered_until_newline() {
+        let mut d = SseByteDecoder::new();
+        assert!(d.push(b"data: hel").is_empty());
+        assert!(d.push(b"lo wor").is_empty());
+        let lines = d.push(b"ld\n");
+        assert_eq!(lines, vec!["data: hello world"]);
+    }
+
+    /// A multibyte emoji split across two chunks decodes intact (the core #228
+    /// UTF-8 chunk-boundary fix). Naive per-chunk `from_utf8_lossy` would emit
+    /// U+FFFD replacement characters here.
+    #[test]
+    fn multibyte_emoji_split_across_chunks_is_intact() {
+        let emoji = "🚀"; // 4 bytes: F0 9F 9A 80
+        let bytes = emoji.as_bytes();
+        let mut d = SseByteDecoder::new();
+
+        // Split the emoji down the middle across two network chunks.
+        let mut first = b"data: ".to_vec();
+        first.extend_from_slice(&bytes[..2]);
+        let mut second = bytes[2..].to_vec();
+        second.extend_from_slice(b"!\n");
+
+        assert!(d.push(&first).is_empty(), "no complete line yet");
+        let lines = d.push(&second);
+        assert_eq!(lines, vec![format!("data: {emoji}!")]);
+        // No replacement characters leaked through.
+        assert!(!lines[0].contains('\u{FFFD}'));
+    }
+
+    /// A CJK character split across chunks also survives.
+    #[test]
+    fn cjk_split_across_chunks_is_intact() {
+        let s = "日本語"; // each char is 3 UTF-8 bytes
+        let bytes = s.as_bytes();
+        let mut d = SseByteDecoder::new();
+        // Split in the middle of the second character.
+        assert!(d.push(&bytes[..4]).is_empty());
+        let mut rest = bytes[4..].to_vec();
+        rest.push(b'\n');
+        let lines = d.push(&rest);
+        assert_eq!(lines, vec![s]);
+    }
+
+    /// A tool-call JSON fragment whose multibyte content is split across chunk
+    /// boundaries reassembles into valid, parseable JSON.
+    #[test]
+    fn tool_call_json_fragment_split_across_chunks_assembles() {
+        // A realistic streamed tool_use argument containing a multibyte char.
+        let full = "data: {\"name\":\"search\",\"arguments\":{\"q\":\"café ☕\"}}\n";
+        let bytes = full.as_bytes();
+
+        // Split at every possible boundary to stress mid-codepoint splits.
+        let mut assembled: Vec<String> = Vec::new();
+        for i in 1..bytes.len() {
+            let mut d2 = SseByteDecoder::new();
+            d2.push(&bytes[..i]);
+            let mut lines = d2.push(&bytes[i..]);
+            assembled = std::mem::take(&mut lines);
+            assert_eq!(assembled.len(), 1, "split at {i} should yield one line");
+            let line = &assembled[0];
+            assert!(!line.contains('\u{FFFD}'), "no U+FFFD when split at {i}");
+            let data = line.strip_prefix("data: ").expect("data prefix");
+            let v: serde_json::Value =
+                serde_json::from_str(data).expect("valid JSON regardless of split point");
+            assert_eq!(v["arguments"]["q"], "café ☕");
+        }
+        assert_eq!(assembled, vec!["data: {\"name\":\"search\",\"arguments\":{\"q\":\"café ☕\"}}"]);
+    }
+
+    /// Multiple complete lines that arrive together are all returned; the split
+    /// artifact (empty piece after the final '\n') is dropped, but genuine blank
+    /// lines between events survive so SSE frame terminators are preserved.
+    #[test]
+    fn multiple_frames_and_blank_lines_preserved() {
+        let mut d = SseByteDecoder::new();
+        let lines = d.push(b"data: a\n\ndata: b\n\n");
+        assert_eq!(lines, vec!["data: a", "", "data: b", ""]);
+    }
+
+    /// `\r\n` line endings keep the `\r` (callers trim it themselves).
+    #[test]
+    fn carriage_returns_are_preserved_for_caller() {
+        let mut d = SseByteDecoder::new();
+        let lines = d.push(b"data: x\r\n");
+        assert_eq!(lines, vec!["data: x\r"]);
+    }
+
+    /// Content only becomes available once the terminating newline of the line
+    /// arrives, even across many tiny single-byte chunks.
+    #[test]
+    fn byte_at_a_time_delivery() {
+        let payload = "data: hi 世界\n";
+        let mut d = SseByteDecoder::new();
+        let mut out: Vec<String> = Vec::new();
+        for b in payload.as_bytes() {
+            out.extend(d.push(&[*b]));
+        }
+        assert_eq!(out, vec!["data: hi 世界"]);
     }
 }

--- a/src-rust/crates/tui/src/model_picker.rs
+++ b/src-rust/crates/tui/src/model_picker.rs
@@ -117,21 +117,6 @@ fn is_gpt5_reasoning_model(id: &str) -> bool {
     id.starts_with("gpt-5") && !id.contains("-chat") && !id.contains("-pro")
 }
 
-/// Returns a short description string based on the model family inferred from
-/// the model ID.  Used when converting API model entries to `ModelEntry`.
-pub fn model_family_description(id: &str) -> String {
-    let lower = id.to_lowercase();
-    if lower.contains("opus") {
-        "Most capable — best for complex reasoning and analysis".to_string()
-    } else if lower.contains("sonnet") {
-        "Balanced performance and speed — great for coding tasks".to_string()
-    } else if lower.contains("haiku") {
-        "Fast and efficient — ideal for quick completions".to_string()
-    } else {
-        "AI model".to_string()
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Provider grouping helpers
 // ---------------------------------------------------------------------------
@@ -523,12 +508,20 @@ pub struct ModelPickerState {
 // ---------------------------------------------------------------------------
 
 impl ModelPickerState {
-    /// Create a new picker with the default model list (not yet visible).
+    /// Create a new picker (not yet visible).
+    ///
+    /// The model list starts empty; it is populated purely from the
+    /// models.dev-backed [`ModelRegistry`](claurst_api::ModelRegistry) via
+    /// [`set_models`](Self::set_models) (see
+    /// `models_for_provider_from_registry`) each time the picker opens for a
+    /// provider. There is deliberately no hardcoded fallback list — a hardcoded
+    /// Claude list previously clobbered the registry and hid newly-shipped
+    /// models (#228).
     pub fn new() -> Self {
         Self {
             visible: false,
             selected_idx: 0,
-            models: Self::default_models(),
+            models: Vec::new(),
             title: "Select model".to_string(),
             filter: String::new(),
             effort_level: EffortLevel::Normal,
@@ -709,105 +702,6 @@ impl ModelPickerState {
         if count > 0 && self.selected_idx >= count {
             self.selected_idx = count - 1;
         }
-    }
-
-    /// Fetch the list of available models from the Anthropic API and convert
-    /// them to `ModelEntry` values.
-    ///
-    /// On success, models are sorted newest-first (by `created_at` descending).
-    /// On any error, returns `default_models()` as a fallback so the picker is
-    /// never left empty.
-    pub async fn fetch_models(client: &claurst_api::AnthropicClient) -> Vec<ModelEntry> {
-        match client.fetch_available_models().await {
-            Ok(available) => {
-                if available.is_empty() {
-                    return Self::default_models();
-                }
-
-                let mut entries: Vec<(i64, ModelEntry)> = available
-                    .into_iter()
-                    .map(|m| {
-                        let display = m
-                            .display_name
-                            .clone()
-                            .unwrap_or_else(|| m.id.clone());
-                        let description = model_family_description(&m.id);
-                        let ts = m.created_at.unwrap_or(0);
-                        (ts, ModelEntry {
-                            id: m.id,
-                            display_name: display,
-                            description,
-                            is_current: false,
-                        })
-                    })
-                    .collect();
-
-                // Sort newest-first.
-                entries.sort_by(|a, b| b.0.cmp(&a.0));
-                entries.into_iter().map(|(_, e)| e).collect()
-            }
-            Err(_) => Self::default_models(),
-        }
-    }
-
-    /// Hardcoded list of Claude models available as of 2025.
-    pub fn default_models() -> Vec<ModelEntry> {
-        vec![
-            ModelEntry {
-                id: "claude-opus-4-6".to_string(),
-                display_name: "Claude Opus 4.6".to_string(),
-                description: "Most capable model — best for complex reasoning and analysis".to_string(),
-                is_current: false,
-            },
-            ModelEntry {
-                id: "claude-sonnet-4-6".to_string(),
-                display_name: "Claude Sonnet 4.6".to_string(),
-                description: "Balanced performance and speed — great for coding tasks".to_string(),
-                is_current: false,
-            },
-            ModelEntry {
-                id: "claude-haiku-4-5-20251001".to_string(),
-                display_name: "Claude Haiku 4.5 (2025-10-01)".to_string(),
-                description: "Fast and efficient — ideal for quick completions".to_string(),
-                is_current: false,
-            },
-            ModelEntry {
-                id: "claude-opus-4-5".to_string(),
-                display_name: "Claude Opus 4.5".to_string(),
-                description: "Previous Opus generation — powerful multimodal reasoning".to_string(),
-                is_current: false,
-            },
-            ModelEntry {
-                id: "claude-sonnet-4-5".to_string(),
-                display_name: "Claude Sonnet 4.5".to_string(),
-                description: "Previous Sonnet generation — solid coding and writing".to_string(),
-                is_current: false,
-            },
-            ModelEntry {
-                id: "claude-haiku-4-5".to_string(),
-                display_name: "Claude Haiku 4.5".to_string(),
-                description: "Previous Haiku generation — lightweight and responsive".to_string(),
-                is_current: false,
-            },
-            ModelEntry {
-                id: "claude-3-7-sonnet-20250219".to_string(),
-                display_name: "Claude 3.7 Sonnet (2025-02-19)".to_string(),
-                description: "Sonnet 3.7 with enhanced instruction following".to_string(),
-                is_current: false,
-            },
-            ModelEntry {
-                id: "claude-3-5-sonnet-20241022".to_string(),
-                display_name: "Claude 3.5 Sonnet (2024-10-22)".to_string(),
-                description: "Highly capable 3.5 Sonnet — reliable and well-tested".to_string(),
-                is_current: false,
-            },
-            ModelEntry {
-                id: "claude-3-5-haiku-20241022".to_string(),
-                display_name: "Claude 3.5 Haiku (2024-10-22)".to_string(),
-                description: "Fast 3.5 Haiku — great for high-throughput pipelines".to_string(),
-                is_current: false,
-            },
-        ]
     }
 }
 
@@ -1047,27 +941,93 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
 mod tests {
     use super::*;
 
-    fn make_picker_with_current(current: &str) -> ModelPickerState {
+    /// A small, controlled model list used to exercise the picker's selection /
+    /// filter / effort behaviour independently of both the (now-removed)
+    /// hardcoded list and the exact contents of the bundled registry snapshot.
+    /// In production this list comes from `set_models(models_for_provider_from_registry(..))`.
+    fn sample_models() -> Vec<ModelEntry> {
+        vec![
+            ModelEntry {
+                id: "claude-opus-4-6".to_string(),
+                display_name: "Claude Opus 4.6".to_string(),
+                description: "200K context".to_string(),
+                is_current: false,
+            },
+            ModelEntry {
+                id: "claude-sonnet-4-6".to_string(),
+                display_name: "Claude Sonnet 4.6".to_string(),
+                description: "200K context".to_string(),
+                is_current: false,
+            },
+            ModelEntry {
+                id: "claude-haiku-4-5".to_string(),
+                display_name: "Claude Haiku 4.5".to_string(),
+                description: "200K context".to_string(),
+                is_current: false,
+            },
+        ]
+    }
+
+    /// A picker seeded with `sample_models()` — the unit-test analogue of the
+    /// registry-projection seeding that happens when the picker opens.
+    fn make_picker() -> ModelPickerState {
         let mut p = ModelPickerState::new();
+        p.set_models(sample_models());
+        p
+    }
+
+    fn make_picker_with_current(current: &str) -> ModelPickerState {
+        let mut p = make_picker();
         p.open(current);
         p
     }
 
-    // 1. Default model list is non-empty and contains expected IDs.
+    // 1. A model newly added to the registry surfaces in the picker immediately.
+    //    The picker list is a pure projection of the models.dev registry, not a
+    //    hardcoded set — regression guard for #228 ("latest model won't show").
     #[test]
-    fn default_models_are_populated() {
-        let models = ModelPickerState::default_models();
-        assert!(!models.is_empty(), "default model list must not be empty");
-        let ids: Vec<&str> = models.iter().map(|m| m.id.as_str()).collect();
-        assert!(ids.contains(&"claude-sonnet-4-6"));
-        assert!(ids.contains(&"claude-opus-4-6"));
-        assert!(ids.contains(&"claude-3-5-haiku-20241022"));
+    fn newly_added_registry_model_surfaces_in_picker() {
+        let mut registry = claurst_api::ModelRegistry::new();
+
+        // A fabricated future id that cannot already be in the bundled snapshot.
+        let novel_id = "claude-opus-9-9-20991231";
+        assert!(
+            registry.get("anthropic", novel_id).is_none(),
+            "fixture id must not already exist in the snapshot"
+        );
+
+        // Inject it exactly as the background refresh does: a models.dev-format
+        // catalog fragment merged in via load_cache.
+        let json = format!(
+            r#"{{"anthropic":{{"id":"anthropic","name":"Anthropic","models":{{"{novel_id}":{{"id":"{novel_id}","name":"Claude Opus 9.9","release_date":"2099-12-31","limit":{{"context":200000,"output":64000}}}}}}}}}}"#
+        );
+        let path = std::env::temp_dir().join(format!(
+            "claurst_picker_{}_{}.json",
+            std::process::id(),
+            novel_id
+        ));
+        std::fs::write(&path, json).expect("write temp catalog");
+        registry.load_cache(&path);
+        let _ = std::fs::remove_file(&path);
+
+        let picker = models_for_provider_from_registry("anthropic", &registry);
+        let novel = picker.iter().find(|m| m.id == novel_id);
+        assert!(
+            novel.is_some(),
+            "a model added to the registry must surface in the picker"
+        );
+        assert_eq!(novel.unwrap().display_name, "Claude Opus 9.9");
+        // Newest release_date sorts to the top of the projection.
+        assert_eq!(
+            picker[0].id, novel_id,
+            "the freshest model must sort to the top of the picker"
+        );
     }
 
     // 2. open() marks exactly one model as current.
     #[test]
     fn open_marks_current_model() {
-        let mut p = ModelPickerState::new();
+        let mut p = make_picker();
         p.open("claude-sonnet-4-6");
         let current_count = p.models.iter().filter(|m| m.is_current).count();
         assert_eq!(current_count, 1);
@@ -1093,7 +1053,7 @@ mod tests {
     // 3. open() with an unknown model ID marks none as current and sets idx=0.
     #[test]
     fn open_unknown_model_selects_first() {
-        let mut p = ModelPickerState::new();
+        let mut p = make_picker();
         p.open("unknown-model");
         assert_eq!(p.selected_idx, 0);
         assert!(p.models.iter().all(|m| !m.is_current));
@@ -1223,7 +1183,7 @@ mod tests {
     // 14. render_model_picker does not panic for a default-area call.
     #[test]
     fn render_does_not_panic() {
-        let mut p = ModelPickerState::new();
+        let mut p = make_picker();
         p.open("claude-sonnet-4-6");
         let area = Rect::new(0, 0, 120, 40);
         let mut buf = Buffer::empty(area);


### PR DESCRIPTION
Addresses #228 (MI-1). **Phase 1:** a shared `SseByteDecoder` backs all 7 provider SSE loops, fixing the systemic UTF-8 chunk-boundary corruption (multibyte/tool-call JSON split across chunks) + a latent Anthropic frame-split bug (8 tests). **Phase 2:** picker drops the stale hardcoded model list + dead code, drives purely from the models.dev registry — fixes 'latest model won't show' (test: new registry model surfaces). **Phase 3:** extracted the OpenAI-Chat protocol decoder + scaffolded a `protocol` layer; the deeper unifications (Anthropic two-stack collapse, per-provider decoders, minimax-is-Anthropic) are deferred with precise `TODO(#228)` notes since blind merging would change behavior. `cargo test --workspace` green; no new deps.

The two high-value fixes (UTF-8, picker) are complete; the full protocol re-architecture is scaffolded and partially deferred. Closes #228 (follow-up tracked in the TODO(#228) notes).