### PR TITLE
feat(models): fresh models.dev + experimental-modes expansion + additive discovery (port from opencode, phase 1)

### DIFF
--- a/src-rust/crates/api/src/model_registry.rs
+++ b/src-rust/crates/api/src/model_registry.rs
@@ -247,6 +247,17 @@ pub struct ModelEntry {
     /// Per-mode dispatch alternatives (rarely populated).
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub experimental_modes: HashMap<String, ExperimentalMode>,
+    /// Default request-body options for this model, camelCase-keyed. Populated
+    /// for entries synthesized from an [`ExperimentalMode`] (opencode
+    /// `provider.body`, see [`expand_experimental_modes`]); empty for base
+    /// catalog models.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub options: HashMap<String, serde_json::Value>,
+    /// Default request headers for this model. Populated for synthesized
+    /// experimental-mode entries (opencode `provider.headers`); empty for base
+    /// catalog models.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub headers: HashMap<String, String>,
 }
 
 fn default_true() -> bool { true }
@@ -555,13 +566,135 @@ fn transform_api(api: md::ApiJson) -> ParsedSnapshot {
                 cost,
                 provider_override: m.provider,
                 experimental_modes,
+                options: HashMap::new(),
+                headers: HashMap::new(),
             };
 
             out.models.insert(key, entry);
         }
     }
 
+    // Expand each model's experimental.modes into extra listed models, mirroring
+    // opencode's `fromModelsDevProvider` (provider.ts:1247-1264).
+    expand_experimental_modes(&mut out.models);
+
     out
+}
+
+/// Expand each model's `experimental.modes` into additional listed models,
+/// mirroring opencode's `fromModelsDevProvider` (provider.ts:1247-1264).
+///
+/// For every model with a non-empty `experimental_modes` map, a sibling entry
+/// is synthesized keyed `"<provider>/<model>-<mode>"`, named `"<name> <Mode>"`
+/// (only the first letter of the mode is upper-cased, matching
+/// `mode[0].toUpperCase()`), with:
+///   * `cost` = the mode's `cost` deep-merged over the base cost (else base),
+///   * `options` = the mode's `provider.body` with snake_case→camelCase keys,
+///   * `headers` = the mode's `provider.headers` (else the base's).
+///
+/// The synthesized entries are what makes the extra modes appear in the picker.
+fn expand_experimental_modes(models: &mut HashMap<String, ModelEntry>) {
+    let mut synthesized: Vec<(String, ModelEntry)> = Vec::new();
+    for entry in models.values() {
+        if entry.experimental_modes.is_empty() {
+            continue;
+        }
+        let base_id: &str = &entry.info.id;
+        let provider_id: &str = &entry.info.provider_id;
+        for (mode, opts) in &entry.experimental_modes {
+            let mode_id = format!("{base_id}-{mode}");
+            let key = format!("{provider_id}/{mode_id}");
+            let mut synth = entry.clone();
+            synth.info.id = ModelId::new(mode_id);
+            synth.info.name = format!("{} {}", entry.info.name, capitalize_first(mode));
+
+            // cost: mode cost deep-merged over the base cost (opencode:
+            // `opts.cost ? mergeDeep(base.cost, cost(opts.cost)) : base.cost`).
+            if let Some(mode_cost) = &opts.cost {
+                synth.cost = merge_cost(&entry.cost, mode_cost);
+                synth.cost_input = synth.cost.input;
+                synth.cost_output = synth.cost.output;
+                synth.cost_cache_read = synth.cost.cache_read;
+                synth.cost_cache_write = synth.cost.cache_write;
+            }
+
+            // options: provider.body with snake_case → camelCase keys
+            // (opencode provider.ts:1256). When absent, keep the base's.
+            if !opts.provider_body.is_empty() {
+                synth.options = opts
+                    .provider_body
+                    .iter()
+                    .map(|(k, v)| (snake_to_camel(k), v.clone()))
+                    .collect();
+            }
+
+            // headers: mode headers override the base's (`opts.provider?.headers
+            // ?? base.headers`).
+            if !opts.provider_headers.is_empty() {
+                synth.headers = opts.provider_headers.clone();
+            }
+
+            // A synthesized entry must not itself be re-expanded.
+            synth.experimental_modes = HashMap::new();
+            synthesized.push((key, synth));
+        }
+    }
+    for (key, entry) in synthesized {
+        models.insert(key, entry);
+    }
+}
+
+/// Deep-merge cost `over` onto `base` (opencode `mergeDeep`): a `Some` value in
+/// `over` wins, a `None` keeps the `base` value; recurses into the 200K tier.
+fn merge_cost(base: &CostBreakdown, over: &CostBreakdown) -> CostBreakdown {
+    CostBreakdown {
+        input: over.input.or(base.input),
+        output: over.output.or(base.output),
+        cache_read: over.cache_read.or(base.cache_read),
+        cache_write: over.cache_write.or(base.cache_write),
+        input_audio: over.input_audio.or(base.input_audio),
+        output_audio: over.output_audio.or(base.output_audio),
+        reasoning: over.reasoning.or(base.reasoning),
+        context_over_200k: match (&over.context_over_200k, &base.context_over_200k) {
+            (Some(o), Some(b)) => Some(Box::new(merge_cost(b, o))),
+            (Some(o), None) => Some(o.clone()),
+            (None, b) => b.clone(),
+        },
+    }
+}
+
+/// Convert snake_case keys to camelCase, matching opencode's
+/// `k.replace(/_([a-z])/g, (_, c) => c.toUpperCase())` (provider.ts:1256): only
+/// an underscore immediately followed by an ASCII lowercase letter is collapsed
+/// (upper-casing that letter); every other underscore is preserved verbatim.
+fn snake_to_camel(key: &str) -> String {
+    let mut out = String::with_capacity(key.len());
+    let mut chars = key.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '_' {
+            if let Some(&next) = chars.peek() {
+                if next.is_ascii_lowercase() {
+                    out.push(next.to_ascii_uppercase());
+                    chars.next();
+                    continue;
+                }
+            }
+            out.push('_');
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// Upper-case only the first character of `s` (mirrors opencode's
+/// `${mode[0].toUpperCase()}${mode.slice(1)}`).
+fn capitalize_first(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1329,6 +1462,90 @@ mod tests {
         assert!(
             parsed.models.contains_key("opencode-zen/qwen3.6-plus-free"),
             "model key must use opencode-zen prefix"
+        );
+    }
+
+    // ---- experimental.modes expansion (opencode provider.ts:1247-1264) ----
+
+    #[test]
+    fn experimental_modes_expand_into_listed_models() {
+        // A model with an experimental.modes map must yield an extra sibling
+        // entry keyed "<provider>/<model>-<mode>", with cost deep-merged, the
+        // provider.body camelCased into `options`, and provider.headers carried.
+        let json = r#"{"myprov":{"id":"myprov","name":"My Provider","env":[],"models":{"base-model":{"id":"base-model","name":"Base Model","cost":{"input":1.0,"output":2.0},"limit":{"context":100000,"output":8000},"experimental":{"modes":{"fast":{"cost":{"output":5.0},"provider":{"body":{"max_output_tokens":1024,"reasoning_effort":"low"},"headers":{"x-mode":"fast"}}}}}}}}}"#;
+        let parsed = parse_snapshot_str(json).expect("parse must succeed");
+
+        // Base entry still present.
+        assert!(
+            parsed.models.contains_key("myprov/base-model"),
+            "base model must remain"
+        );
+
+        // Synthesized mode entry present under the "-fast" key.
+        let synth = parsed
+            .models
+            .get("myprov/base-model-fast")
+            .expect("experimental mode must be expanded into a listed model");
+        assert_eq!(&*synth.info.id, "base-model-fast");
+        assert_eq!(synth.info.name, "Base Model Fast");
+
+        // Cost is the mode's cost deep-merged over the base: output overridden,
+        // input retained from the base.
+        assert_eq!(synth.cost_input, Some(1.0));
+        assert_eq!(synth.cost_output, Some(5.0));
+
+        // provider.body keys are snake_case → camelCase converted.
+        assert_eq!(
+            synth.options.get("maxOutputTokens").and_then(|v| v.as_u64()),
+            Some(1024)
+        );
+        assert_eq!(
+            synth.options.get("reasoningEffort").and_then(|v| v.as_str()),
+            Some("low")
+        );
+
+        // provider.headers carried through verbatim.
+        assert_eq!(
+            synth.headers.get("x-mode").map(String::as_str),
+            Some("fast")
+        );
+
+        // The synthesized entry must not carry modes to re-expand.
+        assert!(synth.experimental_modes.is_empty());
+    }
+
+    #[test]
+    fn snake_to_camel_matches_opencode() {
+        assert_eq!(snake_to_camel("max_output_tokens"), "maxOutputTokens");
+        assert_eq!(snake_to_camel("reasoning_effort"), "reasoningEffort");
+        // Trailing / doubled underscores and non-alpha follows are preserved.
+        assert_eq!(snake_to_camel("already"), "already");
+        assert_eq!(snake_to_camel("trailing_"), "trailing_");
+        assert_eq!(snake_to_camel("a_1b"), "a_1b");
+    }
+
+    #[test]
+    fn hardcoded_list_providers_surface_full_catalog() {
+        // cohere/azure/amazon-bedrock/minimax previously overwrote the catalog
+        // via a tiny hardcoded discover_models() (2/4/3/1 models). The catalog
+        // itself carries the full models.dev list for each; the provider fix
+        // stops the overwrite so these surface in the picker.
+        let reg = ModelRegistry::new();
+        assert!(
+            reg.list_by_provider("cohere").len() >= 10,
+            "cohere catalog must surface (~12), not the old hardcoded 2"
+        );
+        assert!(
+            reg.list_by_provider("azure").len() >= 50,
+            "azure catalog must surface (~108), not the old hardcoded 4"
+        );
+        assert!(
+            reg.list_by_provider("amazon-bedrock").len() >= 50,
+            "bedrock catalog must surface (~85), not the old hardcoded 3"
+        );
+        assert!(
+            reg.list_by_provider("minimax").len() >= 5,
+            "minimax catalog must surface (~6), not the old hardcoded 1"
         );
     }
 

--- a/src-rust/crates/api/src/providers/azure.rs
+++ b/src-rust/crates/api/src/providers/azure.rs
@@ -11,14 +11,14 @@ use std::pin::Pin;
 
 use async_stream::stream;
 use async_trait::async_trait;
-use claurst_core::provider_id::{ModelId, ProviderId};
+use claurst_core::provider_id::ProviderId;
 use claurst_core::types::{ContentBlock, UsageInfo};
 use futures::Stream;
 use serde_json::{json, Value};
 use tracing::debug;
 
 use crate::error_handling::parse_error_response;
-use crate::provider::{LlmProvider, ModelInfo};
+use crate::provider::LlmProvider;
 use crate::provider_error::ProviderError;
 use crate::provider_types::{
     ProviderCapabilities, ProviderRequest, ProviderResponse, ProviderStatus, StreamEvent,
@@ -432,43 +432,6 @@ impl LlmProvider for AzureProvider {
         };
 
         Ok(Box::pin(s))
-    }
-
-    async fn discover_models(&self) -> Result<Vec<ModelInfo>, ProviderError> {
-        Ok(vec![
-            ModelInfo {
-                id: ModelId::new("gpt-4o"),
-                provider_id: self.id.clone(),
-                name: "GPT-4o (Azure)".to_string(),
-                context_window: 128_000,
-                max_output_tokens: 16_384,
-                ..Default::default()
-            },
-            ModelInfo {
-                id: ModelId::new("gpt-4o-mini"),
-                provider_id: self.id.clone(),
-                name: "GPT-4o Mini (Azure)".to_string(),
-                context_window: 128_000,
-                max_output_tokens: 16_384,
-                ..Default::default()
-            },
-            ModelInfo {
-                id: ModelId::new("gpt-4-turbo"),
-                provider_id: self.id.clone(),
-                name: "GPT-4 Turbo (Azure)".to_string(),
-                context_window: 128_000,
-                max_output_tokens: 4_096,
-                ..Default::default()
-            },
-            ModelInfo {
-                id: ModelId::new("gpt-35-turbo"),
-                provider_id: self.id.clone(),
-                name: "GPT-3.5 Turbo (Azure)".to_string(),
-                context_window: 16_385,
-                max_output_tokens: 4_096,
-                ..Default::default()
-            },
-        ])
     }
 
     async fn health_check(&self) -> Result<ProviderStatus, ProviderError> {

--- a/src-rust/crates/api/src/providers/bedrock.rs
+++ b/src-rust/crates/api/src/providers/bedrock.rs
@@ -17,14 +17,14 @@ use std::pin::Pin;
 
 use async_stream::stream;
 use async_trait::async_trait;
-use claurst_core::provider_id::{ModelId, ProviderId};
+use claurst_core::provider_id::ProviderId;
 use claurst_core::types::{ContentBlock, MessageContent, Role, ToolResultContent, UsageInfo};
 use futures::Stream;
 use serde_json::{json, Value};
 use tracing::debug;
 
 use crate::error_handling::parse_error_response;
-use crate::provider::{LlmProvider, ModelInfo};
+use crate::provider::LlmProvider;
 use crate::provider_error::ProviderError;
 use crate::provider_types::{
     ProviderCapabilities, ProviderRequest, ProviderResponse, ProviderStatus, StopReason,
@@ -720,35 +720,6 @@ impl LlmProvider for BedrockProvider {
         };
 
         Ok(Box::pin(s))
-    }
-
-    async fn discover_models(&self) -> Result<Vec<ModelInfo>, ProviderError> {
-        Ok(vec![
-            ModelInfo {
-                id: ModelId::new("anthropic.claude-opus-4-6"),
-                provider_id: self.id.clone(),
-                name: "Claude Opus 4.6 (Bedrock)".to_string(),
-                context_window: 200_000,
-                max_output_tokens: 32_000,
-                ..Default::default()
-            },
-            ModelInfo {
-                id: ModelId::new("anthropic.claude-sonnet-4-6"),
-                provider_id: self.id.clone(),
-                name: "Claude Sonnet 4.6 (Bedrock)".to_string(),
-                context_window: 200_000,
-                max_output_tokens: 16_000,
-                ..Default::default()
-            },
-            ModelInfo {
-                id: ModelId::new("anthropic.claude-haiku-4-5-20251001"),
-                provider_id: self.id.clone(),
-                name: "Claude Haiku 4.5 (Bedrock)".to_string(),
-                context_window: 200_000,
-                max_output_tokens: 8_192,
-                ..Default::default()
-            },
-        ])
     }
 
     async fn health_check(&self) -> Result<ProviderStatus, ProviderError> {

--- a/src-rust/crates/api/src/providers/cohere.rs
+++ b/src-rust/crates/api/src/providers/cohere.rs
@@ -10,13 +10,13 @@ use std::pin::Pin;
 
 use async_stream::stream;
 use async_trait::async_trait;
-use claurst_core::provider_id::{ModelId, ProviderId};
+use claurst_core::provider_id::ProviderId;
 use claurst_core::types::{ContentBlock, UsageInfo};
 use futures::Stream;
 use serde_json::{json, Value};
 use tracing::debug;
 
-use crate::provider::{LlmProvider, ModelInfo};
+use crate::provider::LlmProvider;
 use crate::provider_error::ProviderError;
 use crate::provider_types::{
     ProviderCapabilities, ProviderRequest, ProviderResponse, ProviderStatus, StopReason,
@@ -642,27 +642,6 @@ impl LlmProvider for CohereProvider {
         };
 
         Ok(Box::pin(s))
-    }
-
-    async fn discover_models(&self) -> Result<Vec<ModelInfo>, ProviderError> {
-        Ok(vec![
-            ModelInfo {
-                id: ModelId::new("command-r-plus"),
-                provider_id: self.id.clone(),
-                name: "Command R+".to_string(),
-                context_window: 128_000,
-                max_output_tokens: 4_000,
-                ..Default::default()
-            },
-            ModelInfo {
-                id: ModelId::new("command-r"),
-                provider_id: self.id.clone(),
-                name: "Command R".to_string(),
-                context_window: 128_000,
-                max_output_tokens: 4_000,
-                ..Default::default()
-            },
-        ])
     }
 
     async fn health_check(&self) -> Result<ProviderStatus, ProviderError> {

--- a/src-rust/crates/api/src/providers/minimax.rs
+++ b/src-rust/crates/api/src/providers/minimax.rs
@@ -5,13 +5,13 @@ use std::pin::Pin;
 
 use async_stream::stream;
 use async_trait::async_trait;
-use claurst_core::provider_id::{ModelId, ProviderId};
+use claurst_core::provider_id::ProviderId;
 use claurst_core::types::{ContentBlock, UsageInfo};
 use futures::Stream;
 use reqwest::{Client, header};
 use serde_json::Value;
 
-use crate::provider::{LlmProvider, ModelInfo};
+use crate::provider::LlmProvider;
 use crate::provider_error::ProviderError;
 use crate::provider_types::{
     ProviderCapabilities, ProviderRequest, ProviderResponse, ProviderStatus, StopReason,
@@ -383,20 +383,6 @@ impl LlmProvider for MinimaxProvider {
         };
 
         Ok(Box::pin(s))
-    }
-
-    async fn discover_models(&self) -> Result<Vec<ModelInfo>, ProviderError> {
-        let minimax_id = ProviderId::new(ProviderId::MINIMAX);
-        Ok(vec![
-            ModelInfo {
-                id: ModelId::new("MiniMax-M2.7"),
-                provider_id: minimax_id.clone(),
-                name: "MiniMax-M2.7".to_string(),
-                context_window: 128_000,
-                max_output_tokens: 8192,
-                ..Default::default()
-            },
-        ])
     }
 
     async fn health_check(&self) -> Result<ProviderStatus, ProviderError> {

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -3427,14 +3427,16 @@ async fn run_interactive(
                         .strip_prefix(&provider_prefix)
                         .unwrap_or(app.model_name.as_str())
                         .to_string();
-                    // Only let a live-discovery result replace the list when it
-                    // actually returned models. An empty result — catalog-backed
-                    // provider (now the trait default), an unreachable endpoint,
-                    // or a missing entitlement — must never wipe the registry
-                    // projection set when the picker opened.
-                    if !entries.is_empty() {
-                        app.model_picker.set_models(entries);
-                    }
+                    // Additively merge the live-discovery result onto the
+                    // catalog projection already loaded when the picker opened,
+                    // mirroring opencode's github-copilot models.ts merge-by-id
+                    // (models.ts:229-255): keep the catalog metadata for ids in
+                    // both, append only live ids not already listed. An empty
+                    // result — catalog-backed provider (now the trait default),
+                    // an unreachable endpoint, or a missing entitlement — is a
+                    // no-op and never wipes the projection. For copilot the id
+                    // IS the api.id, so this is the by-api.id merge.
+                    app.model_picker.merge_models(entries);
                     for m in &mut app.model_picker.models {
                         m.is_current = m.id == current;
                     }

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -1199,7 +1199,34 @@ fn spawn_models_cache_refresh() {
         tracing::debug!("CLAURST_DISABLE_MODELS_FETCH set — skipping models.dev refresh");
         return;
     }
+    tokio::spawn(async move {
+        refresh_models_cache_once().await;
+    });
+}
 
+/// TUI-startup analogue of opencode's `ModelsDev` background refresh
+/// (models-dev.ts:233-236): fire one refresh now (gated by the 5-minute TTL),
+/// then repeat spaced ~60 minutes so a long-running session keeps a fresh
+/// catalog on disk for the `/model` picker to reload. Non-blocking — the UI is
+/// never held on the network.
+fn spawn_models_cache_refresh_loop() {
+    if std::env::var("CLAURST_DISABLE_MODELS_FETCH").is_ok() {
+        tracing::debug!("CLAURST_DISABLE_MODELS_FETCH set — skipping models.dev refresh loop");
+        return;
+    }
+    tokio::spawn(async move {
+        loop {
+            refresh_models_cache_once().await;
+            tokio::time::sleep(std::time::Duration::from_secs(60 * 60)).await;
+        }
+    });
+}
+
+/// Fetch the models.dev catalog into the on-disk cache once, honoring the
+/// 5-minute mtime freshness check (mirrors opencode `ModelsDev.fresh()`). All
+/// network/parse failures are silent — the bundled snapshot is always
+/// sufficient.
+async fn refresh_models_cache_once() {
     let cache_path = models_cache_path();
     let legacy_cache_path = models_dev_cache_path();
     let ttl = std::time::Duration::from_secs(5 * 60);
@@ -1209,43 +1236,41 @@ fn spawn_models_cache_refresh() {
         return;
     }
 
-    tokio::spawn(async move {
-        let client = match reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(10))
-            .build()
-        {
-            Ok(c) => c,
-            Err(_) => return,
-        };
-        let url = models_source_url();
-        let resp = match client
-            .get(&url)
-            .header("User-Agent", concat!("Claurst/", env!("CARGO_PKG_VERSION")))
-            .send()
-            .await
-        {
-            Ok(r) => r,
-            Err(err) => {
-                tracing::debug!(?err, "models.dev refresh: network error");
-                return;
-            }
-        };
-        if !resp.status().is_success() {
-            tracing::debug!(status = ?resp.status(), "models.dev refresh: non-2xx");
+    let client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+    {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+    let url = models_source_url();
+    let resp = match client
+        .get(&url)
+        .header("User-Agent", concat!("Claurst/", env!("CARGO_PKG_VERSION")))
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(err) => {
+            tracing::debug!(?err, "models.dev refresh: network error");
             return;
         }
-        let text = match resp.text().await {
-            Ok(t) => t,
-            Err(_) => return,
-        };
-        if let Some(parent) = cache_path.parent() {
-            let _ = std::fs::create_dir_all(parent);
-        }
-        // Write canonical path + legacy path so older installs keep working.
-        let _ = std::fs::write(&cache_path, &text);
-        let _ = std::fs::write(&legacy_cache_path, &text);
-        tracing::info!(path = %cache_path.display(), "Models cache refreshed from {}", url);
-    });
+    };
+    if !resp.status().is_success() {
+        tracing::debug!(status = ?resp.status(), "models.dev refresh: non-2xx");
+        return;
+    }
+    let text = match resp.text().await {
+        Ok(t) => t,
+        Err(_) => return,
+    };
+    if let Some(parent) = cache_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    // Write canonical path + legacy path so older installs keep working.
+    let _ = std::fs::write(&cache_path, &text);
+    let _ = std::fs::write(&legacy_cache_path, &text);
+    tracing::info!(path = %cache_path.display(), "Models cache refreshed from {}", url);
 }
 
 async fn remove_file_if_exists(path: &std::path::Path) -> anyhow::Result<()> {
@@ -1805,11 +1830,12 @@ async fn run_interactive(
     app.refresh_context_window_size();
     app.auto_compact_enabled = live_config.auto_compact;
 
-    // Background: refresh the model registry from models.dev.
-    // The fetched JSON is saved as a cache file; the App will reload it from
-    // disk whenever the /model picker opens.
+    // Background: keep the model registry fresh from models.dev for the whole
+    // TUI session (opencode-style: refresh now, then every ~60 min, gated by a
+    // 5-min TTL). The fetched JSON is saved as a cache file; the App reloads it
+    // from disk whenever the /model picker opens. Non-blocking.
     {
-        spawn_models_cache_refresh();
+        spawn_models_cache_refresh_loop();
     }
 
     // Wire the ask-user question channel into the app so the TUI can show

--- a/src-rust/crates/tui/src/model_picker.rs
+++ b/src-rust/crates/tui/src/model_picker.rs
@@ -301,18 +301,34 @@ pub fn default_model_for_provider(
 /// the models.dev catalog — i.e. the provider has **no** live model-discovery
 /// endpoint and its `discover_models()` is the empty trait default.
 ///
-/// For these providers (Anthropic, OpenAI, Google) the displayed list must come
-/// from [`models_for_provider_from_registry`] and nothing else; the event loop
-/// skips the background discovery fetch entirely so a provider return value can
-/// never replace the catalog projection. This is what makes a fresh
-/// `claude-opus-*` point-release surface the instant the snapshot ships it.
+/// For these providers the displayed list must come from
+/// [`models_for_provider_from_registry`] and nothing else; the event loop skips
+/// the background discovery fetch entirely so a provider return value can never
+/// replace the catalog projection. This is what makes a fresh `claude-opus-*`
+/// point-release surface the instant the snapshot ships it.
 ///
-/// Live-endpoint providers (Ollama/LM Studio/llama.cpp, Copilot, Azure, the
-/// openai-compatible gateways, …) and curated-list providers (Bedrock, Codex,
-/// free, Cohere, MiniMax) are intentionally excluded: they keep populating the
-/// picker from their `discover_models()` result.
+/// Anthropic/OpenAI/Google never had a live endpoint. Azure, Amazon Bedrock,
+/// Cohere and MiniMax used to ship a tiny hardcoded `discover_models()` list
+/// that clobbered the far richer catalog (108/85/12/6 rows); that override was
+/// removed, so they are projected from the models.dev catalog here too rather
+/// than fetched.
+///
+/// Live-endpoint providers (Ollama/LM Studio/llama.cpp, Copilot, the
+/// openai-compatible gateways, …) and curated-list providers (Codex, free) are
+/// intentionally excluded: they keep populating the picker from their
+/// `discover_models()` result, which the event loop merges additively onto the
+/// catalog projection.
 pub fn provider_uses_catalog_projection(provider_id: &str) -> bool {
-    matches!(provider_id, "anthropic" | "openai" | "google")
+    matches!(
+        provider_id,
+        "anthropic"
+            | "openai"
+            | "google"
+            | "azure"
+            | "amazon-bedrock"
+            | "cohere"
+            | "minimax"
+    )
 }
 
 /// Whether `provider_id` refers to the OpenAI Codex provider under either of
@@ -635,6 +651,44 @@ impl ModelPickerState {
     /// Resets `loading_models` and sets `models_loaded`.
     pub fn set_models(&mut self, entries: Vec<ModelEntry>) {
         self.models = entries;
+        self.loading_models = false;
+        self.models_loaded = true;
+        // Keep selected_idx in bounds.
+        let count = self.filtered_models().len();
+        if count > 0 && self.selected_idx >= count {
+            self.selected_idx = count - 1;
+        }
+    }
+
+    /// Additively merge live-discovered entries into the existing list.
+    ///
+    /// Mirrors opencode's github-copilot `models.ts` merge (by id / api.id;
+    /// models.ts:229-255): the catalog projection already loaded into the picker
+    /// is authoritative — its richer cost/context/reasoning metadata is kept for
+    /// every id present in both — and only live models whose id isn't already
+    /// present are appended. A non-empty live result also clears the synthetic
+    /// "no catalog entry" placeholder that [`models_for_provider_from_registry`]
+    /// emits for providers with no catalog rows (e.g. self-hosted endpoints).
+    ///
+    /// Unlike copilot's merge this does **not** prune catalog ids missing from
+    /// the endpoint — the overlay is purely additive, so a stale catalog row is
+    /// preferred over dropping a model the user may still have access to.
+    pub fn merge_models(&mut self, entries: Vec<ModelEntry>) {
+        if entries.is_empty() {
+            self.loading_models = false;
+            return;
+        }
+        // A real list supersedes the synthetic "no catalog" placeholder.
+        self.models
+            .retain(|m| !(m.id == "default" && m.display_name == "Default model"));
+
+        let existing: std::collections::HashSet<String> =
+            self.models.iter().map(|m| m.id.clone()).collect();
+        for e in entries {
+            if !existing.contains(&e.id) {
+                self.models.push(e);
+            }
+        }
         self.loading_models = false;
         self.models_loaded = true;
         // Keep selected_idx in bounds.
@@ -1298,5 +1352,106 @@ mod tests {
         p.set_models(openai_models);
         let ids: Vec<&str> = p.models.iter().map(|m| m.id.as_str()).collect();
         assert!(!ids.iter().any(|id| id.contains("claude")));
+    }
+
+    // 19. merge_models is additive: it keeps the catalog projection (including
+    //     its richer metadata) for ids present in both, and appends only live
+    //     ids not already listed. Mirrors copilot models.ts merge-by-id.
+    #[test]
+    fn merge_models_is_additive_and_keeps_catalog_metadata() {
+        let mut p = ModelPickerState::new();
+        p.set_models(sample_models()); // catalog projection: opus/sonnet/haiku
+
+        let live = vec![
+            // Overlaps an existing catalog id but with poorer metadata —
+            // the catalog row must win (no overwrite).
+            ModelEntry {
+                id: "claude-opus-4-6".to_string(),
+                display_name: "LIVE OVERWRITE".to_string(),
+                description: "live desc".to_string(),
+                is_current: false,
+            },
+            // A brand-new live id absent from the catalog — must be appended.
+            ModelEntry {
+                id: "gpt-5.5-live".to_string(),
+                display_name: "GPT-5.5 (live)".to_string(),
+                description: "live only".to_string(),
+                is_current: false,
+            },
+        ];
+        p.merge_models(live);
+
+        let opus = p
+            .models
+            .iter()
+            .find(|m| m.id == "claude-opus-4-6")
+            .expect("catalog opus retained");
+        assert_eq!(
+            opus.display_name, "Claude Opus 4.6",
+            "catalog metadata must be kept for shared ids (no live overwrite)"
+        );
+        assert!(
+            p.models.iter().any(|m| m.id == "gpt-5.5-live"),
+            "new live id must be appended"
+        );
+        assert!(
+            p.models.iter().filter(|m| m.id == "claude-opus-4-6").count() == 1,
+            "no duplicate for a shared id"
+        );
+        // All three original catalog ids are still present.
+        for id in ["claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"] {
+            assert!(p.models.iter().any(|m| m.id == id), "catalog id {id} kept");
+        }
+    }
+
+    // 20. An empty live result never wipes the catalog projection.
+    #[test]
+    fn merge_models_empty_keeps_catalog() {
+        let mut p = ModelPickerState::new();
+        p.set_models(sample_models());
+        p.merge_models(Vec::new());
+        assert_eq!(p.models.len(), 3, "empty live merge must not clear the list");
+        assert!(!p.loading_models);
+    }
+
+    // 21. A non-empty live result clears the synthetic "no catalog" placeholder.
+    #[test]
+    fn merge_models_clears_placeholder() {
+        let mut p = ModelPickerState::new();
+        p.set_models(vec![model_entry(
+            "default",
+            "Default model",
+            "no catalog entry for this provider",
+        )]);
+        p.merge_models(vec![ModelEntry {
+            id: "llama3.3".to_string(),
+            display_name: "Llama 3.3".to_string(),
+            description: "local".to_string(),
+            is_current: false,
+        }]);
+        assert!(
+            !p.models.iter().any(|m| m.id == "default"),
+            "placeholder must be dropped once a real list arrives"
+        );
+        assert!(p.models.iter().any(|m| m.id == "llama3.3"));
+    }
+
+    // 22. The four providers whose hardcoded discover_models() was removed now
+    //     project from the catalog (no live fetch that could clobber it).
+    #[test]
+    fn hardcoded_list_providers_use_catalog_projection() {
+        for pid in ["azure", "amazon-bedrock", "cohere", "minimax"] {
+            assert!(
+                provider_uses_catalog_projection(pid),
+                "{pid} must project from the catalog after its hardcoded list was removed"
+            );
+        }
+        // Live/curated providers must NOT be treated as catalog projections.
+        for pid in ["ollama", "github-copilot", "codex", "free"] {
+            assert!(
+                !provider_uses_catalog_projection(pid),
+                "{pid} must keep its live/curated discovery"
+            );
+        }
     }
 }


### PR DESCRIPTION
Port of opencode's model detection so claurst lists the same models. **(1A)** 60-min non-blocking models.dev auto-refresh in the TUI (5-min TTL), merge does opencode-style new-key insertion + field overlay. **(1B)** `expand_experimental_modes` synthesizes `<provider>/<model>-<mode>` entries (merged cost, camelCased options/headers) — 6 on the current snapshot. **(1C)** live discovery is now an additive merge-by-id (keeps catalog metadata) instead of replace, and the 4 hardcoded providers project the full catalog: **cohere 2→12, azure 4→108, bedrock 3→85, minimax 1→6**. 5 commits + tests, `cargo check --workspace` + clippy -D warnings green, CRLF preserved. (Effort/variants is phase 2.)

Part of the model-system port (task: audit + opencode port).