### PR TITLE
chore: remove /feedback, /bug, /report, /install-slack-app (broken/useless commands)

### DIFF
--- a/src-rust/crates/commands/src/extras.rs
+++ b/src-rust/crates/commands/src/extras.rs
@@ -1,4 +1,4 @@
-// Assorted commands: `/advisor`, `/install-slack-app`, `/fast`, `/feedback`, `/color` (full).
+// Assorted commands: `/advisor`, `/fast`, `/color` (full).
 //
 // Extracted from lib.rs (issue #232). Behavior-preserving move.
 
@@ -6,9 +6,7 @@ use super::*;
 use async_trait::async_trait;
 
 pub struct AdvisorCommand;
-pub struct InstallSlackAppCommand;
 pub struct FastCommand;
-pub struct FeedbackCommand;
 pub struct ColorSetCommand;
 
 // ---- /advisor ------------------------------------------------------------
@@ -72,37 +70,6 @@ impl SlashCommand for AdvisorCommand {
                 }
             }
         }
-    }
-}
-
-// ---- /install-slack-app --------------------------------------------------
-
-#[async_trait]
-impl SlashCommand for InstallSlackAppCommand {
-    fn name(&self) -> &str { "install-slack-app" }
-    fn description(&self) -> &str { "Install the Claurst Slack integration" }
-    fn help(&self) -> &str {
-        "Usage: /install-slack-app\n\n\
-         Opens instructions for installing the Claurst Slack app.\n\
-         Requires a Claurst for Enterprise subscription."
-    }
-
-    async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
-        CommandResult::Message(
-            "Claurst Slack Integration\n\
-             ─────────────────────────────\n\
-             To install Claurst in Slack:\n\n\
-             1. Ensure you have a Claurst for Enterprise subscription\n\
-             2. Visit your Anthropic Console → Integrations → Slack\n\
-             3. Click \"Add to Slack\" and authorize the app\n\
-             4. Invite @Claurst to any channel with: /invite @Claurst\n\n\
-             In Slack, you can then:\n\
-             • Mention @Claurst to ask questions in any channel\n\
-             • Use /claude for direct commands\n\
-             • Share code snippets for review\n\n\
-             See: https://docs.anthropic.com/claude-code/slack"
-                .to_string(),
-        )
     }
 }
 
@@ -175,44 +142,6 @@ impl SlashCommand for FastCommand {
                     restored_model
                 ),
             )
-        }
-    }
-}
-
-// ---- /feedback (standalone, supplements BugCommand alias) ----------------
-
-#[async_trait]
-impl SlashCommand for FeedbackCommand {
-    fn name(&self) -> &str { "report" }
-    fn aliases(&self) -> Vec<&str> { vec![] }
-    fn description(&self) -> &str { "Open the GitHub issues page to report a bug or request a feature" }
-    fn hidden(&self) -> bool { true } // surfaced via BugCommand alias; hidden to avoid duplicate
-    fn help(&self) -> &str {
-        "Usage: /report [description]\n\n\
-         Opens the GitHub issues tracker. If a description is provided,\n\
-         it is shown as a suggested pre-fill for the issue body."
-    }
-
-    async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
-        let url = "https://github.com/anthropics/claude-code/issues/new";
-        let report = args.trim();
-        let display_url = if report.is_empty() {
-            url.to_string()
-        } else {
-            // Append as a body query param
-            format!(
-                "{}?body={}",
-                url,
-                urlencoding::encode(report)
-            )
-        };
-
-        match open_with_system(&display_url) {
-            Ok(_) => CommandResult::Message(format!("Opened issue tracker: {}", url)),
-            Err(_) => CommandResult::Message(format!(
-                "Please visit {} to submit a report.",
-                url
-            )),
         }
     }
 }

--- a/src-rust/crates/commands/src/lib.rs
+++ b/src-rust/crates/commands/src/lib.rs
@@ -279,7 +279,6 @@ pub struct VersionCommand;
 pub struct ResumeCommand;
 pub struct StatusCommand;
 pub struct DiffCommand;
-pub struct BugCommand;
 pub struct InitCommand;
 pub struct HooksCommand;
 pub struct ImportConfigCommand;
@@ -503,7 +502,7 @@ fn command_category(name: &str) -> &'static str {
         "mcp" | "hooks" | "ide" | "chrome" => "Integrations",
         "session" | "resume" | "remote-control" | "remote-env"
         | "teleport" => "Sessions & Remote",
-        "help" | "exit" | "feedback" | "bug" => "General",
+        "help" | "exit" => "General",
         "think-back" | "thinkback-play" | "thinking" | "plan" | "tasks" => "AI & Thinking",
         "copy" | "skills" | "agents" | "plugin" | "reload-plugins"
         | "stickers" | "passes" | "desktop" | "mobile" | "btw" => "Tools & Extras",
@@ -990,31 +989,6 @@ impl SlashCommand for DiffCommand {
     }
 }
 
-// ---- /bug ----------------------------------------------------------------
-
-#[async_trait]
-impl SlashCommand for BugCommand {
-    fn name(&self) -> &str { "feedback" }
-    fn aliases(&self) -> Vec<&str> { vec!["bug"] }
-    fn description(&self) -> &str { "Submit feedback about Claurst" }
-    fn help(&self) -> &str { "Usage: /feedback [report]" }
-
-    async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
-        let report = args.trim();
-        if report.is_empty() {
-            CommandResult::Message(
-                "To submit feedback or report a bug, visit: https://github.com/anthropics/claude-code/issues"
-                    .to_string(),
-            )
-        } else {
-            CommandResult::Message(format!(
-                "To submit feedback or report a bug, visit: https://github.com/anthropics/claude-code/issues\nSuggested report summary: {}",
-                report
-            ))
-        }
-    }
-}
-
 // ---- /init ---------------------------------------------------------------
 
 #[async_trait]
@@ -1173,7 +1147,6 @@ pub fn all_commands() -> Vec<Box<dyn SlashCommand>> {
         Box::new(StatusCommand),
         Box::new(DiffCommand),
         Box::new(MemoryCommand),
-        Box::new(BugCommand),
         Box::new(UsageCommand),
         Box::new(DoctorCommand),
         Box::new(LoginCommand),
@@ -1591,7 +1564,6 @@ mod tests {
         assert!(find_command("c").is_some());
         assert!(find_command("settings").is_some());
         assert!(find_command("continue").is_some());
-        assert!(find_command("bug").is_some());
         assert!(find_command("bashes").is_some());
         assert!(find_command("remote").is_some());
         assert!(find_command("remote-setup").is_some());
@@ -1608,7 +1580,7 @@ mod tests {
             "help", "clear", "compact", "cost", "exit", "model",
             "config", "version", "status", "diff", "memory", "hooks",
             "permissions", "plan", "tasks", "session", "login", "logout", "refresh",
-            "feedback", "usage", "plugin", "reload-plugins",
+            "usage", "plugin", "reload-plugins",
             "add-dir", "agents", "branch", "tag",
             "passes", "ide", "pr-comments", "desktop", "mobile",
             "install-github-app", "web-setup", "stickers",

--- a/src-rust/crates/commands/src/lib.rs
+++ b/src-rust/crates/commands/src/lib.rs
@@ -1313,16 +1313,14 @@ pub fn all_commands() -> Vec<Box<dyn SlashCommand>> {
         Box::new(FastCommand),
         Box::new(ThinkBackCommand),
         Box::new(ThinkBackPlayCommand),
-        Box::new(FeedbackCommand),
         Box::new(ColorSetCommand),
         // New commands: teleport, btw, ctx-viz, sandbox-toggle
         Box::new(TeleportCommand),
         Box::new(BtwCommand),
         Box::new(CtxVizCommand),
         Box::new(SandboxToggleCommand),
-        // Advisor and Slack integration
+        // Advisor
         Box::new(AdvisorCommand),
-        Box::new(InstallSlackAppCommand),
         // Diagnostics / analysis
         Box::new(HeapdumpCommand),
         Box::new(InsightsCommand),

--- a/src-rust/crates/core/src/tips.rs
+++ b/src-rust/crates/core/src/tips.rs
@@ -132,11 +132,6 @@ static ALL_TIPS: Lazy<Vec<Tip>> = Lazy::new(|| {
             cooldown_sessions: 15,
         },
         Tip {
-            id: "feedback-command",
-            content: "Use /feedback to help us improve!",
-            cooldown_sessions: 15,
-        },
-        Tip {
             id: "status-line",
             content: "Use /statusline to set up a custom status line that will display beneath the input box",
             cooldown_sessions: 25,

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -69,7 +69,6 @@ const PROMPT_SLASH_COMMANDS: &[(&str, &str)] = &[
     ("import-config", "Import CLAUDE.md and settings.json from ~/.claude"),
     ("init", "Initialize AGENTS.md for this project"),
     ("insights", "Generate a session analysis report with conversation statistics"),
-    ("install-slack-app", "Install the Claurst Slack integration"),
     ("keybindings", "Show keybinding configuration"),
     ("links", "Open URLs from this session in your browser"),
     ("login", "Log in to Claurst"),

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -60,7 +60,6 @@ const PROMPT_SLASH_COMMANDS: &[(&str, &str)] = &[
     ("exit", "Quit Claurst"),
     ("export", "Export conversation"),
     ("fast", "Toggle fast mode"),
-    ("feedback", "Open session feedback survey"),
     ("fork", "Fork session into a new branch"),
     ("goal", "Set or view the current session goal"),
     ("heapdump", "Show process memory and diagnostic information"),
@@ -110,7 +109,7 @@ fn help_command_category(name: &str) -> &'static str {
         "config" | "settings" | "theme" | "keybindings" | "hooks" | "mcp" | "import-config" => {
             "Workspace"
         }
-        "agent" | "agents" | "memory" | "plugin" | "feedback" | "survey" => "Tools",
+        "agent" | "agents" | "memory" | "plugin" | "survey" => "Tools",
         "session" | "resume" | "rename" | "fork" | "clear" | "compact" | "quit" | "exit" => {
             "Session"
         }
@@ -2093,7 +2092,7 @@ impl App {
                 self.global_search.open();
                 true
             }
-            "survey" | "feedback" => {
+            "survey" => {
                 self.feedback_survey.open();
                 true
             }


### PR DESCRIPTION
Closes #276. Removes the useless/broken commands: `/feedback` + `/bug` (BugCommand — only printed a stale anthropics/claude-code URL), `/report` (FeedbackCommand — same broken URL), and `/install-slack-app`. Also detaches the survey's `feedback` trigger (the session survey stays reachable via `/survey`) and drops a tip promoting the removed command. Tests updated; `cargo test -p claurst-commands` = 47 passed; clippy -D warnings clean; CRLF preserved.

Closes #276