### PR TITLE
fix(security): sanitize session_id to prevent path traversal

### DIFF
--- a/src-rust/crates/commands/src/history.rs
+++ b/src-rust/crates/commands/src/history.rs
@@ -115,7 +115,10 @@ impl SlashCommand for RevertCommand {
         // back to a destructive truncate for legacy/unchained transcripts.
         let project_root = claurst_core::git_utils::get_repo_root(&ctx.working_dir)
             .unwrap_or_else(|| ctx.working_dir.clone());
-        let path = claurst_core::session_storage::transcript_path(&project_root, &ctx.session_id);
+        let path = match claurst_core::session_storage::transcript_path(&project_root, &ctx.session_id) {
+            Ok(p) => p,
+            Err(e) => return CommandResult::Error(format!("Invalid session ID: {e}")),
+        };
         if path.exists() {
             if let Err(e) = claurst_core::session_storage::branch_before(&path, &target_uuid).await {
                 return CommandResult::Error(format!("Reverted files but could not update transcript: {e}"));

--- a/src-rust/crates/core/src/session_storage.rs
+++ b/src-rust/crates/core/src/session_storage.rs
@@ -266,8 +266,17 @@ pub fn transcript_dir_in(config_dir: &Path, project_root: &Path) -> PathBuf {
 }
 
 /// Returns the full path to a session's JSONL transcript file.
-pub fn transcript_path(project_root: &Path, session_id: &str) -> PathBuf {
-    transcript_dir(project_root).join(format!("{}.jsonl", session_id))
+///
+/// # Errors
+/// Returns `crate::ClaudeError::Other` if `session_id` contains path components
+/// (`/`, `\`, or `..`) that could be used for directory traversal (issue #204).
+pub fn transcript_path(project_root: &Path, session_id: &str) -> crate::Result<PathBuf> {
+    if session_id.contains('/') || session_id.contains('\\') || session_id.contains("..") {
+        return Err(crate::ClaudeError::Other(
+            "session_id contains illegal characters".into(),
+        ));
+    }
+    Ok(transcript_dir(project_root).join(format!("{}.jsonl", session_id)))
 }
 
 // ---------------------------------------------------------------------------
@@ -1200,7 +1209,7 @@ mod tests {
     #[test]
     fn transcript_path_encoding_is_reversible() {
         let root = Path::new("/Users/alice/my-project");
-        let path = transcript_path(root, "test-session");
+        let path = transcript_path(root, "test-session").unwrap();
         // The directory component after "projects/" should decode back to the root.
         let encoded_dir = path
             .parent()

--- a/src-rust/crates/tools/src/todo_write.rs
+++ b/src-rust/crates/tools/src/todo_write.rs
@@ -11,9 +11,19 @@ use tracing::debug;
 // Session-aware persistence helpers
 // ---------------------------------------------------------------------------
 
+/// Validate that `session_id` is a plain filename — no path separators or
+/// `..` components that could be used for directory traversal (issue #204).
+fn validate_session_id(session_id: &str) -> Result<(), String> {
+    if session_id.contains('/') || session_id.contains('\\') || session_id.contains("..") {
+        return Err("session_id contains illegal characters".into());
+    }
+    Ok(())
+}
+
 /// Returns the path to the persisted todo list for `session_id`.
-pub fn todos_path(session_id: &str) -> PathBuf {
-    todos_dir().join(format!("{}.json", session_id))
+pub fn todos_path(session_id: &str) -> anyhow::Result<PathBuf> {
+    validate_session_id(session_id).map_err(|e| anyhow::anyhow!(e))?;
+    Ok(todos_dir().join(format!("{}.json", session_id)))
 }
 
 /// Directory holding persisted todo lists (`<claurst home>/todos`).
@@ -22,14 +32,21 @@ fn todos_dir() -> PathBuf {
 }
 
 /// Load the persisted todo list for `session_id`. Returns an empty vec if the
-/// file does not exist or cannot be parsed.
+/// file does not exist, cannot be parsed, or if `session_id` contains illegal
+/// path characters (issue #204).
 pub fn load_todos(session_id: &str) -> Vec<Value> {
     load_todos_in(&todos_dir(), session_id)
 }
 
 /// Like [`load_todos`] but reads from an explicit todos directory. Lets tests
 /// run hermetically without depending on a writable HOME.
+///
+/// Returns an empty vec when `session_id` contains illegal path characters
+/// (issue #204).
 pub fn load_todos_in(dir: &Path, session_id: &str) -> Vec<Value> {
+    if validate_session_id(session_id).is_err() {
+        return vec![];
+    }
     let path = dir.join(format!("{}.json", session_id));
     std::fs::read_to_string(&path)
         .ok()
@@ -44,7 +61,13 @@ pub fn save_todos(session_id: &str, todos: &[Value]) {
 
 /// Like [`save_todos`] but writes into an explicit todos directory. Lets tests
 /// run hermetically without depending on a writable HOME.
+///
+/// Silently returns when `session_id` contains illegal path characters
+/// (issue #204).
 pub fn save_todos_in(dir: &Path, session_id: &str, todos: &[Value]) {
+    if validate_session_id(session_id).is_err() {
+        return;
+    }
     let path = dir.join(format!("{}.json", session_id));
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
@@ -356,7 +379,7 @@ mod tests {
 
     #[test]
     fn test_todos_path_contains_session_id() {
-        let path = todos_path("my-session-123");
+        let path = todos_path("my-session-123").unwrap();
         let path_str = path.to_string_lossy();
         assert!(
             path_str.contains("my-session-123"),


### PR DESCRIPTION
Fixes #204

Adds input validation to `transcript_path` and `todos_path` to reject `session_id` values containing `/`, `\\`, or `..` that could escape the intended transcript/todo directory.

### Changes
- `core/src/session_storage.rs`: `transcript_path` now returns `crate::Result<PathBuf>` with validation
- `commands/src/history.rs`: handle the new `Result` return
- `tools/src/todo_write.rs`: `todos_path` returns `anyhow::Result`, `load_todos_in`/`save_todos_in` validate before path construction