### PR TITLE
test(core): make XDG path tests hermetic (fix red main CI)

### DIFF
--- a/src-rust/crates/core/src/feature_flags.rs
+++ b/src-rust/crates/core/src/feature_flags.rs
@@ -234,7 +234,9 @@ mod tests {
     #[test]
     fn test_cache_path() {
         let path = FeatureFlagManager::get_cache_path();
-        assert!(path.to_string_lossy().contains(".claurst"));
+        // "claurst" (not ".claurst"): the config dir is legacy ~/.claurst on
+        // existing installs but XDG ~/.config/claurst on fresh ones (#207).
+        assert!(path.to_string_lossy().contains("claurst"));
         assert!(path.to_string_lossy().contains("feature_flags.json"));
     }
 

--- a/src-rust/crates/core/src/paths.rs
+++ b/src-rust/crates/core/src/paths.rs
@@ -20,7 +20,10 @@ pub fn claurst_home() -> PathBuf {
     crate::config::Settings::config_dir()
 }
 
-#[cfg(test)]
+// These tests drive the resolver through `HOME`/`XDG_CONFIG_HOME`, which only
+// govern `dirs::home_dir()` on Unix — on Windows the home dir comes from the OS
+// profile API and can't be pinned via env, so they'd be non-hermetic there.
+#[cfg(all(test, unix))]
 mod tests {
     use crate::config::Settings;
     use std::path::PathBuf;


### PR DESCRIPTION
Main CI went red after #263/#266: `feature_flags::test_cache_path` asserted `.claurst`, but on fresh XDG installs the config dir is `~/.config/claurst` (no dot) — so it fails on CI (no legacy `~/.claurst`). Relaxed to `claurst`. The `paths::tests` drive HOME/XDG which only govern `dirs::home_dir()` on Unix (Windows uses the OS profile API), so they're gated to `#[cfg(all(test, unix))]`. Both only passed locally because `~/.claurst` exists here; #263/#266 shifted test order and surfaced the latent non-hermeticity. Verified: core tests pass with a clean HOME; clippy -D warnings clean.