### PR TITLE
feat: ultracode mode — bundled skill + purple-gradient keyword + submit-time activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ It's fast, it's memory-efficient, it's yours to run however you want, and there'
 > - **Free Mode:** Try out Free in '/connect' to get a great agentic coding experience in Claurst for absolutely free (or as good as free gets you :P). `[EXPERIMENTAL]` 
 >
 > - **/goal support:** Try out `/goal <objective>` to see claurst keep working an objective, spanning multiple turns instead of stopping after one normal turn. `[EXPERIMENTAL]`
+>
+> - **ultracode:** Type **`ultracode`** (or `ultra code`) anywhere in your prompt — the keyword lights up with a purple gradient (claurst's take on Claude Code's `ultrathink`) and that turn switches into a disciplined plan → delegate → integrate → verify workflow that fans bounded packets out across native subagents (`Agent`), swarms (`TeamCreate`), and background tasks (`TaskCreate`). Composes with `/goal` for sustained multi-turn objectives, and is also available as the `/ultracode` skill. `[EXPERIMENTAL]`
 
 ---
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -15,7 +15,7 @@ This document is the complete reference for every slash command available in Cla
 7. [Memory & Context](#memory--context) — `/memory`, `/usage`, `/cost`, `/stats`, `/status`, `/insights`
 8. [Agents & Tasks](#agents--tasks) — `/agents`, `/tasks`, `/goal`, `/managed-agents`, `/agent`
 9. [Planning & Review](#planning--review) — `/plan`, `/ultraplan`, `/ultrareview`
-10. [MCP & Integrations](#mcp--integrations) — `/mcp`, `/skills`, `/plugin`, `/chrome`
+10. [MCP & Integrations](#mcp--integrations) — `/mcp`, `/skills`, `/ultracode`, `/plugin`, `/chrome`
 11. [Authentication](#authentication) — `/login`, `/logout`, `/accounts`, `/switch`, `/refresh`
 12. [Display & Terminal](#display--terminal) — `/theme`, `/output-style`, `/statusline`, `/vim`, `/terminal-setup`, `/caveman`, `/rocky`, `/normal`, `/mobile`, `/color`, `/stickers`
 13. [Diagnostics & Info](#diagnostics--info) — `/doctor`, `/version`, `/update`
@@ -779,6 +779,32 @@ List and manage skills. Skills are bundled prompt-commands that extend Claurst's
 /skills disable <skill-name>
 /skills reload
 ```
+
+---
+
+### /ultracode (skill + keyword)
+
+Run a disciplined **ultracode** workflow for serious coding tasks. Ultracode is claurst's take on Claude Code's `ultrathink`: a supervised procedure that classifies the task, picks a mode, and — when it genuinely helps — delegates bounded work across claurst's native agent primitives, then integrates and verifies in the parent session.
+
+There are two ways to trigger it:
+
+- **As a keyword.** Type `ultracode` (or `ultra code`) anywhere in a normal prompt. The keyword renders with a purple gradient in the input, and for that turn the agent operates in ultracode mode (the skill's operating procedure is injected as a system-prompt addendum). No keyword means no change to normal prompts.
+- **As a skill.** Run `/ultracode <task>` (alias `/ultra code`) to invoke it explicitly.
+
+```
+/ultracode <task>          — run the given task in ultracode mode
+please ultracode <task>    — same, activated by the inline keyword
+```
+
+**What it does**
+
+1. **Classify** the task by type, risk, blast radius, verification needs, and whether independent packets exist.
+2. **Pick a mode** — *Direct* (small, tightly-coupled work), *Workflow* (multi-phase work executed as isolated passes), or *Delegated* (the default for non-trivial work with independent packets).
+3. **Delegate** in delegated mode using native primitives: `Agent` for bounded subagents (with `isolation: "worktree"` / `run_in_background: true`), `TeamCreate` for parallel swarms, and `TaskCreate` for background tasks. It fans out **2–4** subagents (cap ~5) on non-overlapping packets while the parent keeps the blocking critical path.
+4. **Integrate** every result in the parent, checking claimed edits against the files and rejecting evidence-free outputs.
+5. **Verify** with checks scaled to risk (targeted tests → lint/typecheck → build → smoke → independent review), reporting any skipped checks honestly.
+
+**Composes with `/goal`.** Ultracode governs *how* a turn plans, delegates, integrates, and verifies; `/goal <objective>` keeps the work going *across* turns. Combine them for long, autonomous objectives — the goal loop spans turns while ultracode structures each one.
 
 ---
 

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -63,7 +63,7 @@ use claurst_api::{
 use claurst_core::config::Config;
 use claurst_core::cost::CostTracker;
 use claurst_core::error::ClaudeError;
-use claurst_core::types::{ContentBlock, Message, ToolResultContent, UsageInfo};
+use claurst_core::types::{ContentBlock, Message, Role, ToolResultContent, UsageInfo};
 use claurst_tools::{PermissionLevel, Tool, ToolContext, ToolResult};
 use serde_json::Value;
 use std::sync::Arc;
@@ -293,6 +293,25 @@ const MAX_STEPS_DEGRADATION_MSG: &str =
 const TOOL_CANCELLED_MSG: &str = "Tool execution was cancelled by the user before it completed.";
 
 // Spinner verbs are imported from claurst_core::spinner
+
+/// Ultracode submit-time activation: if the most recent user message in
+/// `messages` contains the ultracode keyword (whole-word-ish, case-insensitive),
+/// return the per-turn system-prompt addendum that puts the agent into ultracode
+/// mode for this turn. Otherwise return `None`.
+///
+/// The addendum text is sourced from the single bundled `ultracode` skill
+/// definition (see `claurst_tools::bundled_skills`), so this never duplicates
+/// the operating procedure — it is the same source of truth as `/ultracode`.
+/// Checking only the *last* user message keeps the mode scoped to the turn that
+/// actually asked for it (a later plain turn deactivates it automatically).
+fn ultracode_addendum_for_messages(messages: &[Message]) -> Option<String> {
+    let last_user = messages.iter().rev().find(|m| m.role == Role::User)?;
+    if claurst_tools::bundled_skills::text_triggers_ultracode(&last_user.get_all_text()) {
+        claurst_tools::bundled_skills::ultracode_system_prompt_addendum()
+    } else {
+        None
+    }
+}
 
 /// Run the agentic query loop.
 ///
@@ -631,6 +650,19 @@ pub async fn run_query_loop(
                         None => addendum,
                     });
                 }
+            }
+
+            // Ultracode mode (keyword-activated). When the current turn's user
+            // message contains the ultracode keyword, inject the bundled
+            // `ultracode` skill's operating procedure as a per-turn addendum
+            // (same source of truth as `/ultracode`). Applied fresh each turn so
+            // it naturally deactivates once the keyword turn ends. Composes with
+            // goal mode: a keyword turn under an active goal gets both addenda.
+            if let Some(uc_addendum) = ultracode_addendum_for_messages(messages.as_slice()) {
+                patched.append_system_prompt = Some(match patched.append_system_prompt.take() {
+                    Some(existing) => format!("{}\n{}", existing, uc_addendum),
+                    None => uc_addendum,
+                });
             }
 
             build_system_prompt(&patched)
@@ -2924,5 +2956,58 @@ mod tests {
             claurst_core::GoalStatus::Paused,
             "runaway goal must be persisted as paused"
         );
+    }
+
+    // ---- ultracode activation -------------------------------------------
+
+    #[test]
+    fn ultracode_addendum_present_when_keyword_in_last_user_message() {
+        let msgs = vec![Message::user("please ultracode this refactor")];
+        let add = ultracode_addendum_for_messages(&msgs).expect("addendum expected");
+        assert!(add.contains("Ultracode Mode"));
+    }
+
+    #[test]
+    fn ultracode_addendum_absent_without_keyword() {
+        let msgs = vec![Message::user("please refactor this module")];
+        assert!(ultracode_addendum_for_messages(&msgs).is_none());
+    }
+
+    #[test]
+    fn ultracode_addendum_checks_only_the_last_user_message() {
+        // Keyword in an earlier turn does not keep ultracode active on a later
+        // plain turn.
+        let msgs = vec![
+            Message::user("ultracode: kick things off"),
+            Message::assistant("working on it"),
+            Message::user("now just tidy up the docs"),
+        ];
+        assert!(ultracode_addendum_for_messages(&msgs).is_none());
+    }
+
+    #[test]
+    fn ultracode_addendum_flows_into_built_system_prompt() {
+        // Mirrors the loop wiring: the addendum is threaded through
+        // `append_system_prompt` into the assembled system prompt.
+        let msgs = vec![Message::user("ultracode: audit the query loop")];
+        let addendum = ultracode_addendum_for_messages(&msgs).expect("addendum expected");
+        let opts = claurst_core::system_prompt::SystemPromptOptions {
+            append_system_prompt: Some(addendum),
+            skip_env_info: true,
+            ..Default::default()
+        };
+        let prompt = claurst_core::system_prompt::build_system_prompt(&opts);
+        assert!(prompt.contains("Ultracode Mode"));
+        assert!(prompt.contains("TeamCreate"));
+
+        // Absent path: no keyword -> no ultracode text in the built prompt.
+        assert!(ultracode_addendum_for_messages(&[Message::user("hi there")]).is_none());
+        let plain = claurst_core::system_prompt::build_system_prompt(
+            &claurst_core::system_prompt::SystemPromptOptions {
+                skip_env_info: true,
+                ..Default::default()
+            },
+        );
+        assert!(!plain.contains("Ultracode Mode"));
     }
 }

--- a/src-rust/crates/tools/src/bundled_skills.rs
+++ b/src-rust/crates/tools/src/bundled_skills.rs
@@ -406,6 +406,124 @@ $ARGUMENTS"#,
         allowed_tools: Some(&["CronCreate", "CronList"]),
         user_invocable: true,
     },
+
+    // -----------------------------------------------------------------------
+    // ultracode
+    // -----------------------------------------------------------------------
+    BundledSkill {
+        name: "ultracode",
+        description: "Run a disciplined ultracode workflow for serious coding work: classify the task, pick a mode (Direct / Workflow / Delegated), and when useful delegate bounded sidecar packets across claurst's native primitives (Agent subagents, TeamCreate swarms, TaskCreate background tasks), then integrate in the parent and verify.",
+        aliases: &["ultra code"],
+        when_to_use: Some("When the user invokes ultracode / ultra code, or wants a planned, multi-agent, delegated workflow with integration and an independent verification pass for a non-trivial coding task."),
+        argument_hint: Some("[task to run in ultracode mode]"),
+        prompt_template: r#"# Ultracode
+
+You are operating in **ultracode** mode: a disciplined, supervised workflow for
+serious coding work. Plan, split, delegate when it genuinely helps, integrate in
+the parent session, and verify. Use the smallest workflow that can prove the
+result -- do not manufacture ceremony for small tasks.
+
+## Contract
+
+- Ultracode is a claurst operating procedure, not a separate runtime. System,
+  developer, and user rules always win over this text.
+- Do NOT commit, push, publish, deploy, or delete anything unless the user
+  explicitly asks. Ask one clear approval question before any destructive or
+  irreversible action (mass rename/delete, force-push, migrations, production
+  data, credentials/secrets/billing, broad codemods, or large agent fan-out).
+  If approval is missing, continue only with safe read-only or draft work.
+- Never use delegation to avoid understanding the integration path. The parent
+  session owns integration, verification, and the final answer.
+
+## 1. Classify the task
+
+Before acting, state briefly:
+
+- **type**: research | code change | bug fix | migration | audit | docs | design | QA | release
+- **risk**: low | medium | high
+- **blast radius**: single file | module | repo-wide | external system
+- **verification**: none | command | tests | build | manual checklist
+- **delegation**: useful | not useful (do bounded, independent packets exist?)
+
+Then pick ONE mode.
+
+## 2. Pick a mode
+
+### Direct
+Small, clear, tightly-coupled tasks with no useful independent packets (one file,
+one command, a small function, a typo). Just do it, then run the narrowest useful
+check. No artifacts.
+
+### Workflow
+Multi-phase or risky work that benefits from separated packets, but delegation is
+not useful or not available. Keep a concrete plan (goal, success criteria,
+constraints, risk, packets, verification), execute packets as isolated passes in
+this session, integrate, then verify. Write scratch notes under
+`.workflow/ultracode/<slug>/` only when they reduce risk.
+
+### Delegated (default for non-trivial ultracode work)
+When the work has bounded, non-overlapping, independent packets and delegation is
+allowed, use claurst's native delegation primitives. Keep the blocking critical
+path in the parent; delegate only useful sidecar work.
+
+## 3. Delegated mode -- claurst native primitives
+
+- **`Agent`** -- spawn a subagent for one bounded packet (read-only exploration,
+  test writing, triage, or a disjoint write scope). Use `isolation: "worktree"`
+  for write-heavy packets that must not collide, and `run_in_background: true` to
+  fan several out at once, then integrate their final messages in the parent.
+- **`TeamCreate`** (+ `TeamDelete`) -- stand up a named swarm/coordinator when
+  several agents should work a shared task in parallel with restricted tool lists
+  and aggregated output. Good for parallel audits or multi-track implementation.
+- **`TaskCreate`** (+ `TaskGet` / `TaskUpdate` / `TaskList` / `TaskStop`) --
+  track and run background work items; poll or stop them from the parent.
+
+Rules:
+
+- Plan first, then split into bounded, non-overlapping packets before spawning.
+- Default to **2-4** subagents for useful independent work; do not exceed **~5**
+  total without explicit user approval. Run at most one broad implementation wave
+  and one review/verification wave unless the user approves more.
+- Prefer delegation for read-heavy exploration, test writing, triage, and
+  summarization. Use write-capable agents only when file ownership is disjoint.
+- Tell every write-capable agent: "You are not alone in the codebase. Do not
+  revert edits made by others; adapt to nearby changes." Give each a concrete
+  objective, explicit ownership, and an expected-output shape.
+- Only wait on an agent when its result blocks the next parent step.
+- If native agents are unavailable or not useful, fall back to Workflow mode and
+  say so briefly with the concrete reason.
+
+## 4. Integrate (parent-owned)
+
+Read each result, check claimed edits against the actual files, resolve
+disagreements with source/tests/docs, and reject outputs that lack evidence.
+Never paste raw agent logs as the final answer.
+
+## 5. Verify (scaled by risk)
+
+- **low**: inspect the diff + a targeted test.
+- **medium**: targeted tests + typecheck/lint + affected build.
+- **high**: full tests (if practical) + build + smoke + an independent review pass.
+
+Mark each check pass | fail | skipped (with reason). Report skipped checks
+honestly. Finish with a short summary: outcome, key files changed, verification
+run, and remaining risk.
+
+## Composing with /goal (multi-turn)
+
+Ultracode is compatible with claurst's continuation/goal mode: a large task can
+span multiple turns. For a long, autonomous objective, combine ultracode with
+`/goal <objective>` -- the goal loop keeps working across turns while ultracode
+governs *how* each turn plans, delegates, integrates, and verifies. Ultracode
+mode itself is scoped to the current turn; re-invoke it (or run it under a goal)
+for sustained multi-turn work.
+
+## Your task
+
+$ARGUMENTS"#,
+        allowed_tools: None,
+        user_invocable: true,
+    },
 ];
 
 // ---------------------------------------------------------------------------
@@ -445,6 +563,71 @@ pub fn expand_prompt(skill: &BundledSkill, args: &str) -> String {
         .prompt_template
         .replace("$ARGUMENTS_SUFFIX", &suffix)
         .replace("$ARGUMENTS", args)
+}
+
+// ---------------------------------------------------------------------------
+// Ultracode keyword detection + system-prompt addendum
+// ---------------------------------------------------------------------------
+
+/// Keywords that activate ultracode mode, longest-first so a spaced match wins.
+pub const ULTRACODE_KEYWORDS: &[&str] = &["ultra code", "ultracode"];
+
+/// Find every whole-word-ish, case-insensitive occurrence of an ultracode
+/// keyword in `text`, returned as non-overlapping `(start, end)` byte ranges
+/// into `text`.
+///
+/// The keywords are ASCII, so an ASCII-lowercased copy preserves byte length
+/// and offsets exactly; every match therefore maps back onto `text` at valid
+/// char boundaries. "Whole-word-ish" means the byte immediately before/after a
+/// match must not be ASCII alphanumeric (so `ultracoder` does not match).
+pub fn ultracode_match_ranges(text: &str) -> Vec<(usize, usize)> {
+    let hay = text.as_bytes().to_ascii_lowercase();
+    let bytes = text.as_bytes();
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+    let mut i = 0usize;
+    'scan: while i < hay.len() {
+        for kw in ULTRACODE_KEYWORDS {
+            let k = kw.as_bytes();
+            if i + k.len() <= hay.len() && &hay[i..i + k.len()] == k {
+                let end = i + k.len();
+                let left_ok = i == 0 || !bytes[i - 1].is_ascii_alphanumeric();
+                let right_ok = end == bytes.len() || !bytes[end].is_ascii_alphanumeric();
+                if left_ok && right_ok {
+                    ranges.push((i, end));
+                    i = end;
+                    continue 'scan;
+                }
+            }
+        }
+        i += 1;
+    }
+    ranges
+}
+
+/// Whether `text` contains an ultracode keyword (whole-word-ish, case-insensitive).
+pub fn text_triggers_ultracode(text: &str) -> bool {
+    !ultracode_match_ranges(text).is_empty()
+}
+
+/// Build the per-turn system-prompt addendum for ultracode mode.
+///
+/// This is the *single source of truth* for ultracode's operating procedure:
+/// it expands the bundled `ultracode` skill's `prompt_template` (the same text
+/// the `/ultracode` skill runs) and wraps it with a short activation framing.
+/// Returns `None` only if the skill is somehow missing from `BUNDLED_SKILLS`.
+pub fn ultracode_system_prompt_addendum() -> Option<String> {
+    let skill = find_bundled_skill("ultracode")?;
+    let body = expand_prompt(
+        skill,
+        "(the task is the user's latest message in this conversation)",
+    );
+    Some(format!(
+        "\n## Ultracode Mode (activated by keyword)\n\
+         The user's message invoked **ultracode**. Operate in ultracode mode for \
+         this turn using the procedure below (the same procedure as the bundled \
+         `ultracode` skill).\n\n{}\n",
+        body
+    ))
 }
 
 // ---------------------------------------------------------------------------
@@ -570,5 +753,73 @@ mod tests {
                 name
             );
         }
+    }
+
+    // ---- ultracode -------------------------------------------------------
+
+    #[test]
+    fn ultracode_skill_present_and_user_invocable() {
+        let skill = find_bundled_skill("ultracode").expect("ultracode skill missing");
+        assert_eq!(skill.name, "ultracode");
+        assert!(skill.user_invocable);
+        assert!(skill.allowed_tools.is_none(), "ultracode should expose the full toolset");
+    }
+
+    #[test]
+    fn ultracode_resolvable_by_alias_and_case() {
+        assert_eq!(find_bundled_skill("ultra code").unwrap().name, "ultracode");
+        assert_eq!(find_bundled_skill("UltraCode").unwrap().name, "ultracode");
+        assert_eq!(find_bundled_skill("ULTRA CODE").unwrap().name, "ultracode");
+    }
+
+    #[test]
+    fn ultracode_template_names_native_primitives() {
+        let skill = find_bundled_skill("ultracode").unwrap();
+        for needle in ["Agent", "TeamCreate", "TaskCreate", "/goal", "Delegated"] {
+            assert!(
+                skill.prompt_template.contains(needle),
+                "ultracode template missing `{needle}`"
+            );
+        }
+    }
+
+    #[test]
+    fn ultracode_match_ranges_finds_keyword() {
+        let text = "please ultracode this";
+        let r = ultracode_match_ranges(text);
+        assert_eq!(r.len(), 1);
+        let (s, e) = r[0];
+        assert_eq!(&text[s..e], "ultracode");
+    }
+
+    #[test]
+    fn ultracode_match_ranges_case_insensitive_and_spaced() {
+        assert_eq!(ultracode_match_ranges("UltraCode now").len(), 1);
+        let text = "do ULTRA CODE it";
+        let r = ultracode_match_ranges(text);
+        assert_eq!(r.len(), 1);
+        let (s, e) = r[0];
+        // Offsets map onto the original bytes (ASCII), case aside.
+        assert_eq!(&text[s..e].to_ascii_lowercase(), "ultra code");
+    }
+
+    #[test]
+    fn ultracode_match_ranges_respects_word_boundaries() {
+        assert!(ultracode_match_ranges("ultracoder").is_empty());
+        assert!(ultracode_match_ranges("supraultracode1").is_empty());
+        assert!(text_triggers_ultracode("(ultracode)"));
+        assert!(text_triggers_ultracode("ultracode."));
+        assert!(!text_triggers_ultracode("this is a normal prompt"));
+    }
+
+    #[test]
+    fn ultracode_addendum_reuses_skill_body() {
+        let add = ultracode_system_prompt_addendum().expect("addendum present");
+        assert!(add.contains("Ultracode Mode"));
+        assert!(add.contains("## Your task"));
+        // Sourced from the skill template, not a duplicate literal.
+        assert!(add.contains("Agent"));
+        assert!(add.contains("TeamCreate"));
+        assert!(!add.contains("$ARGUMENTS"), "template placeholder must be expanded");
     }
 }

--- a/src-rust/crates/tui/src/prompt_input.rs
+++ b/src-rust/crates/tui/src/prompt_input.rs
@@ -2897,6 +2897,62 @@ pub fn wrap_line(line: &str, width: usize) -> Vec<String> {
     out
 }
 
+/// Purple-gradient endpoints for the ultracode keyword, mirroring how Claude
+/// Code highlights "ultrathink": a light violet fading into a deeper purple.
+const ULTRACODE_GRADIENT_START: (u8, u8, u8) = (168, 85, 247);
+const ULTRACODE_GRADIENT_END: (u8, u8, u8) = (124, 58, 237);
+
+/// Linearly interpolate between two RGB colors at `t` in `[0, 1]`.
+fn ultracode_lerp_rgb(a: (u8, u8, u8), b: (u8, u8, u8), t: f32) -> Color {
+    let t = t.clamp(0.0, 1.0);
+    let mix = |x: u8, y: u8| (x as f32 + (y as f32 - x as f32) * t).round() as u8;
+    Color::Rgb(mix(a.0, b.0), mix(a.1, b.1), mix(a.2, b.2))
+}
+
+/// Build the styled spans for a single display-line `text`, rendering any
+/// ultracode keyword occurrence ("ultracode" / "ultra code", case-insensitive,
+/// whole-word-ish) with a per-character purple gradient, bold.
+///
+/// VISUAL ONLY: the returned spans concatenate back to exactly `text`, in order,
+/// with identical characters and widths -- only the *style* differs on keyword
+/// characters. Text outside any keyword is emitted as a single span carrying
+/// `base_style`, so cursor positioning, wrapping, and editing are unaffected.
+pub(crate) fn styled_spans_with_ultracode_gradient(
+    text: &str,
+    base_style: Style,
+) -> Vec<Span<'static>> {
+    let ranges = claurst_tools::bundled_skills::ultracode_match_ranges(text);
+    if ranges.is_empty() {
+        return vec![Span::styled(text.to_string(), base_style)];
+    }
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    let mut pos = 0usize;
+    for (start, end) in ranges {
+        if start > pos {
+            spans.push(Span::styled(text[pos..start].to_string(), base_style));
+        }
+        let keyword = &text[start..end];
+        let char_count = keyword.chars().count().max(1);
+        for (i, ch) in keyword.chars().enumerate() {
+            let t = if char_count == 1 {
+                0.0
+            } else {
+                i as f32 / (char_count - 1) as f32
+            };
+            let color = ultracode_lerp_rgb(ULTRACODE_GRADIENT_START, ULTRACODE_GRADIENT_END, t);
+            spans.push(Span::styled(
+                ch.to_string(),
+                base_style.fg(color).add_modifier(Modifier::BOLD),
+            ));
+        }
+        pos = end;
+    }
+    if pos < text.len() {
+        spans.push(Span::styled(text[pos..].to_string(), base_style));
+    }
+    spans
+}
+
 /// Render the prompt input widget in the same low-chrome style as Claurst:
 /// multi-line input rows (one per logical line in the text) plus an accent
 /// underline. Suggestions are rendered by the footer, not as a boxed dropdown
@@ -3102,15 +3158,16 @@ pub fn render_prompt_input(
         let is_first_row_of_first_logical = display_idx == 0 && scroll_offset == 0;
 
         let spans: Vec<Span<'static>> = if is_first_row_of_first_logical {
-            vec![
-                Span::styled(prompt_prefix.clone(), Style::default().fg(accent).add_modifier(Modifier::BOLD)),
-                Span::styled(chunk.clone(), text_style),
-            ]
+            let mut v = vec![Span::styled(
+                prompt_prefix.clone(),
+                Style::default().fg(accent).add_modifier(Modifier::BOLD),
+            )];
+            v.extend(styled_spans_with_ultracode_gradient(chunk, text_style));
+            v
         } else {
-            vec![
-                Span::raw(" ".repeat(prefix_width as usize)),
-                Span::styled(chunk.clone(), text_style),
-            ]
+            let mut v = vec![Span::raw(" ".repeat(prefix_width as usize))];
+            v.extend(styled_spans_with_ultracode_gradient(chunk, text_style));
+            v
         };
 
         Paragraph::new(Line::from(spans)).render(
@@ -4622,5 +4679,64 @@ mod tests {
         let mut buf = Buffer::empty(area);
         // Reaching the end of this call without panicking is the assertion.
         render_prompt_input(&s, area, &mut buf, true, InputMode::Default, Color::Blue, false);
+    }
+
+    // ---- ultracode gradient --------------------------------------------
+
+    #[test]
+    fn ultracode_gradient_highlights_keyword_visual_only() {
+        let base = Style::default().fg(Color::White);
+        let text = "please ultracode this";
+        let spans = styled_spans_with_ultracode_gradient(text, base);
+
+        // Visual only: reassembled text is byte-identical to the input.
+        let joined: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(joined, text);
+        // Total display width is unchanged.
+        assert_eq!(
+            UnicodeWidthStr::width(joined.as_str()),
+            UnicodeWidthStr::width(text)
+        );
+
+        // Each keyword character gets its own bold Rgb purple span, and the
+        // per-char colors actually vary across the gradient.
+        let mut bold_rgb = 0usize;
+        let mut colors = std::collections::HashSet::new();
+        for s in &spans {
+            if let Some(Color::Rgb(r, g, b)) = s.style.fg {
+                if s.style.add_modifier.contains(Modifier::BOLD) {
+                    bold_rgb += 1;
+                    colors.insert((r, g, b));
+                }
+            }
+        }
+        assert_eq!(bold_rgb, "ultracode".len(), "one styled span per keyword char");
+        assert!(colors.len() > 1, "gradient should vary per character");
+    }
+
+    #[test]
+    fn ultracode_gradient_untouched_without_keyword() {
+        let base = Style::default().fg(Color::White);
+        let text = "just a normal prompt";
+        let spans = styled_spans_with_ultracode_gradient(text, base);
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].content.as_ref(), text);
+        assert_eq!(spans[0].style.fg, Some(Color::White));
+        assert!(!spans[0].style.add_modifier.contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn ultracode_gradient_handles_spaced_and_repeated() {
+        let base = Style::default().fg(Color::White);
+        let text = "ultra code then ultracode again";
+        let spans = styled_spans_with_ultracode_gradient(text, base);
+        let joined: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(joined, text, "text preserved across multiple matches");
+        let bold = spans
+            .iter()
+            .filter(|s| s.style.add_modifier.contains(Modifier::BOLD))
+            .count();
+        // "ultra code" (10) + "ultracode" (9) styled chars.
+        assert_eq!(bold, "ultra code".len() + "ultracode".len());
     }
 }


### PR DESCRIPTION
The v0.1.7 capstone. Typing **ultracode** (or 'ultra code') in the prompt renders it with a purple gradient (Claude-Code style, visual-only — cursor/wrapping untouched) and activates ultracode mode for that turn: a per-turn system addendum drives a disciplined classify → pick mode (Direct/Workflow/Delegated) → delegate via claurst's native `Agent`/`TeamCreate`/`TaskCreate` primitives → integrate → verify procedure, composing with `/goal`. Also invocable as the bundled `/ultracode` skill (single source of truth for both paths). Adapted from the ultracode-skill reference. 4 commits, 14 tests, docs (README + docs/commands.md), clippy -D warnings clean, CRLF preserved.

Closes #8 (ultracode capstone).