### PR TITLE
feat: XDG base directory support + CLAURST_HOME override (back-compatible)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -37,7 +37,7 @@ Options:
     -Help                   Show this help
     -Version <version>      Install a specific version (e.g., 0.1.0)
     -Binary <path>          Install from a local binary instead of downloading
-    -InstallDir <path>      Override install location (default: %USERPROFILE%\.claurst\bin)
+    -InstallDir <path>      Override install location (default: %LOCALAPPDATA%\Programs\claurst)
     -NoModifyPath           Don't add the install dir to user PATH
 
 Examples:
@@ -68,8 +68,15 @@ function Get-Arch {
 }
 
 # ----- Resolve install directory -----
+# Binary location is independent of the claurst data dir. Default to the
+# per-user programs location (%LOCALAPPDATA%\Programs\claurst), falling back to
+# the user profile when LOCALAPPDATA is unavailable.
 if ([string]::IsNullOrEmpty($InstallDir)) {
-    $InstallDir = Join-Path $env:USERPROFILE ".claurst\bin"
+    if (-not [string]::IsNullOrEmpty($env:LOCALAPPDATA)) {
+        $InstallDir = Join-Path $env:LOCALAPPDATA "Programs\claurst"
+    } else {
+        $InstallDir = Join-Path $env:USERPROFILE ".local\bin"
+    }
 }
 if (-not (Test-Path $InstallDir)) {
     New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null

--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ Options:
     -v, --version <version> Install a specific version (e.g., 0.1.0 or v0.1.0)
     -b, --binary <path>     Install from a local binary instead of downloading
         --no-modify-path    Don't modify shell config files (.zshrc, .bashrc, etc.)
-        --install-dir <dir> Override install location (default: ~/.claurst/bin)
+        --install-dir <dir> Override install location (default: ${XDG_BIN_HOME:-~/.local/bin})
 
 Examples:
     curl -fsSL https://github.com/Kuberwastaken/claurst/releases/latest/download/install.sh | bash
@@ -104,7 +104,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-INSTALL_DIR="${install_dir_override:-$HOME/.claurst/bin}"
+INSTALL_DIR="${install_dir_override:-${XDG_BIN_HOME:-$HOME/.local/bin}}"
 mkdir -p "$INSTALL_DIR"
 
 # ----- Detect platform & arch -----

--- a/src-rust/crates/commands/src/memory.rs
+++ b/src-rust/crates/commands/src/memory.rs
@@ -33,10 +33,7 @@ impl SlashCommand for MemoryCommand {
     async fn execute(&self, args: &str, ctx: &mut CommandContext) -> CommandResult {
         let project_claude_dir = ctx.working_dir.join(".claurst").join("AGENTS.md");
         let project_root = ctx.working_dir.join("AGENTS.md");
-        let global_path = dirs::home_dir()
-            .unwrap_or_default()
-            .join(".claurst")
-            .join("AGENTS.md");
+        let global_path = claurst_core::config::Settings::config_dir().join("AGENTS.md");
 
         let locations = [
             ("project (.claurst/AGENTS.md)", project_claude_dir.clone()),

--- a/src-rust/crates/commands/src/named_commands.rs
+++ b/src-rust/crates/commands/src/named_commands.rs
@@ -511,9 +511,7 @@ impl NamedCommand for IdeCommand {
         };
 
         // ---- Lockfile-based connection status --------------------------------
-        let lockfile_dir = dirs::home_dir()
-            .map(|h| h.join(".claurst").join("ide"))
-            .unwrap_or_default();
+        let lockfile_dir = claurst_core::config::Settings::config_dir().join("ide");
 
         let mut ides = Vec::new();
         if let Ok(entries) = std::fs::read_dir(&lockfile_dir) {

--- a/src-rust/crates/commands/src/session_tools.rs
+++ b/src-rust/crates/commands/src/session_tools.rs
@@ -26,10 +26,7 @@ impl SlashCommand for SkillsCommand {
         let mut found: Vec<String> = Vec::new();
         let dirs = [
             ctx.working_dir.join(".claurst").join("commands"),
-            dirs::home_dir()
-                .unwrap_or_default()
-                .join(".claurst")
-                .join("commands"),
+            claurst_core::config::Settings::config_dir().join("commands"),
         ];
 
         for dir in &dirs {

--- a/src-rust/crates/commands/src/teleport.rs
+++ b/src-rust/crates/commands/src/teleport.rs
@@ -114,10 +114,8 @@ impl SlashCommand for TeleportCommand {
                     if let Some(p) = explicit {
                         p
                     } else {
-                        // Default: ~/.claurst/teleport_<session_id>.json
-                        let base = dirs::home_dir()
-                            .unwrap_or_else(|| std::path::PathBuf::from("."))
-                            .join(".claurst");
+                        // Default: <claurst home>/teleport_<session_id>.json
+                        let base = claurst_core::config::Settings::config_dir();
                         let _ = std::fs::create_dir_all(&base);
                         base.join(format!("teleport_{}.json", ctx.session_id))
                     }

--- a/src-rust/crates/core/src/accounts.rs
+++ b/src-rust/crates/core/src/accounts.rs
@@ -250,9 +250,9 @@ pub fn ensure_unique_profile_id(
     }
 }
 
-/// `~/.claurst/`.
+/// The canonical claurst home directory.
 pub fn claurst_dir() -> PathBuf {
-    dirs::home_dir().unwrap_or_else(|| PathBuf::from(".")).join(".claurst")
+    crate::config::Settings::config_dir()
 }
 
 /// `~/.claurst/accounts/<provider>/<id>/`.

--- a/src-rust/crates/core/src/attachments.rs
+++ b/src-rust/crates/core/src/attachments.rs
@@ -85,7 +85,7 @@ pub fn get_attachments(ctx: &AttachmentContext<'_>) -> Vec<Attachment> {
 /// Returns a formatted string like:
 /// `IDE: VS Code, workspace: /path/to/project, selection: L10-L20 in foo.rs`
 pub fn get_ide_context() -> Option<String> {
-    let lockfile_dir = dirs::home_dir()?.join(".claurst").join("ide");
+    let lockfile_dir = crate::config::Settings::config_dir().join("ide");
     let entries = std::fs::read_dir(&lockfile_dir).ok()?;
 
     for entry in entries.flatten() {

--- a/src-rust/crates/core/src/auth_store.rs
+++ b/src-rust/crates/core/src/auth_store.rs
@@ -30,10 +30,7 @@ pub struct AuthStore {
 impl AuthStore {
     /// Path to the auth store file.
     pub fn path() -> PathBuf {
-        let dir = dirs::home_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join(".claurst");
-        dir.join("auth.json")
+        crate::config::Settings::config_dir().join("auth.json")
     }
 
     /// Load the store from disk (returns default if missing or invalid).

--- a/src-rust/crates/core/src/claudemd.rs
+++ b/src-rust/crates/core/src/claudemd.rs
@@ -227,9 +227,10 @@ fn load_scope_files(dir: &Path, scope: MemoryScope, files: &mut Vec<MemoryFileIn
 pub fn load_all_memory_files(project_root: &Path) -> Vec<MemoryFileInfo> {
     let mut files = Vec::new();
 
-    // 1. Managed: ~/.claurst/rules/*.md
-    if let Some(home) = dirs::home_dir() {
-        let rules_dir = home.join(".claurst/rules");
+    // 1. Managed: <claurst home>/rules/*.md
+    {
+        let claurst = crate::config::Settings::config_dir();
+        let rules_dir = claurst.join("rules");
         if let Ok(entries) = std::fs::read_dir(&rules_dir) {
             let mut paths: Vec<PathBuf> = entries
                 .flatten()
@@ -246,8 +247,8 @@ pub fn load_all_memory_files(project_root: &Path) -> Vec<MemoryFileInfo> {
             }
         }
 
-        // 2. User: ~/.claurst/AGENTS.md then ~/.claurst/CLAUDE.md
-        load_scope_files(&home.join(".claurst"), MemoryScope::User, &mut files);
+        // 2. User: <claurst home>/AGENTS.md then <claurst home>/CLAUDE.md
+        load_scope_files(&claurst, MemoryScope::User, &mut files);
     }
 
     // 3. Project: {project_root}/AGENTS.md then {project_root}/CLAUDE.md

--- a/src-rust/crates/core/src/context_collapse.rs
+++ b/src-rust/crates/core/src/context_collapse.rs
@@ -153,10 +153,7 @@ fn summarize_messages(messages: Vec<Message>, _max_tokens: u64) -> (Vec<Message>
 /// Persist collapse state to ~/.claurst/context_collapse_state.json
 #[cfg(feature = "cached_microcompact")]
 pub fn save_collapse_state(_session_id: &str, state: &CollapseState) -> anyhow::Result<()> {
-    let path = dirs::home_dir()
-        .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?
-        .join(".claurst")
-        .join("context_collapse_state.json");
+    let path = crate::config::Settings::config_dir().join("context_collapse_state.json");
 
     std::fs::create_dir_all(path.parent().unwrap())?;
     let json = serde_json::to_string(state)?;
@@ -167,9 +164,7 @@ pub fn save_collapse_state(_session_id: &str, state: &CollapseState) -> anyhow::
 /// Load collapse state from ~/.claurst/context_collapse_state.json
 #[cfg(feature = "cached_microcompact")]
 pub fn load_collapse_state(_session_id: &str) -> Option<CollapseState> {
-    let path = dirs::home_dir()?
-        .join(".claurst")
-        .join("context_collapse_state.json");
+    let path = crate::config::Settings::config_dir().join("context_collapse_state.json");
 
     if !path.exists() {
         return None;

--- a/src-rust/crates/core/src/feature_flags.rs
+++ b/src-rust/crates/core/src/feature_flags.rs
@@ -70,8 +70,7 @@ impl FeatureFlagManager {
 
     /// Get the cache file path (~/.claurst/feature_flags.json)
     fn get_cache_path() -> PathBuf {
-        let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
-        home.join(".claurst").join("feature_flags.json")
+        crate::config::Settings::config_dir().join("feature_flags.json")
     }
 
     /// Check if a feature flag is enabled

--- a/src-rust/crates/core/src/goal.rs
+++ b/src-rust/crates/core/src/goal.rs
@@ -163,7 +163,7 @@ impl GoalStore {
 
     /// Default path: `~/.claurst/goals.sqlite`.
     pub fn default_path() -> Option<PathBuf> {
-        dirs::home_dir().map(|h| h.join(".claurst").join("goals.sqlite"))
+        Some(crate::config::Settings::config_dir().join("goals.sqlite"))
     }
 
     /// Open using the default path (best-effort; returns None on failure).

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -2214,10 +2214,10 @@ pub mod context {
         async fn find_and_read_claude_md(&self) -> Option<String> {
             let mut claude_mds = vec![];
 
-            // Global ~/.claurst/AGENTS.md
-            if let Some(home) = dirs::home_dir() {
-                let global_claude_md =
-                    home.join(".claurst").join(crate::constants::CLAUDE_MD_FILENAME);
+            // Global <claurst home>/AGENTS.md
+            {
+                let global_claude_md = crate::config::Settings::config_dir()
+                    .join(crate::constants::CLAUDE_MD_FILENAME);
                 if global_claude_md.exists() {
                     if let Ok(content) = tokio::fs::read_to_string(&global_claude_md).await {
                         claude_mds.push(format!(
@@ -3890,10 +3890,7 @@ pub mod oauth {
         /// Legacy token file path — kept for backward-compat reads when no
         /// account registry exists yet. New writes go to per-account dirs.
         pub fn token_file_path() -> std::path::PathBuf {
-            dirs::home_dir()
-                .unwrap_or_else(|| std::path::PathBuf::from("."))
-                .join(".claurst")
-                .join("oauth_tokens.json")
+            crate::config::Settings::config_dir().join("oauth_tokens.json")
         }
 
         /// Save tokens for a specific account profile under

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -90,6 +90,7 @@ pub use skill_discovery::{DiscoveredSkill, discover_skills, parse_skill_file};
 pub use cost::CostTracker;
 pub use history::ConversationSession;
 pub use feature_flags::FeatureFlagManager;
+pub use paths::claurst_home;
 pub use permissions::{
     AutoPermissionHandler, InteractivePermissionHandler,
     ManagedAutoPermissionHandler, ManagedInteractivePermissionHandler,
@@ -1572,11 +1573,45 @@ pub mod config {
     }
 
     impl Settings {
-        /// The per-user configuration directory (`~/.claurst`).
+        /// The canonical per-user claurst home directory — the single source of
+        /// truth for where claurst keeps everything (settings, sessions,
+        /// accounts, skills, …). Every subdirectory (`config_dir().join("sessions")`,
+        /// `.join("accounts")`, …) lives under this one root.
+        ///
+        /// Resolution precedence (see issue #207 — XDG Base Directory support,
+        /// kept fully back-compatible so existing installs are untouched):
+        ///
+        /// 1. **`$CLAURST_HOME`** — if set and non-empty, used verbatim.
+        /// 2. **Legacy `~/.claurst`** — if that directory already exists, it is
+        ///    reused so existing users need no migration.
+        /// 3. **XDG** — `$XDG_CONFIG_HOME/claurst` when `$XDG_CONFIG_HOME` is set
+        ///    (and absolute, per the spec), otherwise `~/.config/claurst`. Fresh
+        ///    installs land here.
         pub fn config_dir() -> PathBuf {
-            dirs::home_dir()
-                .unwrap_or_else(|| PathBuf::from("."))
-                .join(".claurst")
+            // 1. Explicit override wins, used verbatim.
+            if let Some(explicit) = std::env::var_os("CLAURST_HOME") {
+                if !explicit.is_empty() {
+                    return PathBuf::from(explicit);
+                }
+            }
+
+            let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+
+            // 2. Back-compat: an existing legacy `~/.claurst` is used as-is.
+            let legacy = home.join(".claurst");
+            if legacy.is_dir() {
+                return legacy;
+            }
+
+            // 3. XDG config location for fresh installs.
+            if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+                let xdg = PathBuf::from(xdg);
+                // Per the XDG spec a relative $XDG_CONFIG_HOME must be ignored.
+                if xdg.is_absolute() {
+                    return xdg.join("claurst");
+                }
+            }
+            home.join(".config").join("claurst")
         }
 
         /// Full path to the global settings JSON file.
@@ -4129,6 +4164,7 @@ pub mod prompt_history;
 pub mod bash_classifier;
 pub mod ps_classifier;
 pub mod mcp_trust;
+pub mod paths;
 
 // ---------------------------------------------------------------------------
 // tasks module — background task registry

--- a/src-rust/crates/core/src/memdir.rs
+++ b/src-rust/crates/core/src/memdir.rs
@@ -346,11 +346,7 @@ pub fn auto_memory_path(project_root: &Path) -> PathBuf {
     // 2. Determine the memory base directory.
     let memory_base = std::env::var("CLAURST_REMOTE_MEMORY_DIR")
         .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            dirs::home_dir()
-                .unwrap_or_else(|| PathBuf::from("."))
-                .join(".claurst")
-        });
+        .unwrap_or_else(|_| crate::config::Settings::config_dir());
 
     // 3. Sanitize the project root into a safe directory name.
     let sanitized = sanitize_path_component(&project_root.to_string_lossy());

--- a/src-rust/crates/core/src/oauth_config.rs
+++ b/src-rust/crates/core/src/oauth_config.rs
@@ -419,7 +419,7 @@ pub struct CodexTokens {
 /// Legacy single-file path: `~/.claurst/codex_tokens.json`. Kept for
 /// backward-compat reads when no account registry exists.
 fn codex_tokens_path() -> Option<std::path::PathBuf> {
-    dirs::home_dir().map(|h| h.join(".claurst").join("codex_tokens.json"))
+    Some(crate::config::Settings::config_dir().join("codex_tokens.json"))
 }
 
 /// Save Codex OAuth tokens for a named profile under

--- a/src-rust/crates/core/src/paths.rs
+++ b/src-rust/crates/core/src/paths.rs
@@ -1,0 +1,157 @@
+//! Canonical filesystem locations for claurst.
+//!
+//! Everything claurst persists lives under a single root directory. This module
+//! exposes the one resolver ([`claurst_home`]) that the whole workspace routes
+//! through, so the home-dir precedence (see [`crate::config::Settings::config_dir`])
+//! is defined in exactly one place.
+
+use std::path::PathBuf;
+
+/// The canonical claurst home directory — the single source of truth for where
+/// claurst keeps its data. Thin wrapper over
+/// [`crate::config::Settings::config_dir`]; prefer this at call sites that only
+/// need the root path.
+///
+/// Resolution precedence (issue #207 — XDG support, back-compatible):
+/// 1. `$CLAURST_HOME` if set and non-empty (verbatim).
+/// 2. Legacy `~/.claurst` if it already exists.
+/// 3. `$XDG_CONFIG_HOME/claurst` (when absolute) else `~/.config/claurst`.
+pub fn claurst_home() -> PathBuf {
+    crate::config::Settings::config_dir()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::Settings;
+    use std::path::PathBuf;
+    use std::sync::Mutex;
+
+    // The resolver reads process-global env (`CLAURST_HOME`, `HOME`,
+    // `XDG_CONFIG_HOME`). Serialize every test that mutates them.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        saved: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    }
+
+    impl EnvGuard {
+        fn new() -> Self {
+            let keys = ["CLAURST_HOME", "HOME", "XDG_CONFIG_HOME"];
+            let saved = keys
+                .iter()
+                .map(|k| (*k, std::env::var_os(k)))
+                .collect::<Vec<_>>();
+            for k in keys {
+                std::env::remove_var(k);
+            }
+            Self { saved }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, v) in &self.saved {
+                match v {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn claurst_home_env_override_wins() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::new();
+        let tmp = tempfile::tempdir().unwrap();
+        // Set HOME + an existing legacy dir + XDG too, to prove the override
+        // takes precedence over every other rule and is used verbatim.
+        let home = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(home.path().join(".claurst")).unwrap();
+        std::env::set_var("HOME", home.path());
+        std::env::set_var("XDG_CONFIG_HOME", home.path());
+        std::env::set_var("CLAURST_HOME", tmp.path());
+
+        assert_eq!(Settings::config_dir(), tmp.path());
+    }
+
+    #[test]
+    fn claurst_home_empty_env_override_ignored() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::new();
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", home.path());
+        std::env::set_var("CLAURST_HOME", "");
+
+        // Empty override falls through to XDG (no legacy dir, no XDG_CONFIG_HOME).
+        assert_eq!(
+            Settings::config_dir(),
+            home.path().join(".config").join("claurst")
+        );
+    }
+
+    #[test]
+    fn claurst_home_legacy_dir_used_when_present() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::new();
+        let home = tempfile::tempdir().unwrap();
+        let legacy = home.path().join(".claurst");
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::env::set_var("HOME", home.path());
+        // XDG set, but legacy already exists → legacy wins (back-compat).
+        std::env::set_var("XDG_CONFIG_HOME", home.path().join("xdg"));
+
+        assert_eq!(Settings::config_dir(), legacy);
+    }
+
+    #[test]
+    fn claurst_home_xdg_used_when_set_and_no_legacy() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::new();
+        let home = tempfile::tempdir().unwrap();
+        let xdg = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", home.path());
+        std::env::set_var("XDG_CONFIG_HOME", xdg.path());
+
+        assert_eq!(Settings::config_dir(), xdg.path().join("claurst"));
+    }
+
+    #[test]
+    fn claurst_home_xdg_default_when_no_env() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::new();
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", home.path());
+
+        // No CLAURST_HOME, no legacy dir, no XDG_CONFIG_HOME → ~/.config/claurst.
+        assert_eq!(
+            Settings::config_dir(),
+            home.path().join(".config").join("claurst")
+        );
+    }
+
+    #[test]
+    fn claurst_home_relative_xdg_ignored() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::new();
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", home.path());
+        // Per the XDG spec a relative $XDG_CONFIG_HOME is invalid and ignored.
+        std::env::set_var("XDG_CONFIG_HOME", "relative/path");
+
+        assert_eq!(
+            Settings::config_dir(),
+            home.path().join(".config").join("claurst")
+        );
+    }
+
+    #[test]
+    fn claurst_home_wrapper_matches_config_dir() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::new();
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("CLAURST_HOME", tmp.path());
+        assert_eq!(super::claurst_home(), Settings::config_dir());
+        assert_eq!(super::claurst_home(), PathBuf::from(tmp.path()));
+    }
+}

--- a/src-rust/crates/core/src/prompt_history.rs
+++ b/src-rust/crates/core/src/prompt_history.rs
@@ -137,9 +137,7 @@ static STATE: once_cell::sync::Lazy<Mutex<HistoryState>> =
 // ---------------------------------------------------------------------------
 
 fn claude_home() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".claurst")
+    crate::config::Settings::config_dir()
 }
 
 fn history_path() -> PathBuf {

--- a/src-rust/crates/core/src/remote_settings.rs
+++ b/src-rust/crates/core/src/remote_settings.rs
@@ -405,11 +405,9 @@ pub fn merge_remote_into_local(local: &Value, remote: &Value) -> Value {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Return the ~/.claurst directory, falling back to the current directory.
+/// Return the canonical claurst home directory.
 fn claude_config_dir() -> PathBuf {
-    dirs::home_dir()
-        .map(|h| h.join(".claurst"))
-        .unwrap_or_else(|| PathBuf::from(".claurst"))
+    crate::config::Settings::config_dir()
 }
 
 /// Exponential backoff delay for retry attempt `n` (1-indexed).

--- a/src-rust/crates/core/src/settings_sync.rs
+++ b/src-rust/crates/core/src/settings_sync.rs
@@ -436,11 +436,9 @@ async fn write_file_for_sync(path: &PathBuf, content: &str) -> Result<()> {
     Ok(())
 }
 
-/// Return the ~/.claurst directory.
+/// Return the canonical claurst home directory.
 fn claude_config_dir() -> PathBuf {
-    dirs::home_dir()
-        .map(|h| h.join(".claurst"))
-        .unwrap_or_else(|| PathBuf::from(".claurst"))
+    crate::config::Settings::config_dir()
 }
 
 /// Exponential backoff delay for retry attempt `n` (1-indexed), capped at 30 s.

--- a/src-rust/crates/core/src/skill_discovery.rs
+++ b/src-rust/crates/core/src/skill_discovery.rs
@@ -172,10 +172,10 @@ pub fn discover_skills(
         }
     }
 
-    // ---- 2. Global skills: ~/.claurst/skills/ --------------------------------
-    if let Some(home) = dirs::home_dir() {
-        add(scan_dir(&home.join(".claurst").join("skills")));
-    }
+    // ---- 2. Global skills: <claurst home>/skills/ ---------------------------
+    add(scan_dir(
+        &crate::config::Settings::config_dir().join("skills"),
+    ));
 
     // ---- 3. Configured extra paths ------------------------------------------
     for path_str in &config_skills.paths {

--- a/src-rust/crates/core/src/tips.rs
+++ b/src-rust/crates/core/src/tips.rs
@@ -191,7 +191,7 @@ pub struct TipHistory {
 impl TipHistory {
     /// Path to the persisted history file: `~/.claurst/tip_history.json`.
     fn history_path() -> Option<std::path::PathBuf> {
-        dirs::home_dir().map(|h| h.join(".claurst").join("tip_history.json"))
+        Some(crate::config::Settings::config_dir().join("tip_history.json"))
     }
 
     /// Load history from `~/.claurst/tip_history.json`.

--- a/src-rust/crates/mcp/src/oauth.rs
+++ b/src-rust/crates/mcp/src/oauth.rs
@@ -40,7 +40,7 @@ impl McpToken {
 
 /// Directory holding the MCP OAuth token store.
 ///
-/// Defaults to `~/.claurst/mcp-tokens`, but can be redirected with the
+/// Defaults to `<claurst home>/mcp-tokens`, but can be redirected with the
 /// `CLAURST_MCP_TOKENS_DIR` environment variable. The override lets tests run
 /// hermetically (and lets packagers/sandboxes relocate the store) without
 /// writing to the real HOME, which is unwritable in sandboxed builds.
@@ -48,9 +48,7 @@ fn token_store_dir() -> PathBuf {
     if let Some(dir) = std::env::var_os("CLAURST_MCP_TOKENS_DIR") {
         return PathBuf::from(dir);
     }
-    dirs::home_dir()
-        .unwrap_or_default()
-        .join(".claurst/mcp-tokens")
+    claurst_core::config::Settings::config_dir().join("mcp-tokens")
 }
 
 /// Path to the token store for a given MCP server.

--- a/src-rust/crates/plugins/src/loader.rs
+++ b/src-rust/crates/plugins/src/loader.rs
@@ -16,9 +16,9 @@ use std::path::{Path, PathBuf};
 // Public helpers
 // ---------------------------------------------------------------------------
 
-/// Return the default user-level plugins directory: `~/.claurst/plugins`.
+/// Return the default user-level plugins directory: `<claurst home>/plugins`.
 pub fn default_user_plugins_dir() -> Option<PathBuf> {
-    dirs::home_dir().map(|h| h.join(".claurst").join("plugins"))
+    Some(claurst_core::config::Settings::config_dir().join("plugins"))
 }
 
 /// Return the project-level plugins directory: `<project>/.claurst/plugins`.

--- a/src-rust/crates/plugins/src/marketplace.rs
+++ b/src-rust/crates/plugins/src/marketplace.rs
@@ -208,9 +208,7 @@ pub async fn marketplace_update(name: &str) -> Result<Option<String>, String> {
 
 /// List all installed plugins.
 pub fn list_installed() -> Vec<InstalledPlugin> {
-    let plugins_dir = dirs::home_dir()
-        .map(|h| h.join(".claurst").join("plugins"))
-        .unwrap_or_default();
+    let plugins_dir = claurst_core::config::Settings::config_dir().join("plugins");
 
     let Ok(entries) = std::fs::read_dir(&plugins_dir) else {
         return Vec::new();
@@ -268,9 +266,7 @@ pub fn marketplace_uninstall(name: &str) -> Result<(), String> {
 }
 
 fn plugin_install_dir(name: &str) -> std::path::PathBuf {
-    dirs::home_dir()
-        .unwrap_or_default()
-        .join(".claurst")
+    claurst_core::config::Settings::config_dir()
         .join("plugins")
         .join(name)
 }

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -1641,9 +1641,9 @@ pub async fn run_query_loop(
                 // the spawn doesn't call run_query_loop recursively from within
                 // its own future (which would make the future !Send).
                 {
-                    let memory_dir = dirs::home_dir().map(|h| h.join(".claurst").join("memory"));
-                    let conversations_dir =
-                        dirs::home_dir().map(|h| h.join(".claurst").join("conversations"));
+                    let claurst_home = claurst_core::config::Settings::config_dir();
+                    let memory_dir = Some(claurst_home.join("memory"));
+                    let conversations_dir = Some(claurst_home.join("conversations"));
                     if let (Some(mem), Some(conv)) = (memory_dir, conversations_dir) {
                         let dreamer = crate::auto_dream::AutoDream::new(mem, conv);
                         if let Ok(Some(task)) = dreamer.maybe_trigger().await {

--- a/src-rust/crates/query/src/skill_prefetch.rs
+++ b/src-rust/crates/query/src/skill_prefetch.rs
@@ -71,12 +71,10 @@ pub type SharedSkillIndex = Arc<RwLock<SkillIndex>>;
 pub async fn prefetch_skills(project_root: &Path, index: SharedSkillIndex) {
     let mut local = SkillIndex::default();
 
-    // 1. User-defined skills: ~/.claurst/skills/*.md + {project_root}/.claurst/skills/*.md
+    // 1. User-defined skills: <claurst home>/skills/*.md + {project_root}/.claurst/skills/*.md
     let search_dirs: Vec<std::path::PathBuf> = {
         let mut dirs = Vec::new();
-        if let Some(home) = dirs::home_dir() {
-            dirs.push(home.join(".claurst").join("skills"));
-        }
+        dirs.push(claurst_core::config::Settings::config_dir().join("skills"));
         dirs.push(project_root.join(".claurst").join("skills"));
         dirs
     };

--- a/src-rust/crates/tools/src/cron.rs
+++ b/src-rust/crates/tools/src/cron.rs
@@ -58,7 +58,7 @@ static CRON_STORE: Lazy<Arc<RwLock<HashMap<String, CronTask>>>> =
 
 /// Path to `~/.claurst/scheduled_tasks.json`.
 fn scheduled_tasks_path() -> Option<PathBuf> {
-    dirs::home_dir().map(|h| h.join(".claurst").join("scheduled_tasks.json"))
+    Some(claurst_core::config::Settings::config_dir().join("scheduled_tasks.json"))
 }
 
 /// Ensure the store has been loaded from disk (once per process).

--- a/src-rust/crates/tools/src/skill_tool.rs
+++ b/src-rust/crates/tools/src/skill_tool.rs
@@ -134,9 +134,7 @@ fn skill_search_dirs(ctx: &ToolContext) -> Vec<PathBuf> {
     let mut dirs = vec![
         ctx.working_dir.join(".claurst").join("commands"),
     ];
-    if let Some(home) = dirs::home_dir() {
-        dirs.push(home.join(".claurst").join("commands"));
-    }
+    dirs.push(claurst_core::config::Settings::config_dir().join("commands"));
     dirs
 }
 

--- a/src-rust/crates/tools/src/team_tool.rs
+++ b/src-rust/crates/tools/src/team_tool.rs
@@ -107,7 +107,7 @@ static ACTIVE_TEAMS: Lazy<DashMap<String, Vec<CancellationToken>>> =
 // ---------------------------------------------------------------------------
 
 fn teams_base_dir() -> Option<std::path::PathBuf> {
-    dirs::home_dir().map(|h| h.join(".claurst").join("teams"))
+    Some(claurst_core::config::Settings::config_dir().join("teams"))
 }
 
 fn team_dir(team_name: &str) -> Option<std::path::PathBuf> {

--- a/src-rust/crates/tools/src/todo_write.rs
+++ b/src-rust/crates/tools/src/todo_write.rs
@@ -16,12 +16,9 @@ pub fn todos_path(session_id: &str) -> PathBuf {
     todos_dir().join(format!("{}.json", session_id))
 }
 
-/// Directory holding persisted todo lists (`~/.claurst/todos`).
+/// Directory holding persisted todo lists (`<claurst home>/todos`).
 fn todos_dir() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or_default()
-        .join(".claurst")
-        .join("todos")
+    claurst_core::config::Settings::config_dir().join("todos")
 }
 
 /// Load the persisted todo list for `session_id`. Returns an empty vec if the
@@ -365,9 +362,13 @@ mod tests {
             path_str.contains("my-session-123"),
             "todos_path should embed the session id"
         );
+        // Route the assertion through the same canonical resolver instead of
+        // hardcoding `.claurst`: the todos file must live under the resolved
+        // claurst home (which may be ~/.claurst, $CLAURST_HOME, or the XDG dir).
+        let home = claurst_core::config::Settings::config_dir();
         assert!(
-            path_str.contains(".claurst"),
-            "todos_path should be under ~/.claurst"
+            path.starts_with(home.join("todos")),
+            "todos_path should be under the claurst home"
         );
         assert!(
             path_str.ends_with(".json"),

--- a/src-rust/crates/tools/src/web_fetch.rs
+++ b/src-rust/crates/tools/src/web_fetch.rs
@@ -30,10 +30,7 @@ fn url_hash(url: &str) -> String {
 
 /// Get the cache directory for web_fetch content.
 fn get_cache_dir() -> PathBuf {
-    let mut dir = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
-    dir.push(".claurst");
-    dir.push("web_cache");
-    dir
+    claurst_core::config::Settings::config_dir().join("web_cache")
 }
 
 /// Attempt to load cached extracted content for a URL.

--- a/src-rust/crates/tui/src/agents_view.rs
+++ b/src-rust/crates/tui/src/agents_view.rs
@@ -394,7 +394,7 @@ impl Default for AgentsMenuState {
 pub fn load_agent_definitions(project_root: &std::path::Path) -> Vec<AgentDefinition> {
     let mut defs = Vec::new();
     let dirs = [
-        dirs::home_dir().map(|h| h.join(".claurst").join("agents")),
+        Some(claurst_core::config::Settings::config_dir().join("agents")),
         Some(project_root.join(".claurst").join("agents")),
     ];
 

--- a/src-rust/crates/tui/src/overlays.rs
+++ b/src-rust/crates/tui/src/overlays.rs
@@ -586,10 +586,7 @@ impl HistoryEntry {
 // ---------------------------------------------------------------------------
 
 fn pins_path() -> std::path::PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from("."))
-        .join(".claurst")
-        .join("history_pins.json")
+    claurst_core::config::Settings::config_dir().join("history_pins.json")
 }
 
 /// Load the set of pinned entry texts from `~/.claurst/history_pins.json`.

--- a/src-rust/crates/tui/src/stats_dialog.rs
+++ b/src-rust/crates/tui/src/stats_dialog.rs
@@ -76,9 +76,7 @@ pub struct ModelBreakdown {
 
 /// Load and aggregate stats from ~/.claurst/stats.jsonl
 pub fn load_stats() -> AggregatedStats {
-    let path = dirs::home_dir()
-        .map(|h| h.join(".claurst").join("stats.jsonl"))
-        .unwrap_or_default();
+    let path = claurst_core::config::Settings::config_dir().join("stats.jsonl");
 
     let content = match std::fs::read_to_string(&path) {
         Ok(c) => c,


### PR DESCRIPTION
Fixes #207. Single canonical resolver `Settings::config_dir()` / `claurst_home()` with precedence: `$CLAURST_HOME` → existing `~/.claurst` (existing installs untouched, no migration) → XDG (`$XDG_CONFIG_HOME/claurst` or `~/.config/claurst` for fresh installs). Routed ~40 home-dir sites across core/mcp/query/plugins/tools/commands/tui through it; left project-local `.claurst`, temp-scratch names, and sync-protocol keys alone. install.sh → `${XDG_BIN_HOME:-~/.local/bin}`, install.ps1 → `%LOCALAPPDATA%`. 9 commits, 7 resolver tests, `cargo test --workspace` green, CRLF preserved. (Some user-facing help strings still literally say ~/.claurst — cosmetic, flagged for a possible follow-up.)

Closes #207