### PR TITLE
fix(tui): fix Linux-only clippy (collapsible_if in image_paste)

### DIFF
--- a/src-rust/crates/tui/src/image_paste.rs
+++ b/src-rust/crates/tui/src/image_paste.rs
@@ -240,18 +240,20 @@ fn try_save_linux_image(path: &PathBuf) -> bool {
         .args(["-selection", "clipboard", "-t", "image/png", "-o"])
         .output()
     {
-        if out.status.success() && !out.stdout.is_empty() {
-            if std::fs::write(path, &out.stdout).is_ok() {
-                return true;
-            }
+        if out.status.success()
+            && !out.stdout.is_empty()
+            && std::fs::write(path, &out.stdout).is_ok()
+        {
+            return true;
         }
     }
     // wl-paste
     if let Ok(out) = Command::new("wl-paste").args(["--type", "image/png"]).output() {
-        if out.status.success() && !out.stdout.is_empty() {
-            if std::fs::write(path, &out.stdout).is_ok() {
-                return true;
-            }
+        if out.status.success()
+            && !out.stdout.is_empty()
+            && std::fs::write(path, &out.stdout).is_ok()
+        {
+            return true;
         }
     }
     false


### PR DESCRIPTION
The enforced clippy gate (#227) was failing on the **ubuntu** CI job — the xclip/wl-paste image-paste code in `image_paste.rs` is Linux-only (`#[cfg(not(macos/windows))]`), so clippy on macOS (where the subagents ran) never lints it. A clippy toolchain update surfaced `collapsible_if` there, reddening every recent merge on Linux. Collapsed the two nested ifs into `&&` chains. macOS `cargo check` parses the cfg'd code clean; CI will confirm the Linux clippy job.