### PR TITLE
feat(commands): port /new (lazy home) and /move (re-home session) from opencode

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -70,13 +70,41 @@ Display all available commands with their descriptions. Respects `isHidden` flag
 ---
 
 ### /clear
-**Aliases:** `reset`, `new`
+**Aliases:** `reset`, `c`
 
-Clear the current conversation history and start a fresh session. The session file is retained on disk; only the in-memory message list is cleared.
+Clear the current conversation history. The session id and its on-disk file are retained — only the in-memory message list is wiped, so you stay in the same session. Use `/new` to start a genuinely fresh session instead.
 
 ```
 /clear
 ```
+
+---
+
+### /new
+
+Start a fresh session, mirroring opencode's `/new`. The transcript resets to a blank home and a brand-new session id begins, while your current model, provider, effort level and working directory carry over. The new session is *lazy* — it is not written to disk until your first message, so opening `/new` without typing anything leaves no trace.
+
+Unlike `/clear` (which keeps the same session id and history file), `/new` opens a clean, separate session.
+
+```
+/new
+```
+
+---
+
+### /move
+
+Re-home the current session to another worktree or directory of the **same project**, mirroring opencode's `/move`. Any uncommitted changes in the current directory are carried over to the destination and reset in the original location; the model is informed of the new working directory on its next turn.
+
+The destination must belong to the same git repository (typically a linked `git worktree`); moving to an unrelated project is refused. Pass `--no-changes` to re-home the session without relocating working-tree changes.
+
+```
+/move <directory>
+/move ../myapp-feature
+/move --no-changes /path/to/other/worktree
+```
+
+**Adaptation note:** opencode presents an interactive worktree picker and can create a new worktree on the fly. Claurst takes the destination directory as an argument and re-homes the live session's working directory (claurst has no separate session-per-worktree registry). Uncommitted changes are relocated with `git diff`/`git apply` and the source is reset with `git checkout` (index preserved) plus `git clean` (untracked removed), matching opencode's `move-session` change handling.
 
 ---
 

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -2283,6 +2283,83 @@ async fn run_interactive(
                                     app.status_message =
                                         Some("Conversation cleared.".to_string());
                                 }
+                                Some(CommandResult::NewSession) => {
+                                    // Fresh lazy-home session (opencode /new):
+                                    // preserve the current model / provider / effort
+                                    // selection and working directory. The new
+                                    // session is only persisted once the first
+                                    // message completes a turn, matching opencode's
+                                    // lazy-session semantics.
+                                    let model = claurst_api::effective_model_for_config(
+                                        &cmd_ctx.config,
+                                        &model_registry,
+                                    );
+                                    session = claurst_commands::build_home_session(
+                                        model,
+                                        Some(tool_ctx.working_dir.display().to_string()),
+                                    );
+                                    messages.clear();
+                                    app.replace_messages(Vec::new());
+                                    tool_ctx.session_id = session.id.clone();
+                                    cmd_ctx.session_id = session.id.clone();
+                                    cmd_ctx.session_title = None;
+                                    // Reset per-turn diff/turn bookkeeping, as
+                                    // ResumeSession does when swapping sessions.
+                                    tool_ctx.file_history = Arc::new(ParkingMutex::new(
+                                        claurst_core::file_history::FileHistory::new(),
+                                    ));
+                                    tool_ctx.current_turn = Arc::new(
+                                        std::sync::atomic::AtomicUsize::new(0),
+                                    );
+                                    app.attach_turn_diff_state(
+                                        tool_ctx.file_history.clone(),
+                                        tool_ctx.current_turn.clone(),
+                                    );
+                                    claurst_tui::update_terminal_title(None);
+                                    app.status_message =
+                                        Some("Started a new session.".to_string());
+                                }
+                                Some(CommandResult::MoveSession {
+                                    destination,
+                                    moved_changes,
+                                }) => {
+                                    // Re-home the live session to the destination
+                                    // worktree (opencode /move). The working-tree
+                                    // changes were already relocated inside the
+                                    // command; here we repoint every cwd-aware
+                                    // surface so tools, the system prompt and the
+                                    // saved session all track the new location.
+                                    tool_ctx.working_dir = destination.clone();
+                                    cmd_ctx.working_dir = destination.clone();
+                                    cmd_ctx.config.project_dir = Some(destination.clone());
+                                    tool_ctx.config.project_dir = Some(destination.clone());
+                                    app.config.project_dir = Some(destination.clone());
+                                    base_query_config.working_directory =
+                                        Some(destination.display().to_string());
+                                    session.working_dir =
+                                        Some(destination.display().to_string());
+                                    session.updated_at = chrono::Utc::now();
+                                    let _ =
+                                        claurst_core::history::save_session(&session).await;
+                                    // NOTE: opencode appends a synthetic
+                                    // <system-reminder> prompt after a move. claurst
+                                    // re-derives working_directory into every turn's
+                                    // system prompt (qcfg.working_directory below),
+                                    // so repointing tool_ctx.working_dir already
+                                    // tells the model on its next turn — we skip the
+                                    // dangling user message that would otherwise
+                                    // break user/assistant role alternation.
+                                    let carried = if moved_changes {
+                                        " (carried over uncommitted changes)"
+                                    } else {
+                                        ""
+                                    };
+                                    app.status_message = Some(format!(
+                                        "Moved session to {}{}",
+                                        destination.display(),
+                                        carried
+                                    ));
+                                }
                                 Some(CommandResult::SetMessages(new_msgs)) => {
                                     let removed =
                                         messages.len().saturating_sub(new_msgs.len());

--- a/src-rust/crates/commands/src/lib.rs
+++ b/src-rust/crates/commands/src/lib.rs
@@ -96,6 +96,19 @@ pub enum CommandResult {
     /// Activate a speech mode (caveman/rocky) with level, or deactivate (normal).
     /// (mode, level) — mode=None means deactivate.
     SpeechMode { mode: Option<String>, level: String },
+    /// Start a fresh session (opencode's `/new`): reset to a blank home,
+    /// preserving the current model/provider/effort selection and working
+    /// directory. Lazy — the new session is only persisted on the first message.
+    NewSession,
+    /// Re-home the current session to another worktree/directory of the same
+    /// project (opencode's `/move`). The git working-tree changes have already
+    /// been relocated by the command; the CLI just repoints the live session.
+    MoveSession {
+        /// Absolute destination directory the session now lives in.
+        destination: std::path::PathBuf,
+        /// Whether uncommitted changes were carried across (for the status line).
+        moved_changes: bool,
+    },
 }
 
 /// Every slash command implements this trait.
@@ -264,6 +277,8 @@ mod extras;
 pub use extras::*;
 mod ui_settings;
 use ui_settings::*;
+mod new_move;
+pub use new_move::*;
 
 // ---------------------------------------------------------------------------
 // Built-in commands
@@ -487,7 +502,7 @@ fn execute_named_command_from_slash(
 /// Category labels for help grouping.
 fn command_category(name: &str) -> &'static str {
     match name {
-        "clear" | "compact" | "rewind" | "summary" | "export" | "rename" | "branch" | "fork" => {
+        "clear" | "new" | "compact" | "rewind" | "summary" | "export" | "rename" | "branch" | "fork" => {
             "Conversation"
         }
         "model" | "config" | "theme" | "color" | "vim" | "fast" | "effort"
@@ -501,7 +516,7 @@ fn command_category(name: &str) -> &'static str {
         | "security-review" | "import-config" => "Project",
         "mcp" | "hooks" | "ide" | "chrome" => "Integrations",
         "session" | "resume" | "remote-control" | "remote-env"
-        | "teleport" => "Sessions & Remote",
+        | "teleport" | "move" => "Sessions & Remote",
         "help" | "exit" => "General",
         "think-back" | "thinkback-play" | "thinking" | "plan" | "tasks" => "AI & Thinking",
         "copy" | "skills" | "agents" | "plugin" | "reload-plugins"
@@ -602,7 +617,7 @@ impl SlashCommand for HelpCommand {
 #[async_trait]
 impl SlashCommand for ClearCommand {
     fn name(&self) -> &str { "clear" }
-    fn aliases(&self) -> Vec<&str> { vec!["c", "reset", "new"] }
+    fn aliases(&self) -> Vec<&str> { vec!["c", "reset"] }
     fn description(&self) -> &str { "Clear the conversation history" }
 
     async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
@@ -1314,6 +1329,9 @@ pub fn all_commands() -> Vec<Box<dyn SlashCommand>> {
         Box::new(ManagedAgentsCommand),
         // Durable long-running goals
         Box::new(GoalCommand),
+        // Session navigation ported from opencode: /new (lazy home) + /move.
+        Box::new(NewCommand),
+        Box::new(MoveCommand),
     ]
 }
 
@@ -1602,6 +1620,47 @@ mod tests {
         let cmd = find_command("clear").unwrap();
         let result = cmd.execute("", &mut ctx).await;
         assert!(matches!(result, CommandResult::ClearConversation));
+    }
+
+    #[test]
+    fn test_new_and_move_commands_present() {
+        assert!(find_command("new").is_some());
+        assert!(find_command("move").is_some());
+    }
+
+    #[test]
+    fn test_clear_no_longer_aliases_new() {
+        // /new is now its own lazy-home command; /clear keeps its other aliases.
+        let clear = find_command("clear").unwrap();
+        assert!(!clear.aliases().contains(&"new"));
+        assert_eq!(find_command("new").unwrap().name(), "new");
+    }
+
+    #[tokio::test]
+    async fn test_new_command_returns_new_session() {
+        let mut ctx = make_ctx();
+        let cmd = find_command("new").unwrap();
+        let result = cmd.execute("", &mut ctx).await;
+        assert!(matches!(result, CommandResult::NewSession));
+    }
+
+    #[tokio::test]
+    async fn test_move_command_without_dir_shows_usage() {
+        let mut ctx = make_ctx();
+        let cmd = find_command("move").unwrap();
+        let result = cmd.execute("", &mut ctx).await;
+        // No target → usage message, never a MoveSession side effect.
+        assert!(matches!(result, CommandResult::Message(_)));
+    }
+
+    #[tokio::test]
+    async fn test_move_command_rejects_missing_directory() {
+        let mut ctx = make_ctx();
+        let cmd = find_command("move").unwrap();
+        let result = cmd
+            .execute("/definitely/not/a/real/path/xyz123", &mut ctx)
+            .await;
+        assert!(matches!(result, CommandResult::Error(_)));
     }
 
     #[tokio::test]

--- a/src-rust/crates/commands/src/new_move.rs
+++ b/src-rust/crates/commands/src/new_move.rs
@@ -1,0 +1,575 @@
+// Session-navigation commands ported from opencode: `/new` and `/move`.
+//
+// `/new`  mirrors opencode's `session.new` (packages/tui/src/app.tsx): it clears
+//         the view to a blank "home" and begins a brand-new session, preserving
+//         the current model / provider / effort selection and the working
+//         directory. It is *lazy* — the fresh session is not written to disk
+//         until the first message arrives (ConversationSession is only persisted
+//         after a turn completes), matching opencode's lazy-home semantics.
+//
+// `/move` mirrors opencode's `ControlPlaneMoveSession.moveSession`
+//         (packages/core/src/control-plane/move-session.ts): it re-homes the
+//         current session to a DIFFERENT worktree/directory of the SAME project,
+//         carrying over uncommitted changes and resetting them in the old
+//         location.
+//
+// Architectural adaptation vs opencode:
+//   * opencode models a first-class Project (one git repo) with many worktrees
+//     tracked in a control plane, and a session carries a `location.directory`.
+//     claurst has no project/worktree registry — a session simply carries a
+//     `working_dir`. We therefore identify "the same project" by the git *common
+//     directory* (`git rev-parse --git-common-dir`), which is shared by every
+//     linked worktree of a repo, and take the destination as a `/move <dir>`
+//     argument instead of an interactive worktree picker.
+//   * opencode injects a synthetic `<system-reminder>` prompt after a move so the
+//     model learns the cwd changed. claurst re-derives the working directory into
+//     every turn's system prompt (crates/query working_directory +
+//     crates/cli qcfg.working_directory), so re-homing the working_dir already
+//     informs the model on its next turn; we surface the move as a status line
+//     instead of appending a dangling user message that would break Anthropic's
+//     user/assistant role alternation.
+
+use super::{CommandContext, CommandResult, SlashCommand};
+use async_trait::async_trait;
+use claurst_core::git_utils::get_repo_root;
+use claurst_core::history::ConversationSession;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+// ---------------------------------------------------------------------------
+// /new — lazy-home / fresh session
+// ---------------------------------------------------------------------------
+
+pub struct NewCommand;
+
+#[async_trait]
+impl SlashCommand for NewCommand {
+    fn name(&self) -> &str {
+        "new"
+    }
+
+    fn description(&self) -> &str {
+        "Start a fresh session — keeps your model, provider and directory"
+    }
+
+    fn help(&self) -> &str {
+        "Usage: /new\n\n\
+         Clears the transcript to a blank home and begins a brand-new session. \
+         Your model, provider, effort level and working directory carry over, and \
+         the new session is not written to disk until your first message (a \
+         \"lazy\" session).\n\n\
+         Compare with /clear, which wipes the transcript but keeps the same \
+         session id (continuing the same on-disk history)."
+    }
+
+    async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
+        CommandResult::NewSession
+    }
+}
+
+/// Build the fresh "home" session for `/new`: a brand-new session id with an
+/// empty transcript, preserving the current model and working directory.
+///
+/// Mirrors opencode's lazy `session.new` — the returned session is not persisted
+/// here; the REPL only writes it once the first message completes a turn.
+pub fn build_home_session(model: String, working_dir: Option<String>) -> ConversationSession {
+    let mut session = ConversationSession::new(model);
+    session.working_dir = working_dir;
+    session
+}
+
+// ---------------------------------------------------------------------------
+// /move — re-home the session to another worktree of the same project
+// ---------------------------------------------------------------------------
+
+pub struct MoveCommand;
+
+#[async_trait]
+impl SlashCommand for MoveCommand {
+    fn name(&self) -> &str {
+        "move"
+    }
+
+    fn description(&self) -> &str {
+        "Re-home this session to another worktree of the same project"
+    }
+
+    fn help(&self) -> &str {
+        "Usage: /move [--no-changes] <directory>\n\n\
+         Moves the current session to another directory (typically a git \
+         worktree) of the SAME project, carrying your uncommitted changes across \
+         and resetting them in the old location. The model is told about the new \
+         working directory on its next turn.\n\n\
+         Pass --no-changes to re-home without moving working-tree changes.\n\n\
+         Examples:\n\
+         \x20 /move ../myapp-feature\n\
+         \x20 /move --no-changes /path/to/other/worktree"
+    }
+
+    async fn execute(&self, args: &str, ctx: &mut CommandContext) -> CommandResult {
+        // ---- argument parsing (dir + optional --no-changes flag) -----------
+        let mut move_changes = true;
+        let mut positional: Vec<&str> = Vec::new();
+        for token in args.split_whitespace() {
+            match token {
+                "--no-changes" | "--keep-changes" | "--keep" => move_changes = false,
+                other => positional.push(other),
+            }
+        }
+        if positional.is_empty() {
+            return CommandResult::Message(
+                "Usage: /move [--no-changes] <directory>\n\
+                 Re-homes this session to another worktree of the same project."
+                    .to_string(),
+            );
+        }
+        let target_raw = positional.join(" ");
+
+        // ---- resolve destination -------------------------------------------
+        let mut dest = expand_tilde(&target_raw);
+        if dest.is_relative() {
+            dest = ctx.working_dir.join(dest);
+        }
+        if !dest.exists() {
+            return CommandResult::Error(format!("Directory does not exist: {}", dest.display()));
+        }
+        if !dest.is_dir() {
+            return CommandResult::Error(format!("Not a directory: {}", dest.display()));
+        }
+        let dest = dest.canonicalize().unwrap_or(dest);
+        let source = ctx
+            .working_dir
+            .canonicalize()
+            .unwrap_or_else(|_| ctx.working_dir.clone());
+
+        // Same directory → no-op (matches opencode's early return).
+        if dest == source {
+            return CommandResult::Message(format!(
+                "Session is already located at {}",
+                dest.display()
+            ));
+        }
+
+        // ---- same-project check (opencode's DestinationProjectMismatch) ----
+        // Two worktrees of one repo share a git common directory; require it to
+        // match so /move only re-homes within the same project. When the source
+        // isn't a git repo there is no project identity to enforce.
+        let source_common = git_common_dir(&source);
+        if let Some(source_common) = source_common.as_ref() {
+            match git_common_dir(&dest) {
+                Some(dest_common) if &dest_common != source_common => {
+                    return CommandResult::Error(
+                        "Destination belongs to a different project. /move only \
+                         re-homes a session between worktrees of the same repository."
+                            .to_string(),
+                    );
+                }
+                None => {
+                    return CommandResult::Error(
+                        "Destination is not a git repository, so it can't be a \
+                         worktree of this project."
+                            .to_string(),
+                    );
+                }
+                _ => {}
+            }
+        }
+
+        // ---- carry uncommitted changes -------------------------------------
+        match move_session_changes(&source, &dest, move_changes) {
+            Ok(moved_changes) => CommandResult::MoveSession {
+                destination: dest,
+                moved_changes,
+            },
+            Err(err) => CommandResult::Error(format!("Move failed: {err}")),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Git change relocation (faithful port of git.change.capture/apply/discard)
+// ---------------------------------------------------------------------------
+
+/// Errors raised while relocating uncommitted changes between worktrees.
+#[derive(Debug)]
+pub enum MoveError {
+    /// The source directory is not inside a git repository.
+    SourceNotAGitRepo(PathBuf),
+    /// The destination directory is not inside a git repository.
+    DestNotAGitRepo(PathBuf),
+    /// `git diff`/`ls-files` failed while capturing the source changes.
+    Capture(String),
+    /// `git apply` failed while applying the patch to the destination.
+    Apply(String),
+    /// `git checkout`/`git clean` failed while resetting the source.
+    Reset(String),
+}
+
+impl fmt::Display for MoveError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MoveError::SourceNotAGitRepo(p) => {
+                write!(f, "source is not a git repository ({})", p.display())
+            }
+            MoveError::DestNotAGitRepo(p) => {
+                write!(f, "destination is not a git repository ({})", p.display())
+            }
+            MoveError::Capture(m) => write!(f, "could not capture changes: {m}"),
+            MoveError::Apply(m) => write!(f, "could not apply changes: {m}"),
+            MoveError::Reset(m) => write!(f, "could not reset the source: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for MoveError {}
+
+/// Relocate uncommitted changes from `source` to `dest` and reset the source,
+/// mirroring opencode's `MoveSession.moveSession` change handling.
+///
+/// Captures tracked (`git diff --binary HEAD`) and untracked
+/// (`git ls-files --others` + `git diff --no-index`) changes scoped to the
+/// session directory, applies them to the destination worktree, then discards
+/// them from the source (`git checkout --` preserving the index, `git clean -fd`
+/// removing untracked files).
+///
+/// Returns `true` when any changes were carried across, `false` when there was
+/// nothing to move (or `move_changes` was `false`).
+pub fn move_session_changes(source: &Path, dest: &Path, move_changes: bool) -> Result<bool, MoveError> {
+    if !move_changes {
+        return Ok(false);
+    }
+    let source_root =
+        get_repo_root(source).ok_or_else(|| MoveError::SourceNotAGitRepo(source.to_path_buf()))?;
+    let dest_root =
+        get_repo_root(dest).ok_or_else(|| MoveError::DestNotAGitRepo(dest.to_path_buf()))?;
+
+    let scope = scope_of(&source_root, source);
+    let patch = capture_changes(&source_root, &scope)?;
+    if patch.trim().is_empty() {
+        return Ok(false);
+    }
+    apply_changes(&dest_root, &patch)?;
+    reset_source(&source_root, &scope)?;
+    Ok(true)
+}
+
+/// Path of `dir` relative to the repository `root`, forward-slashed, or `"."`
+/// when `dir` is the root itself. Matches the `scope` git uses in opencode.
+fn scope_of(root: &Path, dir: &Path) -> String {
+    match dir.strip_prefix(root) {
+        Ok(rel) if rel.as_os_str().is_empty() => ".".to_string(),
+        Ok(rel) => rel.to_string_lossy().replace('\\', "/"),
+        Err(_) => ".".to_string(),
+    }
+}
+
+fn run_git(dir: &Path, args: &[&str]) -> std::io::Result<std::process::Output> {
+    Command::new("git").current_dir(dir).args(args).output()
+}
+
+/// Capture tracked + untracked changes under `scope` as a single git patch.
+fn capture_changes(source_root: &Path, scope: &str) -> Result<String, MoveError> {
+    // Tracked changes (staged + unstaged) versus HEAD.
+    let tracked = run_git(source_root, &["diff", "--binary", "HEAD", "--", scope])
+        .map_err(|e| MoveError::Capture(e.to_string()))?;
+    if !tracked.status.success() {
+        return Err(MoveError::Capture(git_stderr(
+            &tracked,
+            "failed to capture tracked changes",
+        )));
+    }
+    let mut parts = vec![String::from_utf8_lossy(&tracked.stdout).into_owned()];
+
+    // Untracked files, NUL-separated so paths with newlines survive.
+    let untracked = run_git(
+        source_root,
+        &["ls-files", "--others", "--exclude-standard", "-z", "--", scope],
+    )
+    .map_err(|e| MoveError::Capture(e.to_string()))?;
+    if !untracked.status.success() {
+        return Err(MoveError::Capture(git_stderr(
+            &untracked,
+            "failed to list untracked changes",
+        )));
+    }
+
+    for file in String::from_utf8_lossy(&untracked.stdout)
+        .split('\0')
+        .filter(|s| !s.is_empty())
+    {
+        let created = run_git(source_root, &["diff", "--binary", "--no-index", "--", "/dev/null", file])
+            .map_err(|e| MoveError::Capture(e.to_string()))?;
+        // `git diff --no-index` exits 1 when it finds differences (the normal
+        // case for a brand-new file); 0 or 1 are both success here.
+        match created.status.code() {
+            Some(0) | Some(1) => parts.push(String::from_utf8_lossy(&created.stdout).into_owned()),
+            _ => {
+                return Err(MoveError::Capture(git_stderr(
+                    &created,
+                    &format!("failed to capture untracked change: {file}"),
+                )))
+            }
+        }
+    }
+
+    Ok(parts
+        .into_iter()
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n"))
+}
+
+/// Apply a captured patch to the destination worktree via `git apply -`.
+fn apply_changes(dest_root: &Path, patch: &str) -> Result<(), MoveError> {
+    use std::io::Write;
+    use std::process::Stdio;
+
+    let mut child = Command::new("git")
+        .current_dir(dest_root)
+        .args(["apply", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| MoveError::Apply(e.to_string()))?;
+
+    // Stream the patch on a separate thread so a large patch can't deadlock
+    // against git filling its stdout/stderr pipes.
+    let mut stdin = child.stdin.take().expect("stdin was requested as piped");
+    let patch_owned = patch.to_string();
+    let writer = std::thread::spawn(move || {
+        let _ = stdin.write_all(patch_owned.as_bytes());
+        // `stdin` drops here, closing the pipe so git sees EOF.
+    });
+
+    let output = child
+        .wait_with_output()
+        .map_err(|e| MoveError::Apply(e.to_string()))?;
+    let _ = writer.join();
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(MoveError::Apply(git_stderr(&output, "git apply failed")))
+    }
+}
+
+/// Discard the moved changes from the source: restore tracked files from the
+/// index (preserving staged state) and remove untracked files.
+fn reset_source(source_root: &Path, scope: &str) -> Result<(), MoveError> {
+    let checkout = run_git(source_root, &["checkout", "--", scope])
+        .map_err(|e| MoveError::Reset(e.to_string()))?;
+    if !checkout.status.success() {
+        return Err(MoveError::Reset(git_stderr(
+            &checkout,
+            "failed to restore tracked changes",
+        )));
+    }
+    let clean = run_git(source_root, &["clean", "-fd", "--", scope])
+        .map_err(|e| MoveError::Reset(e.to_string()))?;
+    if !clean.status.success() {
+        return Err(MoveError::Reset(git_stderr(
+            &clean,
+            "failed to remove untracked changes",
+        )));
+    }
+    Ok(())
+}
+
+fn git_stderr(output: &std::process::Output, fallback: &str) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let trimmed = stderr.trim();
+    if trimmed.is_empty() {
+        fallback.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Expand a leading `~` to the user's home directory.
+fn expand_tilde(path: &str) -> PathBuf {
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(rest);
+        }
+    } else if path == "~" {
+        if let Some(home) = dirs::home_dir() {
+            return home;
+        }
+    }
+    PathBuf::from(path)
+}
+
+/// Absolute git *common directory* for `start`, shared by every linked worktree
+/// of a repository. Used to decide whether two directories belong to the same
+/// project (opencode compares `projectID`).
+pub fn git_common_dir(start: &Path) -> Option<PathBuf> {
+    let root = get_repo_root(start)?;
+
+    // Prefer an absolute answer (git >= 2.31).
+    let abs = Command::new("git")
+        .current_dir(&root)
+        .args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .filter(|s| !s.is_empty());
+    if let Some(s) = abs {
+        let p = PathBuf::from(&s);
+        return Some(p.canonicalize().unwrap_or(p));
+    }
+
+    // Fallback for older git: resolve the (possibly relative) common dir.
+    let rel = Command::new("git")
+        .current_dir(&root)
+        .args(["rev-parse", "--git-common-dir"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .filter(|s| !s.is_empty())?;
+    let p = PathBuf::from(&rel);
+    let abs = if p.is_absolute() { p } else { root.join(p) };
+    Some(abs.canonicalize().unwrap_or(abs))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    // ---- /new home-state reset ------------------------------------------
+
+    #[test]
+    fn build_home_session_preserves_model_and_dir() {
+        let old = {
+            let mut s = ConversationSession::new("claude-sonnet-4-6".to_string());
+            s.working_dir = Some("/tmp/project".to_string());
+            s.messages.push(claurst_core::types::Message::user("hi"));
+            s.title = Some("Old title".to_string());
+            s
+        };
+
+        let fresh = build_home_session(old.model.clone(), old.working_dir.clone());
+
+        // Model + working directory carry over (provider/effort live in Config).
+        assert_eq!(fresh.model, "claude-sonnet-4-6");
+        assert_eq!(fresh.working_dir.as_deref(), Some("/tmp/project"));
+        // Genuinely new session: different id, empty transcript, no title.
+        assert_ne!(fresh.id, old.id);
+        assert!(fresh.messages.is_empty());
+        assert!(fresh.title.is_none());
+    }
+
+    #[test]
+    fn build_home_session_generates_unique_ids() {
+        let a = build_home_session("m".to_string(), None);
+        let b = build_home_session("m".to_string(), None);
+        assert_ne!(a.id, b.id);
+    }
+
+    // ---- /move change relocation ----------------------------------------
+
+    fn git_ok(dir: &Path, args: &[&str]) -> bool {
+        Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    /// Init a repo with one commit; returns the canonical repo root, or `None`
+    /// when git is unavailable (so the test degenerates to a no-op).
+    fn init_repo(dir: &Path) -> Option<PathBuf> {
+        if !git_ok(dir, &["init", "-q"]) {
+            return None;
+        }
+        git_ok(dir, &["config", "user.email", "test@example.com"]);
+        git_ok(dir, &["config", "user.name", "Test"]);
+        fs::write(dir.join("tracked.txt"), "original\n").ok()?;
+        if !git_ok(dir, &["add", "-A"]) {
+            return None;
+        }
+        if !git_ok(dir, &["commit", "-q", "-m", "init"]) {
+            return None;
+        }
+        dir.canonicalize().ok()
+    }
+
+    #[test]
+    fn move_changes_disabled_is_noop() {
+        assert!(!move_session_changes(
+            Path::new("/nonexistent-a"),
+            Path::new("/nonexistent-b"),
+            false
+        )
+        .unwrap());
+    }
+
+    #[test]
+    fn move_carries_and_resets_uncommitted_changes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        let Some(repo) = init_repo(&repo) else {
+            eprintln!("git unavailable; skipping move_carries_and_resets_uncommitted_changes");
+            return;
+        };
+
+        // Add a second worktree of the SAME project.
+        let wt2 = tmp.path().join("wt2");
+        if !git_ok(&repo, &["worktree", "add", "-q", "--detach", wt2.to_str().unwrap()]) {
+            eprintln!("git worktree unsupported; skipping test");
+            return;
+        }
+        let wt2 = wt2.canonicalize().unwrap();
+
+        // Same project → identical git common directory.
+        assert_eq!(git_common_dir(&repo), git_common_dir(&wt2));
+
+        // Uncommitted work in the source: modify a tracked file + add an
+        // untracked one.
+        fs::write(repo.join("tracked.txt"), "modified\n").unwrap();
+        fs::write(repo.join("untracked.txt"), "brand new\n").unwrap();
+
+        let moved = move_session_changes(&repo, &wt2, true).unwrap();
+        assert!(moved, "expected changes to be carried across");
+
+        // Destination now has both changes.
+        assert_eq!(fs::read_to_string(wt2.join("tracked.txt")).unwrap(), "modified\n");
+        assert_eq!(fs::read_to_string(wt2.join("untracked.txt")).unwrap(), "brand new\n");
+
+        // Source is reset: tracked file restored, untracked removed.
+        assert_eq!(fs::read_to_string(repo.join("tracked.txt")).unwrap(), "original\n");
+        assert!(!repo.join("untracked.txt").exists());
+    }
+
+    #[test]
+    fn move_with_no_changes_returns_false() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        let Some(repo) = init_repo(&repo) else {
+            eprintln!("git unavailable; skipping move_with_no_changes_returns_false");
+            return;
+        };
+        let wt2 = tmp.path().join("wt2");
+        if !git_ok(&repo, &["worktree", "add", "-q", "--detach", wt2.to_str().unwrap()]) {
+            return;
+        }
+        let wt2 = wt2.canonicalize().unwrap();
+        // Clean working tree → nothing to move.
+        assert!(!move_session_changes(&repo, &wt2, true).unwrap());
+    }
+}

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -76,6 +76,8 @@ const PROMPT_SLASH_COMMANDS: &[(&str, &str)] = &[
     ("mcp", "Browse configured MCP servers"),
     ("memory", "Browse and open AGENTS.md memory files"),
     ("model", "Change the AI model"),
+    ("move", "Re-home this session to another worktree of the same project"),
+    ("new", "Start a fresh session (keeps model, provider & directory)"),
     ("output-style", "Toggle output style (auto/stream/verbose)"),
     ("plugin", "Manage plugins (list/info/enable/disable/reload)"),
     ("providers", "List available AI providers and their status"),
@@ -110,9 +112,8 @@ fn help_command_category(name: &str) -> &'static str {
             "Workspace"
         }
         "agent" | "agents" | "memory" | "plugin" | "survey" => "Tools",
-        "session" | "resume" | "rename" | "fork" | "clear" | "compact" | "quit" | "exit" => {
-            "Session"
-        }
+        "session" | "resume" | "rename" | "fork" | "clear" | "new" | "move" | "compact"
+        | "quit" | "exit" => "Session",
         _ => "Commands",
     }
 }
@@ -2186,7 +2187,10 @@ impl App {
                 self.session_list_pending = true;
                 true
             }
-            "clear" => {
+            // `/new` (opencode's lazy-home) resets the same visible transcript
+            // state as `/clear`; the CLI layer then swaps in a brand-new session
+            // and overrides the status line to "Started a new session.".
+            "clear" | "new" => {
                 self.messages.clear();
                 self.system_annotations.clear();
                 self.display_messages.clear();


### PR DESCRIPTION
Faithful port of opencode's `/new` and `/move` slash commands (part of the model-system/opencode port; phase 3).

**`/new`** — lazy-home: opens a fresh session (new UUID, empty transcript) preserving the current model/provider/effort selection + cwd, and resets per-turn diff bookkeeping. Genuinely lazy (claurst only persists after a turn), matching opencode's `session.new`. Removed the `new` alias from `/clear` so the two are distinct (`/clear` wipes transcript, keeps session id; `/new` opens a separate session).

**`/move [--no-changes] <dir>`** — re-homes the current session to another **worktree of the same project**, carrying uncommitted changes. Ports move-session.ts: same-project check via git common-dir, `git diff --binary HEAD` + untracked capture → `git apply` to destination → reset source (`git checkout --` + `git clean -fd`), then repoints the live session's working dir (every turn re-derives `working_directory` into the system prompt, so the model sees the move next turn).

**Adaptations (no project/worktree registry in claurst):** destination is a `<dir>` arg instead of an interactive picker; same-project decided by git common-dir instead of a control-plane projectID; move surfaced as a status line (no dangling user message, preserving role alternation). All documented with `// NOTE:`.

3 commits + tests (incl. an end-to-end `move_carries_and_resets_uncommitted_changes` using a real second `git worktree`). `cargo check --workspace` + clippy -D warnings green; CRLF preserved (no churn).