### PR TITLE
test(commands): fix /move test on Windows (autocrlf line-ending mismatch)

### DIFF
--- a/src-rust/crates/commands/src/new_move.rs
+++ b/src-rust/crates/commands/src/new_move.rs
@@ -497,6 +497,14 @@ mod tests {
         }
         git_ok(dir, &["config", "user.email", "test@example.com"]);
         git_ok(dir, &["config", "user.name", "Test"]);
+        // Pin line-ending handling so the round-trip is byte-exact regardless of
+        // the host's global git config. GitHub's Windows runners set
+        // core.autocrlf=true globally, which would rewrite the moved file's LF to
+        // CRLF on checkout into the destination worktree and break the content
+        // assertions below. This config lives in the shared common dir, so it
+        // also governs any worktree added off this repo.
+        git_ok(dir, &["config", "core.autocrlf", "false"]);
+        git_ok(dir, &["config", "core.eol", "lf"]);
         fs::write(dir.join("tracked.txt"), "original\n").ok()?;
         if !git_ok(dir, &["add", "-A"]) {
             return None;


### PR DESCRIPTION
The `move_carries_and_resets_uncommitted_changes` test failed on windows-latest: `"modified\r\n" != "modified\n"`. GitHub's Windows runners have global `core.autocrlf=true`, which rewrites the moved file's LF→CRLF on checkout into the destination worktree. Pin `core.autocrlf=false` + `core.eol=lf` in the test's temp repos so the round-trip is byte-exact regardless of host git config (the config lives in the shared common dir, so it also governs the added worktree). The `/move` command itself is unaffected — it relocates changes via `git diff --binary` patches. Test-only change.