### PR TITLE
feat: conditional tool guidelines + functional ToolSearch discovery (MI-6)

### DIFF
--- a/src-rust/crates/core/src/system_prompt.rs
+++ b/src-rust/crates/core/src/system_prompt.rs
@@ -222,6 +222,15 @@ pub struct SystemPromptOptions {
     pub skip_env_info: bool,
     /// Active goal addendum (injected in dynamic section when a goal is running).
     pub active_goal_addendum: Option<String>,
+    /// Names of the tools actually enabled for this session (issue #233).
+    ///
+    /// When `Some`, the "Tool use guidelines" section only emits the
+    /// per-tool guidance blocks for tools present in this list, so we don't
+    /// pay the fixed prompt tax for guidance about tools that aren't loaded.
+    /// When `None` (the default), the enabled set is treated as *unknown* and
+    /// all per-tool guidance is emitted — preserving the previous behaviour
+    /// for callers that don't yet thread the tool list through.
+    pub enabled_tools: Option<Vec<String>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -263,8 +272,8 @@ pub fn build_system_prompt(opts: &SystemPromptOptions) -> String {
     // 2. Core capabilities
     parts.push(CORE_CAPABILITIES.to_string());
 
-    // 3. Tool use guidelines
-    parts.push(TOOL_USE_GUIDELINES.to_string());
+    // 3. Tool use guidelines (per-tool blocks are conditional on the enabled set)
+    parts.push(build_tool_use_guidelines(opts.enabled_tools.as_deref()));
 
     // 4. Executing actions with care
     parts.push(ACTIONS_SECTION.to_string());
@@ -487,15 +496,92 @@ You have access to powerful tools for software engineering tasks:
 4. **Communicate blockers**: If stuck, ask the user rather than guessing
 "#;
 
-const TOOL_USE_GUIDELINES: &str = r#"
-## Tool use guidelines
+// ---------------------------------------------------------------------------
+// Tool use guidelines (issue #233: progressive tool disclosure)
+//
+// The section is split into two parts:
+//   * general, tool-agnostic guidance that is always emitted, and
+//   * per-tool guidance blocks that are emitted only when the corresponding
+//     tool is actually enabled for the session.
+//
+// Emitting only the relevant per-tool blocks removes the fixed prompt tax we
+// used to pay for describing tools that aren't even loaded.
+// ---------------------------------------------------------------------------
 
-- Use dedicated tools (Read, Edit, Glob, Grep) instead of bash equivalents
-- For searches, prefer Grep over `grep`; prefer Glob over `find`
-- Parallelize independent tool calls in a single response
-- For file edits: always read the file first, then make targeted edits
-- Bash commands timeout after 2 minutes; use background mode for long operations
-"#;
+/// Tools we ship a dedicated guideline block for, in the order they should
+/// appear.  A tool not in this list simply contributes no per-tool guidance.
+const GUIDELINE_TOOLS: &[&str] = &[
+    "Bash",
+    "Read",
+    "Edit",
+    "Write",
+    "Glob",
+    "Grep",
+    "WebSearch",
+    "WebFetch",
+    "Agent",
+    "TodoWrite",
+    "NotebookEdit",
+    "Skill",
+    "AskUserQuestion",
+];
+
+/// The per-tool guidance line for `tool`, or `None` if we ship no block for it.
+fn tool_specific_guideline(tool: &str) -> Option<&'static str> {
+    Some(match tool {
+        "Bash" => "- Bash commands time out after 2 minutes; use background mode for long-running operations.",
+        "Read" => "- Read a file with the Read tool before editing it; Read also handles images and large files.",
+        "Edit" => "- For edits, read the file first, then make targeted string replacements with Edit.",
+        "Write" => "- Use Write to create new files or fully overwrite; prefer Edit for partial changes.",
+        "Glob" => "- To find files by name or pattern, prefer the Glob tool over `find`/`ls`.",
+        "Grep" => "- To search file contents, prefer the Grep tool over shelling out to `grep`/`rg`.",
+        "WebSearch" => "- Use WebSearch to find current information on the internet.",
+        "WebFetch" => "- Use WebFetch to retrieve and read the contents of a specific URL.",
+        "Agent" => "- Delegate complex, multi-step, or parallelizable subtasks to sub-agents via the Agent tool.",
+        "TodoWrite" => "- Use TodoWrite to plan and track multi-step work; keep exactly one item in_progress.",
+        "NotebookEdit" => "- Use NotebookEdit to modify Jupyter (.ipynb) cells instead of editing raw JSON.",
+        "Skill" => "- Invoke Skill to run a matching skill/slash-command instead of reimplementing it.",
+        "AskUserQuestion" => "- Use AskUserQuestion when the user must choose between options or clarify intent.",
+        _ => return None,
+    })
+}
+
+/// Build the "Tool use guidelines" section.
+///
+/// `enabled` is the set of tool names active for the session:
+///   * `Some(names)` → emit per-tool blocks only for tools in `names`.
+///   * `None`        → enabled set unknown; emit every per-tool block
+///                     (backwards-compatible behaviour).
+///
+/// The general, tool-agnostic guidance is always emitted unchanged.
+fn build_tool_use_guidelines(enabled: Option<&[String]>) -> String {
+    let mut lines: Vec<String> = vec![
+        String::new(),
+        "## Tool use guidelines".to_string(),
+        String::new(),
+        "- Prefer purpose-built tools over raw shell commands when a dedicated tool exists."
+            .to_string(),
+        "- Parallelize independent tool calls by issuing them together in a single response."
+            .to_string(),
+        "- When you're unsure which tool fits a task, use ToolSearch to discover an appropriate one."
+            .to_string(),
+    ];
+
+    for &tool in GUIDELINE_TOOLS {
+        let include = match enabled {
+            None => true,
+            Some(names) => names.iter().any(|n| n == tool),
+        };
+        if include {
+            if let Some(line) = tool_specific_guideline(tool) {
+                lines.push(line.to_string());
+            }
+        }
+    }
+
+    lines.push(String::new());
+    lines.join("\n")
+}
 
 const ACTIONS_SECTION: &str = r#"
 ## Executing actions with care

--- a/src-rust/crates/core/src/system_prompt.rs
+++ b/src-rust/crates/core/src/system_prompt.rs
@@ -740,6 +740,75 @@ mod tests {
     }
 
     #[test]
+    fn test_no_enabled_set_emits_all_tool_guidelines() {
+        // enabled_tools = None (default) → every per-tool block is emitted.
+        let prompt = build_system_prompt(&default_opts());
+        assert!(prompt.contains("Bash commands time out"));
+        assert!(prompt.contains("prefer the Grep tool"));
+        assert!(prompt.contains("prefer the Glob tool"));
+        assert!(prompt.contains("Read a file with the Read tool"));
+        assert!(prompt.contains("Use WebSearch"));
+        // General guidance is always present.
+        assert!(prompt.contains("Parallelize independent tool calls"));
+    }
+
+    #[test]
+    fn test_conditional_tool_guidelines_only_enabled() {
+        let opts = SystemPromptOptions {
+            enabled_tools: Some(vec!["Read".to_string(), "Edit".to_string()]),
+            ..Default::default()
+        };
+        let prompt = build_system_prompt(&opts);
+
+        // Guidance for enabled tools is present.
+        assert!(
+            prompt.contains("Read a file with the Read tool"),
+            "Read guideline should be emitted"
+        );
+        assert!(
+            prompt.contains("targeted string replacements with Edit"),
+            "Edit guideline should be emitted"
+        );
+
+        // Guidance for tools NOT in the enabled set is omitted.
+        assert!(
+            !prompt.contains("Bash commands time out"),
+            "Bash guideline must be omitted when Bash is not enabled"
+        );
+        assert!(
+            !prompt.contains("prefer the Grep tool"),
+            "Grep guideline must be omitted when Grep is not enabled"
+        );
+        assert!(
+            !prompt.contains("prefer the Glob tool"),
+            "Glob guideline must be omitted when Glob is not enabled"
+        );
+        assert!(
+            !prompt.contains("Use WebSearch"),
+            "WebSearch guideline must be omitted when WebSearch is not enabled"
+        );
+
+        // General, tool-agnostic guidance stays regardless of the enabled set.
+        assert!(prompt.contains("## Tool use guidelines"));
+        assert!(prompt.contains("Parallelize independent tool calls"));
+    }
+
+    #[test]
+    fn test_empty_enabled_set_omits_all_tool_specific_guidelines() {
+        // Some(empty) is an *explicit* empty set → no per-tool blocks at all,
+        // but the general guidance still renders.
+        let opts = SystemPromptOptions {
+            enabled_tools: Some(vec![]),
+            ..Default::default()
+        };
+        let prompt = build_system_prompt(&opts);
+        assert!(prompt.contains("## Tool use guidelines"));
+        assert!(prompt.contains("Parallelize independent tool calls"));
+        assert!(!prompt.contains("Bash commands time out"));
+        assert!(!prompt.contains("Read a file with the Read tool"));
+    }
+
+    #[test]
     fn test_clear_section_cache() {
         // Populate cache then clear it — should not panic.
         {

--- a/src-rust/crates/query/src/agent_tool.rs
+++ b/src-rust/crates/query/src/agent_tool.rs
@@ -366,6 +366,9 @@ impl Tool for AgentTool {
             agent_definition: None,
             model_registry: Some(model_registry),
             managed_agents: None,
+            // Progressive tool disclosure (issue #233): the sub-agent's system
+            // prompt only needs guideline blocks for the tools it actually has.
+            enabled_tools: Some(agent_tools.iter().map(|t| t.name().to_string()).collect()),
         };
         // -----------------------------------------------------------------------
         // Background mode: spawn and return agent_id immediately.
@@ -635,6 +638,11 @@ pub fn init_team_swarm_runner() {
                     output_style_prompt: ctx.config.resolve_output_style_prompt(),
                     provider_registry: Some(Arc::new(provider_registry)),
                     model_registry: Some(model_registry),
+                    // Progressive tool disclosure (issue #233): only emit
+                    // per-tool guidance for tools this team sub-agent has.
+                    enabled_tools: Some(
+                        agent_tools.iter().map(|t| t.name().to_string()).collect(),
+                    ),
                     ..Default::default()
                 };
 

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -128,6 +128,21 @@ pub struct QueryConfig {
     pub model_registry: Option<std::sync::Arc<claurst_api::ModelRegistry>>,
     /// Managed agent (manager-executor) configuration.
     pub managed_agents: Option<claurst_core::ManagedAgentConfig>,
+    /// Names of the tools enabled for this session (issue #233).
+    ///
+    /// When populated, `build_system_prompt` forwards these to
+    /// `SystemPromptOptions::enabled_tools` so the "Tool use guidelines"
+    /// section only emits per-tool guidance for tools that are actually
+    /// loaded. `None`/empty means "unknown" and every block is emitted,
+    /// which keeps existing behaviour for callers that don't set it.
+    ///
+    // TODO(#233): populate this from the live tool set. The authoritative
+    // list is the `tools: &[Box<dyn Tool>]` argument of `run_query_loop`,
+    // but that function is under active refactor elsewhere and is off-limits
+    // here, so callers that build both the tool vec and the config (or a
+    // future hook inside the loop) should set this field to activate
+    // progressive tool disclosure in production.
+    pub enabled_tools: Option<Vec<String>>,
 }
 
 impl Default for QueryConfig {
@@ -154,6 +169,7 @@ impl Default for QueryConfig {
             agent_definition: None,
             model_registry: None,
             managed_agents: None,
+            enabled_tools: None,
         }
     }
 }
@@ -2407,6 +2423,9 @@ fn build_system_prompt(config: &QueryConfig) -> SystemPrompt {
         output_style: config.output_style,
         custom_output_style_prompt: config.output_style_prompt.clone(),
         working_directory: config.working_directory.clone(),
+        // Forward the session's enabled tool set so per-tool guideline blocks
+        // are only emitted for tools that are actually loaded (issue #233).
+        enabled_tools: config.enabled_tools.clone(),
         ..Default::default()
     };
 
@@ -2532,6 +2551,7 @@ mod tests {
             agent_definition: None,
             model_registry: None,
             managed_agents: None,
+            enabled_tools: None,
         }
     }
 

--- a/src-rust/crates/tools/src/lib.rs
+++ b/src-rust/crates/tools/src/lib.rs
@@ -526,6 +526,23 @@ pub trait Tool: Send + Sync {
         false
     }
 
+    /// Whether this tool is "advanced" / rarely used and a candidate for
+    /// deferred (on-demand) disclosure rather than being sent in every request.
+    ///
+    /// Defaults to `false` (always disclosed). This is purely a metadata hint
+    /// today — the prompt/tool-definition layer can read it to decide which
+    /// tools to omit from the initial request and surface only via `ToolSearch`.
+    ///
+    // TODO(#233): wire this into the request assembly so `advanced()` tools are
+    // omitted from the initial `tools` array and loaded on demand. That requires
+    // a mutable *active tool set* tracked across turns inside `run_query_loop`,
+    // which is under active refactor on other branches and intentionally left
+    // untouched here. Land the tracking + gated re-injection there, then have
+    // `all_tools()` callers filter on `advanced()` for the first request.
+    fn advanced(&self) -> bool {
+        false
+    }
+
     /// JSON Schema describing the tool's input parameters.
     fn input_schema(&self) -> Value;
 

--- a/src-rust/crates/tools/src/tool_search.rs
+++ b/src-rust/crates/tools/src/tool_search.rs
@@ -1,15 +1,15 @@
-// ToolSearchTool: search for tools by name or keyword.
+// ToolSearchTool: discover tools by name or keyword.
 //
-// This is used by the model to discover "deferred" tools that are not yet
-// loaded into context. In the Rust port there is no deferred-tool mechanism
-// (all tools are always available), but this tool still provides a useful
-// search interface for the model to discover available capabilities.
+// The model uses this to find the right tool for a task, or to look up a
+// tool it half-remembers. The catalog is built from the *actually registered*
+// tools (`all_tools()`), so it always reflects real tool names and their
+// one-line descriptions instead of a hand-maintained list that can drift.
 //
 // Supports two query modes:
-//   - "select:ToolName"  → direct lookup by exact name
-//   - "keyword search"   → fuzzy name + description match with scoring
+//   - "select:ToolName[,Other]" → direct lookup by exact name(s)
+//   - "keyword search"          → ranked name + description + keyword match
 
-use crate::{PermissionLevel, Tool, ToolContext, ToolResult};
+use crate::{all_tools, PermissionLevel, Tool, ToolContext, ToolResult};
 use async_trait::async_trait;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -23,64 +23,137 @@ struct ToolSearchInput {
     max_results: usize,
 }
 
-fn default_max() -> usize { 5 }
+fn default_max() -> usize {
+    5
+}
 
-/// A minimal catalog entry describing one tool.
-#[derive(Debug, Clone)]
-struct ToolEntry {
-    name: &'static str,
-    description: &'static str,
+/// A catalog entry describing one searchable tool.
+struct CatalogEntry {
+    name: String,
+    description: String,
     keywords: &'static [&'static str],
 }
 
-/// Static catalog of all built-in tools with keywords for scoring.
-static TOOL_CATALOG: &[ToolEntry] = &[
-    ToolEntry { name: "Bash", description: "Execute shell commands", keywords: &["shell", "run", "command", "exec", "terminal"] },
-    ToolEntry { name: "Read", description: "Read file contents", keywords: &["file", "read", "cat", "content"] },
-    ToolEntry { name: "Write", description: "Write or create files", keywords: &["file", "write", "create", "save"] },
-    ToolEntry { name: "Edit", description: "Edit existing files with string replacement", keywords: &["file", "edit", "modify", "replace", "patch"] },
-    ToolEntry { name: "Glob", description: "Find files by pattern", keywords: &["find", "pattern", "search", "files", "glob"] },
-    ToolEntry { name: "Grep", description: "Search file contents with regex", keywords: &["search", "regex", "grep", "find", "content"] },
-    ToolEntry { name: "WebFetch", description: "Fetch web page content", keywords: &["web", "fetch", "http", "url", "browser"] },
-    ToolEntry { name: "WebSearch", description: "Search the web", keywords: &["web", "search", "internet", "query"] },
-    ToolEntry { name: "NotebookEdit", description: "Edit Jupyter notebook cells", keywords: &["notebook", "jupyter", "ipynb", "cell"] },
-    ToolEntry { name: "TodoWrite", description: "Manage todo list", keywords: &["todo", "task", "list", "write"] },
-    ToolEntry { name: "AskUserQuestion", description: "Ask the user a question", keywords: &["ask", "question", "user", "input", "clarify"] },
-    ToolEntry { name: "EnterPlanMode", description: "Enter planning mode", keywords: &["plan", "mode", "planning"] },
-    ToolEntry { name: "ExitPlanMode", description: "Exit planning mode", keywords: &["plan", "exit", "mode"] },
-    ToolEntry { name: "Sleep", description: "Wait for a duration", keywords: &["sleep", "wait", "delay", "pause"] },
-    ToolEntry { name: "PowerShell", description: "Execute PowerShell commands", keywords: &["powershell", "windows", "ps", "command"] },
-    ToolEntry { name: "CronCreate", description: "Schedule a recurring cron task", keywords: &["cron", "schedule", "recurring", "timer"] },
-    ToolEntry { name: "CronDelete", description: "Cancel a scheduled cron task", keywords: &["cron", "delete", "cancel", "remove"] },
-    ToolEntry { name: "CronList", description: "List all cron tasks", keywords: &["cron", "list", "scheduled", "tasks"] },
-    ToolEntry { name: "EnterWorktree", description: "Create and enter a git worktree", keywords: &["worktree", "git", "branch", "isolate"] },
-    ToolEntry { name: "ExitWorktree", description: "Exit the current git worktree", keywords: &["worktree", "git", "exit", "restore"] },
-    ToolEntry { name: "TaskCreate", description: "Create a background task", keywords: &["task", "create", "background", "async"] },
-    ToolEntry { name: "TaskGet", description: "Get task details", keywords: &["task", "get", "status", "details"] },
-    ToolEntry { name: "TaskUpdate", description: "Update a task's status", keywords: &["task", "update", "status", "progress"] },
-    ToolEntry { name: "TaskList", description: "List all tasks", keywords: &["task", "list", "all", "tasks"] },
-    ToolEntry { name: "TaskStop", description: "Stop a running task", keywords: &["task", "stop", "kill", "cancel"] },
-    ToolEntry { name: "TaskOutput", description: "Get task output/logs", keywords: &["task", "output", "logs", "result"] },
-    ToolEntry { name: "ListMcpResources", description: "List MCP server resources", keywords: &["mcp", "resource", "list", "server"] },
-    ToolEntry { name: "ReadMcpResource", description: "Read an MCP resource", keywords: &["mcp", "resource", "read", "server"] },
-    ToolEntry { name: "Agent", description: "Launch a sub-agent for complex tasks", keywords: &["agent", "subagent", "task", "parallel", "delegate"] },
-    ToolEntry { name: "Brief", description: "Send a formatted message to the user", keywords: &["brief", "message", "notify", "proactive", "status", "update"] },
-    ToolEntry { name: "Config", description: "Get or set Claurst configuration", keywords: &["config", "settings", "model", "verbose", "permission", "configure"] },
-    ToolEntry { name: "SendMessage", description: "Send a message to another agent", keywords: &["send", "message", "agent", "broadcast", "communicate", "inbox"] },
-    ToolEntry { name: "Skill", description: "Execute a skill prompt template", keywords: &["skill", "command", "template", "prompt", "slash", "custom"] },
-];
+/// Extra search synonyms for high-value tools, keyed by canonical name.
+/// These improve recall for natural-language queries (e.g. "search the web").
+fn keywords_for(name: &str) -> &'static [&'static str] {
+    match name {
+        "Bash" => &["shell", "run", "command", "exec", "terminal"],
+        "Read" => &["file", "cat", "content", "open"],
+        "Write" => &["file", "create", "save", "new"],
+        "Edit" => &["file", "modify", "replace", "patch", "change"],
+        "Glob" => &["find", "pattern", "files", "filename"],
+        "Grep" => &["search", "regex", "content", "ripgrep"],
+        "WebFetch" => &["web", "url", "http", "download", "browse", "internet"],
+        "WebSearch" => &["web", "internet", "google", "browse", "news"],
+        "NotebookEdit" => &["notebook", "jupyter", "ipynb", "cell"],
+        "TodoWrite" => &["todo", "task", "plan", "checklist"],
+        "AskUserQuestion" => &["ask", "question", "clarify", "choose"],
+        "Agent" => &["agent", "subagent", "delegate", "parallel", "spawn"],
+        "Skill" => &["skill", "slash", "command", "template", "prompt"],
+        "Config" => &["config", "settings", "model", "permission"],
+        "SendMessage" => &["message", "broadcast", "inbox", "communicate"],
+        _ => &[],
+    }
+}
+
+/// Tools that are registered outside `all_tools()` (e.g. the Agent tool lives
+/// in the query crate) but should still be discoverable here.
+static SUPPLEMENTAL_TOOLS: &[(&str, &str)] = &[(
+    "Agent",
+    "Launch a sub-agent to handle a complex, multi-step task in parallel.",
+)];
+
+/// Collapse a possibly multi-line/verbose description into a single tidy line.
+fn one_line(desc: &str) -> String {
+    let collapsed = desc.split_whitespace().collect::<Vec<_>>().join(" ");
+    // Prefer the first sentence; otherwise cap the length so results stay terse.
+    let first_sentence = collapsed
+        .find(". ")
+        .map(|i| &collapsed[..=i]) // include the period
+        .unwrap_or(&collapsed);
+    let trimmed = first_sentence.trim_end_matches('.').trim();
+    if trimmed.chars().count() > 160 {
+        let cut: String = trimmed.chars().take(157).collect();
+        format!("{}...", cut.trim_end())
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// Build the searchable catalog from the live tool registry plus supplements.
+fn build_catalog() -> Vec<CatalogEntry> {
+    let mut entries: Vec<CatalogEntry> = all_tools()
+        .iter()
+        .map(|t| CatalogEntry {
+            name: t.name().to_string(),
+            description: one_line(t.description()),
+            keywords: keywords_for(t.name()),
+        })
+        .collect();
+
+    for (name, desc) in SUPPLEMENTAL_TOOLS {
+        if !entries.iter().any(|e| e.name == *name) {
+            entries.push(CatalogEntry {
+                name: (*name).to_string(),
+                description: one_line(desc),
+                keywords: keywords_for(name),
+            });
+        }
+    }
+
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+    entries
+}
+
+/// Score a single catalog entry against the lowercase query terms.
+/// Name matches dominate, then keywords, then description hits.
+fn score_entry(entry: &CatalogEntry, terms: &[&str]) -> usize {
+    let name_lower = entry.name.to_lowercase();
+    let desc_lower = entry.description.to_lowercase();
+    let mut score = 0usize;
+
+    for term in terms {
+        if name_lower == *term {
+            score += 25; // exact name match ranks highest
+        } else if name_lower.contains(term) {
+            score += 10;
+        }
+
+        for &kw in entry.keywords {
+            if kw == *term {
+                score += 8;
+            } else if kw.contains(term) {
+                score += 3;
+            }
+        }
+
+        if desc_lower.split_whitespace().any(|w| w.trim_matches(|c: char| !c.is_alphanumeric()) == *term) {
+            score += 5; // whole-word description hit
+        } else if desc_lower.contains(term) {
+            score += 2; // substring description hit
+        }
+    }
+
+    score
+}
 
 #[async_trait]
 impl Tool for ToolSearchTool {
-    fn name(&self) -> &str { "ToolSearch" }
-
-    fn description(&self) -> &str {
-        "Search for available tools by name or keyword. Use 'select:ToolName' for direct \
-         lookup or provide keywords for fuzzy search. Returns matching tool names and their \
-         descriptions. Max 5 results by default."
+    fn name(&self) -> &str {
+        "ToolSearch"
     }
 
-    fn permission_level(&self) -> PermissionLevel { PermissionLevel::None }
+    fn description(&self) -> &str {
+        "Find the right tool for a task. Search all available tools by name or keyword and \
+         get back the best-matching tool names with a one-line description each. Use a natural \
+         phrase (e.g. 'search the web', 'edit a file') to discover a capability, or \
+         'select:ToolName' for a direct lookup. Returns up to 5 results by default."
+    }
+
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::None
+    }
 
     fn input_schema(&self) -> Value {
         json!({
@@ -88,11 +161,11 @@ impl Tool for ToolSearchTool {
             "properties": {
                 "query": {
                     "type": "string",
-                    "description": "Query: use 'select:ToolName' for direct selection, or keywords to search"
+                    "description": "A task description or keywords to find a tool, or 'select:ToolName' for a direct lookup"
                 },
                 "max_results": {
                     "type": "number",
-                    "description": "Maximum results to return (default: 5)"
+                    "description": "Maximum results to return (default: 5, max: 20)"
                 }
             },
             "required": ["query"]
@@ -106,18 +179,24 @@ impl Tool for ToolSearchTool {
         };
 
         let query = params.query.trim();
-        let max = params.max_results.min(20);
+        let max = params.max_results.clamp(1, 20);
+        let catalog = build_catalog();
 
-        // select: prefix — direct lookup
+        // ---- select: prefix — direct lookup by exact name(s) ----------------
         if let Some(names_str) = query.strip_prefix("select:").map(str::trim) {
-            let requested: Vec<&str> = names_str.split(',').map(str::trim).collect();
+            let requested: Vec<&str> = names_str
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .collect();
             let mut found = Vec::new();
             let mut missing = Vec::new();
 
             for name in requested {
-                if let Some(entry) = TOOL_CATALOG.iter().find(|e| {
-                    e.name.eq_ignore_ascii_case(name)
-                }) {
+                if let Some(entry) = catalog
+                    .iter()
+                    .find(|e| e.name.eq_ignore_ascii_case(name))
+                {
                     found.push(format!("{}: {}", entry.name, entry.description));
                 } else {
                     missing.push(name.to_string());
@@ -138,51 +217,43 @@ impl Tool for ToolSearchTool {
             return ToolResult::success(out);
         }
 
-        // Keyword search with scoring
+        // ---- keyword search with scoring ------------------------------------
         let q_lower = query.to_lowercase();
-        let terms: Vec<&str> = q_lower.split_whitespace().collect();
+        let terms: Vec<&str> = q_lower
+            .split(|c: char| !c.is_alphanumeric())
+            .filter(|t| t.len() > 1) // drop empties and single-char noise
+            .collect();
 
-        let mut scored: Vec<(usize, &ToolEntry)> = TOOL_CATALOG
+        if terms.is_empty() {
+            return ToolResult::success(format!(
+                "Empty query. Provide keywords or a task description, or use 'select:ToolName'. \
+                 {} tools available.",
+                catalog.len()
+            ));
+        }
+
+        let mut scored: Vec<(usize, &CatalogEntry)> = catalog
             .iter()
             .filter_map(|entry| {
-                let mut score = 0usize;
-                let name_lower = entry.name.to_lowercase();
-                let desc_lower = entry.description.to_lowercase();
-
-                for term in &terms {
-                    // Exact name match
-                    if name_lower == *term {
-                        score += 20;
-                    } else if name_lower.contains(term) {
-                        score += 10;
-                    }
-
-                    // Description match
-                    if desc_lower.contains(term) {
-                        score += 5;
-                    }
-
-                    // Keyword match
-                    for &kw in entry.keywords {
-                        if kw == *term {
-                            score += 8;
-                        } else if kw.contains(term) {
-                            score += 3;
-                        }
-                    }
+                let score = score_entry(entry, &terms);
+                if score > 0 {
+                    Some((score, entry))
+                } else {
+                    None
                 }
-
-                if score > 0 { Some((score, entry)) } else { None }
             })
             .collect();
 
-        scored.sort_by(|a, b| b.0.cmp(&a.0));
+        // Highest score first; break ties by name for deterministic output.
+        scored.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.name.cmp(&b.1.name)));
         scored.truncate(max);
 
         if scored.is_empty() {
             return ToolResult::success(format!(
-                "No tools found matching '{}'. Try broader keywords or use 'select:ToolName'.",
-                query
+                "No tools matched '{}'. Try broader keywords or use 'select:ToolName'. \
+                 {} tools are available.",
+                query,
+                catalog.len()
             ));
         }
 
@@ -192,10 +263,75 @@ impl Tool for ToolSearchTool {
             .collect();
 
         ToolResult::success(format!(
-            "Tools matching '{}':\n\n{}\n\nTotal tools available: {}",
+            "Tools matching '{}' (use one of these for the task):\n\n{}\n\n{} of {} tools shown.",
             query,
             lines.join("\n"),
-            TOOL_CATALOG.len()
+            scored.len(),
+            catalog.len()
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> ToolContext {
+        crate::test_support::allow_all_context(std::env::temp_dir())
+    }
+
+    async fn run(query: &str) -> String {
+        let tool = ToolSearchTool;
+        let out = tool
+            .execute(json!({ "query": query }), &ctx())
+            .await;
+        out.content
+    }
+
+    #[tokio::test]
+    async fn web_query_surfaces_web_tools() {
+        let out = run("search the web").await;
+        assert!(
+            out.contains("WebSearch"),
+            "expected WebSearch in results, got:\n{out}"
+        );
+        // WebSearch should rank ahead of WebFetch for this query.
+        let ws = out.find("WebSearch");
+        let wf = out.find("WebFetch");
+        if let (Some(ws), Some(wf)) = (ws, wf) {
+            assert!(ws < wf, "WebSearch should rank above WebFetch:\n{out}");
+        }
+    }
+
+    #[tokio::test]
+    async fn exact_name_ranks_first() {
+        let out = run("grep").await;
+        let first_line = out
+            .lines()
+            .find(|l| l.contains(": "))
+            .unwrap_or_default();
+        assert!(
+            first_line.starts_with("Grep:"),
+            "exact name match should rank first, got first result line: {first_line:?}\n{out}"
+        );
+    }
+
+    #[tokio::test]
+    async fn select_prefix_direct_lookup() {
+        let out = run("select:WebFetch,DoesNotExist").await;
+        assert!(out.contains("WebFetch:"), "should find WebFetch:\n{out}");
+        assert!(
+            out.contains("Not found: DoesNotExist"),
+            "should report the missing tool:\n{out}"
+        );
+    }
+
+    #[tokio::test]
+    async fn agent_is_discoverable_via_supplement() {
+        let out = run("delegate a subagent task").await;
+        assert!(
+            out.contains("Agent"),
+            "Agent tool should be discoverable even though it lives outside all_tools():\n{out}"
+        );
     }
 }


### PR DESCRIPTION
Addresses #233 (MI-6). Splits the monolithic tool guidelines into always-on general guidance + per-tool blocks emitted only for enabled tools (`SystemPromptOptions.enabled_tools`; `None`=all, back-compat); threaded via `QueryConfig.enabled_tools` through the out-of-loop `build_system_prompt` wrapper (run_query_loop body untouched) and already active for sub-agents. ToolSearch rebuilt into a real registry-driven, ranked discovery aid. Additive `Tool::advanced()` hint added for the deferred on-demand-schema mechanism (TODO(#233), needs the run_query_loop active-tool-set work). 5 commits, tests, `cargo check --workspace` green.

The top-level interactive session gets trimmed guidelines once run_query_loop populates `enabled_tools` (one-line hop, to be wired during the #232 refactor). Closes #233.