### PR TITLE
fix(update): show real install methods in /update (drop bogus cargo install)

### DIFF
--- a/src-rust/crates/cli/src/upgrade.rs
+++ b/src-rust/crates/cli/src/upgrade.rs
@@ -137,7 +137,7 @@ fn print_help() {
            -f, --force         Reinstall even if already up to date\n\
            -h, --help          Show this help\n\n\
          Downloads the latest claurst release from GitHub and replaces this\n\
-         binary in place. Settings in ~/.claurst are preserved."
+         binary in place. Your settings and sessions are preserved."
     );
 }
 

--- a/src-rust/crates/commands/src/maintenance.rs
+++ b/src-rust/crates/commands/src/maintenance.rs
@@ -165,8 +165,10 @@ impl SlashCommand for UpgradeCommand {
                          Release page:     {url}\n\n\
                          Upgrade in place (recommended):\n\
                            claurst upgrade\n\n\
-                         Or build from source:\n\
-                           cargo install claurst --force"
+                         Or reinstall with your original method:\n\
+                           npm install -g claurst\n\
+                           curl -fsSL https://github.com/kuberwastaken/claurst/releases/latest/download/install.sh | bash   (macOS/Linux)\n\
+                           irm https://github.com/kuberwastaken/claurst/releases/latest/download/install.ps1 | iex          (Windows)"
                     ))
                 }
             }


### PR DESCRIPTION
The `/update` screen recommended `cargo install claurst --force`, but claurst isn't on crates.io — it ships via `install.sh`, npm, and GitHub releases. Replaced it with the actual reinstall methods (npm / curl install.sh / irm install.ps1) alongside the in-place `claurst upgrade`, and made the `claurst upgrade` help text location-agnostic (settings moved to XDG dirs in #207). The `claurst upgrade` self-updater itself is fine — it replaces the running binary via `current_exe()`, location-independent.