### PR TITLE
chore(ci): enforce clippy (fix ~255 warnings); keep rustfmt advisory; RC deps noted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,12 +63,14 @@ jobs:
         # parallel execution, flaking non-deterministically across runners.
         run: cargo test --workspace --locked -- --test-threads=1
 
-      # Advisory for now: the codebase has pre-existing clippy warnings and
-      # rustfmt drift. Flip continue-on-error off once they are cleaned up.
-      - name: Clippy (advisory)
+      # Enforced (#227): clippy is clean under `-D warnings`, aside from a few
+      # documented crate-level / targeted `#[allow]`s for noisy or risky lints.
+      # rustfmt stays advisory below: the tree is intentionally not fmt-clean
+      # (CRLF-terminated files and pre-existing drift), so running fmt --check
+      # here is informational only.
+      - name: Clippy
         if: runner.os == 'Linux'
         working-directory: src-rust
-        continue-on-error: true
         run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: rustfmt (advisory)

--- a/src-rust/Cargo.toml
+++ b/src-rust/Cargo.toml
@@ -34,6 +34,10 @@ async-stream = "0.3"
 # de symboles (openssl-sys ↔ boring-sys). aws-lc-rs préfixe ses symboles.
 reqwest = { version = "0.13", features = ["json", "stream", "rustls", "multipart", "form", "query"], default-features = false }
 # wreq = client BoringSSL avec impersonation TLS (profil Bun) — chemin Anthropic uniquement.
+# TODO(#227): pinned to the 6.x / 3.x release-candidate line. No stable (non-rc)
+# release exists yet — the latest stable is wreq 5.3.0 / wreq-util 2.2.6, a major
+# version behind that drops the TLS-impersonation API this crate relies on.
+# Revisit unpinning once wreq 6.0.0 / wreq-util 3.0.0 ship a stable release.
 wreq = { version = "=6.0.0-rc.29", features = ["json", "stream"] }
 wreq-util = "=3.0.0-rc.12"
 

--- a/src-rust/crates/api/src/lib.rs
+++ b/src-rust/crates/api/src/lib.rs
@@ -463,18 +463,16 @@ pub mod client {
 
     /// Provider selection for API calls.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[derive(Default)]
     pub enum Provider {
         /// Use Anthropic's API
+        #[default]
         Anthropic,
         /// Use OpenAI Codex via OAuth
         Codex,
     }
 
-    impl Default for Provider {
-        fn default() -> Self {
-            Provider::Anthropic
-        }
-    }
+    
 
     /// Configuration for the HTTP client.
     #[derive(Debug, Clone)]
@@ -1381,6 +1379,12 @@ enum PartialBlock {
         thinking_buf: String,
         signature_buf: String,
     },
+}
+
+impl Default for StreamAccumulator {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl StreamAccumulator {

--- a/src-rust/crates/api/src/model_registry.rs
+++ b/src-rust/crates/api/src/model_registry.rs
@@ -57,16 +57,15 @@ pub enum Modality {
 /// Model lifecycle status as reported by models.dev.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[derive(Default)]
 pub enum ModelStatus {
+    #[default]
     Active,
     Beta,
     Alpha,
     Deprecated,
 }
 
-impl Default for ModelStatus {
-    fn default() -> Self { ModelStatus::Active }
-}
 
 impl ModelStatus {
     /// Whether to surface this model in default UI listings.
@@ -851,7 +850,7 @@ impl ModelRegistry {
     /// List all known providers (sorted by id for stable output).
     pub fn list_providers(&self) -> Vec<&ProviderEntry> {
         let mut v: Vec<&ProviderEntry> = self.providers.values().collect();
-        v.sort_by(|a, b| (&*a.id).cmp(&*b.id));
+        v.sort_by(|a, b| (*a.id).cmp(&*b.id));
         v
     }
 

--- a/src-rust/crates/api/src/model_registry.rs
+++ b/src-rust/crates/api/src/model_registry.rs
@@ -850,6 +850,9 @@ impl ModelRegistry {
     /// List all known providers (sorted by id for stable output).
     pub fn list_providers(&self) -> Vec<&ProviderEntry> {
         let mut v: Vec<&ProviderEntry> = self.providers.values().collect();
+        // ProviderId sorts by its `&str` deref; a sort_by_key would need an
+        // owned key, so keep the explicit comparator.
+        #[allow(clippy::unnecessary_sort_by)]
         v.sort_by(|a, b| (*a.id).cmp(&*b.id));
         v
     }
@@ -1422,9 +1425,11 @@ mod tests {
         );
 
         // The single resolver agrees when only the provider (no model) is set.
-        let mut cfg = claurst_core::config::Config::default();
-        cfg.provider = Some("qwen".to_string());
-        cfg.model = None;
+        let cfg = claurst_core::config::Config {
+            provider: Some("qwen".to_string()),
+            model: None,
+            ..Default::default()
+        };
         let resolved = effective_model_for_config(&cfg, &reg);
         assert!(
             !resolved.contains("claude"),

--- a/src-rust/crates/api/src/provider_types.rs
+++ b/src-rust/crates/api/src/provider_types.rs
@@ -19,8 +19,10 @@ pub use crate::types::{ThinkingConfig, SystemPrompt};
 /// The reason a model stopped generating tokens.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum StopReason {
     /// The model reached a natural stopping point.
+    #[default]
     EndTurn,
     /// The model generated a stop sequence.
     StopSequence,
@@ -34,11 +36,6 @@ pub enum StopReason {
     Other(String),
 }
 
-impl Default for StopReason {
-    fn default() -> Self {
-        StopReason::EndTurn
-    }
-}
 
 // ---------------------------------------------------------------------------
 // ProviderRequest

--- a/src-rust/crates/api/src/providers/bedrock.rs
+++ b/src-rust/crates/api/src/providers/bedrock.rs
@@ -226,13 +226,13 @@ impl BedrockProvider {
                 mac.update(service.as_bytes());
                 mac.finalize().into_bytes()
             };
-            let k_signing = {
+            
+            {
                 let mut mac = HmacSha256::new_from_slice(&k_service)
                     .expect("HMAC init failed");
                 mac.update(b"aws4_request");
                 mac.finalize().into_bytes()
-            };
-            k_signing
+            }
         };
 
         let signature = {

--- a/src-rust/crates/api/src/providers/bedrock.rs
+++ b/src-rust/crates/api/src/providers/bedrock.rs
@@ -342,6 +342,10 @@ impl BedrockProvider {
         }
     }
 
+    // `role` is threaded through to the recursive calls for tool-result blocks
+    // to keep the Converse mapping symmetric; keep the parameter rather than
+    // dropping it and changing the recursion's shape.
+    #[allow(clippy::only_used_in_recursion)]
     fn content_block_to_converse(block: &ContentBlock, role: &Role) -> Option<Value> {
         match block {
             ContentBlock::Text { text } => Some(json!({ "text": text })),
@@ -1138,6 +1142,11 @@ fn drain_event_stream_frames(
 ) -> Vec<Result<StreamEvent, ProviderError>> {
     let mut out = Vec::new();
 
+    // Kept as an explicit `loop`: each frame's payload is parsed into an owned
+    // value inside the match arm to release the `buf` borrow before we drain the
+    // consumed frame below — a `while let` binding on `buf` would hold that
+    // borrow across the mutation and fail to compile.
+    #[allow(clippy::while_let_loop)]
     loop {
         // Parse the payload into an owned value inside the match arm so the
         // borrow on `buf` is released before we drain the consumed frame below.

--- a/src-rust/crates/api/src/providers/copilot.rs
+++ b/src-rust/crates/api/src/providers/copilot.rs
@@ -63,7 +63,7 @@ impl CopilotProvider {
     }
 
     pub fn from_env() -> Option<Self> {
-        std::env::var("GITHUB_TOKEN").ok().map(|t| Self::new(t))
+        std::env::var("GITHUB_TOKEN").ok().map(Self::new)
     }
 
     fn base_url() -> &'static str {

--- a/src-rust/crates/api/src/providers/google.rs
+++ b/src-rust/crates/api/src/providers/google.rs
@@ -144,16 +144,12 @@ impl GoogleProvider {
                             "mimeType": mime
                         }
                     }))
-                } else if let Some(url) = &source.url {
-                    Some(json!({
+                } else { source.url.as_ref().map(|url| json!({
                         "fileData": {
                             "fileUri": url,
                             "mimeType": source.media_type.as_deref().unwrap_or("image/jpeg")
                         }
-                    }))
-                } else {
-                    None
-                }
+                    })) }
             }
 
             ContentBlock::ToolUse { name, input, .. } => Some(json!({
@@ -176,16 +172,12 @@ impl GoogleProvider {
                             "mimeType": mime
                         }
                     }))
-                } else if let Some(url) = &source.url {
-                    Some(json!({
+                } else { source.url.as_ref().map(|url| json!({
                         "fileData": {
                             "fileUri": url,
                             "mimeType": source.media_type.as_deref().unwrap_or("application/pdf")
                         }
-                    }))
-                } else {
-                    None
-                }
+                    })) }
             }
 
             // Render UI-only / metadata blocks as text so context is not lost.

--- a/src-rust/crates/api/src/providers/google.rs
+++ b/src-rust/crates/api/src/providers/google.rs
@@ -279,24 +279,22 @@ impl GoogleProvider {
                     }
 
                     // Filter required to only include keys present in properties.
-                    if let Some(required) = map.get("required").cloned() {
-                        if let Value::Array(req_arr) = required {
-                            let prop_keys: std::collections::HashSet<String> = map
-                                .get("properties")
-                                .and_then(|p| p.as_object())
-                                .map(|o| o.keys().cloned().collect())
-                                .unwrap_or_default();
+                    if let Some(Value::Array(req_arr)) = map.get("required").cloned() {
+                        let prop_keys: std::collections::HashSet<String> = map
+                            .get("properties")
+                            .and_then(|p| p.as_object())
+                            .map(|o| o.keys().cloned().collect())
+                            .unwrap_or_default();
 
-                            let filtered: Vec<Value> = req_arr
-                                .into_iter()
-                                .filter(|v| {
-                                    v.as_str()
-                                        .map(|s| prop_keys.contains(s))
-                                        .unwrap_or(false)
-                                })
-                                .collect();
-                            map.insert("required".to_string(), Value::Array(filtered));
-                        }
+                        let filtered: Vec<Value> = req_arr
+                            .into_iter()
+                            .filter(|v| {
+                                v.as_str()
+                                    .map(|s| prop_keys.contains(s))
+                                    .unwrap_or(false)
+                            })
+                            .collect();
+                        map.insert("required".to_string(), Value::Array(filtered));
                     }
                 } else {
                     // Non-object types must not carry properties/required.

--- a/src-rust/crates/api/src/providers/openai.rs
+++ b/src-rust/crates/api/src/providers/openai.rs
@@ -612,7 +612,11 @@ impl OpenAiProvider {
     }
 }
 
+// The `LlmProvider` impl and capability helpers below are declared after this
+// module; keeping these wire-format tests next to the helpers they exercise is
+// intentional, so allow the item-ordering lint here.
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod tests {
     use super::*;
     use claurst_core::types::Message;

--- a/src-rust/crates/api/src/providers/openai_compat.rs
+++ b/src-rust/crates/api/src/providers/openai_compat.rs
@@ -769,8 +769,7 @@ impl OpenAiCompatProvider {
         let (base, tag) = raw.split_once(':').unwrap_or((raw, "latest"));
 
         let pretty_base = base
-            .replace('-', " ")
-            .replace('_', " ")
+            .replace(['-', '_'], " ")
             .split_whitespace()
             .map(|word| {
                 let mut chars = word.chars();

--- a/src-rust/crates/api/src/providers/openai_compat.rs
+++ b/src-rust/crates/api/src/providers/openai_compat.rs
@@ -195,7 +195,7 @@ impl OpenAiCompatProvider {
 
     /// Apply `scrub_tool_id` to every tool-call id/tool_call_id in a messages
     /// array that was already built by `OpenAiProvider::to_openai_messages`.
-    fn apply_tool_id_quirks(&self, messages: &mut Vec<Value>) {
+    fn apply_tool_id_quirks(&self, messages: &mut [Value]) {
         if self.quirks.tool_id_max_len.is_none() && !self.quirks.tool_id_alphanumeric_only {
             return;
         }
@@ -291,7 +291,7 @@ impl OpenAiCompatProvider {
     /// on turns where tool calls occurred. Turns without tool calls omit it —
     /// the API ignores it anyway and skipping saves tokens.
     fn inject_reasoning_for_tool_turns(
-        json_messages: &mut Vec<Value>,
+        json_messages: &mut [Value],
         original_messages: &[claurst_core::types::Message],
         field: &str,
     ) {
@@ -366,7 +366,7 @@ impl OpenAiCompatProvider {
     /// (it treats null as absent and then complains that neither content nor
     /// tool_calls is set).  Replacing with an empty string satisfies the
     /// validation while preserving semantics.
-    fn ensure_content_not_null(messages: &mut Vec<Value>) {
+    fn ensure_content_not_null(messages: &mut [Value]) {
         for msg in messages.iter_mut() {
             let is_assistant =
                 msg.get("role").and_then(|r| r.as_str()) == Some("assistant");

--- a/src-rust/crates/api/src/registry.rs
+++ b/src-rust/crates/api/src/registry.rs
@@ -500,7 +500,7 @@ impl ProviderRegistry {
         // env vars.
         let auth_store = claurst_core::AuthStore::load();
 
-        for (provider_id, _cred) in &auth_store.credentials {
+        for provider_id in auth_store.credentials.keys() {
             let pid = claurst_core::ProviderId::new(provider_id.as_str());
             // Skip if already registered from env vars.
             if registry.get(&pid).is_some() {

--- a/src-rust/crates/api/src/transform.rs
+++ b/src-rust/crates/api/src/transform.rs
@@ -32,6 +32,9 @@ pub trait MessageTransformer: Send + Sync {
 
     /// Deserialize a provider-specific JSON response body into a
     /// `ProviderResponse`.
+    // `from_provider` takes `&self` intentionally: it is a transformer instance
+    // method, not a constructor, so the std `from_*` self-convention doesn't apply.
+    #[allow(clippy::wrong_self_convention)]
     fn from_provider(
         &self,
         response: &serde_json::Value,

--- a/src-rust/crates/bridge/src/lib.rs
+++ b/src-rust/crates/bridge/src/lib.rs
@@ -1632,7 +1632,7 @@ mod tests {
     #[test]
     fn test_jwt_decode_invalid() {
         assert!(JwtClaims::decode("notajwt").is_err());
-        assert!(JwtClaims::decode("only.two").is_ok() == false || true); // either way, must not panic
+        assert!(!JwtClaims::decode("only.two").is_ok() || true); // either way, must not panic
     }
 
     #[test]

--- a/src-rust/crates/bridge/src/lib.rs
+++ b/src-rust/crates/bridge/src/lib.rs
@@ -56,11 +56,7 @@ impl JwtClaims {
     /// Returns an error if the token is malformed or the JSON is invalid.
     pub fn decode(token: &str) -> anyhow::Result<Self> {
         // Strip session-ingress prefix used by Anthropic's ingress tokens.
-        let jwt = if token.starts_with("sk-ant-si-") {
-            &token["sk-ant-si-".len()..]
-        } else {
-            token
-        };
+        let jwt = token.strip_prefix("sk-ant-si-").unwrap_or(token);
 
         let parts: Vec<&str> = jwt.split('.').collect();
         if parts.len() < 2 {
@@ -1632,7 +1628,9 @@ mod tests {
     #[test]
     fn test_jwt_decode_invalid() {
         assert!(JwtClaims::decode("notajwt").is_err());
-        assert!(!JwtClaims::decode("only.two").is_ok() || true); // either way, must not panic
+        // Malformed-but-two-segment input: either Ok or Err is acceptable, the
+        // contract is only that decoding must not panic.
+        let _ = JwtClaims::decode("only.two");
     }
 
     #[test]
@@ -1649,8 +1647,7 @@ mod tests {
 
     #[test]
     fn test_bridge_config_with_token_still_needs_enabled() {
-        let mut cfg = BridgeConfig::default();
-        cfg.session_token = Some("tok".into());
+        let mut cfg = BridgeConfig { session_token: Some("tok".into()), ..Default::default() };
         assert!(!cfg.is_active(), "needs enabled=true too");
         cfg.enabled = true;
         assert!(cfg.is_active());

--- a/src-rust/crates/buddy/src/lib.rs
+++ b/src-rust/crates/buddy/src/lib.rs
@@ -1010,7 +1010,7 @@ mod tests {
         let mut rng = Mulberry32::new(42);
         for _ in 0..1000 {
             let v = rng.next_f64();
-            assert!(v >= 0.0 && v < 1.0, "out of range: {v}");
+            assert!((0.0..1.0).contains(&v), "out of range: {v}");
         }
     }
 

--- a/src-rust/crates/cli/src/codex_oauth_flow.rs
+++ b/src-rust/crates/cli/src/codex_oauth_flow.rs
@@ -27,7 +27,7 @@ pub fn generate_code_verifier() -> String {
     let u3 = uuid::Uuid::new_v4();
     bytes[32..48].copy_from_slice(&u3.as_bytes()[..16]);
 
-    URL_SAFE_NO_PAD.encode(&bytes)
+    URL_SAFE_NO_PAD.encode(bytes)
 }
 
 /// Compute PKCE code challenge (SHA-256 of verifier, base64url encoded).

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -756,7 +756,7 @@ async fn main() -> anyhow::Result<()> {
     // but we guard with a std::sync::OnceLock internally).
     {
         static SWARM_INIT: std::sync::OnceLock<()> = std::sync::OnceLock::new();
-        SWARM_INIT.get_or_init(|| claurst_query::init_team_swarm_runner());
+        SWARM_INIT.get_or_init(claurst_query::init_team_swarm_runner);
     }
 
     // Build the full tool list: built-ins from cc-tools plus AgentTool from cc-query
@@ -1038,14 +1038,14 @@ async fn run_models_command(args: &[String]) -> anyhow::Result<()> {
     // Stable order: provider id, then by descending release_date so newest
     // models appear first.
     entries.sort_by(|a, b| {
-        (&*a.info.provider_id)
+        (*a.info.provider_id)
             .cmp(&*b.info.provider_id)
             .then_with(|| {
                 let rd_a = a.release_date.as_deref().unwrap_or("");
                 let rd_b = b.release_date.as_deref().unwrap_or("");
                 rd_b.cmp(rd_a)
             })
-            .then_with(|| (&*a.info.id).cmp(&*b.info.id))
+            .then_with(|| (*a.info.id).cmp(&*b.info.id))
     });
 
     if as_json {
@@ -2871,10 +2871,7 @@ async fn run_interactive(
                                                 }
                                             }
                                             Some('p') => {
-                                                let mut settings = match claurst_core::config::Settings::load_sync() {
-                                                    Ok(s) => s,
-                                                    Err(_) => claurst_core::config::Settings::default(),
-                                                };
+                                                let mut settings = claurst_core::config::Settings::load_sync().unwrap_or_default();
                                                 if let Some(path) = selected_path.as_deref() {
                                                     let pattern = format!("{}*", path);
                                                     let _ = manager.add_persistent_allow_path(&pending.request.tool_name, &pattern, &mut settings);
@@ -3223,15 +3220,14 @@ async fn run_interactive(
                                         Ok(msgs) if !msgs.is_empty() => {
                                             for msg in &msgs {
                                                 since_id = Some(msg.id.clone());
-                                                if msg.role == "user" {
-                                                    if poll_tx
+                                                if msg.role == "user"
+                                                    && poll_tx
                                                         .send(msg.content.clone())
                                                         .await
                                                         .is_err()
                                                     {
                                                         return;
                                                     }
-                                                }
                                             }
                                         }
                                         _ => {}

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -8,6 +8,10 @@
 //    - Headless (--print / -p) mode: single query, output to stdout
 //    - Interactive REPL mode: full TUI with ratatui
 
+// too_many_arguments: the top-level interactive/headless runners thread many
+// parameters; grouping them into structs is a larger refactor out of scope here.
+#![allow(clippy::too_many_arguments)]
+
 mod oauth_flow;
 mod codex_oauth_flow;
 mod upgrade;
@@ -979,14 +983,10 @@ fn models_dev_cache_path() -> PathBuf {
 /// Implementation of the `claurst models` subcommand.
 ///
 /// Flags:
-///   * `--refresh`   — force-fetch from models.dev (ignoring the 5-minute
-///                     freshness window), then list.
-///   * `--verbose`   — also print release date, status, modalities,
-///                     cache pricing, and capability flags.
-///   * `--json`      — emit the registry as a JSON object keyed by
-///                     `provider/model` (suitable for piping into `jq`).
-///   * `<provider>`  — first non-flag arg filters by provider id
-///                     (e.g. `claurst models openai`).
+/// * `--refresh` — force-fetch from models.dev (ignoring the 5-minute freshness window), then list.
+/// * `--verbose` — also print release date, status, modalities, cache pricing, and capability flags.
+/// * `--json` — emit the registry as a JSON object keyed by `provider/model` (suitable for piping into `jq`).
+/// * `<provider>` — first non-flag arg filters by provider id (e.g. `claurst models openai`).
 async fn run_models_command(args: &[String]) -> anyhow::Result<()> {
     let mut refresh = false;
     let mut verbose = false;
@@ -3412,13 +3412,8 @@ async fn run_interactive(
 
         // Drain CLAUDE_STATUS_COMMAND results (most recent wins)
         if status_cmd_str.is_some() {
-            loop {
-                match status_cmd_rx.try_recv() {
-                    Ok(text) => {
-                        app.status_line_override = if text.is_empty() { None } else { Some(text) };
-                    }
-                    Err(_) => break,
-                }
+            while let Ok(text) = status_cmd_rx.try_recv() {
+                app.status_line_override = if text.is_empty() { None } else { Some(text) };
             }
         }
 

--- a/src-rust/crates/cli/src/oauth_flow.rs
+++ b/src-rust/crates/cli/src/oauth_flow.rs
@@ -99,8 +99,8 @@ pub async fn run_oauth_login_flow_with_label(
     } else {
         oauth::CONSOLE_AUTHORIZE_URL
     };
-    let manual_url = oauth::build_auth_url(&authorize_base, &code_challenge, &state, port, true);
-    let automatic_url = oauth::build_auth_url(&authorize_base, &code_challenge, &state, port, false);
+    let manual_url = oauth::build_auth_url(authorize_base, &code_challenge, &state, port, true);
+    let automatic_url = oauth::build_auth_url(authorize_base, &code_challenge, &state, port, false);
 
     // 4. Print URL and try to open browser
     println!("\nOpening browser for authentication...");

--- a/src-rust/crates/cli/src/oauth_flow.rs
+++ b/src-rust/crates/cli/src/oauth_flow.rs
@@ -269,12 +269,10 @@ async fn run_callback_server(listener: TcpListener, expected_state: &str) -> any
         .find(|(k, _)| k == "state")
         .map(|(_, v)| v.to_string());
 
-    // Send success redirect to the browser before validating, so the browser shows a page
-    let location = if received_state.as_deref() == Some(expected_state) && code.is_some() {
-        oauth::CLAUDEAI_SUCCESS_URL
-    } else {
-        oauth::CLAUDEAI_SUCCESS_URL // Show same page on error (browser UX)
-    };
+    // Send success redirect to the browser before validating. The same success
+    // page is shown on both the valid and error paths (browser UX); request
+    // validation happens after this redirect is written.
+    let location = oauth::CLAUDEAI_SUCCESS_URL;
 
     let response = format!(
         "HTTP/1.1 302 Found\r\nLocation: {}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",

--- a/src-rust/crates/commands/src/accounts.rs
+++ b/src-rust/crates/commands/src/accounts.rs
@@ -25,8 +25,8 @@ impl SlashCommand for LoginCommand {
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let tokens: Vec<&str> = args.split_whitespace().collect();
-        let use_codex = tokens.iter().any(|t| *t == "--codex");
-        let login_with_claude_ai = !tokens.iter().any(|t| *t == "--console");
+        let use_codex = tokens.contains(&"--codex");
+        let login_with_claude_ai = !tokens.contains(&"--console");
         let label = parse_label_arg(&tokens);
 
         let provider = if use_codex {
@@ -71,8 +71,8 @@ impl SlashCommand for LogoutCommand {
 
     async fn execute(&self, args: &str, ctx: &mut CommandContext) -> CommandResult {
         let tokens: Vec<&str> = args.split_whitespace().collect();
-        let use_codex = tokens.iter().any(|t| *t == "--codex");
-        let purge_all = tokens.iter().any(|t| *t == "--all");
+        let use_codex = tokens.contains(&"--codex");
+        let purge_all = tokens.contains(&"--all");
 
         if use_codex {
             if purge_all {
@@ -194,7 +194,7 @@ impl SlashCommand for SwitchCommand {
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let tokens: Vec<&str> = args.split_whitespace().collect();
-        let use_codex = tokens.iter().any(|t| *t == "--codex");
+        let use_codex = tokens.contains(&"--codex");
         let provider = if use_codex {
             claurst_core::accounts::PROVIDER_CODEX
         } else {

--- a/src-rust/crates/commands/src/chrome.rs
+++ b/src-rust/crates/commands/src/chrome.rs
@@ -60,7 +60,7 @@ mod chrome_cdp {
     ) -> anyhow::Result<Value> {
         let id = next_id();
         let request = json!({ "id": id, "method": method, "params": params });
-        ws.send(WsMessage::Text(request.to_string().into())).await?;
+        ws.send(WsMessage::Text(request.to_string())).await?;
 
         // Drain messages until we get the one with our id (ignore events).
         loop {

--- a/src-rust/crates/commands/src/display.rs
+++ b/src-rust/crates/commands/src/display.rs
@@ -25,18 +25,9 @@ impl SlashCommand for ContextCommand {
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         let model = ctx.config.effective_model();
 
-        // Determine context window size from known model names
-        let context_window: u64 = if model.contains("claude-3-5") || model.contains("claude-3.5") {
-            200_000
-        } else if model.contains("opus") {
-            200_000
-        } else if model.contains("sonnet") {
-            200_000
-        } else if model.contains("haiku") {
-            200_000
-        } else {
-            200_000 // safe default for any Claude model
-        };
+        // Every currently-supported Claude model family (3.5, opus, sonnet,
+        // haiku) shares a 200k-token context window, so this is constant for now.
+        let context_window: u64 = 200_000;
 
         let used_tokens = ctx.cost_tracker.total_tokens();
         let pct = if context_window > 0 {

--- a/src-rust/crates/commands/src/history.rs
+++ b/src-rust/crates/commands/src/history.rs
@@ -82,7 +82,7 @@ impl SlashCommand for RevertCommand {
             Some(checkpoints[checkpoints.len() - n])
         } else {
             checkpoints.iter().copied()
-                .find(|m| m.uuid.as_deref().map_or(false, |u| u.starts_with(args)))
+                .find(|m| m.uuid.as_deref().is_some_and(|u| u.starts_with(args)))
         };
 
         let target = match target {

--- a/src-rust/crates/commands/src/lib.rs
+++ b/src-rust/crates/commands/src/lib.rs
@@ -340,7 +340,7 @@ fn open_with_system(target: &str) -> std::io::Result<()> {
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .spawn()?;
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(not(any(target_os = "windows", target_os = "macos")))]

--- a/src-rust/crates/commands/src/mcp.rs
+++ b/src-rust/crates/commands/src/mcp.rs
@@ -112,16 +112,11 @@ impl SlashCommand for McpCommand {
         if sub == "status" {
             let mut output = String::from("MCP Server Status\n─────────────────\n");
             for srv in &ctx.config.mcp_servers {
-                let kind = match srv.server_type.as_str() {
-                    "stdio" => "stdio",
-                    "sse" => "sse",
-                    "http" => "http",
-                    other => other,
-                };
+                let kind = srv.server_type.as_str();
                 let endpoint = srv
                     .url
                     .as_deref()
-                    .or_else(|| srv.command.as_deref())
+                    .or(srv.command.as_deref())
                     .unwrap_or("(unknown)");
 
                 // Fetch live status from the manager if available.

--- a/src-rust/crates/commands/src/named_commands.rs
+++ b/src-rust/crates/commands/src/named_commands.rs
@@ -517,7 +517,7 @@ impl NamedCommand for IdeCommand {
         if let Ok(entries) = std::fs::read_dir(&lockfile_dir) {
             for entry in entries.flatten() {
                 let path = entry.path();
-                if path.extension().map_or(false, |e| e == "lock") {
+                if path.extension().is_some_and(|e| e == "lock") {
                     if let Ok(lock_content) = std::fs::read_to_string(&path) {
                         if let Ok(info) = serde_json::from_str::<serde_json::Value>(&lock_content) {
                             let pid = info["pid"].as_u64().unwrap_or(0);
@@ -663,7 +663,7 @@ impl NamedCommand for DesktopCommand {
         // If a remote session is active the user is already bridged — show a
         // deep link so they can open the current session in Desktop.
         if let Some(ref session_url) = ctx.remote_session_url {
-            let session_id = session_url.split('/').last().unwrap_or("");
+            let session_id = session_url.split('/').next_back().unwrap_or("");
             let deep_link = format!("claude://session/{}", session_id);
 
             let mut msg = String::new();
@@ -1226,7 +1226,7 @@ mod tests {
 
     #[test]
     fn test_branch_create_no_session_returns_error() {
-        let ctx = make_ctx(); // session_id = "named-test-session" — no saved session
+        let _ctx = make_ctx(); // session_id = "named-test-session" — no saved session
         let cmd = BranchCommand;
         // Calling create on a session that isn't "pre-session" but also doesn't exist
         // on disk: we can't call block_in_place outside a tokio runtime in a sync test,

--- a/src-rust/crates/commands/src/session_tools.rs
+++ b/src-rust/crates/commands/src/session_tools.rs
@@ -33,7 +33,7 @@ impl SlashCommand for SkillsCommand {
             if let Ok(entries) = std::fs::read_dir(dir) {
                 for entry in entries.flatten() {
                     let p = entry.path();
-                    if p.extension().map_or(false, |e| e == "md") {
+                    if p.extension().is_some_and(|e| e == "md") {
                         if let Some(stem) = p.file_stem().and_then(|s| s.to_str()) {
                             let name = stem.to_string();
                             if !found.contains(&name) {
@@ -61,7 +61,7 @@ impl SlashCommand for SkillsCommand {
                                     }
                                 }
                             }
-                        } else if p.extension().map_or(false, |e| e == "md") {
+                        } else if p.extension().is_some_and(|e| e == "md") {
                             if let Some(stem) = p.file_stem().and_then(|s| s.to_str()) {
                                 let name = stem.to_string();
                                 if !found.contains(&name) {
@@ -389,9 +389,7 @@ impl SlashCommand for EffortCommand {
 
     async fn execute(&self, args: &str, ctx: &mut CommandContext) -> CommandResult {
         match args.trim() {
-            "" => CommandResult::Message(format!(
-                "Current effort: normal\nUse /effort [low|normal|high] to change."
-            )),
+            "" => CommandResult::Message("Current effort: normal\nUse /effort [low|normal|high] to change.".to_string()),
             "low" => {
                 // Low effort: smaller max_tokens
                 ctx.config.max_tokens = Some(4096);

--- a/src-rust/crates/core/src/attachments.rs
+++ b/src-rust/crates/core/src/attachments.rs
@@ -90,7 +90,7 @@ pub fn get_ide_context() -> Option<String> {
 
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.extension().map_or(false, |e| e == "lock") {
+        if path.extension().is_some_and(|e| e == "lock") {
             if let Ok(content) = std::fs::read_to_string(&path) {
                 if let Ok(info) = serde_json::from_str::<serde_json::Value>(&content) {
                     let pid = info["pid"].as_u64().unwrap_or(0);

--- a/src-rust/crates/core/src/bash_classifier.rs
+++ b/src-rust/crates/core/src/bash_classifier.rs
@@ -128,11 +128,10 @@ pub fn classify_bash_command(command: &str) -> BashRiskLevel {
     }
 
     // dd with an if= (disk image writing) — extremely destructive
-    if cmd.starts_with("dd ") || cmd == "dd" {
-        if cmd.contains("if=") {
+    if (cmd.starts_with("dd ") || cmd == "dd")
+        && cmd.contains("if=") {
             return BashRiskLevel::Critical;
         }
-    }
 
     // mkfs — format filesystem
     if cmd.starts_with("mkfs") || cmd.starts_with("mkfs.") {
@@ -145,8 +144,7 @@ pub fn classify_bash_command(command: &str) -> BashRiskLevel {
     }
 
     // Detect `rm` with `-rf` (or `-fr`) targeting root or very short paths
-    if cmd.starts_with("rm ") {
-        let args = &cmd[3..];
+    if let Some(args) = cmd.strip_prefix("rm ") {
         let has_r = has_flag(args, "-r")
             || has_flag(args, "-R")
             || has_flag(args, "-rf")
@@ -171,8 +169,7 @@ pub fn classify_bash_command(command: &str) -> BashRiskLevel {
     }
 
     // chmod 777 on / or critical paths
-    if cmd.starts_with("chmod ") {
-        let args = &cmd[6..];
+    if let Some(args) = cmd.strip_prefix("chmod ") {
         if (args.contains("777") || args.contains("a+rwx"))
             && (args.contains(" /") || args.ends_with('/'))
         {
@@ -251,8 +248,7 @@ pub fn classify_bash_command(command: &str) -> BashRiskLevel {
     }
 
     // mv that targets sensitive paths
-    if cmd.starts_with("mv ") {
-        let args = &cmd[3..];
+    if let Some(args) = cmd.strip_prefix("mv ") {
         let sensitive = [" /etc/", " /bin/", " /usr/", " /lib/", " /boot/"];
         for s in &sensitive {
             if args.contains(s) {

--- a/src-rust/crates/core/src/claudemd.rs
+++ b/src-rust/crates/core/src/claudemd.rs
@@ -236,7 +236,7 @@ pub fn load_all_memory_files(project_root: &Path) -> Vec<MemoryFileInfo> {
                 .flatten()
                 .filter_map(|e| {
                     let p = e.path();
-                    if p.extension().map_or(false, |x| x == "md") { Some(p) } else { None }
+                    if p.extension().is_some_and(|x| x == "md") { Some(p) } else { None }
                 })
                 .collect();
             paths.sort();

--- a/src-rust/crates/core/src/cloud_session.rs
+++ b/src-rust/crates/core/src/cloud_session.rs
@@ -72,7 +72,7 @@ pub fn message_to_cloud(msg: &Message, session_id: &str, msg_id: &str, ts: u64) 
         .into_iter()
         .map(|block| {
             serde_json::to_value(&block)
-                .unwrap_or_else(|_| Value::Null)
+                .unwrap_or(Value::Null)
         })
         .collect();
 

--- a/src-rust/crates/core/src/feature_flags.rs
+++ b/src-rust/crates/core/src/feature_flags.rs
@@ -50,6 +50,12 @@ pub struct FeatureFlagManager {
     http_client: reqwest::Client,
 }
 
+impl Default for FeatureFlagManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FeatureFlagManager {
     /// Create a new feature flag manager
     ///

--- a/src-rust/crates/core/src/goal.rs
+++ b/src-rust/crates/core/src/goal.rs
@@ -346,7 +346,7 @@ fn uuid_v4() -> String {
     format!(
         "{:08x}-{:04x}-4{:03x}-{:04x}-{:012x}",
         (h1 >> 32) as u32,
-        (h1 >> 16) as u16 & 0xffff,
+        ((h1 >> 16) as u16),
         (h1) as u16 & 0x0fff,
         ((h2 >> 48) as u16 & 0x3fff) | 0x8000,
         h2 & 0x0000_ffff_ffff_ffff,

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -777,8 +777,10 @@ pub mod config {
     /// Budget allocation strategy between manager and executor agents.
     #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
     #[serde(tag = "type", rename_all = "snake_case")]
+    #[derive(Default)]
     pub enum BudgetSplitPolicy {
         /// Shared pool — no split (default).
+        #[default]
         SharedPool,
         /// Manager gets manager_pct% of total budget.
         Percentage { manager_pct: u8 },
@@ -786,9 +788,7 @@ pub mod config {
         FixedCaps { manager_usd: f64, executor_usd: f64 },
     }
 
-    impl Default for BudgetSplitPolicy {
-        fn default() -> Self { BudgetSplitPolicy::SharedPool }
-    }
+    
 
     /// Configuration for manager-executor agent architecture.
     #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1237,6 +1237,7 @@ pub mod config {
 
     /// Configuration for a file formatter tool.
     #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[derive(Default)]
     pub struct FormatterConfig {
         /// Command to run, e.g. `["prettier", "--write"]`.
         pub command: Vec<String>,
@@ -1247,11 +1248,7 @@ pub mod config {
         pub disabled: bool,
     }
 
-    impl Default for FormatterConfig {
-        fn default() -> Self {
-            Self { command: Vec::new(), extensions: Vec::new(), disabled: false }
-        }
-    }
+    
 
     #[derive(Debug, Clone, Serialize, Deserialize, Default)]
     pub struct ProjectSettings {
@@ -1515,11 +1512,7 @@ pub mod config {
                 tokens
             };
 
-            if let Some(cred) = tokens.effective_credential() {
-                Some((cred.to_string(), tokens.uses_bearer_auth()))
-            } else {
-                None
-            }
+            tokens.effective_credential().map(|cred| (cred.to_string(), tokens.uses_bearer_auth()))
         }
 
         pub fn resolve_provider_api_base(&self, provider_id: &str) -> Option<String> {
@@ -3338,22 +3331,19 @@ pub mod history {
         }
 
         let mut sessions = vec![];
-        match tokio::fs::read_dir(&dir).await {
-            Ok(mut entries) => {
-                while let Ok(Some(entry)) = entries.next_entry().await {
-                    let path = entry.path();
-                    if path.extension().and_then(|s| s.to_str()) == Some("json") {
-                        if let Ok(content) = tokio::fs::read_to_string(&path).await {
-                            if let Ok(session) =
-                                serde_json::from_str::<ConversationSession>(&content)
-                            {
-                                sessions.push(session);
-                            }
+        if let Ok(mut entries) = tokio::fs::read_dir(&dir).await {
+            while let Ok(Some(entry)) = entries.next_entry().await {
+                let path = entry.path();
+                if path.extension().and_then(|s| s.to_str()) == Some("json") {
+                    if let Ok(content) = tokio::fs::read_to_string(&path).await {
+                        if let Ok(session) =
+                            serde_json::from_str::<ConversationSession>(&content)
+                        {
+                            sessions.push(session);
                         }
                     }
                 }
             }
-            Err(_) => {}
         }
 
         sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
@@ -3958,7 +3948,7 @@ pub mod oauth {
 
             let profile = AccountProfile {
                 id: id.clone(),
-                label: label.map(|l| slugify_profile_id(l)),
+                label: label.map(slugify_profile_id),
                 email: self.email.clone(),
                 account_id: self.account_uuid.clone(),
                 organization_uuid: self.organization_uuid.clone(),

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -3,6 +3,14 @@
 //
 // All sub-modules are defined inline below.
 
+// too_many_arguments: several config-import and permission-resolution helpers
+// legitimately thread many parameters; grouping them into structs is a larger
+// refactor out of scope for this cleanup.
+#![allow(clippy::too_many_arguments)]
+// should_implement_trait: intentional inherent `from_str` constructors that
+// return domain-specific types, not the std `FromStr` trait.
+#![allow(clippy::should_implement_trait)]
+
 // Branded provider / model identifier newtypes.
 pub mod provider_id;
 pub use provider_id::{ProviderId, ModelId};
@@ -1449,6 +1457,7 @@ pub mod config {
         /// Returns `(credential, use_bearer_auth)`.
         /// - For Console OAuth flow: credential is the stored API key, bearer=false.
         /// - For Claude.ai OAuth flow: credential is the access token, bearer=true.
+        ///
         /// Silently attempts token refresh when the access token is expired.
         pub async fn resolve_auth_async(&self) -> Option<(String, bool)> {
             if self.selected_provider_id() != "anthropic" {
@@ -1961,8 +1970,7 @@ pub mod config {
 
         #[test]
         fn global_request_timeout_serde_roundtrips_with_camelcase_key() {
-            let mut config = Config::default();
-            config.request_timeout_secs = Some(1800);
+            let config = Config { request_timeout_secs: Some(1800), ..Default::default() };
             // Serialises with the documented camelCase key.
             let json = serde_json::to_string(&config).expect("serialise");
             assert!(
@@ -1994,10 +2002,8 @@ pub mod config {
 
         #[test]
         fn per_provider_override_wins_over_global() {
-            let mut config = Config::default();
-            config.request_timeout_secs = Some(1200);
-            let mut provider = ProviderConfig::default();
-            provider.request_timeout_secs = Some(3600);
+            let mut config = Config { request_timeout_secs: Some(1200), ..Default::default() };
+            let provider = ProviderConfig { request_timeout_secs: Some(3600), ..Default::default() };
             config
                 .provider_configs
                 .insert("ollama".to_string(), provider);
@@ -2011,8 +2017,7 @@ pub mod config {
         fn effective_config_merges_top_level_provider_timeout() {
             let mut settings = Settings::default();
             settings.config.request_timeout_secs = Some(1200);
-            let mut provider = ProviderConfig::default();
-            provider.request_timeout_secs = Some(3600);
+            let provider = ProviderConfig { request_timeout_secs: Some(3600), ..Default::default() };
             settings.providers.insert("ollama".to_string(), provider);
             let config = settings.effective_config();
             assert_eq!(config.resolve_request_timeout_secs("ollama"), 3600);
@@ -2021,8 +2026,7 @@ pub mod config {
 
         #[test]
         fn zero_is_treated_as_unset() {
-            let mut config = Config::default();
-            config.request_timeout_secs = Some(0);
+            let config = Config { request_timeout_secs: Some(0), ..Default::default() };
             assert_eq!(
                 config.resolve_request_timeout_secs("openai"),
                 DEFAULT_REQUEST_TIMEOUT_SECS
@@ -2801,9 +2805,7 @@ pub mod permissions {
             match self.mode {
                 PermissionMode::BypassPermissions => PermissionDecision::Allow,
                     PermissionMode::AcceptEdits => {
-                        if request.tool_name == "Edit" {
-                            PermissionDecision::Allow
-                        } else if request.is_read_only {
+                        if request.tool_name == "Edit" || request.is_read_only {
                             PermissionDecision::Allow
                         } else {
                             PermissionDecision::Deny
@@ -3346,7 +3348,7 @@ pub mod history {
             }
         }
 
-        sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        sessions.sort_by_key(|b| std::cmp::Reverse(b.updated_at));
         sessions
     }
 
@@ -3537,9 +3539,7 @@ pub mod cost {
         /// Pick pricing based on model name substring matching.
         pub fn for_model(model: &str) -> Self {
             // Check for free models first (those with "-free" suffix, "free/" prefix, or upstream-prefixed free model)
-            if model.ends_with("-free") || model.starts_with("free/") {
-                Self::FREE
-            } else if is_free_upstream_model(model) {
+            if model.ends_with("-free") || model.starts_with("free/") || is_free_upstream_model(model) {
                 Self::FREE
             } else if model.contains("opus") {
                 Self::OPUS
@@ -4441,8 +4441,7 @@ mod tests {
 
     #[test]
     fn test_config_mouse_capture_explicit_off() {
-        let mut cfg = crate::config::Config::default();
-        cfg.mouse_capture = Some(false);
+        let mut cfg = crate::config::Config { mouse_capture: Some(false), ..Default::default() };
         assert!(!cfg.mouse_capture_enabled());
         cfg.mouse_capture = Some(true);
         assert!(cfg.mouse_capture_enabled());
@@ -4460,8 +4459,7 @@ mod tests {
         assert!(back.mouse_capture_enabled());
 
         // Explicit off serializes the key and round-trips as disabled.
-        let mut cfg = crate::config::Config::default();
-        cfg.mouse_capture = Some(false);
+        let cfg = crate::config::Config { mouse_capture: Some(false), ..Default::default() };
         let json = serde_json::to_string(&cfg).unwrap();
         assert!(json.contains("\"mouseCapture\":false"));
         let back: crate::config::Config = serde_json::from_str(&json).unwrap();
@@ -4477,8 +4475,7 @@ mod tests {
 
     #[test]
     fn test_config_effective_model_override() {
-        let mut cfg = crate::config::Config::default();
-        cfg.model = Some("claude-haiku-4-5-20251001".to_string());
+        let cfg = crate::config::Config { model: Some("claude-haiku-4-5-20251001".to_string()), ..Default::default() };
         assert_eq!(cfg.effective_model(), "claude-haiku-4-5-20251001");
     }
 
@@ -4490,8 +4487,7 @@ mod tests {
 
     #[test]
     fn test_config_effective_max_tokens_override() {
-        let mut cfg = crate::config::Config::default();
-        cfg.max_tokens = Some(8192);
+        let cfg = crate::config::Config { max_tokens: Some(8192), ..Default::default() };
         assert_eq!(cfg.effective_max_tokens(), 8192);
     }
 
@@ -4502,8 +4498,7 @@ mod tests {
         let orig = std::env::var("ANTHROPIC_API_KEY").ok();
         std::env::remove_var("ANTHROPIC_API_KEY");
 
-        let mut cfg = crate::config::Config::default();
-        cfg.api_key = Some("sk-ant-config-key".to_string());
+        let cfg = crate::config::Config { api_key: Some("sk-ant-config-key".to_string()), ..Default::default() };
         assert_eq!(cfg.resolve_api_key(), Some("sk-ant-config-key".to_string()));
 
         if let Some(k) = orig {

--- a/src-rust/crates/core/src/lsp.rs
+++ b/src-rust/crates/core/src/lsp.rs
@@ -565,13 +565,10 @@ impl LspClient {
             .await?;
 
         let mut symbols = Vec::new();
-        match &result {
-            serde_json::Value::Array(arr) => {
-                for sym in arr {
-                    collect_symbol(sym, 0, &mut symbols);
-                }
+        if let serde_json::Value::Array(arr) = &result {
+            for sym in arr {
+                collect_symbol(sym, 0, &mut symbols);
             }
-            _ => {}
         }
         Ok(symbols)
     }

--- a/src-rust/crates/core/src/mcp_trust.rs
+++ b/src-rust/crates/core/src/mcp_trust.rs
@@ -139,7 +139,7 @@ impl McpTrustStore {
             std::fs::create_dir_all(parent)?;
         }
         let content = serde_json::to_string_pretty(self)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            .map_err(std::io::Error::other)?;
         // Write-then-rename so a concurrent reader never sees a half-written
         // (corrupt) trust file. Rename is atomic within the same directory.
         let tmp = path.with_extension("json.tmp");

--- a/src-rust/crates/core/src/mcp_trust.rs
+++ b/src-rust/crates/core/src/mcp_trust.rs
@@ -278,7 +278,7 @@ mod tests {
         session.insert(server_fingerprint(&p));
         let store = McpTrustStore::default();
         // Same identity: allowed.
-        let d = partition_mcp_servers(&[p.clone()], None, false, &session, &store);
+        let d = partition_mcp_servers(std::slice::from_ref(&p), None, false, &session, &store);
         assert_eq!(d.allowed.len(), 1);
         assert!(d.pending.is_empty());
         // Different command under the same name: re-prompted (not allowed).
@@ -337,7 +337,7 @@ mod tests {
 
         // A persisted approval clears the gate even with no session trust.
         let d = partition_mcp_servers(
-            &[server.clone()],
+            std::slice::from_ref(&server),
             Some(root.as_path()),
             false,
             &HashSet::new(),

--- a/src-rust/crates/core/src/memdir.rs
+++ b/src-rust/crates/core/src/memdir.rs
@@ -113,7 +113,7 @@ pub fn scan_memory_dir(dir: &Path) -> Vec<MemoryFileMeta> {
     collect_md_files(dir, dir, &mut files);
 
     // Sort newest-first.
-    files.sort_by(|a, b| b.modified_secs.cmp(&a.modified_secs));
+    files.sort_by_key(|b| std::cmp::Reverse(b.modified_secs));
     files.truncate(MAX_MEMORY_FILES);
     files
 }

--- a/src-rust/crates/core/src/remote_settings.rs
+++ b/src-rust/crates/core/src/remote_settings.rs
@@ -279,17 +279,14 @@ impl RemoteSettingsManager {
     /// Fails open: returns the stale cached value (or `None`) on any error.
     pub async fn fetch_once_and_cache(&self) -> Option<Value> {
         // Load any previously cached settings to compute an ETag checksum.
-        let cached_raw = match tokio::fs::read_to_string(&self.cache_path).await {
-            Ok(text) => Some(text),
-            Err(_) => None,
-        };
+        let cached_raw = tokio::fs::read_to_string(&self.cache_path).await.ok();
         let cached_settings: Option<Value> = cached_raw
             .as_deref()
             .and_then(|t| serde_json::from_str(t).ok());
 
         let cached_checksum = cached_settings
             .as_ref()
-            .map(|s| compute_checksum_from_settings(s));
+            .map(compute_checksum_from_settings);
 
         match self
             .fetch_with_retry(cached_checksum.as_deref())

--- a/src-rust/crates/core/src/session_storage.rs
+++ b/src-rust/crates/core/src/session_storage.rs
@@ -484,12 +484,11 @@ pub async fn truncate_after(path: &Path, from_uuid: &str) -> crate::Result<()> {
     for entry in entries {
         if found { continue; }
         match &entry {
-            TranscriptEntry::User(m) | TranscriptEntry::Assistant(m) => {
-                if m.message.uuid.as_deref() == Some(from_uuid) {
+            TranscriptEntry::User(m) | TranscriptEntry::Assistant(m)
+                if m.message.uuid.as_deref() == Some(from_uuid) => {
                     found = true;
                     continue; // drop this entry and everything after
                 }
-            }
             _ => {}
         }
         keep.push(entry);
@@ -607,13 +606,13 @@ async fn read_session_tail_metadata(path: &Path) -> (Option<String>, Option<Stri
 
     use tokio::io::{AsyncReadExt, AsyncSeekExt};
     let mut file = file;
-    if let Err(_) = file
+    if file
         .seek(std::io::SeekFrom::Start(offset))
-        .await
+        .await.is_err()
     {
         return (None, None);
     }
-    if let Err(_) = file.read_exact(&mut buf).await {
+    if file.read_exact(&mut buf).await.is_err() {
         return (None, None);
     }
 

--- a/src-rust/crates/core/src/session_storage.rs
+++ b/src-rust/crates/core/src/session_storage.rs
@@ -354,10 +354,8 @@ pub async fn load_transcript(path: &Path) -> crate::Result<Vec<TranscriptEntry>>
         }
         // Cheap structural check before full parse.
         if trimmed.contains("\"type\":\"tombstone\"") || trimmed.contains("\"type\": \"tombstone\"") {
-            if let Ok(entry) = serde_json::from_str::<TranscriptEntry>(trimmed) {
-                if let TranscriptEntry::Tombstone(t) = entry {
-                    tombstoned.insert(t.deleted_uuid);
-                }
+            if let Ok(TranscriptEntry::Tombstone(t)) = serde_json::from_str::<TranscriptEntry>(trimmed) {
+                tombstoned.insert(t.deleted_uuid);
             }
         }
     }
@@ -454,7 +452,7 @@ pub async fn list_sessions_in(
     }
 
     // Sort newest-first.
-    sessions.sort_by(|a, b| b.mtime.cmp(&a.mtime));
+    sessions.sort_by_key(|b| std::cmp::Reverse(b.mtime));
     Ok(sessions)
 }
 
@@ -631,10 +629,8 @@ async fn read_session_tail_metadata(path: &Path) -> (Option<String>, Option<Stri
             && (trimmed.contains("\"type\":\"last-prompt\"")
                 || trimmed.contains("\"type\": \"last-prompt\""))
         {
-            if let Ok(e) = serde_json::from_str::<TranscriptEntry>(trimmed) {
-                if let TranscriptEntry::LastPrompt(lp) = e {
-                    last_prompt = Some(lp.last_prompt);
-                }
+            if let Ok(TranscriptEntry::LastPrompt(lp)) = serde_json::from_str::<TranscriptEntry>(trimmed) {
+                last_prompt = Some(lp.last_prompt);
             }
         }
 
@@ -642,10 +638,8 @@ async fn read_session_tail_metadata(path: &Path) -> (Option<String>, Option<Stri
             && (trimmed.contains("\"type\":\"custom-title\"")
                 || trimmed.contains("\"type\": \"custom-title\""))
         {
-            if let Ok(e) = serde_json::from_str::<TranscriptEntry>(trimmed) {
-                if let TranscriptEntry::CustomTitle(ct) = e {
-                    title = Some(ct.custom_title);
-                }
+            if let Ok(TranscriptEntry::CustomTitle(ct)) = serde_json::from_str::<TranscriptEntry>(trimmed) {
+                title = Some(ct.custom_title);
             }
         }
 

--- a/src-rust/crates/core/src/skill_discovery.rs
+++ b/src-rust/crates/core/src/skill_discovery.rs
@@ -42,8 +42,7 @@ pub fn parse_skill_file(content: &str, path: &Path) -> Option<DiscoveredSkill> {
         return None;
     }
 
-    let (name, description, template) = if content.starts_with("---") {
-        let after_open = &content[3..];
+    let (name, description, template) = if let Some(after_open) = content.strip_prefix("---") {
         // Accept both `\n---` and `\r\n---` as closing delimiter.
         if let Some(close_pos) = after_open.find("\n---") {
             let frontmatter = &after_open[..close_pos];
@@ -218,7 +217,7 @@ fn fetch_git_skills(url: &str) -> Option<Vec<DiscoveredSkill>> {
     // Use the last path segment of the URL as the local directory name.
     let repo_name = url
         .split('/')
-        .last()?
+        .next_back()?
         .trim_end_matches(".git");
 
     if repo_name.is_empty() {

--- a/src-rust/crates/core/src/snapshot/shadow.rs
+++ b/src-rust/crates/core/src/snapshot/shadow.rs
@@ -121,9 +121,8 @@ impl ShadowSnapshot {
             warn!("snapshot: cannot create gitdir: {e}");
             return None;
         }
-        if !existed {
-            if !self.init_shadow().await { return None; }
-        }
+        if !existed
+            && !self.init_shadow().await { return None; }
         self.stage().await;
         let r = self.shadow(vec!["write-tree"]).await;
         if r.code != 0 {
@@ -182,7 +181,7 @@ impl ShadowSnapshot {
                 let key = fwd_str(abs);
                 if !seen.insert(key) { continue; }
                 let rel = abs.strip_prefix(&self.worktree)
-                    .map(|p| fwd_str(p))
+                    .map(fwd_str)
                     .unwrap_or_else(|_| fwd_str(abs));
                 ops.push(Op { hash: patch.hash.clone(), abs: abs.clone(), rel });
             }

--- a/src-rust/crates/core/src/status_notices.rs
+++ b/src-rust/crates/core/src/status_notices.rs
@@ -91,6 +91,6 @@ pub fn compact_warning_notice(fill_pct: f64) -> StatusNotice {
 }
 
 /// Sort notices by priority (highest first), then by ID for stability.
-pub fn sort_notices(notices: &mut Vec<StatusNotice>) {
+pub fn sort_notices(notices: &mut [StatusNotice]) {
     notices.sort_by(|a, b| b.priority.cmp(&a.priority).then(a.id.cmp(&b.id)));
 }

--- a/src-rust/crates/core/src/system_prompt.rs
+++ b/src-rust/crates/core/src/system_prompt.rs
@@ -260,29 +260,23 @@ pub fn build_system_prompt(opts: &SystemPromptOptions) -> String {
             )
         });
 
-    let mut parts: Vec<String> = Vec::new();
-
     // ------------------------------------------------------------------ //
     // CACHEABLE sections (before the dynamic boundary)                   //
     // ------------------------------------------------------------------ //
-
-    // 1. Attribution header
-    parts.push(prefix.attribution_text().to_string());
-
-    // 2. Core capabilities
-    parts.push(CORE_CAPABILITIES.to_string());
-
-    // 3. Tool use guidelines (per-tool blocks are conditional on the enabled set)
-    parts.push(build_tool_use_guidelines(opts.enabled_tools.as_deref()));
-
-    // 4. Executing actions with care
-    parts.push(ACTIONS_SECTION.to_string());
-
-    // 5. Safety guidelines
-    parts.push(SAFETY_GUIDELINES.to_string());
-
-    // 6. Cyber-risk instruction (owned by safeguards — do not edit)
-    parts.push(CYBER_RISK_INSTRUCTION.to_string());
+    let mut parts: Vec<String> = vec![
+        // 1. Attribution header
+        prefix.attribution_text().to_string(),
+        // 2. Core capabilities
+        CORE_CAPABILITIES.to_string(),
+        // 3. Tool use guidelines (per-tool blocks are conditional on the enabled set)
+        build_tool_use_guidelines(opts.enabled_tools.as_deref()),
+        // 4. Executing actions with care
+        ACTIONS_SECTION.to_string(),
+        // 5. Safety guidelines
+        SAFETY_GUIDELINES.to_string(),
+        // 6. Cyber-risk instruction (owned by safeguards — do not edit)
+        CYBER_RISK_INSTRUCTION.to_string(),
+    ];
 
     // 7. Output style (cacheable when non-Default; its content is stable)
     if let Some(style_text) = opts
@@ -549,9 +543,8 @@ fn tool_specific_guideline(tool: &str) -> Option<&'static str> {
 /// Build the "Tool use guidelines" section.
 ///
 /// `enabled` is the set of tool names active for the session:
-///   * `Some(names)` → emit per-tool blocks only for tools in `names`.
-///   * `None`        → enabled set unknown; emit every per-tool block
-///                     (backwards-compatible behaviour).
+/// * `Some(names)` → emit per-tool blocks only for tools in `names`.
+/// * `None` → enabled set unknown; emit every per-tool block (backwards-compatible behaviour).
 ///
 /// The general, tool-agnostic guidance is always emitted unchanged.
 fn build_tool_use_guidelines(enabled: Option<&[String]>) -> String {

--- a/src-rust/crates/core/src/tips.rs
+++ b/src-rust/crates/core/src/tips.rs
@@ -304,7 +304,7 @@ pub fn select_tip(session_num: u64) -> Option<&'static Tip> {
     }
 
     // Sort by least recently shown (highest `sessions_since` first).
-    candidates.sort_by(|a, b| b.1.cmp(&a.1));
+    candidates.sort_by_key(|b| std::cmp::Reverse(b.1));
     Some(candidates[0].0)
 }
 

--- a/src-rust/crates/core/tests/parity_smoke.rs
+++ b/src-rust/crates/core/tests/parity_smoke.rs
@@ -2,7 +2,7 @@
 //! Verifies that core data structures are usable as the TS CLI would use them.
 
 use claurst_core::{
-    session_storage::{TranscriptEntry, transcript_dir},
+    session_storage::transcript_dir,
     prompt_history::HistoryEntry,
     file_history::FileHistory,
     claudemd::load_all_memory_files,

--- a/src-rust/crates/core/tests/snapshot_tests.rs
+++ b/src-rust/crates/core/tests/snapshot_tests.rs
@@ -168,7 +168,7 @@ async fn binary_file_tracked_and_reverted() {
     let snap = snap_or_skip(p);
 
     let before = snap.track().await.expect("track");
-    fs::write(p.join("image.png"), &[0x89u8, 0x50, 0x4e, 0x47]).unwrap();
+    fs::write(p.join("image.png"), [0x89u8, 0x50, 0x4e, 0x47]).unwrap();
 
     let patch = snap.patch(&before).await;
     assert!(patch.files.contains(&fwd(p, "image.png")), "binary file in patch");

--- a/src-rust/crates/core/tests/snapshot_tests.rs
+++ b/src-rust/crates/core/tests/snapshot_tests.rs
@@ -1,13 +1,13 @@
-/// Integration tests for ShadowSnapshot — ported from opencode's snapshot.test.ts.
-///
-/// Each test:
-///   1. Creates a real temp git repo
-///   2. Makes file changes
-///   3. Exercises ShadowSnapshot methods
-///   4. Asserts filesystem + return-value invariants
-///
-/// Tests are async and require git to be on PATH.  They are skipped gracefully
-/// when git is unavailable.
+//! Integration tests for ShadowSnapshot — ported from opencode's snapshot.test.ts.
+//!
+//! Each test:
+//! 1. Creates a real temp git repo
+//! 2. Makes file changes
+//! 3. Exercises ShadowSnapshot methods
+//! 4. Asserts filesystem + return-value invariants
+//!
+//! Tests are async and require git to be on PATH.  They are skipped gracefully
+//! when git is unavailable.
 
 use std::path::{Path, PathBuf};
 use std::fs;

--- a/src-rust/crates/mcp/src/lib.rs
+++ b/src-rust/crates/mcp/src/lib.rs
@@ -1312,7 +1312,7 @@ impl McpManager {
 
         // Spawn a task for each client to handle notifications via the stream
         for client in clients.values() {
-            let client_clone = Arc::clone(&client);
+            let client_clone = Arc::clone(client);
             let manager_weak = Arc::downgrade(&self);
 
             tokio::spawn(async move {

--- a/src-rust/crates/mcp/src/oauth.rs
+++ b/src-rust/crates/mcp/src/oauth.rs
@@ -63,7 +63,7 @@ pub fn store_mcp_token(token: &McpToken) -> std::io::Result<()> {
         std::fs::create_dir_all(parent)?;
     }
     let json = serde_json::to_string_pretty(token)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        .map_err(std::io::Error::other)?;
     std::fs::write(&path, json)
 }
 

--- a/src-rust/crates/plugins/src/lib.rs
+++ b/src-rust/crates/plugins/src/lib.rs
@@ -228,7 +228,7 @@ pub async fn load_plugins(
     // Extra paths.
     for path in extra_paths {
         let (plugins, errors) =
-            discover_plugins(&[path.clone()], PluginSource::Extra(path.to_string_lossy().into_owned())).await;
+            discover_plugins(std::slice::from_ref(path), PluginSource::Extra(path.to_string_lossy().into_owned())).await;
         registry.extend(plugins, errors);
     }
 

--- a/src-rust/crates/plugins/src/marketplace.rs
+++ b/src-rust/crates/plugins/src/marketplace.rs
@@ -113,7 +113,7 @@ pub async fn marketplace_install(name_or_url: &str) -> Result<InstalledPlugin, S
         MarketplaceEntry {
             name: name_or_url
                 .split('/')
-                .last()
+                .next_back()
                 .unwrap_or("plugin")
                 .trim_end_matches(".zip")
                 .to_string(),

--- a/src-rust/crates/query/src/agent_tool.rs
+++ b/src-rust/crates/query/src/agent_tool.rs
@@ -272,7 +272,7 @@ impl Tool for AgentTool {
                     if let Ok(entries) = std::fs::read_dir(&agent_dir) {
                         for entry in entries.flatten() {
                             let p = entry.path();
-                            if p.extension().map_or(false, |e| e == "md") {
+                            if p.extension().is_some_and(|e| e == "md") {
                                 if let Ok(content) = std::fs::read_to_string(&p) {
                                     let name = p
                                         .file_stem()

--- a/src-rust/crates/query/src/compact.rs
+++ b/src-rust/crates/query/src/compact.rs
@@ -143,20 +143,17 @@ fn extract_topic_hint(messages: &[Message]) -> Option<String> {
             _ => continue,
         };
         for block in blocks {
-            match block {
-                ContentBlock::ToolUse { name, input, .. } => {
-                    // Try to get a file_path from input, else use tool name
-                    if let Some(fp) = input.get("file_path").and_then(|v| v.as_str()) {
-                        return Some(fp.to_string());
-                    }
-                    if let Some(cmd) = input.get("command").and_then(|v| v.as_str()) {
-                        // Use first word of command as hint
-                        let first_word = cmd.split_whitespace().next().unwrap_or(cmd);
-                        return Some(first_word.to_string());
-                    }
-                    return Some(name.clone());
+            if let ContentBlock::ToolUse { name, input, .. } = block {
+                // Try to get a file_path from input, else use tool name
+                if let Some(fp) = input.get("file_path").and_then(|v| v.as_str()) {
+                    return Some(fp.to_string());
                 }
-                _ => {}
+                if let Some(cmd) = input.get("command").and_then(|v| v.as_str()) {
+                    // Use first word of command as hint
+                    let first_word = cmd.split_whitespace().next().unwrap_or(cmd);
+                    return Some(first_word.to_string());
+                }
+                return Some(name.clone());
             }
         }
     }
@@ -171,7 +168,7 @@ fn estimate_tokens_for_messages(messages: &[Message]) -> usize {
             MessageContent::Text(t) => t.len(),
             MessageContent::Blocks(blocks) => blocks
                 .iter()
-                .map(|b| estimate_block_chars(b))
+                .map(estimate_block_chars)
                 .sum(),
         })
         .sum();
@@ -188,7 +185,7 @@ fn estimate_block_chars(block: &ContentBlock) -> usize {
         ContentBlock::ToolResult { content, .. } => match content {
             claurst_core::types::ToolResultContent::Text(t) => t.len(),
             claurst_core::types::ToolResultContent::Blocks(blocks) => {
-                blocks.iter().map(|b| estimate_block_chars(b)).sum()
+                blocks.iter().map(estimate_block_chars).sum()
             }
         },
         ContentBlock::Thinking { thinking, .. } => thinking.len(),

--- a/src-rust/crates/query/src/compact.rs
+++ b/src-rust/crates/query/src/compact.rs
@@ -806,9 +806,12 @@ pub fn format_compact_summary(raw: &str) -> String {
 /// [`resolve_context_window`], which consults the models.dev-backed registry
 /// first and only falls back to this heuristic.
 pub fn context_window_for_model(model: &str) -> u64 {
-    if model.contains("opus-4") || model.contains("sonnet-4") || model.contains("haiku-4") {
-        200_000
-    } else if model.contains("claude-3-5") || model.contains("claude-3.5") {
+    if model.contains("opus-4")
+        || model.contains("sonnet-4")
+        || model.contains("haiku-4")
+        || model.contains("claude-3-5")
+        || model.contains("claude-3.5")
+    {
         200_000
     } else {
         100_000
@@ -1784,8 +1787,7 @@ mod tests {
 
     #[test]
     fn test_should_not_compact_when_disabled() {
-        let mut state = AutoCompactState::default();
-        state.disabled = true;
+        let state = AutoCompactState { disabled: true, ..Default::default() };
         assert!(!should_auto_compact(195_000, "claude-sonnet-4-6", &state));
     }
 

--- a/src-rust/crates/query/src/coordinator.rs
+++ b/src-rust/crates/query/src/coordinator.rs
@@ -151,10 +151,10 @@ impl Default for ScratchpadGate {
 ///   full set including Agent/SendMessage/TaskStop).
 /// - `AgentMode::Worker`: COORDINATOR_ONLY_TOOLS are removed.
 /// - `AgentMode::Normal`: no filtering.
-pub fn filter_tools_for_mode<'a>(
-    tools: &'a [Box<dyn claurst_tools::Tool>],
+pub fn filter_tools_for_mode(
+    tools: &[Box<dyn claurst_tools::Tool>],
     mode: AgentMode,
-) -> Vec<&'a Box<dyn claurst_tools::Tool>> {
+) -> Vec<&Box<dyn claurst_tools::Tool>> {
     match mode {
         AgentMode::Coordinator | AgentMode::Normal => tools.iter().collect(),
         AgentMode::Worker => tools

--- a/src-rust/crates/query/src/coordinator.rs
+++ b/src-rust/crates/query/src/coordinator.rs
@@ -151,6 +151,10 @@ impl Default for ScratchpadGate {
 ///   full set including Agent/SendMessage/TaskStop).
 /// - `AgentMode::Worker`: COORDINATOR_ONLY_TOOLS are removed.
 /// - `AgentMode::Normal`: no filtering.
+// borrowed_box: the returned `&Box<dyn Tool>` references are handed straight back
+// to callers that already operate on `&Box<dyn Tool>`; switching to `&dyn Tool`
+// would ripple through those call sites for no functional gain.
+#[allow(clippy::borrowed_box)]
 pub fn filter_tools_for_mode(
     tools: &[Box<dyn claurst_tools::Tool>],
     mode: AgentMode,

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -791,10 +791,10 @@ pub async fn run_query_loop(
 
                 // Rebuild providers using the unified base resolver so overrides
                 // from settings/env/defaults are applied consistently.
-                if let Some(_) = claurst_api::registry::resolve_provider_api_base(
+                if claurst_api::registry::resolve_provider_api_base(
                     &tool_ctx.config,
                     &provider_id_str,
-                ) {
+                ).is_some() {
                     if let Some(overridden) = claurst_api::registry::provider_from_config(
                         &tool_ctx.config,
                         &provider_id_str,
@@ -808,7 +808,7 @@ pub async fn run_query_loop(
                     // Notify TUI that we're calling the provider using a random spinner verb
                     if let Some(ref tx) = event_tx {
                         use claurst_core::sample_spinner_verb;
-                        let seed = (provider_id_str.len() ^ model_id_str.len()) as usize;
+                        let seed = provider_id_str.len() ^ model_id_str.len();
                         let verb = sample_spinner_verb(seed);
                         let _ = tx.send(QueryEvent::Status(format!("✳ {}…", verb)));
                     }
@@ -873,7 +873,7 @@ pub async fn run_query_loop(
                         stop_sequences: vec![],
                         thinking: if caps.thinking {
                             effective_thinking_budget
-                                .map(|b| claurst_api::ThinkingConfig::enabled(b))
+                                .map(claurst_api::ThinkingConfig::enabled)
                         } else {
                             None
                         },
@@ -1148,7 +1148,7 @@ pub async fn run_query_loop(
                                     tool_name
                                 ))
                             } else {
-                                execute_tool(&*tool_name, &tool_input, tools, &tool_ctx).await
+                                execute_tool(&tool_name, &tool_input, tools, tool_ctx).await
                             };
                             if let Some(ref tx) = event_tx {
                                 let _ = tx.send(QueryEvent::ToolEnd {
@@ -1853,7 +1853,7 @@ pub async fn run_query_loop(
                 // block so the conversation and TUI stay consistent.
                 let mut result_blocks: Vec<ContentBlock> =
                     Vec::with_capacity(prepared.len());
-                for (p, result) in prepared.iter().zip(exec_results.into_iter()) {
+                for (p, result) in prepared.iter().zip(exec_results) {
                     if !batch_cancelled {
                         let hooks = &tool_ctx.config.hooks;
                         let post_ctx = claurst_core::hooks::HookContext {
@@ -1941,6 +1941,17 @@ pub async fn run_query_loop(
                 continue_or_end!(assistant_msg, usage);
             }
         }
+    }
+}
+
+/// Stream handler that forwards events to an unbounded channel.
+struct ChannelStreamHandler {
+    tx: mpsc::UnboundedSender<QueryEvent>,
+}
+
+impl StreamHandler for ChannelStreamHandler {
+    fn on_event(&self, event: &AnthropicStreamEvent) {
+        let _ = self.tx.send(QueryEvent::Stream(event.clone()));
     }
 }
 
@@ -2908,16 +2919,5 @@ mod tests {
             claurst_core::GoalStatus::Paused,
             "runaway goal must be persisted as paused"
         );
-    }
-}
-
-/// Stream handler that forwards events to an unbounded channel.
-struct ChannelStreamHandler {
-    tx: mpsc::UnboundedSender<QueryEvent>,
-}
-
-impl StreamHandler for ChannelStreamHandler {
-    fn on_event(&self, event: &AnthropicStreamEvent) {
-        let _ = self.tx.send(QueryEvent::Stream(event.clone()));
     }
 }

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -8,6 +8,10 @@
 // 5. Handles auto-compact when the context window fills up
 // 6. Manages stop conditions (end_turn, max_turns, cancellation)
 
+// too_many_arguments: `run_query_loop` and related orchestration entrypoints
+// thread many parameters by design; splitting would obscure the control flow.
+#![allow(clippy::too_many_arguments)]
+
 pub mod agent_tool;
 pub mod auto_dream;
 pub mod away_summary;
@@ -953,10 +957,11 @@ pub async fn run_query_loop(
                                                 usage.cache_read_input_tokens = u.cache_read_input_tokens;
                                                 usage.cache_creation_input_tokens = u.cache_creation_input_tokens;
                                             }
-                                            claurst_api::StreamEvent::ContentBlockStart { index, content_block } => {
-                                                if let ContentBlock::ToolUse { id, name, .. } = content_block {
-                                                    tool_call_blocks.insert(*index, (id.clone(), name.clone(), String::new()));
-                                                }
+                                            claurst_api::StreamEvent::ContentBlockStart {
+                                                index,
+                                                content_block: ContentBlock::ToolUse { id, name, .. },
+                                            } => {
+                                                tool_call_blocks.insert(*index, (id.clone(), name.clone(), String::new()));
                                             }
                                             claurst_api::StreamEvent::TextDelta { text, .. } => {
                                                 text_chunks.push(text.clone());

--- a/src-rust/crates/query/src/runner/tools.rs
+++ b/src-rust/crates/query/src/runner/tools.rs
@@ -112,7 +112,7 @@ pub(crate) fn build_todo_nudge(session_id: &str) -> String {
     let todos = claurst_tools::todo_write::load_todos(session_id);
     let incomplete_count = todos
         .iter()
-        .filter(|t| t["status"].as_str().map_or(true, |s| s != "completed"))
+        .filter(|t| t["status"].as_str() != Some("completed"))
         .count();
     if incomplete_count == 0 {
         String::new()

--- a/src-rust/crates/query/src/skill_prefetch.rs
+++ b/src-rust/crates/query/src/skill_prefetch.rs
@@ -83,7 +83,7 @@ pub async fn prefetch_skills(project_root: &Path, index: SharedSkillIndex) {
         if let Ok(entries) = std::fs::read_dir(dir) {
             for entry in entries.flatten() {
                 let path = entry.path();
-                if path.extension().map_or(false, |e| e == "md") {
+                if path.extension().is_some_and(|e| e == "md") {
                     if let Some(skill) = load_skill_from_file(&path) {
                         local.insert(skill);
                     }
@@ -102,7 +102,7 @@ pub async fn prefetch_skills(project_root: &Path, index: SharedSkillIndex) {
         if let Ok(entries) = std::fs::read_dir(&bundled) {
             for entry in entries.flatten() {
                 let path = entry.path();
-                if path.extension().map_or(false, |e| e == "md") {
+                if path.extension().is_some_and(|e| e == "md") {
                     if let Some(mut skill) = load_skill_from_file(&path) {
                         skill.source = "bundled".to_string();
                         local.insert(skill);

--- a/src-rust/crates/query/src/skill_prefetch.rs
+++ b/src-rust/crates/query/src/skill_prefetch.rs
@@ -72,12 +72,10 @@ pub async fn prefetch_skills(project_root: &Path, index: SharedSkillIndex) {
     let mut local = SkillIndex::default();
 
     // 1. User-defined skills: <claurst home>/skills/*.md + {project_root}/.claurst/skills/*.md
-    let search_dirs: Vec<std::path::PathBuf> = {
-        let mut dirs = Vec::new();
-        dirs.push(claurst_core::config::Settings::config_dir().join("skills"));
-        dirs.push(project_root.join(".claurst").join("skills"));
-        dirs
-    };
+    let search_dirs: Vec<std::path::PathBuf> = vec![
+        claurst_core::config::Settings::config_dir().join("skills"),
+        project_root.join(".claurst").join("skills"),
+    ];
 
     for dir in &search_dirs {
         if let Ok(entries) = std::fs::read_dir(dir) {
@@ -134,9 +132,9 @@ fn load_skill_from_file(path: &std::path::Path) -> Option<SkillDefinition> {
     let stem = path.file_stem()?.to_string_lossy().to_string();
 
     // Try to parse front-matter
-    if content.starts_with("---") {
-        let end = content[3..].find("\n---")? + 3;
-        let front = &content[3..end];
+    if let Some(after) = content.strip_prefix("---") {
+        let end = after.find("\n---")?;
+        let front = &after[..end];
         let name = extract_yaml_str(front, "name").unwrap_or_else(|| stem.clone());
         let description = extract_yaml_str(front, "description").unwrap_or_default();
         let tags = extract_yaml_list(front, "tags");

--- a/src-rust/crates/tools/src/apply_patch.rs
+++ b/src-rust/crates/tools/src/apply_patch.rs
@@ -65,9 +65,8 @@ fn parse_unified_diff(patch: &str) -> Result<Vec<FilePatch>, String> {
                 file_patches.push(f);
             }
             // Don't extract the path here — we do it from the +++ line.
-        } else if line.starts_with("+++ ") {
+        } else if let Some(raw) = line.strip_prefix("+++ ") {
             // Extract target path, stripping the "b/" prefix if present.
-            let raw = &line[4..];
             let path = raw
                 .trim_start_matches("b/")
                 .trim()

--- a/src-rust/crates/tools/src/apply_patch.rs
+++ b/src-rust/crates/tools/src/apply_patch.rs
@@ -86,12 +86,12 @@ fn parse_unified_diff(patch: &str) -> Result<Vec<FilePatch>, String> {
                 lines: Vec::new(),
             });
         } else if let Some(ref mut hunk) = current_hunk {
-            if line.starts_with('+') {
-                hunk.lines.push(('+', line[1..].to_string()));
-            } else if line.starts_with('-') {
-                hunk.lines.push(('-', line[1..].to_string()));
-            } else if line.starts_with(' ') {
-                hunk.lines.push((' ', line[1..].to_string()));
+            if let Some(rest) = line.strip_prefix('+') {
+                hunk.lines.push(('+', rest.to_string()));
+            } else if let Some(rest) = line.strip_prefix('-') {
+                hunk.lines.push(('-', rest.to_string()));
+            } else if let Some(rest) = line.strip_prefix(' ') {
+                hunk.lines.push((' ', rest.to_string()));
             } else if line.starts_with('\\') {
                 // "\ No newline at end of file" — ignore.
             }

--- a/src-rust/crates/tools/src/cron.rs
+++ b/src-rust/crates/tools/src/cron.rs
@@ -134,7 +134,7 @@ fn cron_field_matches(field: &str, value: u32) -> bool {
     // */N step
     if let Some(step_str) = field.strip_prefix("*/") {
         if let Ok(step) = step_str.parse::<u32>() {
-            return step > 0 && value % step == 0;
+            return step > 0 && value.is_multiple_of(step);
         }
     }
     // Comma-separated list of values or ranges
@@ -153,7 +153,7 @@ fn cron_range_matches(part: &str, value: u32) -> bool {
         value >= lo && value <= hi
     } else {
         part.parse::<u32>()
-            .map_or(false, |n| n == value || (n == 7 && value == 0)) // 7 = Sunday alias
+            .is_ok_and(|n| n == value || (n == 7 && value == 0)) // 7 = Sunday alias
     }
 }
 
@@ -226,8 +226,7 @@ fn cron_to_human(expr: &str) -> String {
     if expr == "* * * * *" {
         return "every minute".to_string();
     }
-    if minute.starts_with("*/") {
-        let n = &minute[2..];
+    if let Some(n) = minute.strip_prefix("*/") {
         return format!("every {} minutes", n);
     }
     if hour == "*" && dom == "*" && month == "*" && dow == "*" {

--- a/src-rust/crates/tools/src/formatter.rs
+++ b/src-rust/crates/tools/src/formatter.rs
@@ -17,7 +17,7 @@ pub async fn try_format_file(path: &str, ctx: &ToolContext) {
         .map(|e| format!(".{}", e))
         .unwrap_or_default();
 
-    for (_name, fmt) in formatters {
+    for fmt in formatters.values() {
         if fmt.disabled || fmt.command.is_empty() {
             continue;
         }

--- a/src-rust/crates/tools/src/glob_tool.rs
+++ b/src-rust/crates/tools/src/glob_tool.rs
@@ -130,7 +130,7 @@ impl Tool for GlobTool {
             })
             .collect();
 
-        entries_with_time.sort_by(|a, b| b.1.cmp(&a.1));
+        entries_with_time.sort_by_key(|b| std::cmp::Reverse(b.1));
 
         let total = entries_with_time.len();
         let max_results = 250;

--- a/src-rust/crates/tools/src/grep_tool.rs
+++ b/src-rust/crates/tools/src/grep_tool.rs
@@ -287,13 +287,13 @@ impl Tool for GrepTool {
                         let start = line_idx.saturating_sub(context_lines);
                         let end = (*line_idx + context_lines + 1).min(lines.len());
 
-                        for ci in start..end {
+                        for (ci, line) in lines.iter().enumerate().take(end).skip(start) {
                             let prefix = if show_line_numbers {
                                 format!("{}:{}:", path.display(), ci + 1)
                             } else {
                                 format!("{}:", path.display())
                             };
-                            results.push(format!("{}{}", prefix, lines[ci]));
+                            results.push(format!("{}{}", prefix, line));
                         }
 
                         if context_lines > 0 {
@@ -369,11 +369,11 @@ impl GrepTool {
                 for line_idx in &matching_lines {
                     let start = line_idx.saturating_sub(context_lines);
                     let end = (*line_idx + context_lines + 1).min(lines.len());
-                    for ci in start..end {
+                    for (ci, line) in lines.iter().enumerate().take(end).skip(start) {
                         if show_line_numbers {
-                            results.push(format!("{}:{}", ci + 1, lines[ci]));
+                            results.push(format!("{}:{}", ci + 1, line));
                         } else {
-                            results.push(lines[ci].to_string());
+                            results.push(line.to_string());
                         }
                     }
                     if context_lines > 0 {

--- a/src-rust/crates/tools/src/lib.rs
+++ b/src-rust/crates/tools/src/lib.rs
@@ -3,6 +3,10 @@
 // Each tool maps to a capability the LLM can invoke: running shell commands,
 // reading/writing/editing files, searching codebases, fetching web pages, etc.
 
+// type_complexity: the REPL tool holds a boxed session-callback map whose full
+// type is unwieldy; a type alias would not meaningfully improve readability.
+#![allow(clippy::type_complexity)]
+
 use async_trait::async_trait;
 use claurst_core::config::PermissionMode;
 use claurst_core::cost::CostTracker;

--- a/src-rust/crates/tools/src/pty_bash.rs
+++ b/src-rust/crates/tools/src/pty_bash.rs
@@ -801,7 +801,7 @@ impl Tool for PtyBashTool {
                     // Update persistent shell state
                     if !state_lines.is_empty() {
                         if let Some((new_cwd, env_delta)) =
-                            parse_shell_state_block(&state_lines.to_vec())
+                            parse_shell_state_block(state_lines)
                         {
                             let mut state = shell_state_arc.lock();
                             state.cwd = Some(new_cwd);

--- a/src-rust/crates/tools/src/skill_tool.rs
+++ b/src-rust/crates/tools/src/skill_tool.rs
@@ -154,7 +154,7 @@ async fn list_skills(dirs: &[PathBuf]) -> ToolResult {
             Ok(mut entries) => {
                 while let Ok(Some(entry)) = entries.next_entry().await {
                     let path = entry.path();
-                    if path.extension().map_or(false, |e| e == "md") {
+                    if path.extension().is_some_and(|e| e == "md") {
                         if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
                             let name = stem.to_string();
                             // Deduplicate — project-level shadows user-level;
@@ -222,9 +222,8 @@ async fn read_skill_description(path: &std::path::Path) -> String {
 
 /// Remove YAML frontmatter delimited by `---` at the start of the file.
 fn strip_frontmatter(content: &str) -> String {
-    if content.starts_with("---") {
+    if let Some(after_open) = content.strip_prefix("---") {
         // Find closing ---
-        let after_open = &content[3..];
         if let Some(close_pos) = after_open.find("\n---") {
             // Skip past the closing delimiter and any leading newline
             let rest = &after_open[close_pos + 4..];

--- a/src-rust/crates/tools/src/skill_tool.rs
+++ b/src-rust/crates/tools/src/skill_tool.rs
@@ -150,25 +150,23 @@ async fn list_skills(dirs: &[PathBuf]) -> ToolResult {
     // Then add disk skills, skipping any that shadow a bundled name.
     let mut disk_skills: Vec<(String, PathBuf)> = Vec::new();
     for dir in dirs {
-        match tokio::fs::read_dir(dir).await {
-            Ok(mut entries) => {
-                while let Ok(Some(entry)) = entries.next_entry().await {
-                    let path = entry.path();
-                    if path.extension().is_some_and(|e| e == "md") {
-                        if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
-                            let name = stem.to_string();
-                            // Deduplicate — project-level shadows user-level;
-                            // bundled skills shadow everything.
-                            if !disk_skills.iter().any(|(n, _)| n == &name)
-                                && !bundled_names.contains(&name.as_str())
-                            {
-                                disk_skills.push((name, path));
-                            }
+        // Missing/unreadable directory: skip silently.
+        if let Ok(mut entries) = tokio::fs::read_dir(dir).await {
+            while let Ok(Some(entry)) = entries.next_entry().await {
+                let path = entry.path();
+                if path.extension().is_some_and(|e| e == "md") {
+                    if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                        let name = stem.to_string();
+                        // Deduplicate — project-level shadows user-level;
+                        // bundled skills shadow everything.
+                        if !disk_skills.iter().any(|(n, _)| n == &name)
+                            && !bundled_names.contains(&name.as_str())
+                        {
+                            disk_skills.push((name, path));
                         }
                     }
                 }
             }
-            Err(_) => {} // directory doesn't exist, skip
         }
     }
 

--- a/src-rust/crates/tools/src/web_search.rs
+++ b/src-rust/crates/tools/src/web_search.rs
@@ -64,7 +64,7 @@ impl Tool for WebSearchTool {
             Err(e) => return ToolResult::error(format!("Invalid input: {}", e)),
         };
 
-        let num_results = params.num_results.min(10).max(1);
+        let num_results = params.num_results.clamp(1, 10);
         debug!(query = %params.query, num_results, "Web search");
 
         // The tool tries SearXNG first, then Brave Search, then DuckDuckGo as a final fallback.

--- a/src-rust/crates/tui/src/agents_view.rs
+++ b/src-rust/crates/tui/src/agents_view.rs
@@ -21,15 +21,14 @@ use crate::overlays::{
 
 /// The role of an agent in the manager-executor architecture.
 #[derive(Debug, Clone, PartialEq)]
+#[derive(Default)]
 pub enum AgentRole {
+    #[default]
     Normal,
     Manager,
     Executor { parent_id: String },
 }
 
-impl Default for AgentRole {
-    fn default() -> Self { AgentRole::Normal }
-}
 
 /// The current status of a sub-agent.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -158,6 +157,12 @@ pub struct AgentEditorState {
     pub selected_field: AgentEditorField,
     pub error: Option<String>,
     pub saved_message: Option<String>,
+}
+
+impl Default for AgentEditorState {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl AgentEditorState {
@@ -403,7 +408,7 @@ pub fn load_agent_definitions(project_root: &std::path::Path) -> Vec<AgentDefini
         let Ok(entries) = std::fs::read_dir(dir) else { continue };
         for entry in entries.flatten() {
             let path = entry.path();
-            if path.extension().map_or(false, |e| e == "md") {
+            if path.extension().is_some_and(|e| e == "md") {
                 if let Some(def) = parse_agent_def(&path) {
                     defs.push(def);
                 }

--- a/src-rust/crates/tui/src/agents_view.rs
+++ b/src-rust/crates/tui/src/agents_view.rs
@@ -423,10 +423,10 @@ fn parse_agent_def(path: &std::path::Path) -> Option<AgentDefinition> {
     let content = std::fs::read_to_string(path).ok()?;
     let stem = path.file_stem()?.to_string_lossy().to_string();
 
-    let (name, model, memory, description, tools, instructions) = if content.starts_with("---") {
-        let end = content[3..].find("\n---")? + 3;
-        let front = &content[3..end];
-        let body = content[end + 4..].trim().to_string();
+    let (name, model, memory, description, tools, instructions) = if let Some(after) = content.strip_prefix("---") {
+        let end = after.find("\n---")?;
+        let front = &after[..end];
+        let body = after[end + 4..].trim().to_string();
         let name = extract_yaml_str(front, "name").unwrap_or_else(|| stem.clone());
         let model = extract_yaml_str(front, "model");
         let memory = extract_yaml_str(front, "memory_scope")

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -375,6 +375,12 @@ pub struct GoToLineDialog {
     pub total_lines: usize,
 }
 
+impl Default for GoToLineDialog {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl GoToLineDialog {
     pub fn new() -> Self {
         Self {
@@ -445,6 +451,12 @@ pub struct HistorySearch {
     pub matches: Vec<usize>,
     /// Which match is currently highlighted.
     pub selected: usize,
+}
+
+impl Default for HistorySearch {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl HistorySearch {
@@ -4621,11 +4633,10 @@ impl App {
                 self.pending_mcp_reconnect = true;
                 self.status_message = Some("Reconnecting MCP runtime...".to_string());
             }
-            KeyCode::Char(c) if key.modifiers.is_empty() => {
-                if self.mcp_view.active_pane != crate::mcp_view::McpViewPane::ServerList {
+            KeyCode::Char(c) if key.modifiers.is_empty()
+                && self.mcp_view.active_pane != crate::mcp_view::McpViewPane::ServerList => {
                     self.mcp_view.push_search_char(c);
                 }
-            }
             _ => {}
         }
         false
@@ -4692,11 +4703,10 @@ impl App {
             }
             KeyCode::PageUp => self.diff_viewer.scroll_detail_up(),
             KeyCode::PageDown => self.diff_viewer.scroll_detail_down(),
-            KeyCode::Char(' ') => {
-                if self.diff_viewer.active_pane == DiffPane::FileList {
+            KeyCode::Char(' ')
+                if self.diff_viewer.active_pane == DiffPane::FileList => {
                     self.diff_viewer.toggle_file_collapse();
                 }
-            }
             _ => {}
         }
     }
@@ -5312,7 +5322,6 @@ impl App {
                         // If this is the prefix-allow option ('P'), record the prefix.
                         self.maybe_record_bash_prefix();
                         self.permission_request = None;
-                        return;
                     }
                 }
             }

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -1163,10 +1163,9 @@ pub struct App {
 
 // Spinner verbs are now imported from claurst_core::spinner
 
-/// Format a duration in milliseconds to a human-readable string.
-///
-/// Matches OpenCode's behaviour: rounds to whole seconds, shows "Xs" for
-/// durations under a minute, "Xm Ys" for longer ones.
+// Format a duration in milliseconds to a human-readable string.
+// Matches OpenCode's behaviour: rounds to whole seconds, shows "Xs" for
+// durations under a minute, "Xm Ys" for longer ones.
 // ---------------------------------------------------------------------------
 // Speech mode prompts (caveman / rocky)
 // ---------------------------------------------------------------------------
@@ -1272,7 +1271,6 @@ fn format_turn_time_label() -> String {
 
 impl App {
     pub fn new(config: Config, cost_tracker: Arc<CostTracker>) -> Self {
-        let config = config;
         let model_name = config.effective_model().to_string();
         let user_keybindings = UserKeybindings::load(&Settings::config_dir());
         Self {
@@ -3631,9 +3629,7 @@ impl App {
                         // so re-prefixing would produce nonsense like
                         // `free/free/auto`.
                         let provider = self.config.provider.as_deref().unwrap_or("anthropic");
-                        let full_model = if provider == "anthropic" {
-                            model_id.clone()
-                        } else if provider == "free" {
+                        let full_model = if provider == "anthropic" || provider == "free" {
                             model_id.clone()
                         } else {
                             format!("{}/{}", provider, model_id)
@@ -5642,6 +5638,7 @@ impl App {
     /// If the pasted text resolves to an existing filesystem path:
     ///   - image files (png/jpg/gif/webp/bmp) → added as an image attachment pill
     ///   - other files → inserted as `@path` mention text
+    ///
     /// Otherwise the text goes through the normal `prompt_input.paste()` path
     /// which applies the multi-line summary placeholder for large pastes.
     fn handle_paste_data(&mut self, data: String) {
@@ -5732,28 +5729,23 @@ impl App {
         let mut buf = String::new();
         buf.push(first);
 
-        loop {
-            match crossterm::event::poll(std::time::Duration::ZERO) {
-                Ok(true) => {
-                    match crossterm::event::read() {
-                        Ok(Event::Key(k)) if k.kind == KeyEventKind::Press => {
-                            match k.code {
-                                KeyCode::Char(c) => buf.push(c),
-                                KeyCode::Enter => buf.push('\n'),
-                                _ => {
-                                    // Non-character key — save it for replay.
-                                    self.pending_key = Some(k);
-                                    break;
-                                }
-                            }
+        while let Ok(true) = crossterm::event::poll(std::time::Duration::ZERO) {
+            match crossterm::event::read() {
+                Ok(Event::Key(k)) if k.kind == KeyEventKind::Press => {
+                    match k.code {
+                        KeyCode::Char(c) => buf.push(c),
+                        KeyCode::Enter => buf.push('\n'),
+                        _ => {
+                            // Non-character key — save it for replay.
+                            self.pending_key = Some(k);
+                            break;
                         }
-                        // Non-key event (mouse, resize, …) — leave in queue by
-                        // not reading it; we already checked poll() so it will
-                        // be re-read next iteration. But we already read it, so
-                        // we just break (the event is consumed but benign).
-                        _ => break,
                     }
                 }
+                // Non-key event (mouse, resize, …) — leave in queue by
+                // not reading it; we already checked poll() so it will
+                // be re-read next iteration. But we already read it, so
+                // we just break (the event is consumed but benign).
                 _ => break,
             }
         }

--- a/src-rust/crates/tui/src/ask_user_dialog.rs
+++ b/src-rust/crates/tui/src/ask_user_dialog.rs
@@ -38,6 +38,7 @@ const INPUT_FG: Color = Color::Rgb(200, 255, 200);
 const NUMBER_FG: Color = Color::Rgb(150, 150, 200);
 
 /// State for the ask-user question dialog overlay.
+#[derive(Default)]
 pub struct AskUserDialogState {
     /// Whether the dialog is currently visible.
     pub visible: bool,
@@ -56,19 +57,6 @@ pub struct AskUserDialogState {
     pub(crate) reply_tx: Option<tokio::sync::oneshot::Sender<String>>,
 }
 
-impl Default for AskUserDialogState {
-    fn default() -> Self {
-        Self {
-            visible: false,
-            question: String::new(),
-            options: None,
-            selected_idx: 0,
-            custom_text: String::new(),
-            in_custom_input: false,
-            reply_tx: None,
-        }
-    }
-}
 
 impl AskUserDialogState {
     pub fn new() -> Self {

--- a/src-rust/crates/tui/src/bridge_state.rs
+++ b/src-rust/crates/tui/src/bridge_state.rs
@@ -5,8 +5,10 @@ use ratatui::text::Span;
 
 /// The current state of the remote bridge connection.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default)]
 pub enum BridgeConnectionState {
     /// No bridge configured / not in use.
+    #[default]
     Disconnected,
     /// Currently attempting to connect.
     Connecting,
@@ -23,11 +25,6 @@ pub enum BridgeConnectionState {
     OutboundOnly,
 }
 
-impl Default for BridgeConnectionState {
-    fn default() -> Self {
-        Self::Disconnected
-    }
-}
 
 impl BridgeConnectionState {
     /// Return a styled status badge `Span` suitable for the status bar.

--- a/src-rust/crates/tui/src/bypass_permissions_dialog.rs
+++ b/src-rust/crates/tui/src/bypass_permissions_dialog.rs
@@ -63,6 +63,10 @@ impl BypassPermissionsDialogState {
 // ---------------------------------------------------------------------------
 
 /// Render the bypass-permissions confirmation dialog over the frame.
+// The dialog body is built as a long, sequential run of `lines.push(...)` calls
+// interleaved with per-option style computation; a single `vec!` literal would
+// be far less readable, so keep the imperative builder here.
+#[allow(clippy::vec_init_then_push)]
 pub fn render_bypass_permissions_dialog(
     frame: &mut Frame,
     state: &BypassPermissionsDialogState,

--- a/src-rust/crates/tui/src/custom_provider_dialog.rs
+++ b/src-rust/crates/tui/src/custom_provider_dialog.rs
@@ -27,6 +27,12 @@ pub struct CustomProviderDialogState {
     pub active_field: CustomProviderField,
 }
 
+impl Default for CustomProviderDialogState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CustomProviderDialogState {
     pub fn new() -> Self {
         Self {

--- a/src-rust/crates/tui/src/device_auth_dialog.rs
+++ b/src-rust/crates/tui/src/device_auth_dialog.rs
@@ -54,6 +54,12 @@ pub struct DeviceAuthDialogState {
     pub auth_url: String,
 }
 
+impl Default for DeviceAuthDialogState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DeviceAuthDialogState {
     pub fn new() -> Self {
         Self {

--- a/src-rust/crates/tui/src/dialogs.rs
+++ b/src-rust/crates/tui/src/dialogs.rs
@@ -15,8 +15,10 @@ use ratatui::Frame;
 /// Distinguishes what kind of action the permission dialog is for.
 /// This drives how many options are shown and what the command block looks like.
 #[derive(Debug, Clone, PartialEq)]
+#[derive(Default)]
 pub enum PermissionDialogKind {
     /// Generic four-option dialog (the previous default).
+    #[default]
     Generic,
     /// Bash command execution — optionally carries a suggested prefix for a
     /// 5th "allow prefix*" option.
@@ -32,11 +34,6 @@ pub enum PermissionDialogKind {
     FileWrite { path: String },
 }
 
-impl Default for PermissionDialogKind {
-    fn default() -> Self {
-        PermissionDialogKind::Generic
-    }
-}
 
 // ---------------------------------------------------------------------------
 // Permission dialog types

--- a/src-rust/crates/tui/src/diff_viewer.rs
+++ b/src-rust/crates/tui/src/diff_viewer.rs
@@ -784,7 +784,7 @@ fn render_diff_detail(state: &DiffViewerState, area: Rect, buf: &mut Buffer) {
                 '\u{25b2}'  // ▲
             } else if row == bar_h - 1 {
                 '\u{25bc}'  // ▼
-            } else if row >= thumb_top + 1 && row < thumb_top + thumb_size + 1 {
+            } else if row > thumb_top && row < thumb_top + thumb_size + 1 {
                 '\u{2588}'  // █ (thumb)
             } else {
                 '\u{2502}'  // │ (track)

--- a/src-rust/crates/tui/src/diff_viewer.rs
+++ b/src-rust/crates/tui/src/diff_viewer.rs
@@ -489,10 +489,10 @@ pub fn parse_unified_diff(text: &str) -> Vec<FileDiffStats> {
                 if let Some(f) = current_file.as_mut() {
                     f.removed += 1;
                 }
-            } else if raw_line.starts_with(' ') {
+            } else if let Some(rest) = raw_line.strip_prefix(' ') {
                 hunk.lines.push(DiffLine {
                     kind: DiffLineKind::Context,
-                    content: raw_line[1..].to_string(),
+                    content: rest.to_string(),
                     old_line_no: Some(old_line),
                     new_line_no: Some(new_line),
                 });
@@ -772,11 +772,9 @@ fn render_diff_detail(state: &DiffViewerState, area: Rect, buf: &mut Buffer) {
         let thumb_size = ((bar_h * bar_h) / total_lines).max(1).min(bar_h);
         // Thumb position
         let scroll_range = total_lines.saturating_sub(bar_h);
-        let thumb_top = if scroll_range > 0 {
-            (scroll * (bar_h.saturating_sub(thumb_size))) / scroll_range
-        } else {
-            0
-        };
+        let thumb_top = (scroll * (bar_h.saturating_sub(thumb_size)))
+            .checked_div(scroll_range)
+            .unwrap_or(0);
 
         for row in 0..bar_h {
             let y = inner.y + row as u16;

--- a/src-rust/crates/tui/src/elicitation_dialog.rs
+++ b/src-rust/crates/tui/src/elicitation_dialog.rs
@@ -449,11 +449,7 @@ pub fn render_elicitation_dialog(state: &ElicitationDialogState, area: Rect, buf
     // Render with scroll if needed
     let total = lines.len();
     let visible_h = inner.height as usize;
-    let scroll = if total > visible_h {
-        total - visible_h
-    } else {
-        0
-    };
+    let scroll = total.saturating_sub(visible_h);
     let visible_lines: Vec<Line> = lines.into_iter().skip(scroll).collect();
     Paragraph::new(visible_lines).render(inner, buf);
 }

--- a/src-rust/crates/tui/src/feedback_survey.rs
+++ b/src-rust/crates/tui/src/feedback_survey.rs
@@ -96,7 +96,7 @@ impl FeedbackSurveyState {
                 true
             }
             FeedbackSurveyStage::SharePrompt => {
-                if matches!(digit, 1 | 2 | 3) {
+                if matches!(digit, 1..=3) {
                     self.stage = FeedbackSurveyStage::Thanks;
                 }
                 true

--- a/src-rust/crates/tui/src/file_injection.rs
+++ b/src-rust/crates/tui/src/file_injection.rs
@@ -84,7 +84,7 @@ pub fn parse_at_refs(text: &str, cwd: &Path, max_size_kb: usize) -> (Vec<AtFileR
         }
 
         let size_kb = match fs::metadata(&expanded_path) {
-            Ok(meta) => (meta.len() as usize + 1023) / 1024, // Round up to KB
+            Ok(meta) => (meta.len() as usize).div_ceil(1024), // Round up to KB
             Err(e) => {
                 oversized.push(AtFileRef {
                     token: token.clone(),

--- a/src-rust/crates/tui/src/file_injection.rs
+++ b/src-rust/crates/tui/src/file_injection.rs
@@ -55,9 +55,9 @@ pub fn parse_at_refs(text: &str, cwd: &Path, max_size_kb: usize) -> (Vec<AtFileR
         }
 
         // Expand ~ to home directory
-        let expanded_path = if path_part.starts_with("~/") {
+        let expanded_path = if let Some(rest) = path_part.strip_prefix("~/") {
             if let Some(home) = dirs::home_dir() {
-                home.join(&path_part[2..])
+                home.join(rest)
             } else {
                 cwd.join(path_part)
             }

--- a/src-rust/crates/tui/src/hooks_config_menu.rs
+++ b/src-rust/crates/tui/src/hooks_config_menu.rs
@@ -498,11 +498,10 @@ fn render_hook_detail(state: &HooksConfigMenuState) -> (&'static str, Vec<Line<'
         Style::default().fg(Color::DarkGray),
     )]));
     // Wrap long target strings across multiple lines
-    for (i, chunk) in hook.target.chars().collect::<Vec<_>>().chunks(60).enumerate() {
+    for chunk in hook.target.chars().collect::<Vec<_>>().chunks(60) {
         let text: String = chunk.iter().collect();
-        let indent = if i == 0 { "    " } else { "    " };
         lines.push(Line::from(vec![Span::styled(
-            format!("{indent}{text}"),
+            format!("    {text}"),
             Style::default().fg(Color::White),
         )]));
     }

--- a/src-rust/crates/tui/src/key_input_dialog.rs
+++ b/src-rust/crates/tui/src/key_input_dialog.rs
@@ -25,6 +25,12 @@ pub struct KeyInputDialogState {
     pub cursor_pos: usize,
 }
 
+impl Default for KeyInputDialogState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl KeyInputDialogState {
     pub fn new() -> Self {
         Self {

--- a/src-rust/crates/tui/src/lib.rs
+++ b/src-rust/crates/tui/src/lib.rs
@@ -12,6 +12,11 @@
 // - Bridge connection status badge
 // - Plugin hint banners
 
+// too_many_arguments: a handful of render/context helpers take many parameters
+// (layout rects, styles, state slices); grouping them is a larger refactor out
+// of scope for this cleanup.
+#![allow(clippy::too_many_arguments)]
+
 use crossterm::event::{
     DisableMouseCapture, EnableMouseCapture, KeyboardEnhancementFlags,
     PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,

--- a/src-rust/crates/tui/src/message_copy.rs
+++ b/src-rust/crates/tui/src/message_copy.rs
@@ -167,7 +167,7 @@ pub fn copy_as_json(message: &Message) -> String {
         "content": match &message.content {
             claurst_core::MessageContent::Text(text) => text.clone(),
             claurst_core::MessageContent::Blocks(blocks) => {
-                blocks.iter().map(|b| format_block_for_json(b)).collect::<Vec<_>>().join("\n")
+                blocks.iter().map(format_block_for_json).collect::<Vec<_>>().join("\n")
             }
         },
         "uuid": message.uuid,
@@ -225,7 +225,7 @@ fn strip_markdown(text: &str) -> String {
                 // Handle markdown links: [text](url) -> text
                 let mut link_text = String::new();
                 let mut found_close = false;
-                while let Some(ch) = chars.next() {
+                for ch in chars.by_ref() {
                     if ch == ']' {
                         found_close = true;
                         break;
@@ -236,7 +236,7 @@ fn strip_markdown(text: &str) -> String {
                 // Skip URL part
                 if found_close && chars.peek() == Some(&'(') {
                     chars.next(); // consume '('
-                    while let Some(ch) = chars.next() {
+                    for ch in chars.by_ref() {
                         if ch == ')' {
                             break;
                         }
@@ -258,14 +258,14 @@ fn strip_markdown(text: &str) -> String {
                 // Skip markdown image syntax ![alt](url)
                 if chars.peek() == Some(&'[') {
                     chars.next();
-                    while let Some(c) = chars.next() {
+                    for c in chars.by_ref() {
                         if c == ']' {
                             break;
                         }
                     }
                     if chars.peek() == Some(&'(') {
                         chars.next();
-                        while let Some(c) = chars.next() {
+                        for c in chars.by_ref() {
                             if c == ')' {
                                 break;
                             }
@@ -296,9 +296,9 @@ fn extract_code_blocks_from_text(text: &str, blocks: &mut Vec<String>) {
     let mut in_block = false;
     let mut current_block = String::new();
     let mut language = String::new();
-    let mut lines = text.lines().peekable();
+    let lines = text.lines().peekable();
 
-    while let Some(line) = lines.next() {
+    for line in lines {
         if line.starts_with("```") {
             if in_block {
                 // End of code block

--- a/src-rust/crates/tui/src/message_copy.rs
+++ b/src-rust/crates/tui/src/message_copy.rs
@@ -299,7 +299,7 @@ fn extract_code_blocks_from_text(text: &str, blocks: &mut Vec<String>) {
     let lines = text.lines().peekable();
 
     for line in lines {
-        if line.starts_with("```") {
+        if let Some(after_fence) = line.strip_prefix("```") {
             if in_block {
                 // End of code block
                 if !current_block.trim().is_empty() {
@@ -311,7 +311,7 @@ fn extract_code_blocks_from_text(text: &str, blocks: &mut Vec<String>) {
             } else {
                 // Start of code block
                 in_block = true;
-                language = line[3..].trim().to_string();
+                language = after_fence.trim().to_string();
             }
         } else if in_block {
             current_block.push_str(line);

--- a/src-rust/crates/tui/src/messages/markdown.rs
+++ b/src-rust/crates/tui/src/messages/markdown.rs
@@ -72,8 +72,7 @@ pub fn render_markdown(text: &str, width: u16) -> Vec<Line<'static>> {
             continue;
         }
 
-        if raw.starts_with("> ") {
-            let quoted = &raw[2..];
+        if let Some(quoted) = raw.strip_prefix("> ") {
             lines.push(Line::from(vec![
                 Span::styled(
                     format!("  {} ", figures::BLOCKQUOTE_BAR),

--- a/src-rust/crates/tui/src/messages/markdown.rs
+++ b/src-rust/crates/tui/src/messages/markdown.rs
@@ -84,9 +84,9 @@ pub fn render_markdown(text: &str, width: u16) -> Vec<Line<'static>> {
             continue;
         }
 
-        if raw.starts_with("### ") {
+        if let Some(rest) = raw.strip_prefix("### ") {
             lines.push(Line::from(vec![Span::styled(
-                format!("  {}", &raw[4..]),
+                format!("  {}", rest),
                 Style::default()
                     .fg(Color::White)
                     .add_modifier(Modifier::BOLD),
@@ -94,9 +94,9 @@ pub fn render_markdown(text: &str, width: u16) -> Vec<Line<'static>> {
             idx += 1;
             continue;
         }
-        if raw.starts_with("## ") {
+        if let Some(rest) = raw.strip_prefix("## ") {
             lines.push(Line::from(vec![Span::styled(
-                format!("  {}", &raw[3..]),
+                format!("  {}", rest),
                 Style::default()
                     .fg(Color::White)
                     .add_modifier(Modifier::BOLD),
@@ -104,9 +104,9 @@ pub fn render_markdown(text: &str, width: u16) -> Vec<Line<'static>> {
             idx += 1;
             continue;
         }
-        if raw.starts_with("# ") {
+        if let Some(rest) = raw.strip_prefix("# ") {
             lines.push(Line::from(vec![Span::styled(
-                format!("  {}", &raw[2..]),
+                format!("  {}", rest),
                 Style::default()
                     .fg(Color::White)
                     .add_modifier(Modifier::BOLD | Modifier::ITALIC | Modifier::UNDERLINED),

--- a/src-rust/crates/tui/src/messages/markdown_enhanced.rs
+++ b/src-rust/crates/tui/src/messages/markdown_enhanced.rs
@@ -266,9 +266,9 @@ pub fn parse_inline_formatting(text: &str) -> Vec<Span<'static>> {
         }
 
         // Check for ** or __ (bold) - with limited nesting support
-        if idx + 1 < chars.len() {
-            if (chars[idx] == '*' && chars[idx + 1] == '*') ||
-               (chars[idx] == '_' && chars[idx + 1] == '_') {
+        if idx + 1 < chars.len()
+            && ((chars[idx] == '*' && chars[idx + 1] == '*') ||
+               (chars[idx] == '_' && chars[idx + 1] == '_')) {
                 let marker = chars[idx];
 
                 // Flush current text
@@ -300,7 +300,6 @@ pub fn parse_inline_formatting(text: &str) -> Vec<Span<'static>> {
                 ));
                 continue;
             }
-        }
 
         // Check for ~~ (strikethrough) - no nesting
         if idx + 1 < chars.len() && chars[idx] == '~' && chars[idx + 1] == '~' {

--- a/src-rust/crates/tui/src/messages/mod.rs
+++ b/src-rust/crates/tui/src/messages/mod.rs
@@ -289,7 +289,7 @@ fn normalize_at_tokens(
         if trimmed.starts_with('@') && trimmed.len() > 1 {
             let mut path_part = trimmed[1..].to_string();
             // Strip trailing punctuation (same logic as parse_at_refs)
-            while path_part.len() > 0 && path_part.ends_with(|c: char| c.is_ascii_punctuation()) && !path_part.ends_with('/') {
+            while !path_part.is_empty() && path_part.ends_with(|c: char| c.is_ascii_punctuation()) && !path_part.ends_with('/') {
                 path_part.pop();
             }
             let punct_suffix = &trimmed[1 + path_part.len()..];
@@ -1817,9 +1817,7 @@ fn extract_goal_objective_from_args(args: &str) -> Option<String> {
     // doesn't include the budget flag.
     let rest = if let Some(after_flag) = trimmed.strip_prefix("--tokens") {
         let after_flag = after_flag.trim_start();
-        after_flag
-            .splitn(2, char::is_whitespace)
-            .nth(1)
+        after_flag.split_once(char::is_whitespace).map(|x| x.1)
             .unwrap_or("")
             .trim()
     } else {

--- a/src-rust/crates/tui/src/messages/mod.rs
+++ b/src-rust/crates/tui/src/messages/mod.rs
@@ -1194,7 +1194,7 @@ pub fn render_tool_result_rejected(tool_name: &str, reason: &str) -> Vec<Line<'s
 pub fn render_attachment_message(kind_label: &str, content: &str, width: u16) -> Vec<Line<'static>> {
     // Reserve space for the "  [label] " prefix and a small margin.
     let prefix_len = kind_label.len() + 6; // "  [label] "
-    let preview_max = (width as usize).saturating_sub(prefix_len).max(20).min(120);
+    let preview_max = (width as usize).saturating_sub(prefix_len).clamp(20, 120);
     let preview: String = content.chars().take(preview_max).collect();
     let preview = if content.chars().count() > preview_max {
         format!("{preview}\u{2026}")

--- a/src-rust/crates/tui/src/model_picker.rs
+++ b/src-rust/crates/tui/src/model_picker.rs
@@ -21,8 +21,10 @@ use crate::overlays::{centered_rect, modal_search_line, CLAURST_PANEL_BG};
 /// is silently ignored.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[derive(Default)]
 pub enum EffortLevel {
     Low,
+    #[default]
     Normal,
     High,
     Max,
@@ -81,9 +83,6 @@ impl EffortLevel {
     }
 }
 
-impl Default for EffortLevel {
-    fn default() -> Self { Self::Normal }
-}
 
 // ---------------------------------------------------------------------------
 // Model capability helpers
@@ -124,7 +123,7 @@ fn is_gpt5_reasoning_model(id: &str) -> bool {
 /// Format context window tokens for display in the model picker.
 pub fn format_context_window(context_window: u32) -> String {
     if context_window >= 1_000_000 {
-        if context_window % 1_000_000 == 0 {
+        if context_window.is_multiple_of(1_000_000) {
             format!("{}M context", context_window / 1_000_000)
         } else {
             format!("{:.1}M context", context_window as f64 / 1_000_000.0)

--- a/src-rust/crates/tui/src/notifications.rs
+++ b/src-rust/crates/tui/src/notifications.rs
@@ -76,7 +76,7 @@ impl NotificationQueue {
     pub fn tick(&mut self) {
         let now = Instant::now();
         self.notifications.retain(|n| {
-            n.expires_at.map_or(true, |exp| exp > now)
+            n.expires_at.is_none_or(|exp| exp > now)
         });
     }
 
@@ -95,7 +95,7 @@ impl NotificationQueue {
     }
 
     pub fn current_is_error(&self) -> bool {
-        self.current().map_or(false, |n| n.kind == NotificationKind::Error)
+        self.current().is_some_and(|n| n.kind == NotificationKind::Error)
     }
 
     /// Return `true` if there are no active notifications.

--- a/src-rust/crates/tui/src/overlays.rs
+++ b/src-rust/crates/tui/src/overlays.rs
@@ -843,8 +843,8 @@ impl HistorySearchOverlay {
         // Sort: pinned entries always first, then by score descending.
         // Stable sort preserves insertion order for ties within each group.
         scored.sort_by(|a, b| {
-            let a_pinned = self.snapshot.get(a.snapshot_idx).map_or(false, |e| e.pinned);
-            let b_pinned = self.snapshot.get(b.snapshot_idx).map_or(false, |e| e.pinned);
+            let a_pinned = self.snapshot.get(a.snapshot_idx).is_some_and(|e| e.pinned);
+            let b_pinned = self.snapshot.get(b.snapshot_idx).is_some_and(|e| e.pinned);
             match (b_pinned, a_pinned) {
                 (true, false) => std::cmp::Ordering::Greater,
                 (false, true) => std::cmp::Ordering::Less,
@@ -1005,7 +1005,7 @@ pub fn render_history_search_overlay(
                 })
                 .unwrap_or("");
 
-            let is_pinned = snap_entry.map_or(false, |e| e.pinned);
+            let is_pinned = snap_entry.is_some_and(|e| e.pinned);
 
             // Relative timestamp (right-aligned suffix)
             let time_suffix: String = snap_entry
@@ -1273,12 +1273,12 @@ fn case_insensitive_find(haystack: &str, needle_lc: &str) -> Option<(usize, usiz
     }
     for (start, _) in haystack.char_indices() {
         let mut hay_chars = haystack[start..].chars();
-        let mut need_chars = needle_lc.chars();
+        let need_chars = needle_lc.chars();
         // Lowercase expansion of one haystack char may yield several chars.
         let mut pending: std::collections::VecDeque<char> = std::collections::VecDeque::new();
         let mut end = start;
         let mut matched = true;
-        'need: while let Some(nc) = need_chars.next() {
+        'need: for nc in need_chars {
             while pending.is_empty() {
                 match hay_chars.next() {
                     Some(hc) => {
@@ -1653,25 +1653,22 @@ impl GlobalSearchState {
         if let Ok(out) = output {
             for line in String::from_utf8_lossy(&out.stdout).lines() {
                 if let Ok(val) = serde_json::from_str::<serde_json::Value>(line) {
-                    match val["type"].as_str() {
-                        Some("match") => {
-                            let data = &val["data"];
-                            let file = data["path"]["text"].as_str().unwrap_or("").to_string();
-                            let line_no = data["line_number"].as_u64().unwrap_or(0) as u32;
-                            let text = data["lines"]["text"].as_str().unwrap_or("").trim_end_matches('\n').to_string();
-                            let col = data["submatches"][0]["start"].as_u64().unwrap_or(0) as u32;
-                            self.results.push(SearchResult {
-                                file,
-                                line: line_no,
-                                col,
-                                text,
-                                context_before: Vec::new(),
-                                context_after: Vec::new(),
-                            });
-                            self.total_matches += 1;
-                            if self.results.len() >= 500 { break; }
-                        }
-                        _ => {}
+                    if let Some("match") = val["type"].as_str() {
+                        let data = &val["data"];
+                        let file = data["path"]["text"].as_str().unwrap_or("").to_string();
+                        let line_no = data["line_number"].as_u64().unwrap_or(0) as u32;
+                        let text = data["lines"]["text"].as_str().unwrap_or("").trim_end_matches('\n').to_string();
+                        let col = data["submatches"][0]["start"].as_u64().unwrap_or(0) as u32;
+                        self.results.push(SearchResult {
+                            file,
+                            line: line_no,
+                            col,
+                            text,
+                            context_before: Vec::new(),
+                            context_after: Vec::new(),
+                        });
+                        self.total_matches += 1;
+                        if self.results.len() >= 500 { break; }
                     }
                 }
             }

--- a/src-rust/crates/tui/src/overlays.rs
+++ b/src-rust/crates/tui/src/overlays.rs
@@ -1106,10 +1106,9 @@ fn build_highlighted_spans<'a>(
     let mut spans: Vec<Span<'a>> = Vec::new();
     let mut current_text = String::new();
     let mut current_highlighted = false;
-    let mut char_count = 0usize;
     let mut truncated = false;
 
-    for (byte_off, ch) in &chars {
+    for (char_count, (byte_off, ch)) in chars.iter().enumerate() {
         if char_count >= max_chars {
             truncated = true;
             break;
@@ -1128,7 +1127,6 @@ fn build_highlighted_spans<'a>(
         }
         current_highlighted = is_hl;
         current_text.push(*ch);
-        char_count += 1;
     }
     if !current_text.is_empty() {
         let style = if current_highlighted {

--- a/src-rust/crates/tui/src/plugin_views.rs
+++ b/src-rust/crates/tui/src/plugin_views.rs
@@ -362,14 +362,12 @@ mod tests {
 
     #[test]
     fn find_first_undismissed() {
-        let hints = vec![
-            {
+        let hints = [{
                 let mut b = PluginHintBanner::new("a", "msg a");
                 b.dismiss();
                 b
             },
-            PluginHintBanner::new("b", "msg b"),
-        ];
+            PluginHintBanner::new("b", "msg b")];
         let visible = hints.iter().find(|h| h.is_visible()).unwrap();
         assert_eq!(visible.plugin_name, "b");
     }

--- a/src-rust/crates/tui/src/prompt_input.rs
+++ b/src-rust/crates/tui/src/prompt_input.rs
@@ -891,7 +891,7 @@ fn vim_operator(
     if key == "g" { *pending = VimPendingState::OperatorG { op, count }; return false; }
     // Simple motions
     let target = match key {
-        "h" => { let mut p = *cursor; for _ in 0..count.max(1) { if p > 0 { p -= 1; } } p }
+        "h" => { let mut p = *cursor; for _ in 0..count.max(1) { p = p.saturating_sub(1); } p }
         "l" => { let mut p = *cursor; for _ in 0..count.max(1) { if p < text.len() { p = text[p..].char_indices().nth(1).map(|(b,_)| p+b).unwrap_or(text.len()); } } p }
         "w" => { let mut p = *cursor; for _ in 0..count.max(1) { p = motion_w(text, p); } p }
         "b" => { let mut p = *cursor; for _ in 0..count.max(1) { p = motion_b(text, p); } p }
@@ -1900,7 +1900,7 @@ impl PromptInputState {
         while idx < chars.len() && chars[idx].is_whitespace() {
             idx += 1;
         }
-        self.cursor = self.cursor + char_idx_to_byte(rest, idx);
+        self.cursor += char_idx_to_byte(rest, idx);
     }
 
     /// Alt+D: Delete word after cursor.
@@ -2608,8 +2608,8 @@ impl PromptInputState {
     /// meaning an `@file` reference is actively being typed.
     pub fn has_active_file_ref(&self) -> bool {
         let text = &self.text[..self.cursor];
-        text.rfind('@').map_or(false, |at_idx| {
-            at_idx == 0 || text[..at_idx].chars().last().map_or(false, |c| c.is_whitespace())
+        text.rfind('@').is_some_and(|at_idx| {
+            at_idx == 0 || text[..at_idx].chars().last().is_some_and(|c| c.is_whitespace())
         })
     }
 
@@ -2820,7 +2820,7 @@ impl PromptInputState {
 
     /// Rough token estimate: ~4 chars per token.
     fn update_token_estimate(&mut self) {
-        self.token_estimate = (self.text.len() + 3) / 4;
+        self.token_estimate = self.text.len().div_ceil(4);
     }
 
     pub fn is_empty(&self) -> bool { self.text.trim().is_empty() }
@@ -2957,7 +2957,7 @@ pub fn render_prompt_input(
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis();
-        (ms / 530) % 2 == 0
+        (ms / 530).is_multiple_of(2)
     } else {
         true
     };

--- a/src-rust/crates/tui/src/prompt_input.rs
+++ b/src-rust/crates/tui/src/prompt_input.rs
@@ -780,7 +780,7 @@ fn vim_normal(
 }
 
 fn vim_g(
-    text: &mut String,
+    text: &mut str,
     cursor: &mut usize,
     key: &str,
     pending: &mut VimPendingState,
@@ -1136,6 +1136,7 @@ pub(crate) fn compute_file_suggestions(
 /// - `"/"` → files in root with full paths (e.g., ["/Users", "/Applications"])
 /// - `"~"` → suggest "~/" if it exists
 /// - `"~/"` → files in home with names only
+///
 /// Note: calls `fs::read_dir` synchronously on every invocation; may stall on slow/network
 /// filesystems. Consider debouncing at the call site if this becomes a problem.
 fn suggest_files(prefix: &str, max_suggestions: usize, show_hidden: bool) -> Vec<TypeaheadSuggestion> {
@@ -3222,6 +3223,10 @@ pub fn render_prompt_input(
 
 #[cfg(test)]
 mod tests {
+    // Several tests are named after the vim key they exercise (e.g. `W`, `G`,
+    // `N`); the uppercase letters are meaningful, matching the motion helpers
+    // above that already carry `#[allow(non_snake_case)]`.
+    #![allow(non_snake_case)]
     use super::*;
 
     // ---- VimMode --------------------------------------------------------

--- a/src-rust/crates/tui/src/render.rs
+++ b/src-rust/crates/tui/src/render.rs
@@ -508,7 +508,7 @@ pub fn render_app(frame: &mut Frame, app: &App) {
             // instead of overflowing the input area.  Cap at 3 lines.
             let usable_width = size.width.max(1) as usize;
             let char_count = text.chars().count();
-            ((char_count + usable_width - 1) / usable_width).max(1).min(3) as u16
+            char_count.div_ceil(usable_width).max(1).min(3) as u16
         } else {
             1
         }
@@ -2154,7 +2154,7 @@ fn render_status_row(frame: &mut Frame, app: &App, area: Rect) {
                     && !t.eq_ignore_ascii_case(STATUS_THINKING)
                     && !t.eq_ignore_ascii_case(STATUS_THINKING_ELLIPSIS)
             })
-            .or_else(|| app.spinner_verb.as_deref())
+            .or(app.spinner_verb.as_deref())
             .unwrap_or("Thinking");
 
         let mut s = vec![Span::styled(

--- a/src-rust/crates/tui/src/render.rs
+++ b/src-rust/crates/tui/src/render.rs
@@ -508,7 +508,7 @@ pub fn render_app(frame: &mut Frame, app: &App) {
             // instead of overflowing the input area.  Cap at 3 lines.
             let usable_width = size.width.max(1) as usize;
             let char_count = text.chars().count();
-            char_count.div_ceil(usable_width).max(1).min(3) as u16
+            char_count.div_ceil(usable_width).clamp(1, 3) as u16
         } else {
             1
         }
@@ -1617,7 +1617,7 @@ fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
 
     // Split inner into left | divider(1) | right
     // Left width: ~28 chars or half the inner width, whichever is smaller
-    let left_w = (inner.width / 2).max(22).min(32).min(inner.width.saturating_sub(3));
+    let left_w = (inner.width / 2).clamp(22, 32).min(inner.width.saturating_sub(3));
     let right_w = inner.width.saturating_sub(left_w + 1);
     let h_chunks = Layout::default()
         .direction(Direction::Horizontal)

--- a/src-rust/crates/tui/src/session_branching.rs
+++ b/src-rust/crates/tui/src/session_branching.rs
@@ -61,6 +61,12 @@ pub struct SessionBranchingState {
 // Implementation
 // ---------------------------------------------------------------------------
 
+impl Default for SessionBranchingState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SessionBranchingState {
     /// Create a new, hidden branching state.
     pub fn new() -> Self {

--- a/src-rust/crates/tui/src/settings_screen.rs
+++ b/src-rust/crates/tui/src/settings_screen.rs
@@ -842,7 +842,7 @@ mod tests {
 
     #[test]
     fn search_filters_entries_correctly() {
-        let mut screen = SettingsScreen::new();
+        let screen = SettingsScreen::new();
         let all = all_entries(&screen);
         let filtered: Vec<_> = all
             .iter()
@@ -874,7 +874,7 @@ mod tests {
         screen.output_style = "default".to_string();
 
         // Simulate cycling through all options
-        let options = vec!["default", "concise", "explanatory", "learning"];
+        let options = ["default", "concise", "explanatory", "learning"];
         let mut idx = options.iter().position(|&o| o == "default").unwrap();
 
         idx = (idx + 1) % options.len();

--- a/src-rust/crates/tui/src/stats_dialog.rs
+++ b/src-rust/crates/tui/src/stats_dialog.rs
@@ -128,7 +128,7 @@ fn timestamp_to_date(ts_ms: u64) -> String {
 }
 
 fn is_leap_year(year: u32) -> bool {
-    year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
+    year.is_multiple_of(4) && (!year.is_multiple_of(100) || year.is_multiple_of(400))
 }
 
 fn day_of_year_to_month_day(doy: u32, leap: bool) -> (u32, u32) {
@@ -599,7 +599,7 @@ fn render_cost_heatmap(data: &AggregatedStats, area: Rect, buf: &mut Buffer) {
     // and place week columns right-to-left from the most-recent week.
     let chunks: Vec<_> = sorted_dates.chunks(7).collect();
     let total_chunks = chunks.len();
-    let start_chunk = if total_chunks > 12 { total_chunks - 12 } else { 0 };
+    let start_chunk = total_chunks.saturating_sub(12);
 
     for (display_col, chunk) in chunks[start_chunk..].iter().enumerate() {
         let x = heatmap_area.x + display_col as u16 * 2;

--- a/src-rust/crates/tui/src/virtual_list.rs
+++ b/src-rust/crates/tui/src/virtual_list.rs
@@ -208,11 +208,7 @@ impl<T: VirtualItem> VirtualList<T> {
             }
 
             // Compute the portion of this item that's visible
-            let visible_start = if current_row < self.scroll_offset {
-                self.scroll_offset - current_row
-            } else {
-                0
-            };
+            let visible_start = self.scroll_offset.saturating_sub(current_row);
             let visible_rows = h
                 .saturating_sub(visible_start)
                 .min(area.y + area.height - screen_row);


### PR DESCRIPTION
Fixes #227 (conservatively scoped for release safety). Cleaned ~255 clippy warnings to `clippy --workspace --all-targets -- -D warnings` = exit 0 (reviewed autofixes + hand-fixes + a handful of targeted, documented `#![allow]`s for risky/noisy lints). Flipped the CI Clippy step to enforcing (removed continue-on-error); rustfmt left advisory (repo isn't fmt-clean; tui/lib.rs is CRLF). RC deps (wreq/wreq-util) kept with a TODO — no clean stable exists (stable wreq drops the TLS-impersonation API). Behavior-preserving; `cargo test --workspace` green; **no line-ending flips** (156 CRLF files identical). 3 commits.

Closes #227