### PR TITLE
refactor(query): /goal as in-loop continuation policy + max-steps graceful degradation (MI-3)

### DIFF
--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -1761,6 +1761,14 @@ async fn run_interactive(
     };
     let initial_messages = session.messages.clone();
     let mut base_query_config = query_config;
+    // Goal autonomy is now an in-loop continuation policy (issue #230 / MI-3):
+    // run_query_loop itself decides whether to continue toward an active goal
+    // after each turn, instead of the REPL re-dispatching a fresh turn. Select
+    // the goal policy for interactive user turns when the /goal feature is on;
+    // the GoalPolicy is a no-op (stops after one turn) when no goal is active.
+    if claurst_core::goals_enabled() {
+        base_query_config.continuation = claurst_query::ContinuationMode::Goal;
+    }
     let mut live_config = config.clone();
     if !session.model.is_empty() {
         live_config.model = Some(session.model.clone());
@@ -2001,8 +2009,6 @@ async fn run_interactive(
     // Active effort level (None = use model default / High).
     // Tracks the user's /effort selection; flows into qcfg each turn.
     let mut current_effort: Option<claurst_core::effort::EffortLevel> = None;
-    // Timestamp of when the most recent query turn was dispatched (for goal elapsed tracking).
-    let mut goal_turn_start: std::time::Instant = std::time::Instant::now();
 
     // Background update check: spawned once at startup; result delivered via channel.
     let (update_tx, mut update_rx) = tokio::sync::mpsc::channel::<Option<String>>(1);
@@ -2776,16 +2782,9 @@ async fn run_interactive(
                         qcfg.output_style = cmd_ctx.config.effective_output_style();
                         qcfg.output_style_prompt = cmd_ctx.config.resolve_output_style_prompt();
                         qcfg.working_directory = Some(tool_ctx.working_dir.display().to_string());
-                        // Inject active goal addendum into system prompt (if goals enabled).
-                        if let Some(goal) = claurst_core::GoalStore::open_default()
-                            .and_then(|s| s.get_active_goal(&session.id))
-                        {
-                            let addendum = claurst_core::goal_system_prompt_addendum(&goal);
-                            qcfg.append_system_prompt = Some(match qcfg.append_system_prompt {
-                                Some(existing) => format!("{}\n{}", existing, addendum),
-                                None => addendum,
-                            });
-                        }
+                        // The active-goal system-prompt addendum is now injected
+                        // inside run_query_loop per turn (issue #230 / MI-3), so
+                        // it also covers in-loop continuation turns.
                         // Apply active effort level (set via /effort command).
                         if let Some(level) = current_effort {
                             qcfg.effort_level = Some(level);
@@ -2803,7 +2802,6 @@ async fn run_interactive(
                         let tracker = cost_tracker.clone();
                         let tx = event_tx.clone();
                         let client_clone = client.clone();
-                        goal_turn_start = std::time::Instant::now();
 
                         let handle = tokio::spawn(async move {
                             let mut msgs = msgs_arc_clone.lock().await.clone();
@@ -3126,6 +3124,9 @@ async fn run_interactive(
                 let mut qcfg = base_query_config.clone();
                 qcfg.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
                 qcfg.max_tokens = cmd_ctx.config.effective_max_tokens();
+                // Auto-compact is a maintenance turn, not a goal turn: never let
+                // it trigger in-loop goal continuation.
+                qcfg.continuation = claurst_query::ContinuationMode::Default;
                 let tracker = cost_tracker.clone();
                 let tx = event_tx.clone();
                 let client_clone = client.clone();
@@ -3760,114 +3761,25 @@ async fn run_interactive(
                     }
                 }
 
-                // --- Goal continuation ---
-                // After every completed turn check if there is an active goal.
-                // If so, inject a continuation user message and dispatch another turn
-                // without waiting for user input.
-                if !app.auto_compact_running && claurst_core::goals_enabled() {
-                    let elapsed_secs = goal_turn_start.elapsed().as_secs();
-                    let total_tokens = cost_tracker.total_tokens();
-                    match claurst_query::check_and_continue_goal(
-                        &session.id,
-                        total_tokens,
-                        elapsed_secs,
-                    ) {
-                        claurst_query::GoalContinuation::Continue { message } => {
-                            // Show a subtle status notice.
-                            app.status_message = Some(
-                                "Goal: continuing autonomously… (use /goal pause to stop)".to_string()
-                            );
-                            // Update the footer badge.
-                            if let Some(goal) = claurst_core::GoalStore::open_default()
-                                .and_then(|s| s.get_active_goal(&session.id))
-                            {
-                                app.active_goal_badge = Some(format!(
-                                    "active · {} · {} turns",
-                                    goal.elapsed_display(),
-                                    goal.turns_used
-                                ));
-                            }
-
-                            // Inject the continuation message into the conversation.
-                            let cont_msg = claurst_core::types::Message::user(message);
-                            messages.push(cont_msg.clone());
-                            app.push_message(cont_msg);
-                            session.messages = messages.clone();
-                            session.updated_at = chrono::Utc::now();
-                            app.is_streaming = true;
-                            app.streaming_text.clear();
-
-                            let ct = CancellationToken::new();
-                            cancel = Some(ct.clone());
-
-                            let msgs_arc = Arc::new(tokio::sync::Mutex::new(messages.clone()));
-                            let msgs_arc_clone = msgs_arc.clone();
-                            let tools_arc_clone = tools_arc.clone();
-                            let mut ctx_clone = tool_ctx.clone();
-                            let mut qcfg = base_query_config.clone();
-                            qcfg.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
-                            qcfg.max_tokens = cmd_ctx.config.effective_max_tokens();
-                            qcfg.append_system_prompt = cmd_ctx.config.append_system_prompt.clone();
-                            qcfg.system_prompt = base_query_config.system_prompt.clone();
-                            qcfg.output_style = cmd_ctx.config.effective_output_style();
-                            qcfg.output_style_prompt = cmd_ctx.config.resolve_output_style_prompt();
-                            qcfg.working_directory = Some(tool_ctx.working_dir.display().to_string());
-                            // Re-inject the goal addendum for this continuation turn.
-                            if let Some(goal) = claurst_core::GoalStore::open_default()
-                                .and_then(|s| s.get_active_goal(&session.id))
-                            {
-                                let addendum = claurst_core::goal_system_prompt_addendum(&goal);
-                                qcfg.append_system_prompt = Some(match qcfg.append_system_prompt {
-                                    Some(existing) => format!("{}\n{}", existing, addendum),
-                                    None => addendum,
-                                });
-                            }
-                            if let Some(level) = current_effort {
-                                qcfg.effort_level = Some(level);
-                            }
-                            if let Some(ref cq) = qcfg.command_queue {
-                                let cq = cq.clone();
-                                ctx_clone.completion_notifier = Some(claurst_tools::CompletionNotifier::new(move |msg| {
-                                    cq.push(
-                                        claurst_query::QueuedCommand::InjectSystemMessage(msg),
-                                        claurst_query::CommandPriority::Normal,
-                                    );
-                                }));
-                            }
-                            let tracker = cost_tracker.clone();
-                            let tx = event_tx.clone();
-                            let client_clone = client.clone();
-                            goal_turn_start = std::time::Instant::now();
-
-                            let handle = tokio::spawn(async move {
-                                let mut msgs = msgs_arc_clone.lock().await.clone();
-                                let outcome = claurst_query::run_query_loop(
-                                    client_clone.as_ref(),
-                                    &mut msgs,
-                                    tools_arc_clone.as_slice(),
-                                    &ctx_clone,
-                                    &qcfg,
-                                    tracker,
-                                    Some(tx),
-                                    ct,
-                                    None,
-                                )
-                                .await;
-                                *msgs_arc_clone.lock().await = msgs;
-                                outcome
-                            });
-                            current_query = Some((handle, msgs_arc));
-                        }
-                        claurst_query::GoalContinuation::Stop { reason } => {
-                            app.active_goal_badge = None;
-                            if let Some(msg) = reason.user_message() {
-                                app.status_message = Some(msg);
-                            }
-                        }
-                        claurst_query::GoalContinuation::NoGoal => {
-                            app.active_goal_badge = None;
-                        }
-                    }
+                // --- Goal continuation (issue #230 / MI-3) ---
+                // Continuation toward an active goal is now decided *inside*
+                // run_query_loop by the goal continuation policy, so the REPL no
+                // longer re-dispatches a follow-up turn here. All that remains
+                // post-loop is to refresh the footer badge from the store: once
+                // the loop returns the goal is paused / complete / budget-limited
+                // (or absent), so this clears the badge in the common case. The
+                // paused / budget / runaway notes are surfaced live from within
+                // the loop via QueryEvent::Status.
+                if claurst_core::goals_enabled() {
+                    app.active_goal_badge = claurst_core::GoalStore::open_default()
+                        .and_then(|s| s.get_active_goal(&session.id))
+                        .map(|goal| {
+                            format!(
+                                "active · {} · {} turns",
+                                goal.elapsed_display(),
+                                goal.turns_used
+                            )
+                        });
                 }
             }
         }

--- a/src-rust/crates/query/src/agent_tool.rs
+++ b/src-rust/crates/query/src/agent_tool.rs
@@ -369,6 +369,9 @@ impl Tool for AgentTool {
             // Progressive tool disclosure (issue #233): the sub-agent's system
             // prompt only needs guideline blocks for the tools it actually has.
             enabled_tools: Some(agent_tools.iter().map(|t| t.name().to_string()).collect()),
+            // Sub-agents run to their own completion and never drive goal
+            // continuation — stop after one turn like every non-goal run.
+            continuation: crate::continuation::ContinuationMode::Default,
         };
         // -----------------------------------------------------------------------
         // Background mode: spawn and return agent_id immediately.

--- a/src-rust/crates/query/src/continuation.rs
+++ b/src-rust/crates/query/src/continuation.rs
@@ -1,0 +1,116 @@
+// continuation.rs — In-loop continuation policy for `run_query_loop`.
+//
+// At the end of every turn that finishes with `end_turn` (no tool calls),
+// `run_query_loop` consults a `ContinuationPolicy` to decide whether to keep
+// going — and if so, with what follow-up user message — instead of always
+// returning after one turn.
+//
+// This mirrors pi's agent-loop callbacks (`shouldStopAfterTurn`,
+// `getFollowUpMessages`, `prepareNextTurn`) and its `agentLoopContinue`
+// primitive for "keep going without a new user message". The decision now
+// lives INSIDE the loop, so autonomous continuation (e.g. `/goal`) no longer
+// requires the CLI REPL to re-dispatch a fresh turn after the loop returns.
+//
+// The default policy is `StopPolicy`: stop after one turn, exactly reproducing
+// the historical non-goal behaviour. Goal-driven continuation is provided by
+// `GoalPolicy` (see the goal-policy section below), which reuses the existing
+// `goal_loop` guards (runaway cap, soft token budget, continuation message).
+
+/// Inputs available to a continuation policy after a turn completes with
+/// `end_turn` (no tool calls were requested).
+pub struct TurnEndContext<'a> {
+    /// Session identifier — used to look up any active goal for this session.
+    pub session_id: &'a str,
+    /// Cumulative token count for the whole session (soft-budget accounting).
+    pub total_tokens_used: u64,
+    /// Wall-clock seconds this turn took (goal time accounting).
+    pub turn_elapsed_secs: u64,
+}
+
+/// Decision returned by a continuation policy at the end of a completed turn.
+#[derive(Debug, Clone)]
+pub enum ContinuationDecision {
+    /// Inject `message` as the next user turn and keep the loop running.
+    Continue { message: String },
+    /// Stop the loop. `note`, when present, is surfaced to the user as a
+    /// status line (e.g. the goal's paused / budget-limited message).
+    Stop { note: Option<String> },
+}
+
+impl ContinuationDecision {
+    /// Whether this decision keeps the loop running.
+    pub fn is_continue(&self) -> bool {
+        matches!(self, ContinuationDecision::Continue { .. })
+    }
+}
+
+/// A policy the runner consults at the end of each completed `end_turn` turn.
+///
+/// Implementations must be cheap and side-effect-aware: `decide` is called at
+/// most once per turn, from the async loop, but must never hold a lock across
+/// an `.await` (it is fully synchronous by design).
+pub trait ContinuationPolicy: Send + Sync {
+    fn decide(&self, ctx: &TurnEndContext<'_>) -> ContinuationDecision;
+}
+
+/// Default policy: always stop after the turn completes.
+///
+/// This is the historical, non-goal behaviour — a normal turn that ends with
+/// `end_turn` returns immediately instead of continuing.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct StopPolicy;
+
+impl ContinuationPolicy for StopPolicy {
+    fn decide(&self, _ctx: &TurnEndContext<'_>) -> ContinuationDecision {
+        ContinuationDecision::Stop { note: None }
+    }
+}
+
+/// Selects which continuation policy `run_query_loop` uses for a run.
+///
+/// Stored on `QueryConfig` so callers opt in per invocation. Subagents,
+/// headless runs, and every non-goal interactive turn use `Default`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ContinuationMode {
+    /// Stop after the turn completes (default, non-goal behaviour).
+    #[default]
+    Default,
+}
+
+impl ContinuationMode {
+    /// Build the concrete policy for this mode.
+    pub fn policy(self) -> Box<dyn ContinuationPolicy> {
+        match self {
+            ContinuationMode::Default => Box::new(StopPolicy),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> TurnEndContext<'static> {
+        TurnEndContext {
+            session_id: "sess",
+            total_tokens_used: 0,
+            turn_elapsed_secs: 0,
+        }
+    }
+
+    #[test]
+    fn stop_policy_always_stops() {
+        let decision = StopPolicy.decide(&ctx());
+        assert!(!decision.is_continue());
+        match decision {
+            ContinuationDecision::Stop { note } => assert!(note.is_none()),
+            _ => panic!("StopPolicy must stop with no note"),
+        }
+    }
+
+    #[test]
+    fn default_mode_resolves_to_stop() {
+        let policy = ContinuationMode::default().policy();
+        assert!(!policy.decide(&ctx()).is_continue());
+    }
+}

--- a/src-rust/crates/query/src/continuation.rs
+++ b/src-rust/crates/query/src/continuation.rs
@@ -66,6 +66,41 @@ impl ContinuationPolicy for StopPolicy {
     }
 }
 
+/// Goal-driven continuation policy (the `/goal` feature).
+///
+/// Reuses the existing `goal_loop` guards verbatim — the runaway turn cap, the
+/// soft token budget, and the per-turn continuation message. While the session
+/// has an active goal and its guards allow, the loop continues with the goal
+/// continuation message injected as the next user turn; otherwise it stops and
+/// surfaces the same paused / budget-limited / runaway note as before.
+///
+/// This policy relocates only WHERE the decision is made (in-loop, per turn),
+/// not the guards themselves: it delegates to
+/// [`crate::goal_loop::check_and_continue_goal`], which opens the default goal
+/// store and applies the identical logic the CLI post-loop path used to run.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GoalPolicy;
+
+impl ContinuationPolicy for GoalPolicy {
+    fn decide(&self, ctx: &TurnEndContext<'_>) -> ContinuationDecision {
+        use crate::goal_loop::GoalContinuation;
+        match crate::goal_loop::check_and_continue_goal(
+            ctx.session_id,
+            ctx.total_tokens_used,
+            ctx.turn_elapsed_secs,
+        ) {
+            GoalContinuation::Continue { message } => ContinuationDecision::Continue { message },
+            // Paused / budget / runaway / complete: stop, surfacing the same
+            // user-facing note the CLI used to print.
+            GoalContinuation::Stop { reason } => ContinuationDecision::Stop {
+                note: reason.user_message(),
+            },
+            // No goal set for this session: behave exactly like `StopPolicy`.
+            GoalContinuation::NoGoal => ContinuationDecision::Stop { note: None },
+        }
+    }
+}
+
 /// Selects which continuation policy `run_query_loop` uses for a run.
 ///
 /// Stored on `QueryConfig` so callers opt in per invocation. Subagents,
@@ -75,6 +110,8 @@ pub enum ContinuationMode {
     /// Stop after the turn completes (default, non-goal behaviour).
     #[default]
     Default,
+    /// Goal-driven autonomous continuation (the `/goal` feature).
+    Goal,
 }
 
 impl ContinuationMode {
@@ -82,6 +119,7 @@ impl ContinuationMode {
     pub fn policy(self) -> Box<dyn ContinuationPolicy> {
         match self {
             ContinuationMode::Default => Box::new(StopPolicy),
+            ContinuationMode::Goal => Box::new(GoalPolicy),
         }
     }
 }

--- a/src-rust/crates/query/src/goal_loop.rs
+++ b/src-rust/crates/query/src/goal_loop.rs
@@ -66,6 +66,22 @@ pub fn check_and_continue_goal(
         None => return GoalContinuation::NoGoal,
     };
 
+    decide_goal_continuation(&store, session_id, total_tokens_used, turn_elapsed_secs)
+}
+
+/// Guard/decision core of [`check_and_continue_goal`], operating on an explicit
+/// [`GoalStore`] so the runaway / budget guards can be exercised against an
+/// in-memory store in tests. `check_and_continue_goal` is the production wrapper
+/// that opens the default store.
+///
+/// The guards are unchanged from the original cross-turn implementation — this
+/// function only relocates WHERE the store is obtained.
+pub fn decide_goal_continuation(
+    store: &GoalStore,
+    session_id: &str,
+    total_tokens_used: u64,
+    turn_elapsed_secs: u64,
+) -> GoalContinuation {
     let goal = match store.get_goal(session_id) {
         Some(g) => g,
         None => return GoalContinuation::NoGoal,

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -3315,6 +3315,329 @@ mod tests {
             "cancelling the parent's token must cancel the sub-agent's child token"
         );
     }
+
+    // ---- Issue #230 (MI-3): in-loop continuation + max-steps degradation -----
+
+    use std::sync::Mutex as StdMutex;
+
+    /// A provider double that records, per request, whether the tool set was
+    /// empty (i.e. tools were disabled — the max-steps degradation turn) and
+    /// replays a scripted response. Drives `run_query_loop` end-to-end.
+    struct RecordingProvider {
+        id: claurst_core::provider_id::ProviderId,
+        /// One entry per request: `true` when its tool set was empty.
+        tools_empty_per_request: Arc<StdMutex<Vec<bool>>>,
+        /// When true, always end the turn with text (ignores tools). Otherwise
+        /// emit a `tool_use` while tools are present and end the turn once
+        /// they're gone (so the degradation turn ends the loop).
+        always_end_turn: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl claurst_api::LlmProvider for RecordingProvider {
+        fn id(&self) -> &claurst_core::provider_id::ProviderId {
+            &self.id
+        }
+        fn name(&self) -> &str {
+            "recording-mock"
+        }
+
+        async fn create_message(
+            &self,
+            _request: claurst_api::ProviderRequest,
+        ) -> Result<claurst_api::ProviderResponse, claurst_api::ProviderError> {
+            unimplemented!("these tests only use create_message_stream")
+        }
+
+        async fn create_message_stream(
+            &self,
+            request: claurst_api::ProviderRequest,
+        ) -> Result<
+            std::pin::Pin<
+                Box<
+                    dyn futures::Stream<
+                            Item = Result<claurst_api::StreamEvent, claurst_api::ProviderError>,
+                        > + Send,
+                >,
+            >,
+            claurst_api::ProviderError,
+        > {
+            use claurst_api::provider_types::StopReason;
+            use claurst_api::StreamEvent;
+
+            let tools_empty = request.tools.is_empty();
+            self.tools_empty_per_request
+                .lock()
+                .unwrap()
+                .push(tools_empty);
+
+            let msg_id = uuid::Uuid::new_v4().to_string();
+            let emit_tool_use = !self.always_end_turn && !tools_empty;
+
+            let events: Vec<Result<StreamEvent, claurst_api::ProviderError>> = if emit_tool_use {
+                let tool_id = uuid::Uuid::new_v4().to_string();
+                vec![
+                    Ok(StreamEvent::MessageStart {
+                        id: msg_id,
+                        model: "mock-model".to_string(),
+                        usage: UsageInfo::default(),
+                    }),
+                    Ok(StreamEvent::ContentBlockStart {
+                        index: 0,
+                        content_block: ContentBlock::ToolUse {
+                            id: tool_id,
+                            name: "noop_tool".to_string(),
+                            input: serde_json::json!({}),
+                        },
+                    }),
+                    Ok(StreamEvent::InputJsonDelta {
+                        index: 0,
+                        partial_json: "{}".to_string(),
+                    }),
+                    Ok(StreamEvent::MessageDelta {
+                        stop_reason: Some(StopReason::ToolUse),
+                        usage: Some(UsageInfo::default()),
+                    }),
+                    Ok(StreamEvent::MessageStop),
+                ]
+            } else {
+                vec![
+                    Ok(StreamEvent::MessageStart {
+                        id: msg_id,
+                        model: "mock-model".to_string(),
+                        usage: UsageInfo::default(),
+                    }),
+                    Ok(StreamEvent::TextDelta {
+                        index: 0,
+                        text: "Progress summary.".to_string(),
+                    }),
+                    Ok(StreamEvent::MessageDelta {
+                        stop_reason: Some(StopReason::EndTurn),
+                        usage: Some(UsageInfo::default()),
+                    }),
+                    Ok(StreamEvent::MessageStop),
+                ]
+            };
+
+            Ok(Box::pin(futures::stream::iter(events)))
+        }
+
+        async fn health_check(
+            &self,
+        ) -> Result<claurst_api::ProviderStatus, claurst_api::ProviderError> {
+            Ok(claurst_api::ProviderStatus::Healthy)
+        }
+
+        fn capabilities(&self) -> claurst_api::ProviderCapabilities {
+            claurst_api::ProviderCapabilities {
+                streaming: true,
+                tool_calling: true,
+                thinking: false,
+                image_input: false,
+                pdf_input: false,
+                audio_input: false,
+                video_input: false,
+                caching: false,
+                structured_output: false,
+                system_prompt_style: claurst_api::SystemPromptStyle::TopLevel,
+            }
+        }
+    }
+
+    fn noop_tools() -> Vec<Box<dyn Tool>> {
+        vec![Box::new(MockTool {
+            name: "noop_tool",
+            level: PermissionLevel::ReadOnly,
+            self_gates: false,
+            ran: Arc::new(AtomicBool::new(false)),
+        })]
+    }
+
+    /// Drive `run_query_loop` against the recording provider. Returns the
+    /// outcome, the per-request "tools were empty" record, and the final
+    /// message history.
+    async fn drive_loop_with_mock(
+        always_end_turn: bool,
+        max_turns: u32,
+        tools: Vec<Box<dyn Tool>>,
+        continuation: crate::continuation::ContinuationMode,
+    ) -> (QueryOutcome, Vec<bool>, Vec<Message>) {
+        let recorded = Arc::new(StdMutex::new(Vec::new()));
+        let provider = Arc::new(RecordingProvider {
+            id: claurst_core::provider_id::ProviderId::new("mockprov"),
+            tools_empty_per_request: recorded.clone(),
+            always_end_turn,
+        });
+        let mut registry = claurst_api::ProviderRegistry::new();
+        registry.register(provider);
+        let registry = Arc::new(registry);
+
+        let client = claurst_api::AnthropicClient::new(claurst_api::client::ClientConfig {
+            api_key: "test-key".to_string(),
+            ..Default::default()
+        })
+        .expect("build test client");
+
+        let mut ctx = deny_all_context();
+        ctx.session_id = "loop-test".to_string();
+        ctx.config.provider = Some("mockprov".to_string());
+
+        let mut config = make_config(None, None);
+        config.model = "mock-model".to_string();
+        config.max_turns = max_turns;
+        config.provider_registry = Some(registry);
+        config.continuation = continuation;
+
+        let cost = claurst_core::cost::CostTracker::new();
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let mut messages = vec![Message::user("start")];
+
+        let outcome = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            run_query_loop(
+                &client,
+                &mut messages,
+                &tools,
+                &ctx,
+                &config,
+                cost,
+                None,
+                cancel,
+                None,
+            ),
+        )
+        .await
+        .expect("loop must not hang");
+
+        let recorded = recorded.lock().unwrap().clone();
+        (outcome, recorded, messages)
+    }
+
+    /// (a) A non-goal turn that ends with `end_turn` stops after exactly one
+    /// turn — the default `StopPolicy` never continues the loop.
+    #[tokio::test]
+    async fn non_goal_turn_stops_after_one_turn() {
+        let (outcome, recorded, _msgs) = drive_loop_with_mock(
+            true,
+            5,
+            noop_tools(),
+            crate::continuation::ContinuationMode::Default,
+        )
+        .await;
+
+        assert!(
+            matches!(outcome, QueryOutcome::EndTurn { .. }),
+            "a completed turn must yield EndTurn"
+        );
+        assert_eq!(
+            recorded.len(),
+            1,
+            "a non-goal end_turn must stop after exactly one request/turn, got {:?}",
+            recorded
+        );
+    }
+
+    /// (c) Hitting `effective_max_turns` runs ONE final turn with tools disabled
+    /// (graceful degradation) rather than returning cold: the last request has
+    /// an empty tool set and the loop then ends.
+    #[tokio::test]
+    async fn max_steps_runs_tool_less_summary_turn_then_ends() {
+        // max_turns = 2: turns 1 & 2 are tool_use turns, turn 3 exceeds the cap
+        // and triggers the tool-less summary turn.
+        let (outcome, recorded, msgs) = drive_loop_with_mock(
+            false,
+            2,
+            noop_tools(),
+            crate::continuation::ContinuationMode::Default,
+        )
+        .await;
+
+        assert!(
+            matches!(outcome, QueryOutcome::EndTurn { .. }),
+            "the loop must end after the degradation summary turn"
+        );
+        assert_eq!(
+            recorded.len(),
+            3,
+            "expected 2 tool turns + 1 degradation turn, got {:?}",
+            recorded
+        );
+        assert!(
+            *recorded.last().unwrap(),
+            "the final (summary) turn must be dispatched with tools DISABLED: {:?}",
+            recorded
+        );
+        assert!(
+            recorded[..recorded.len() - 1].iter().all(|&empty| !empty),
+            "only the degradation turn disables tools: {:?}",
+            recorded
+        );
+        assert!(
+            msgs.iter()
+                .any(|m| m.get_all_text().contains("maximum number of steps")),
+            "the tool-less summary prompt must be injected into the history"
+        );
+    }
+
+    /// (b) The goal continuation guards, exercised against an in-memory store:
+    /// an active goal within its guards continues (recording the turn), while
+    /// the soft-budget and runaway guards each stop with the same paused
+    /// outcome as before.
+    #[test]
+    fn goal_policy_continues_while_active_and_stops_on_guards() {
+        use crate::goal_loop::{decide_goal_continuation, GoalContinuation, StopReason};
+
+        let store =
+            claurst_core::GoalStore::open(std::path::Path::new(":memory:")).expect("open store");
+
+        // Active goal, guards allow → continue with the goal continuation message.
+        store.set_goal("live", "ship the feature", None).unwrap();
+        match decide_goal_continuation(&store, "live", 0, 1) {
+            GoalContinuation::Continue { message } => {
+                assert!(
+                    message.contains("Goal continuation"),
+                    "unexpected continuation message: {}",
+                    message
+                );
+            }
+            _ => panic!("an active goal within its guards must continue"),
+        }
+        // The turn was recorded in the store.
+        assert_eq!(store.get_goal("live").unwrap().turns_used, 1);
+
+        // Soft token budget tripped → budget-limited (paused) outcome.
+        store.set_goal("budget", "big task", Some(100)).unwrap();
+        match decide_goal_continuation(&store, "budget", 500, 1) {
+            GoalContinuation::Stop {
+                reason: StopReason::BudgetLimited,
+            } => {}
+            _ => panic!("an over-budget goal must stop budget-limited"),
+        }
+        assert_eq!(
+            store.get_goal("budget").unwrap().status,
+            claurst_core::GoalStatus::BudgetLimited,
+            "over-budget goal must be persisted as budget-limited"
+        );
+
+        // Runaway guard tripped → paused outcome (same as the cross-turn design).
+        store.set_goal("runaway", "endless", None).unwrap();
+        for _ in 0..claurst_core::MAX_GOAL_TURNS {
+            store.record_turn("runaway", 0).unwrap();
+        }
+        match decide_goal_continuation(&store, "runaway", 0, 1) {
+            GoalContinuation::Stop {
+                reason: StopReason::RunawayGuard { turns_used },
+            } => {
+                assert_eq!(turns_used, claurst_core::MAX_GOAL_TURNS);
+            }
+            _ => panic!("a runaway goal must pause"),
+        }
+        assert_eq!(
+            store.get_goal("runaway").unwrap().status,
+            claurst_core::GoalStatus::Paused,
+            "runaway goal must be persisted as paused"
+        );
+    }
 }
 
 /// Stream handler that forwards events to an unbounded channel.

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -748,6 +748,16 @@ const MAX_TOKENS_RECOVERY_MSG: &str =
      you were doing. Pick up mid-thought if that is where the cut happened. \
      Break remaining work into smaller pieces.";
 
+/// Injected as the final user turn when `effective_max_turns` is reached. That
+/// turn runs with tools DISABLED (graceful degradation, mirroring opencode's
+/// max-steps `toolChoice:"none"` behaviour), so the model produces a plain-text
+/// wrap-up instead of the loop returning cold.
+const MAX_STEPS_DEGRADATION_MSG: &str =
+    "You have reached the maximum number of steps for this run, so tools are now \
+     disabled — do not attempt to call any tools. In plain text, briefly \
+     summarize what you accomplished, what remains unfinished, and exactly where \
+     you stopped, so the work can be resumed later.";
+
 /// Content stored in the synthetic `tool_result` for a tool that was abandoned
 /// mid-flight because the query loop was cancelled (issue #218). Every
 /// outstanding `tool_use` still receives a matching `tool_result` carrying this
@@ -835,6 +845,10 @@ pub async fn run_query_loop(
     let mut used_fallback = false;
     // How many automatic retries remain when a stream stalls (no data for 45s).
     let mut retries_left: u32 = 2;
+    // Max-steps graceful degradation (issue #230 / MI-3): set once the final
+    // tool-less summary turn has been dispatched so it can never re-trigger
+    // (anti-recursion guard).
+    let mut degradation_done = false;
 
     // If an agent defines a max_turns override, respect it (agent wins over config).
     let effective_max_turns = config.agent_definition
@@ -873,24 +887,48 @@ pub async fn run_query_loop(
         tool_ctx
             .current_turn
             .store(turn as usize, std::sync::atomic::Ordering::Relaxed);
-        if turn > effective_max_turns {
-            info!(turns = turn, "Max turns reached");
+        // Max-steps graceful degradation (issue #230 / MI-3). Rather than
+        // returning cold when the turn cap is hit, run ONE final turn with tools
+        // disabled that asks the model to summarize progress and its stopping
+        // point (mirrors opencode's max-steps `toolChoice:"none"` fallback).
+        // `degradation_done` is the anti-recursion guard: the summary turn is
+        // dispatched exactly once, and re-exceeding the cap afterwards returns
+        // cold. Applies to both goal and non-goal runs.
+        let degradation_turn = if turn > effective_max_turns {
+            if degradation_done {
+                info!(
+                    turns = turn,
+                    "Max turns reached after degradation summary — returning"
+                );
+                let last_msg = messages
+                    .last()
+                    .cloned()
+                    .unwrap_or_else(|| Message::assistant("Max turns reached."));
+                return QueryOutcome::EndTurn {
+                    message: last_msg,
+                    usage: UsageInfo::default(),
+                };
+            }
+            degradation_done = true;
+            info!(
+                turns = turn,
+                max = effective_max_turns,
+                "Max turns reached — running final tool-less summary turn"
+            );
             if let Some(ref tx) = event_tx {
                 let _ = tx.send(QueryEvent::Status(format!(
-                    "Reached maximum turn limit ({})",
+                    "Reached maximum turn limit ({}) — summarizing progress before stopping.",
                     effective_max_turns
                 )));
             }
-            // Return the last assistant message if any
-            let last_msg = messages
-                .last()
-                .cloned()
-                .unwrap_or_else(|| Message::assistant("Max turns reached."));
-            return QueryOutcome::EndTurn {
-                message: last_msg,
-                usage: UsageInfo::default(),
-            };
-        }
+            // Inject the summary request as the next user turn. Tools are
+            // disabled for this turn where `api_tools` / `provider_tools` are
+            // built below.
+            messages.push(Message::user(MAX_STEPS_DEGRADATION_MSG));
+            true
+        } else {
+            false
+        };
 
         // Continuation decision at `end_turn` (issue #230 / MI-3). Consults the
         // active continuation policy: `Continue` injects the follow-up message
@@ -901,6 +939,14 @@ pub async fn run_query_loop(
         // Defined as a macro because it must `continue`/`return` the loop.
         macro_rules! continue_or_end {
             ($assistant_msg:expr, $usage:expr) => {{
+                // The tool-less max-steps summary turn must never re-trigger
+                // continuation (anti-recursion): return its wrap-up directly.
+                if degradation_turn {
+                    return QueryOutcome::EndTurn {
+                        message: $assistant_msg,
+                        usage: $usage,
+                    };
+                }
                 let decision = continuation_policy.decide(&crate::continuation::TurnEndContext {
                     session_id: &tool_ctx.session_id,
                     total_tokens_used: cost_tracker.total_tokens(),
@@ -1006,10 +1052,16 @@ pub async fn run_query_loop(
 
         // Build API request
         let api_messages: Vec<ApiMessage> = messages.iter().map(ApiMessage::from).collect();
-        let api_tools: Vec<ApiToolDefinition> = tools
-            .iter()
-            .map(|t| ApiToolDefinition::from(&t.to_definition()))
-            .collect();
+        // Max-steps degradation: the final summary turn is dispatched with NO
+        // tool definitions so the model can only produce text (issue #230).
+        let api_tools: Vec<ApiToolDefinition> = if degradation_turn {
+            Vec::new()
+        } else {
+            tools
+                .iter()
+                .map(|t| ApiToolDefinition::from(&t.to_definition()))
+                .collect()
+        };
 
         // Verification nudge: if there are incomplete todos for this session
         // and the conversation has more than 2 turns, append a reminder.
@@ -1268,7 +1320,10 @@ pub async fn run_query_loop(
                         caps.tool_calling = model_entry.tool_calling;
                         caps.thinking = model_entry.reasoning;
                     }
-                    let provider_tools: Vec<claurst_core::types::ToolDefinition> = if caps.tool_calling {
+                    // Max-steps degradation (issue #230): dispatch the final
+                    // summary turn with no tools so the provider can only emit
+                    // text (opencode's `toolChoice:"none"` equivalent).
+                    let provider_tools: Vec<claurst_core::types::ToolDefinition> = if caps.tool_calling && !degradation_turn {
                         tools.iter().map(|t| t.to_definition()).collect()
                     } else {
                         Vec::new()

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -12,6 +12,7 @@ pub mod agent_tool;
 pub mod auto_dream;
 pub mod away_summary;
 pub mod command_queue;
+pub mod continuation;
 pub mod goal_loop;
 pub mod managed_orchestrator;
 pub mod compact;
@@ -23,6 +24,9 @@ pub mod session_memory;
 pub mod skill_prefetch;
 pub use agent_tool::{AgentTool, init_team_swarm_runner};
 pub use command_queue::{CommandPriority, CommandQueue, QueuedCommand, drain_command_queue};
+pub use continuation::{
+    ContinuationDecision, ContinuationMode, ContinuationPolicy, StopPolicy, TurnEndContext,
+};
 pub use cron_scheduler::start_cron_scheduler;
 pub use goal_loop::{GoalContinuation, StopReason, check_and_continue_goal, mark_goal_complete};
 pub use skill_prefetch::{
@@ -145,6 +149,13 @@ pub struct QueryConfig {
     // future hook inside the loop) should set this field to activate
     // progressive tool disclosure in production.
     pub enabled_tools: Option<Vec<String>>,
+    /// End-of-turn continuation policy (issue #230 / MI-3).
+    ///
+    /// `Default` stops after one turn (normal, non-goal behaviour). Goal-driven
+    /// autonomy selects `Goal`, which keeps the loop running while an active
+    /// goal's guards allow, injecting the goal continuation message as the next
+    /// user turn — instead of the CLI REPL re-dispatching a fresh turn.
+    pub continuation: crate::continuation::ContinuationMode,
 }
 
 impl Default for QueryConfig {
@@ -172,6 +183,7 @@ impl Default for QueryConfig {
             model_registry: None,
             managed_agents: None,
             enabled_tools: None,
+            continuation: crate::continuation::ContinuationMode::Default,
         }
     }
 }
@@ -827,6 +839,17 @@ pub async fn run_query_loop(
         .and_then(|a| a.max_turns)
         .unwrap_or(config.max_turns);
 
+    // In-loop continuation policy (issue #230 / MI-3). Consulted at the end of
+    // every turn that finishes with `end_turn`. The default policy stops after
+    // one turn; the goal policy keeps the loop running while an active goal's
+    // guards allow. Built once per run.
+    let continuation_policy = config.continuation.policy();
+    // Wall-clock start of the current "continuation turn" (a span from a user /
+    // continuation message to the next `end_turn`). Reset on each accepted
+    // continuation so goal time/turn accounting matches the old per-dispatch
+    // measurement.
+    let mut goal_turn_start = std::time::Instant::now();
+
     // Shadow-git snapshot: capture the worktree state before any tools run so we
     // can produce a per-turn file-change patch when the turn ends.
     let shadow_snap: Option<std::sync::Arc<claurst_core::snapshot::ShadowSnapshot>> =
@@ -864,6 +887,52 @@ pub async fn run_query_loop(
                 message: last_msg,
                 usage: UsageInfo::default(),
             };
+        }
+
+        // Continuation decision at `end_turn` (issue #230 / MI-3). Consults the
+        // active continuation policy: `Continue` injects the follow-up message
+        // as the next user turn and keeps looping (resetting the per-turn budget
+        // so `effective_max_turns` bounds tool-rounds *within* a continuation
+        // turn — the cross-turn cap is the policy's own guard, e.g. the goal
+        // runaway limit); `Stop` surfaces any note and returns `EndTurn`.
+        // Defined as a macro because it must `continue`/`return` the loop.
+        macro_rules! continue_or_end {
+            ($assistant_msg:expr, $usage:expr) => {{
+                let decision = continuation_policy.decide(&crate::continuation::TurnEndContext {
+                    session_id: &tool_ctx.session_id,
+                    total_tokens_used: cost_tracker.total_tokens(),
+                    turn_elapsed_secs: goal_turn_start.elapsed().as_secs(),
+                });
+                match decision {
+                    crate::continuation::ContinuationDecision::Continue { message } => {
+                        if let Some(ref tx) = event_tx {
+                            let _ = tx.send(QueryEvent::Status(
+                                "Goal: continuing autonomously… (use /goal pause to stop)"
+                                    .to_string(),
+                            ));
+                        }
+                        messages.push(Message::user(message));
+                        // Fresh per-continuation-turn budget, mirroring the old
+                        // one-loop-per-goal-turn design.
+                        turn = 0;
+                        max_tokens_recovery_count = 0;
+                        retries_left = 2;
+                        goal_turn_start = std::time::Instant::now();
+                        continue;
+                    }
+                    crate::continuation::ContinuationDecision::Stop { note } => {
+                        if let Some(note) = note {
+                            if let Some(ref tx) = event_tx {
+                                let _ = tx.send(QueryEvent::Status(note));
+                            }
+                        }
+                        return QueryOutcome::EndTurn {
+                            message: $assistant_msg,
+                            usage: $usage,
+                        };
+                    }
+                }
+            }};
         }
 
         // Check for cancellation
@@ -1566,10 +1635,7 @@ pub async fn run_query_loop(
                         }
                     }
 
-                    return QueryOutcome::EndTurn {
-                        message: assistant_msg,
-                        usage,
-                    };
+                    continue_or_end!(assistant_msg, usage);
                 } else if provider_id_str != "anthropic" {
                     // Non-Anthropic provider detected but no API key / credentials
                     // available.  Return a clear error instead of silently falling
@@ -2021,10 +2087,7 @@ pub async fn run_query_loop(
                     }
                 }
 
-                return QueryOutcome::EndTurn {
-                    message: assistant_msg,
-                    usage,
-                };
+                continue_or_end!(assistant_msg, usage);
             }
             "max_tokens" => {
                 // Mirror the TS recovery loop: inject a continuation nudge and
@@ -2263,10 +2326,7 @@ pub async fn run_query_loop(
                         assistant_msg.snapshot_patch = Some(patch);
                     }
                 }
-                return QueryOutcome::EndTurn {
-                    message: assistant_msg,
-                    usage,
-                };
+                continue_or_end!(assistant_msg, usage);
             }
             other => {
                 warn!(stop_reason = other, "Unknown stop reason, treating as end_turn");
@@ -2282,10 +2342,7 @@ pub async fn run_query_loop(
                         assistant_msg.snapshot_patch = Some(patch);
                     }
                 }
-                return QueryOutcome::EndTurn {
-                    message: assistant_msg,
-                    usage,
-                };
+                continue_or_end!(assistant_msg, usage);
             }
         }
     }
@@ -2565,6 +2622,7 @@ mod tests {
             model_registry: None,
             managed_agents: None,
             enabled_tools: None,
+            continuation: crate::continuation::ContinuationMode::Default,
         }
     }
 

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -28,7 +28,10 @@ pub use continuation::{
     ContinuationDecision, ContinuationMode, ContinuationPolicy, StopPolicy, TurnEndContext,
 };
 pub use cron_scheduler::start_cron_scheduler;
-pub use goal_loop::{GoalContinuation, StopReason, check_and_continue_goal, mark_goal_complete};
+pub use goal_loop::{
+    GoalContinuation, StopReason, check_and_continue_goal, decide_goal_continuation,
+    mark_goal_complete,
+};
 pub use skill_prefetch::{
     SkillDefinition, SkillIndex, SharedSkillIndex, prefetch_skills, format_skill_listing,
 };
@@ -1043,6 +1046,25 @@ pub async fn run_query_loop(
                     patched.append_system_prompt = Some(match &config.append_system_prompt {
                         Some(existing) => format!("{}\n\n{}", existing, nudge),
                         None => nudge,
+                    });
+                }
+            }
+
+            // Goal system-prompt addendum (issue #230 / MI-3). Applied fresh
+            // each turn (goal state — turns used, elapsed — changes over the
+            // run) whenever goal continuation mode is active and a live goal
+            // exists for this session. This relocates the addendum injection
+            // from the CLI into the loop so continuation turns get it too.
+            // GoalStore access here is fully synchronous (no lock held across
+            // an `.await`).
+            if matches!(config.continuation, crate::continuation::ContinuationMode::Goal) {
+                if let Some(goal) = claurst_core::GoalStore::open_default()
+                    .and_then(|s| s.get_active_goal(&tool_ctx.session_id))
+                {
+                    let addendum = claurst_core::goal_system_prompt_addendum(&goal);
+                    patched.append_system_prompt = Some(match patched.append_system_prompt.take() {
+                        Some(existing) => format!("{}\n{}", existing, addendum),
+                        None => addendum,
                     });
                 }
             }

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -145,12 +145,12 @@ pub struct QueryConfig {
     /// loaded. `None`/empty means "unknown" and every block is emitted,
     /// which keeps existing behaviour for callers that don't set it.
     ///
-    // TODO(#233): populate this from the live tool set. The authoritative
-    // list is the `tools: &[Box<dyn Tool>]` argument of `run_query_loop`,
-    // but that function is under active refactor elsewhere and is off-limits
-    // here, so callers that build both the tool vec and the config (or a
-    // future hook inside the loop) should set this field to activate
-    // progressive tool disclosure in production.
+    // Populated in-loop (issue #233 completion): when left `None`,
+    // `run_query_loop` fills this from its live `tools: &[Box<dyn Tool>]`
+    // argument before assembling the system prompt, so the top-level
+    // interactive session gets progressive tool disclosure. Callers that build
+    // both the tool vec and the config (e.g. sub-agents) may still set it
+    // explicitly; the loop only fills an unset field.
     pub enabled_tools: Option<Vec<String>>,
     /// End-of-turn continuation policy (issue #230 / MI-3).
     ///
@@ -1069,6 +1069,17 @@ pub async fn run_query_loop(
             // Build a (possibly patched) config for system-prompt assembly.
             // Agent prompt prefix and todo nudge are both applied here.
             let mut patched = config.clone();
+
+            // Progressive tool disclosure (issue #233 completion): populate
+            // `enabled_tools` from the live tool set this run exposes so
+            // `build_system_prompt` only emits per-tool guideline blocks for
+            // tools that are actually loaded. This is the boundary #233 wired
+            // up; sub-agents already set it explicitly, so only fill it in when
+            // the caller left it unset.
+            if patched.enabled_tools.is_none() {
+                patched.enabled_tools =
+                    Some(tools.iter().map(|t| t.name().to_string()).collect());
+            }
 
             // Apply agent system-prompt prefix: prepend before the main system prompt.
             if let Some(ref agent) = config.agent_definition {


### PR DESCRIPTION
Fixes #230 (MI-3). Moves /goal multi-turn autonomy out of the CLI post-loop re-dispatch into an in-loop `ContinuationPolicy` (new `continuation.rs`, mirroring pi's shouldStopAfterTurn/getFollowUpMessages): Default=stop-after-one-turn (unchanged); Goal delegates to the byte-for-byte-unchanged runaway/budget guards. Adds opencode-style max-steps graceful degradation (at the turn cap, one final tool-less summary turn; anti-recursion guarded). CLI no longer re-dispatches; goal addendum moved in-loop. Also completes #233 (populate enabled_tools from the live tool set for the top-level session). 6 commits + tests, `cargo test --workspace` clean. One documented equivalent-or-better delta (a goal turn hitting the tool-round cap now gets a graceful summary instead of a silent cut).

Closes #230