### PR TITLE
fix(tui): show real recent activity on the welcome screen

### DIFF
--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -737,6 +737,49 @@ pub enum FocusTarget {
 }
 
 // ---------------------------------------------------------------------------
+// Recent activity
+// ---------------------------------------------------------------------------
+
+/// A lightweight record of a recent session, shown in the welcome screen's
+/// "Recent activity" list.
+///
+/// Loaded asynchronously from `session_storage` (see `recent_sessions_pending`
+/// in the run loop) so the render path never touches disk. Holds only what the
+/// welcome box needs: a display label plus the transcript's modification time,
+/// from which a relative timestamp ("2h ago") is computed at render time.
+#[derive(Debug, Clone)]
+pub struct RecentSession {
+    /// Display label: the custom title, else a truncated last prompt, else
+    /// `"(untitled)"`.
+    pub label: String,
+    /// Transcript modification time, used to derive a relative timestamp.
+    pub mtime: std::time::SystemTime,
+}
+
+/// Build the display label for a recent session: prefer the custom title, fall
+/// back to the first line of the last prompt (truncated), else `"(untitled)"`.
+pub fn recent_session_label(title: Option<String>, last_prompt: Option<String>) -> String {
+    /// Cap stored labels so a huge prompt never bloats `App` state; the render
+    /// path truncates further to the column width.
+    const MAX_LABEL: usize = 80;
+
+    let pick = |s: String| -> Option<String> {
+        // First non-empty line, trimmed.
+        let line = s.lines().find(|l| !l.trim().is_empty())?.trim();
+        if line.is_empty() {
+            return None;
+        }
+        let truncated: String = line.chars().take(MAX_LABEL).collect();
+        Some(truncated)
+    };
+
+    title
+        .and_then(pick)
+        .or_else(|| last_prompt.and_then(pick))
+        .unwrap_or_else(|| "(untitled)".to_string())
+}
+
+// ---------------------------------------------------------------------------
 // App struct
 // ---------------------------------------------------------------------------
 
@@ -995,6 +1038,17 @@ pub struct App {
     /// Receiver for background session-list results.
     pub session_list_rx:
         Option<tokio::sync::mpsc::Receiver<Vec<crate::session_browser::SessionEntry>>>,
+    /// The most-recent sessions shown in the welcome screen's "Recent activity"
+    /// list. Populated once from disk via the background loader below; empty
+    /// until it resolves (or when there are genuinely no sessions).
+    pub recent_sessions: Vec<RecentSession>,
+    /// When `true`, the main event loop should spawn a one-shot async task to
+    /// load recent sessions from disk (mirrors `session_list_pending`). Set once
+    /// at startup and cleared when the load is kicked off, so we never re-list
+    /// every frame.
+    pub recent_sessions_pending: bool,
+    /// Receiver for the background recent-sessions load.
+    pub recent_sessions_rx: Option<tokio::sync::mpsc::Receiver<Vec<RecentSession>>>,
     /// Credential store for provider API keys and OAuth tokens.
     pub auth_store: claurst_core::AuthStore,
     /// Messages typed by the user while a query was streaming. They will be
@@ -1401,6 +1455,10 @@ impl App {
             model_picker_provider_id: None,
             session_list_pending: false,
             session_list_rx: None,
+            recent_sessions: Vec::new(),
+            // Load recent activity once, lazily, on the first run-loop iteration.
+            recent_sessions_pending: true,
+            recent_sessions_rx: None,
             auth_store: claurst_core::AuthStore::load(),
             queued_messages: std::collections::VecDeque::new(),
             pending_auto_submit: false,
@@ -6358,6 +6416,44 @@ impl App {
                         })
                         .collect();
                     let _ = tx.send(entries).await;
+                });
+            }
+
+            // Drain background recent-sessions results into the welcome screen.
+            if let Some(ref mut rx) = self.recent_sessions_rx {
+                match rx.try_recv() {
+                    Ok(sessions) => {
+                        self.recent_sessions = sessions;
+                        self.recent_sessions_rx = None;
+                    }
+                    Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                        self.recent_sessions_rx = None;
+                    }
+                    Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {}
+                }
+            }
+
+            // Spawn the one-shot recent-sessions load when requested (startup).
+            if self.recent_sessions_pending {
+                self.recent_sessions_pending = false;
+                let root = self.project_root();
+                let (tx, rx) = tokio::sync::mpsc::channel(1);
+                self.recent_sessions_rx = Some(rx);
+                tokio::spawn(async move {
+                    // Show at most a handful; list_sessions is already newest-first.
+                    const MAX_RECENT: usize = 5;
+                    let summaries = claurst_core::session_storage::list_sessions(&root)
+                        .await
+                        .unwrap_or_default();
+                    let recent: Vec<RecentSession> = summaries
+                        .into_iter()
+                        .take(MAX_RECENT)
+                        .map(|s| RecentSession {
+                            label: recent_session_label(s.title, s.last_prompt),
+                            mtime: s.mtime,
+                        })
+                        .collect();
+                    let _ = tx.send(recent).await;
                 });
             }
 

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -6756,6 +6756,48 @@ mod tests {
         }
     }
 
+    // ---- recent-activity label (issue #277) ----
+
+    #[test]
+    fn recent_session_label_prefers_title() {
+        let label = recent_session_label(
+            Some("My Title".to_string()),
+            Some("some prompt".to_string()),
+        );
+        assert_eq!(label, "My Title");
+    }
+
+    #[test]
+    fn recent_session_label_falls_back_to_first_prompt_line() {
+        let label = recent_session_label(
+            None,
+            Some("  fix the bug\nand more details".to_string()),
+        );
+        assert_eq!(label, "fix the bug");
+    }
+
+    #[test]
+    fn recent_session_label_skips_blank_title_and_untitled_default() {
+        // Blank/whitespace title is ignored in favour of the prompt.
+        assert_eq!(
+            recent_session_label(Some("   ".to_string()), Some("do it".to_string())),
+            "do it"
+        );
+        // Nothing usable → untitled.
+        assert_eq!(recent_session_label(None, None), "(untitled)");
+        assert_eq!(
+            recent_session_label(Some(String::new()), Some("\n\n".to_string())),
+            "(untitled)"
+        );
+    }
+
+    #[test]
+    fn recent_session_label_truncates_long_prompt() {
+        let long = "x".repeat(200);
+        let label = recent_session_label(None, Some(long));
+        assert_eq!(label.chars().count(), 80);
+    }
+
     // ---- mouse capture gate (issue #104) ----
 
     fn scroll_up_event() -> crossterm::event::MouseEvent {

--- a/src-rust/crates/tui/src/render.rs
+++ b/src-rust/crates/tui/src/render.rs
@@ -208,6 +208,38 @@ fn short_relative_secs(secs: u64) -> String {
     }
 }
 
+/// Build the body lines for the welcome box's "Recent activity" section.
+///
+/// Renders up to five recent sessions as `<label> <relative-time>` (the label
+/// truncated to fit `width`), or a single dimmed "No recent activity" line when
+/// there are none. Split out from [`render_welcome_box`] so it can be unit
+/// tested from controlled state without the surrounding layout.
+fn recent_activity_lines(recent: &[crate::app::RecentSession], width: usize) -> Vec<Line<'static>> {
+    if recent.is_empty() {
+        return vec![Line::from(Span::styled(
+            "No recent activity",
+            Style::default().fg(Color::DarkGray),
+        ))];
+    }
+
+    recent
+        .iter()
+        .take(5)
+        .map(|s| {
+            let when = short_relative_time(s.mtime);
+            // Reserve room for the trailing " <time>" so the label truncates
+            // instead of wrapping onto a second line.
+            let label_w = width.saturating_sub(when.chars().count() + 1);
+            let label = truncate_end(&s.label, label_w.max(1));
+            Line::from(vec![
+                Span::styled(label, Style::default().fg(Color::Gray)),
+                Span::raw(" "),
+                Span::styled(when, Style::default().fg(Color::DarkGray)),
+            ])
+        })
+        .collect()
+}
+
 fn truncate_end(text: &str, max_width: usize) -> String {
     if max_width == 0 {
         return String::new();
@@ -1726,25 +1758,7 @@ fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
         "Recent activity",
         Style::default().fg(accent).add_modifier(Modifier::BOLD),
     )));
-    if app.recent_sessions.is_empty() {
-        right_lines.push(Line::from(Span::styled(
-            "No recent activity",
-            Style::default().fg(Color::DarkGray),
-        )));
-    } else {
-        for s in app.recent_sessions.iter().take(5) {
-            let when = short_relative_time(s.mtime);
-            // Reserve room for the trailing " <time>" so the label truncates
-            // instead of wrapping onto a second line.
-            let label_w = right_w_usize.saturating_sub(when.chars().count() + 1);
-            let label = truncate_end(&s.label, label_w.max(1));
-            right_lines.push(Line::from(vec![
-                Span::styled(label, Style::default().fg(Color::Gray)),
-                Span::raw(" "),
-                Span::styled(when, Style::default().fg(Color::DarkGray)),
-            ]));
-        }
-    }
+    right_lines.extend(recent_activity_lines(&app.recent_sessions, right_w_usize));
 
     frame.render_widget(Paragraph::new(right_lines).wrap(Wrap { trim: false }), h_chunks[2]);
 }
@@ -3664,5 +3678,117 @@ mod effort_dock_tests {
             !open.contains(PROMPT_POINTER),
             "prompt input must NOT be drawn while the picker is open"
         );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Welcome screen: recent activity (issue #277)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod recent_activity_tests {
+    use super::*;
+    use crate::app::{App, RecentSession};
+    use claurst_core::config::Config;
+    use claurst_core::cost::CostTracker;
+    use ratatui::{backend::TestBackend, Terminal};
+    use std::time::{Duration, SystemTime};
+
+    fn recent(label: &str, secs_ago: u64) -> RecentSession {
+        RecentSession {
+            label: label.to_string(),
+            mtime: SystemTime::now() - Duration::from_secs(secs_ago),
+        }
+    }
+
+    fn lines_text(recent: &[RecentSession], width: usize) -> Vec<String> {
+        recent_activity_lines(recent, width)
+            .iter()
+            .map(flatten_line_text)
+            .collect()
+    }
+
+    // -- relative-time formatter ------------------------------------------
+
+    #[test]
+    fn short_relative_secs_buckets() {
+        assert_eq!(short_relative_secs(0), "just now");
+        assert_eq!(short_relative_secs(59), "just now");
+        assert_eq!(short_relative_secs(60), "1m ago");
+        assert_eq!(short_relative_secs(5 * 60), "5m ago");
+        assert_eq!(short_relative_secs(2 * 3_600), "2h ago");
+        assert_eq!(short_relative_secs(3 * 86_400), "3d ago");
+    }
+
+    #[test]
+    fn short_relative_time_handles_future_mtime() {
+        // Clock skew (mtime slightly in the future) must not panic.
+        let future = SystemTime::now() + Duration::from_secs(120);
+        assert_eq!(short_relative_time(future), "just now");
+    }
+
+    // -- render-from-state path -------------------------------------------
+
+    #[test]
+    fn empty_state_shows_placeholder() {
+        let out = lines_text(&[], 40);
+        assert_eq!(out, vec!["No recent activity".to_string()]);
+    }
+
+    #[test]
+    fn populated_state_shows_titles_and_relative_times() {
+        let sessions = vec![
+            recent("Fix the parser bug", 2 * 3_600),
+            recent("Wire up onboarding", 3 * 86_400),
+        ];
+        let out = lines_text(&sessions, 40).join("\n");
+        assert!(out.contains("Fix the parser bug"), "first title: {out:?}");
+        assert!(out.contains("2h ago"), "first time: {out:?}");
+        assert!(out.contains("Wire up onboarding"), "second title: {out:?}");
+        assert!(out.contains("3d ago"), "second time: {out:?}");
+        // The placeholder must NOT appear when there is real activity.
+        assert!(!out.contains("No recent activity"), "no placeholder: {out:?}");
+    }
+
+    #[test]
+    fn caps_at_five_entries() {
+        let sessions: Vec<RecentSession> =
+            (0..8).map(|i| recent(&format!("session {i}"), 60)).collect();
+        assert_eq!(recent_activity_lines(&sessions, 40).len(), 5);
+    }
+
+    #[test]
+    fn long_label_is_truncated_and_leaves_room_for_time() {
+        let sessions = vec![recent(
+            "an extremely long session title that should be truncated to fit",
+            60,
+        )];
+        let out = lines_text(&sessions, 20);
+        assert_eq!(out.len(), 1);
+        let line = &out[0];
+        assert!(line.contains('\u{2026}'), "should be ellipsised: {line:?}");
+        assert!(line.ends_with("1m ago"), "time preserved at end: {line:?}");
+    }
+
+    #[test]
+    fn welcome_box_renders_recent_activity_from_state() {
+        // Full-widget smoke test: the section header renders and, when state is
+        // populated, a session label reaches the screen buffer without panic.
+        let mut app = App::new(Config::default(), CostTracker::new());
+        app.recent_sessions = vec![recent("Sortable label ABCDEF", 2 * 3_600)];
+
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).unwrap();
+        terminal
+            .draw(|frame| render_welcome_box(frame, &app, frame.area()))
+            .unwrap();
+        let screen: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol().chars().next().unwrap_or(' '))
+            .collect();
+        assert!(screen.contains("Recent activity"), "header rendered: present");
+        assert!(screen.contains("Sortable label"), "session label rendered");
     }
 }

--- a/src-rust/crates/tui/src/render.rs
+++ b/src-rust/crates/tui/src/render.rs
@@ -183,6 +183,31 @@ fn render_error_modal(frame: &mut Frame, area: Rect, notification: &Notification
 // Text truncation helpers
 // -----------------------------------------------------------------------
 
+/// Short relative timestamp for the welcome screen's recent-activity list:
+/// "just now", "5m ago", "2h ago", "3d ago". Clock skew (mtime in the future)
+/// degrades gracefully to "just now".
+fn short_relative_time(mtime: std::time::SystemTime) -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(mtime)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    short_relative_secs(secs)
+}
+
+/// Formatter split out from [`short_relative_time`] so it can be unit-tested
+/// without depending on the wall clock.
+fn short_relative_secs(secs: u64) -> String {
+    if secs < 60 {
+        "just now".to_string()
+    } else if secs < 3_600 {
+        format!("{}m ago", secs / 60)
+    } else if secs < 86_400 {
+        format!("{}h ago", secs / 3_600)
+    } else {
+        format!("{}d ago", secs / 86_400)
+    }
+}
+
 fn truncate_end(text: &str, max_width: usize) -> String {
     if max_width == 0 {
         return String::new();
@@ -1701,10 +1726,25 @@ fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
         "Recent activity",
         Style::default().fg(accent).add_modifier(Modifier::BOLD),
     )));
-    right_lines.push(Line::from(Span::styled(
-        "No recent activity",
-        Style::default().fg(Color::DarkGray),
-    )));
+    if app.recent_sessions.is_empty() {
+        right_lines.push(Line::from(Span::styled(
+            "No recent activity",
+            Style::default().fg(Color::DarkGray),
+        )));
+    } else {
+        for s in app.recent_sessions.iter().take(5) {
+            let when = short_relative_time(s.mtime);
+            // Reserve room for the trailing " <time>" so the label truncates
+            // instead of wrapping onto a second line.
+            let label_w = right_w_usize.saturating_sub(when.chars().count() + 1);
+            let label = truncate_end(&s.label, label_w.max(1));
+            right_lines.push(Line::from(vec![
+                Span::styled(label, Style::default().fg(Color::Gray)),
+                Span::raw(" "),
+                Span::styled(when, Style::default().fg(Color::DarkGray)),
+            ]));
+        }
+    }
 
     frame.render_widget(Paragraph::new(right_lines).wrap(Wrap { trim: false }), h_chunks[2]);
 }


### PR DESCRIPTION
Closes #277. The welcome screen's 'Recent activity' was hardcoded; now loads top-5 recent sessions async at startup into `app.recent_sessions` and renders label + relative time. 2 commits, 11 tests, clippy green.

Closes #277