### PR TITLE
feat(models): port opencode variants() effort ladder + unify effort detection (phase 2)

### DIFF
--- a/src-rust/Cargo.lock
+++ b/src-rust/Cargo.lock
@@ -764,6 +764,7 @@ dependencies = [
  "hmac",
  "once_cell",
  "parking_lot",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/src-rust/crates/api/Cargo.toml
+++ b/src-rust/crates/api/Cargo.toml
@@ -20,6 +20,7 @@ tracing = { workspace = true }
 bytes = { workspace = true }
 async-trait = { workspace = true }
 once_cell = { workspace = true }
+regex = { workspace = true }
 parking_lot = { workspace = true }
 async-stream = { workspace = true }
 chrono = { workspace = true }

--- a/src-rust/crates/api/src/effort_support.rs
+++ b/src-rust/crates/api/src/effort_support.rs
@@ -1,48 +1,78 @@
-//! Model-adaptive effort ladders.
+//! Model-adaptive effort ladders — the single, registry-aware surface.
 //!
-//! Different models expose different effort ranges. Reasoning models (the OpenAI
-//! reasoning family, Anthropic thinking models, Gemini thinking models) get the
-//! fuller ladder up through `XHigh` (and `Max` for the top-tier models);
-//! non-reasoning models get a reduced set driven purely by temperature. The
-//! `Ultracode` level is *always* appended — it is a workflow overlay on top of
-//! whatever top reasoning the model can do, so every model can be pushed into it.
+//! Both effort-selection surfaces in the app funnel through here:
+//!   * the `/effort` command (`supported_efforts`, via `app.rs`), and
+//!   * the `/model` picker's inline ←/→ effort selector (`variant_ladder`, via
+//!     `model_picker.rs`).
 //!
-//! This is the clean, public surface the /model + /effort UI redesign (#268)
-//! builds on: given a provider + model (+ optional registry), it returns exactly
-//! the levels that should be selectable, in ascending order, ultracode last.
+//! The per-model reasoning tiers are computed by [`crate::variants`], a faithful
+//! branch-for-branch port of opencode's `ProviderTransform.variants()`. This
+//! module resolves the fields opencode keys off — the provider's npm SDK
+//! package, the model's catalog id, its `release_date`, its provider id, and its
+//! `reasoning` capability — from the [`ModelRegistry`] and hands them to the
+//! port. `Ultracode`, claurst's always-last workflow overlay (not an opencode
+//! tier), is appended by [`supported_efforts`].
 
+use crate::model_registry::canonical_snapshot_key;
 use crate::ModelRegistry;
 use claurst_core::effort::EffortLevel;
+
+/// opencode's ultimate fallback npm when neither the model nor its provider
+/// declares one (`... ?? "@ai-sdk/openai-compatible"`).
+const DEFAULT_NPM: &str = "@ai-sdk/openai-compatible";
+
+/// The reasoning-effort tiers a model exposes, ascending (weakest→strongest),
+/// exactly as opencode's `variants()` would — with **no** `Ultracode` appended
+/// and **no** claurst base augmentation.
+///
+/// This is the raw ladder the /model picker cycles through: empty for a
+/// non-reasoning model (no effort selector), otherwise the model's real tiers.
+///
+/// `registry` supplies the authoritative npm / release_date / reasoning fields.
+/// When it is absent (or the model is unknown), the fields are inferred:
+/// `reasoning` from a model-name heuristic, `npm` from the provider entry (or
+/// the opencode default), and `release_date` as empty (which disables the
+/// date-gated OpenAI tiers).
+pub fn variant_ladder(
+    provider: &str,
+    model: &str,
+    registry: Option<&ModelRegistry>,
+) -> Vec<EffortLevel> {
+    let facts = ModelFacts::resolve(provider, model, registry);
+    crate::variants::variant_efforts(
+        &facts.npm,
+        &facts.id,
+        &facts.release_date,
+        &facts.provider_id,
+        facts.reasoning,
+    )
+}
 
 /// The effort levels selectable for `provider`/`model`, ascending, with
 /// [`EffortLevel::Ultracode`] always last.
 ///
-/// - **Reasoning models** get `Low, Medium, High, XHigh` and, when the model
-///   supports the very top tier (Anthropic Opus, the OpenAI gpt-5 reasoning
-///   family), also `Max`.
-/// - **Non-reasoning models** get `Low, Medium, High` (differentiated by
-///   temperature / prompt only).
-/// - `Ultracode` is appended in every case.
-///
-/// Reasoning capability comes from the registry entry's `reasoning` flag when a
-/// `registry` is supplied and the model is known; otherwise it falls back to
-/// provider/model-name heuristics.
+/// - **Models with reasoning variants** get exactly opencode's `variants()`
+///   tiers for that model (e.g. an Opus 4.7+ gets `Low, Medium, High, XHigh,
+///   Max`; a plain older `gpt-5` gets `Minimal, Low, Medium, High`; `gpt-5-pro`
+///   gets just `High`).
+/// - **Non-reasoning models** (opencode `variants()` == `{}`) still get claurst's
+///   temperature-differentiated base ladder `Low, Medium, High`, because claurst
+///   also uses the effort level to drive temperature / prompt shaping.
+/// - `Ultracode` is appended in every case — it is a workflow overlay on top of
+///   whatever top reasoning the model can do.
 pub fn supported_efforts(
     provider: &str,
     model: &str,
     registry: Option<&ModelRegistry>,
 ) -> Vec<EffortLevel> {
-    let mut levels = vec![EffortLevel::Low, EffortLevel::Medium, EffortLevel::High];
-
-    if model_is_reasoning(provider, model, registry) {
-        levels.push(EffortLevel::XHigh);
-        if model_supports_max_tier(provider, model) {
-            levels.push(EffortLevel::Max);
-        }
-    }
-
-    // Ultracode is a workflow overlay on top of the model's best reasoning, so
-    // it is always available regardless of the model's native ladder.
+    let ladder = variant_ladder(provider, model, registry);
+    let mut levels = if ladder.is_empty() {
+        // No native reasoning tiers — offer the base temperature ladder.
+        vec![EffortLevel::Low, EffortLevel::Medium, EffortLevel::High]
+    } else {
+        ladder
+    };
+    // Ultracode is claurst-only and always the top rung.
     levels.push(EffortLevel::Ultracode);
     levels
 }
@@ -50,47 +80,88 @@ pub fn supported_efforts(
 /// Whether `provider`/`model` is a reasoning/thinking model.
 ///
 /// Prefers the registry `reasoning` flag when the model is known; otherwise uses
-/// provider/model-name heuristics.
+/// a model-name heuristic.
 pub fn model_is_reasoning(provider: &str, model: &str, registry: Option<&ModelRegistry>) -> bool {
-    let bare = bare_model(model);
-    if let Some(reg) = registry {
-        // Try both the bare id and the raw (possibly prefixed) id.
-        if let Some(entry) = reg.get(provider, bare).or_else(|| reg.get(provider, model)) {
-            return entry.reasoning;
+    ModelFacts::resolve(provider, model, registry).reasoning
+}
+
+// ---------------------------------------------------------------------------
+// Field resolution — the (npm, id, release_date, provider_id, reasoning) tuple
+// opencode's variants() keys off.
+// ---------------------------------------------------------------------------
+
+struct ModelFacts {
+    /// `model.provider?.npm ?? provider.npm ?? "@ai-sdk/openai-compatible"`.
+    npm: String,
+    /// `model.id` (== `model.api.id` for models.dev models).
+    id: String,
+    /// `model.release_date ?? ""`.
+    release_date: String,
+    /// `model.providerID`.
+    provider_id: String,
+    /// `model.capabilities.reasoning`.
+    reasoning: bool,
+}
+
+impl ModelFacts {
+    fn resolve(provider: &str, model: &str, registry: Option<&ModelRegistry>) -> Self {
+        let bare = bare_model(model);
+
+        // The provider-level npm (from the provider entry), used when the model
+        // has no per-model override — resolves even for a model not in the
+        // catalog, as long as the provider is known.
+        let provider_npm = registry
+            .and_then(|r| r.provider(canonical_snapshot_key(provider)))
+            .and_then(|p| p.npm.clone());
+
+        // Try the id as given, then its bare (prefix-stripped) form.
+        let entry =
+            registry.and_then(|r| r.get(provider, model).or_else(|| r.get(provider, bare)));
+
+        if let Some(e) = entry {
+            let npm = e
+                .provider_override
+                .as_ref()
+                .and_then(|o| o.npm.clone())
+                .or(provider_npm)
+                .unwrap_or_else(|| DEFAULT_NPM.to_string());
+            Self {
+                npm,
+                id: e.info.id.to_string(),
+                release_date: e.release_date.clone().unwrap_or_default(),
+                provider_id: e.info.provider_id.to_string(),
+                reasoning: e.reasoning,
+            }
+        } else {
+            Self {
+                npm: provider_npm.unwrap_or_else(|| DEFAULT_NPM.to_string()),
+                id: model.to_string(),
+                release_date: String::new(),
+                provider_id: provider.to_string(),
+                reasoning: reasoning_heuristic(bare),
+            }
         }
     }
-    reasoning_heuristic(bare)
 }
 
-/// Whether the model supports the very top `Max` reasoning tier.
-///
-/// Mirrors the picker's historical `model_supports_max_effort`: Anthropic Opus
-/// and the OpenAI gpt-5 reasoning family (which accepts Codex's `xhigh`).
-fn model_supports_max_tier(_provider: &str, model: &str) -> bool {
-    let m = bare_model(model).to_ascii_lowercase();
-    m.starts_with("claude-opus-4") || is_gpt5_reasoning(&m)
-}
-
-/// Name-based reasoning heuristic used when the registry has no entry.
+/// Name-based reasoning heuristic used when the registry has no entry for a
+/// model (self-hosted / freshly-discovered endpoints).
 fn reasoning_heuristic(model: &str) -> bool {
     let m = model.to_ascii_lowercase();
     // Anthropic extended-thinking families.
     let anthropic_thinking = m.starts_with("claude-3-7")
         || m.starts_with("claude-opus-4")
-        || m.starts_with("claude-sonnet-4");
+        || m.starts_with("claude-sonnet-4")
+        || m.starts_with("claude-haiku-4");
     // OpenAI reasoning family.
-    let openai_reasoning =
-        is_gpt5_reasoning(&m) || m.starts_with("o1") || m.starts_with("o3") || m.starts_with("o4");
+    let openai_reasoning = (m.starts_with("gpt-5") && !m.contains("-chat"))
+        || m.starts_with("o1")
+        || m.starts_with("o3")
+        || m.starts_with("o4");
     // Gemini thinking models (2.5 and 3.x).
     let gemini_thinking =
         m.contains("gemini") && (m.contains("2.5") || m.contains("gemini-3") || m.contains("-3-"));
     anthropic_thinking || openai_reasoning || gemini_thinking
-}
-
-/// Whether `id` (already lowercased) is a gpt-5 *reasoning* model — excludes the
-/// non-reasoning chat / pro snapshots that ignore `reasoning_effort`.
-fn is_gpt5_reasoning(id: &str) -> bool {
-    id.starts_with("gpt-5") && !id.contains("-chat") && !id.contains("-pro")
 }
 
 /// Strip a leading `provider/` (or nested `namespace/`) prefix, returning the
@@ -109,7 +180,6 @@ mod tests {
             Some(&EffortLevel::Ultracode),
             "ultracode must always be last: {levels:?}"
         );
-        // ...and appear exactly once.
         assert_eq!(
             levels.iter().filter(|l| l.is_ultracode()).count(),
             1,
@@ -117,60 +187,40 @@ mod tests {
         );
     }
 
+    // The registry-backed path (bundled snapshot) must match opencode's
+    // variants() for representative models.
     #[test]
-    fn reasoning_max_model_gets_full_ladder() {
-        // Anthropic Opus: reasoning + max-tier.
-        let levels = supported_efforts("anthropic", "claude-opus-4-8", None);
+    fn registry_ladders_match_opencode() {
+        use EffortLevel::*;
+        let reg = ModelRegistry::new();
+
+        // Opus 4.8 (adaptive, xhigh+max) + ultracode.
         assert_eq!(
-            levels,
-            vec![
-                EffortLevel::Low,
-                EffortLevel::Medium,
-                EffortLevel::High,
-                EffortLevel::XHigh,
-                EffortLevel::Max,
-                EffortLevel::Ultracode,
-            ]
+            supported_efforts("anthropic", "claude-opus-4-8", Some(&reg)),
+            vec![Low, Medium, High, XHigh, Max, Ultracode]
         );
-        assert_ultracode_last(&levels);
-    }
-
-    #[test]
-    fn reasoning_non_max_model_stops_at_xhigh() {
-        // Sonnet is a thinking model but not the top Max tier.
-        let levels = supported_efforts("anthropic", "claude-sonnet-4-6", None);
+        // Sonnet 4.6: low/medium/high/max.
         assert_eq!(
-            levels,
-            vec![
-                EffortLevel::Low,
-                EffortLevel::Medium,
-                EffortLevel::High,
-                EffortLevel::XHigh,
-                EffortLevel::Ultracode,
-            ]
+            supported_efforts("anthropic", "claude-sonnet-4-6", Some(&reg)),
+            vec![Low, Medium, High, Max, Ultracode]
         );
-        assert!(!levels.contains(&EffortLevel::Max));
-        assert_ultracode_last(&levels);
+        // Modern gpt-5.5: none + xhigh.
+        assert_eq!(
+            supported_efforts("openai", "gpt-5.5", Some(&reg)),
+            vec![None, Low, Medium, High, XHigh, Ultracode]
+        );
+        // gemini-2.5-pro: high/max.
+        assert_eq!(
+            supported_efforts("google", "gemini-2.5-pro", Some(&reg)),
+            vec![High, Max, Ultracode]
+        );
     }
 
     #[test]
-    fn gpt5_reasoning_family_gets_max_but_chat_pro_do_not() {
-        let g5 = supported_efforts("openai", "gpt-5.5", None);
-        assert!(g5.contains(&EffortLevel::XHigh));
-        assert!(g5.contains(&EffortLevel::Max));
-        assert_ultracode_last(&g5);
-
-        // Non-reasoning chat / pro snapshots fall back to the reduced ladder.
-        let chat = supported_efforts("openai", "gpt-5-chat-latest", None);
-        assert!(!chat.contains(&EffortLevel::XHigh));
-        assert!(!chat.contains(&EffortLevel::Max));
-        let pro = supported_efforts("openai", "gpt-5.5-pro", None);
-        assert!(!pro.contains(&EffortLevel::XHigh));
-    }
-
-    #[test]
-    fn non_reasoning_model_gets_reduced_ladder() {
-        let levels = supported_efforts("openai", "gpt-4o", None);
+    fn non_reasoning_model_gets_base_ladder() {
+        let reg = ModelRegistry::new();
+        // gpt-4o has no reasoning variants → base low/medium/high + ultracode.
+        let levels = supported_efforts("openai", "gpt-4o", Some(&reg));
         assert_eq!(
             levels,
             vec![
@@ -182,19 +232,30 @@ mod tests {
         );
         assert!(!levels.contains(&EffortLevel::XHigh));
         assert_ultracode_last(&levels);
+        // The raw ladder (picker) is empty → no inline effort selector.
+        assert!(variant_ladder("openai", "gpt-4o", Some(&reg)).is_empty());
     }
 
     #[test]
-    fn gemini_thinking_gets_xhigh() {
-        let levels = supported_efforts("google", "gemini-3-flash-preview", None);
-        assert!(levels.contains(&EffortLevel::XHigh));
-        // Gemini isn't a Max-tier model in our mapping.
-        assert!(!levels.contains(&EffortLevel::Max));
-        assert_ultracode_last(&levels);
+    fn variant_ladder_omits_ultracode() {
+        let reg = ModelRegistry::new();
+        let raw = variant_ladder("anthropic", "claude-opus-4-8", Some(&reg));
+        assert!(!raw.contains(&EffortLevel::Ultracode));
+        assert_eq!(
+            raw,
+            vec![
+                EffortLevel::Low,
+                EffortLevel::Medium,
+                EffortLevel::High,
+                EffortLevel::XHigh,
+                EffortLevel::Max
+            ]
+        );
     }
 
     #[test]
     fn ultracode_is_always_last_across_model_shapes() {
+        let reg = ModelRegistry::new();
         for (p, m) in [
             ("anthropic", "claude-opus-4-8"),
             ("anthropic", "claude-haiku-4-5"),
@@ -203,35 +264,48 @@ mod tests {
             ("google", "gemini-2.5-pro"),
             ("some-self-hosted", "mystery-model-1"),
         ] {
-            assert_ultracode_last(&supported_efforts(p, m, None));
+            assert_ultracode_last(&supported_efforts(p, m, Some(&reg)));
         }
     }
 
     #[test]
-    fn registry_reasoning_flag_overrides_heuristic() {
-        // A model whose *name* looks non-reasoning, but whose registry entry
-        // says reasoning=true, must still get the fuller ladder.
+    fn no_registry_falls_back_to_name_heuristics() {
+        // Without a registry we can't know npm/release_date, but the name
+        // heuristic still classifies reasoning vs not, and the provider default
+        // npm path yields a sensible ladder.
+        assert!(model_is_reasoning("anthropic", "claude-opus-4-8", None));
+        assert!(!model_is_reasoning("openai", "gpt-4o", None));
+        // A plain unknown model gets the base ladder + ultracode.
+        let levels = supported_efforts("some-self-hosted", "mystery-model-1", None);
+        assert_eq!(levels.last(), Some(&EffortLevel::Ultracode));
+    }
+
+    #[test]
+    fn registry_reasoning_flag_drives_ladder() {
+        // A model whose *name* looks non-reasoning but whose registry entry says
+        // reasoning=true still gets a non-empty raw ladder.
         let mut registry = ModelRegistry::new();
-        let json = r#"{"acme":{"id":"acme","name":"Acme","models":{"reasoner-x":{"id":"reasoner-x","name":"Reasoner X","reasoning":true,"limit":{"context":200000,"output":64000}},"plain-y":{"id":"plain-y","name":"Plain Y","reasoning":false,"limit":{"context":128000,"output":32000}}}}}"#;
-        let path = std::env::temp_dir().join(format!(
-            "claurst_effort_support_{}.json",
-            std::process::id()
-        ));
+        let json = r#"{"acme":{"id":"acme","name":"Acme","npm":"@ai-sdk/openai-compatible","models":{"reasoner-x":{"id":"reasoner-x","name":"Reasoner X","reasoning":true,"limit":{"context":200000,"output":64000}},"plain-y":{"id":"plain-y","name":"Plain Y","reasoning":false,"limit":{"context":128000,"output":32000}}}}}"#;
+        let path = std::env::temp_dir()
+            .join(format!("claurst_effort_support_{}.json", std::process::id()));
         std::fs::write(&path, json).expect("write temp catalog");
         registry.load_cache(&path);
         let _ = std::fs::remove_file(&path);
 
-        let reasoner = supported_efforts("acme", "reasoner-x", Some(&registry));
-        assert!(
-            reasoner.contains(&EffortLevel::XHigh),
-            "registry reasoning=true must yield XHigh: {reasoner:?}"
-        );
-
+        // reasoning=true → openai-compatible OPENAI_EFFORTS.
+        let reasoner = variant_ladder("acme", "reasoner-x", Some(&registry));
+        assert!(!reasoner.is_empty(), "reasoning=true must yield a ladder: {reasoner:?}");
+        // reasoning=false → empty raw ladder, base ladder from supported_efforts.
+        assert!(variant_ladder("acme", "plain-y", Some(&registry)).is_empty());
         let plain = supported_efforts("acme", "plain-y", Some(&registry));
-        assert!(
-            !plain.contains(&EffortLevel::XHigh),
-            "registry reasoning=false must give the reduced ladder: {plain:?}"
+        assert_eq!(
+            plain,
+            vec![
+                EffortLevel::Low,
+                EffortLevel::Medium,
+                EffortLevel::High,
+                EffortLevel::Ultracode,
+            ]
         );
-        assert_ultracode_last(&plain);
     }
 }

--- a/src-rust/crates/api/src/lib.rs
+++ b/src-rust/crates/api/src/lib.rs
@@ -52,6 +52,9 @@ pub mod model_registry;
 // Model-adaptive effort ladders (#267).
 pub mod effort_support;
 
+// opencode variants() effort ladder port (Phase 2, #268).
+pub mod variants;
+
 // Provider-aware error handling (Phase 6).
 pub mod error_handling;
 
@@ -92,7 +95,10 @@ pub use model_registry::{
     CostBreakdown, ExperimentalMode, InterleavedReasoning, Modality, ModelEntry, ModelRegistry,
     ModelStatus, ProviderEntry, ProviderOverride, effective_model_for_config,
 };
-pub use effort_support::{model_is_reasoning, supported_efforts};
+pub use effort_support::{model_is_reasoning, supported_efforts, variant_ladder};
+pub use variants::{
+    variant_efforts, OPENAI_NONE_EFFORT_RELEASE_DATE, OPENAI_XHIGH_EFFORT_RELEASE_DATE,
+};
 
 // Phase 6 re-exports — provider-aware error handling.
 pub use error_handling::{is_context_overflow, parse_error_response, RetryConfig};

--- a/src-rust/crates/api/src/variants.rs
+++ b/src-rust/crates/api/src/variants.rs
@@ -1,0 +1,699 @@
+//! Faithful port of opencode's `ProviderTransform.variants()` effort ladder.
+//!
+//! This module is the single source of truth for *which reasoning-effort tiers a
+//! model exposes*, ported branch-for-branch from
+//! `opencode/packages/opencode/src/provider/transform.ts` (`variants()`,
+//! `openaiReasoningEfforts`, `openaiCompatibleReasoningEfforts`, the anthropic /
+//! google helpers, the glm-5.2 special-cases, and the OpenAI release-date gates).
+//!
+//! opencode's `variants()` returns a map of *variant name → request params*; the
+//! variant names ARE the effort tiers ("none" / "minimal" / "low" / "medium" /
+//! "high" / "xhigh" / "max"). Claurst only needs the ordered set of tiers (it maps
+//! each tier to its own thinking-budget / reasoning-effort in
+//! [`claurst_core::effort::EffortLevel`]), so this port extracts the ordered
+//! *keys* of that map — weakest to strongest — and maps them onto `EffortLevel`.
+//! The param *values* (thinking budgets, `reasoningConfig`, …) are intentionally
+//! dropped: they are re-derived from `EffortLevel` at request-build time.
+//!
+//! Faithfulness notes:
+//! - opencode keys `variants()` off `model.api.npm`, `model.api.id`,
+//!   `model.id`, `model.release_date` and `model.providerID`. For models.dev-
+//!   derived models `model.api.id === model.id` (see `fromModelsDevModel`), and
+//!   models.dev ids are already lowercase, so this port uses a single lowercased
+//!   id for both. `npm` is resolved exactly as opencode does
+//!   (`model.provider?.npm ?? provider.npm ?? "@ai-sdk/openai-compatible"`) by
+//!   the registry-aware caller ([`crate::effort_support`]).
+//! - opencode has no `ultracode` tier; the caller appends claurst's always-last
+//!   `Ultracode` rung on top of whatever this module returns.
+//! - The minimax-m3 adaptive variant map is `{ none, thinking }`; claurst has no
+//!   dedicated "thinking" rung, so `thinking` maps to the nearest rung (`High`).
+//!   See the `// NOTE:` at [`effort_key_to_level`].
+
+use claurst_core::effort::EffortLevel;
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+// ---------------------------------------------------------------------------
+// Release-date gates (identical strings to opencode transform.ts)
+// ---------------------------------------------------------------------------
+
+/// OpenAI rolled out the `none` reasoning_effort tier on this date (Responses
+/// API). Models released before it 400 on `reasoning_effort: "none"`, so it is
+/// only exposed as a variant for models new enough to accept it.
+/// (`OPENAI_NONE_EFFORT_RELEASE_DATE` in transform.ts.)
+pub const OPENAI_NONE_EFFORT_RELEASE_DATE: &str = "2025-11-13";
+
+/// OpenAI rolled out the `xhigh` reasoning_effort tier on this date. Same
+/// reasoning. (`OPENAI_XHIGH_EFFORT_RELEASE_DATE` in transform.ts.)
+pub const OPENAI_XHIGH_EFFORT_RELEASE_DATE: &str = "2025-12-04";
+
+// ---------------------------------------------------------------------------
+// Effort key tables (mirror the const arrays in transform.ts)
+// ---------------------------------------------------------------------------
+
+const WIDELY_SUPPORTED_EFFORTS: &[&str] = &["low", "medium", "high"];
+const OPENAI_EFFORTS: &[&str] = &["none", "minimal", "low", "medium", "high", "xhigh"];
+const OPENAI_GPT5_1_EFFORTS: &[&str] = &["none", "low", "medium", "high"];
+const OPENAI_GPT5_2_PLUS_EFFORTS: &[&str] = &["none", "low", "medium", "high", "xhigh"];
+const OPENAI_GPT5_PRO_EFFORTS: &[&str] = &["high"];
+const OPENAI_GPT5_PRO_2_PLUS_EFFORTS: &[&str] = &["medium", "high", "xhigh"];
+const OPENAI_GPT5_CHAT_EFFORTS: &[&str] = &["medium"];
+const OPENAI_GPT5_CODEX_XHIGH_EFFORTS: &[&str] = &["low", "medium", "high", "xhigh"];
+const OPENAI_GPT5_CODEX_3_PLUS_EFFORTS: &[&str] = &["none", "low", "medium", "high", "xhigh"];
+
+// ---------------------------------------------------------------------------
+// Regexes (mirror the GPT5_* / anthropic / o-series patterns in transform.ts)
+// ---------------------------------------------------------------------------
+
+// Matches members of the gpt-5 family across the id formats we encounter:
+//   "gpt-5", "gpt-5-nano", "gpt-5.4", "openai/gpt-5.4-codex".
+static GPT5_FAMILY_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?:^|/)gpt-5(?:[.-]|$)").unwrap());
+static GPT5_VERSION_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?:^|/)gpt-5[.-](\d+)(?:[.-]|$)").unwrap());
+static GPT5_PRO_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?:^|/)gpt-5[.-]?pro(?:[.-]|$)").unwrap());
+static GPT5_VERSIONED_PRO_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?:^|/)gpt-5[.-]\d+[.-]pro(?:[.-]|$)").unwrap());
+
+// "opus-4.7" (Anthropic/Bedrock/Vertex) and "claude-4.7-opus" (SAP inverted).
+static ANTHROPIC_OPUS_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)opus-(\d+)[.-](\d+)(?:[.@-]|$)|claude-(\d+)[.-](\d+)-opus(?:[.@-]|$)").unwrap()
+});
+static ANTHROPIC_SONNET_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)sonnet-(\d+)(?:[.@-]|$)|claude-(\d+)-sonnet(?:[.@-]|$)").unwrap());
+
+// SAP case: `/\bo[1-9]/.test(id)` — an OpenAI o-series id (o1..o9).
+static O_SERIES_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\bo[1-9]").unwrap());
+
+// ---------------------------------------------------------------------------
+// gpt-5 family helpers (transform.ts:545-598)
+// ---------------------------------------------------------------------------
+
+/// `Number(GPT5_VERSION_RE.exec(apiId)?.[1]) || undefined` — the major version
+/// after `gpt-5.` / `gpt-5-`, or `None` (also `None` for a captured `0`, matching
+/// JS `Number(..) || undefined`).
+fn gpt5_version(id: &str) -> Option<u32> {
+    let caps = GPT5_VERSION_RE.captures(id)?;
+    let n: u32 = caps.get(1)?.as_str().parse().ok()?;
+    if n == 0 { None } else { Some(n) }
+}
+
+fn versioned_gpt5_reasoning_efforts(id: &str) -> Option<&'static [&'static str]> {
+    if GPT5_VERSIONED_PRO_RE.is_match(id) {
+        return Some(OPENAI_GPT5_PRO_2_PLUS_EFFORTS);
+    }
+    match gpt5_version(id) {
+        None => None,
+        Some(1) => Some(OPENAI_GPT5_1_EFFORTS),
+        Some(_) => Some(OPENAI_GPT5_2_PLUS_EFFORTS),
+    }
+}
+
+fn gpt5_codex_reasoning_efforts(id: &str) -> Option<&'static [&'static str]> {
+    if !GPT5_FAMILY_RE.is_match(id) || !id.contains("codex") {
+        return None;
+    }
+    let version = gpt5_version(id);
+    if matches!(version, Some(v) if v >= 3) {
+        return Some(OPENAI_GPT5_CODEX_3_PLUS_EFFORTS);
+    }
+    if id.contains("codex-max") || matches!(version, Some(v) if v >= 2) {
+        return Some(OPENAI_GPT5_CODEX_XHIGH_EFFORTS);
+    }
+    Some(WIDELY_SUPPORTED_EFFORTS)
+}
+
+/// `gpt5ChatReasoningEfforts` — returns `Some(&[])` (an *empty but handled*
+/// ladder) for a version-less `gpt-5-chat`, matching opencode's early-return.
+fn gpt5_chat_reasoning_efforts(id: &str) -> Option<Vec<&'static str>> {
+    if !GPT5_FAMILY_RE.is_match(id) || !id.contains("-chat") {
+        return None;
+    }
+    Some(match gpt5_version(id) {
+        None => Vec::new(),
+        Some(_) => OPENAI_GPT5_CHAT_EFFORTS.to_vec(),
+    })
+}
+
+/// `openaiReasoningEfforts(apiId, releaseDate)` — the reasoning_effort tiers an
+/// OpenAI (or OpenAI-compatible upstream) model exposes, weakest to strongest.
+fn openai_reasoning_efforts(id: &str, release_date: &str) -> Vec<&'static str> {
+    if id.contains("deep-research") {
+        return vec!["medium"];
+    }
+    if let Some(chat) = gpt5_chat_reasoning_efforts(id) {
+        return chat;
+    }
+    if GPT5_PRO_RE.is_match(id) {
+        return OPENAI_GPT5_PRO_EFFORTS.to_vec();
+    }
+    if let Some(codex) = gpt5_codex_reasoning_efforts(id) {
+        return codex.to_vec();
+    }
+    if let Some(versioned) = versioned_gpt5_reasoning_efforts(id) {
+        return versioned.to_vec();
+    }
+    let mut efforts = WIDELY_SUPPORTED_EFFORTS.to_vec();
+    if GPT5_FAMILY_RE.is_match(id) {
+        efforts.insert(0, "minimal");
+    }
+    if release_date >= OPENAI_NONE_EFFORT_RELEASE_DATE {
+        efforts.insert(0, "none");
+    }
+    if release_date >= OPENAI_XHIGH_EFFORT_RELEASE_DATE {
+        efforts.push("xhigh");
+    }
+    efforts
+}
+
+fn openai_compatible_reasoning_efforts(id: &str) -> Vec<&'static str> {
+    if let Some(chat) = gpt5_chat_reasoning_efforts(id) {
+        return chat;
+    }
+    if GPT5_PRO_RE.is_match(id) {
+        return OPENAI_GPT5_PRO_EFFORTS.to_vec();
+    }
+    gpt5_codex_reasoning_efforts(id)
+        .or_else(|| versioned_gpt5_reasoning_efforts(id))
+        .map(|s| s.to_vec())
+        .unwrap_or_else(|| OPENAI_EFFORTS.to_vec())
+}
+
+// ---------------------------------------------------------------------------
+// anthropic adaptive helpers (transform.ts:600-628)
+// ---------------------------------------------------------------------------
+
+fn anthropic_opus_47_or_later(id: &str) -> bool {
+    match ANTHROPIC_OPUS_RE.captures(id) {
+        Some(c) => {
+            let major = c.get(1).or_else(|| c.get(3)).and_then(|m| m.as_str().parse::<u32>().ok());
+            let minor = c.get(2).or_else(|| c.get(4)).and_then(|m| m.as_str().parse::<u32>().ok());
+            match (major, minor) {
+                (Some(major), Some(minor)) => major > 4 || (major == 4 && minor >= 7),
+                _ => false,
+            }
+        }
+        None => false,
+    }
+}
+
+fn anthropic_sonnet_5_or_later(id: &str) -> bool {
+    match ANTHROPIC_SONNET_RE.captures(id) {
+        Some(c) => c
+            .get(1)
+            .or_else(|| c.get(2))
+            .and_then(|m| m.as_str().parse::<u32>().ok())
+            .map(|n| n >= 5)
+            .unwrap_or(false),
+        None => false,
+    }
+}
+
+fn anthropic_adaptive_efforts(id: &str) -> Option<Vec<&'static str>> {
+    if anthropic_opus_47_or_later(id) || anthropic_sonnet_5_or_later(id) || id.contains("fable-5") {
+        return Some(vec!["low", "medium", "high", "xhigh", "max"]);
+    }
+    const V46: &[&str] = &[
+        "opus-4-6", "opus-4.6", "4-6-opus", "4.6-opus", "sonnet-4-6", "sonnet-4.6", "4-6-sonnet",
+        "4.6-sonnet",
+    ];
+    if V46.iter().any(|v| id.contains(v)) {
+        return Some(vec!["low", "medium", "high", "max"]);
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// google thinking helpers (transform.ts:634-671)
+// ---------------------------------------------------------------------------
+
+fn google_thinking_level_efforts(id: &str) -> Vec<&'static str> {
+    if !id.contains("gemini-3") {
+        return vec!["low", "high"];
+    }
+    if id.contains("flash-image") {
+        return vec!["minimal", "high"];
+    }
+    if id.contains("pro-image") {
+        return vec!["high"];
+    }
+    if id.contains("flash") {
+        return vec!["minimal", "low", "medium", "high"];
+    }
+    vec!["low", "medium", "high"]
+}
+
+/// Effort keys of `googleThinkingVariants(model)`: the 2.5 family exposes
+/// `{ high, max }`; everything else maps each thinking-level effort.
+fn google_thinking_variant_keys(id: &str) -> Vec<&'static str> {
+    if id.contains("2.5") {
+        return vec!["high", "max"];
+    }
+    google_thinking_level_efforts(id)
+}
+
+// ---------------------------------------------------------------------------
+// key → EffortLevel
+// ---------------------------------------------------------------------------
+
+/// Map an opencode variant key onto claurst's [`EffortLevel`].
+fn effort_key_to_level(key: &str) -> Option<EffortLevel> {
+    Some(match key {
+        "none" => EffortLevel::None,
+        "minimal" => EffortLevel::Minimal,
+        "low" => EffortLevel::Low,
+        "medium" => EffortLevel::Medium,
+        "high" => EffortLevel::High,
+        "xhigh" => EffortLevel::XHigh,
+        "max" => EffortLevel::Max,
+        // NOTE: opencode's minimax-m3 adaptive map is `{ none, thinking }`.
+        // Claurst has no dedicated "thinking" rung; map it to the nearest one.
+        "thinking" => EffortLevel::High,
+        _ => return None,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// The port: variants() effort keys → ordered EffortLevels
+// ---------------------------------------------------------------------------
+
+/// The ordered opencode `variants()` effort keys (weakest→strongest) for a
+/// model, given the fields opencode keys off. `id` is the models.dev id (==
+/// `model.api.id`); it is lowercased here.
+pub(crate) fn variant_effort_keys(
+    npm: &str,
+    id: &str,
+    release_date: &str,
+    provider_id: &str,
+    reasoning: bool,
+) -> Vec<&'static str> {
+    if !reasoning {
+        return Vec::new();
+    }
+    let id = id.to_ascii_lowercase();
+    let id = id.as_str();
+
+    let glm52 = ["glm-5.2", "glm-5-2", "glm-5p2"].iter().any(|n| id.contains(n));
+
+    if id.contains("minimax-m3") && (npm == "@ai-sdk/anthropic" || npm == "@ai-sdk/openai-compatible")
+    {
+        return vec!["none", "thinking"];
+    }
+
+    let adaptive = anthropic_adaptive_efforts(id);
+
+    if glm52 && npm == "@openrouter/ai-sdk-provider" {
+        // OpenRouter maps xhigh to GLM-5.2's native max effort.
+        return vec!["high", "xhigh"];
+    }
+    if glm52 && npm == "@ai-sdk/openai-compatible" {
+        return vec!["high", "max"];
+    }
+    if glm52 && npm == "@ai-sdk/anthropic" {
+        return vec!["high", "max"];
+    }
+
+    if id.contains("deepseek-chat")
+        || id.contains("deepseek-reasoner")
+        || id.contains("deepseek-r1")
+        || id.contains("deepseek-v3")
+        || id.contains("minimax")
+        || (id.contains("glm") && !glm52)
+        || id.contains("kimi")
+        || id.contains("k2p")
+        || id.contains("qwen")
+        || id.contains("big-pickle")
+    {
+        return Vec::new();
+    }
+
+    if id.contains("grok") && id.contains("grok-3-mini") {
+        return vec!["low", "high"];
+    }
+    if id.contains("grok") {
+        return Vec::new();
+    }
+
+    match npm {
+        "@openrouter/ai-sdk-provider" => {
+            if id.starts_with("openai/") || id.contains("gpt") {
+                openai_compatible_reasoning_efforts(id)
+            } else {
+                WIDELY_SUPPORTED_EFFORTS.to_vec()
+            }
+        }
+        "ai-gateway-provider" => {
+            if id.starts_with("openai/") {
+                openai_reasoning_efforts(id, release_date)
+            } else {
+                WIDELY_SUPPORTED_EFFORTS.to_vec()
+            }
+        }
+        "@ai-sdk/gateway" => {
+            if id.contains("anthropic") {
+                adaptive.unwrap_or_else(|| vec!["high", "max"])
+            } else if id.contains("google") {
+                if id.contains("2.5") {
+                    vec!["high", "max"]
+                } else {
+                    vec!["low", "high"]
+                }
+            } else {
+                openai_compatible_reasoning_efforts(id)
+            }
+        }
+        "@ai-sdk/github-copilot" => {
+            if id.contains("gemini") {
+                // github copilot currently only returns thinking for gemini.
+                Vec::new()
+            } else if id.contains("claude") {
+                WIDELY_SUPPORTED_EFFORTS.to_vec()
+            } else if id.contains("5.1-codex-max") || id.contains("5.2") || id.contains("5.3") {
+                let mut e = WIDELY_SUPPORTED_EFFORTS.to_vec();
+                e.push("xhigh");
+                e
+            } else {
+                let mut e = WIDELY_SUPPORTED_EFFORTS.to_vec();
+                if id.contains("gpt-5") && release_date >= OPENAI_XHIGH_EFFORT_RELEASE_DATE {
+                    e.push("xhigh");
+                }
+                e
+            }
+        }
+        "@ai-sdk/cerebras"
+        | "@ai-sdk/togetherai"
+        | "@ai-sdk/xai"
+        | "@ai-sdk/deepinfra"
+        | "venice-ai-sdk-provider"
+        | "@ai-sdk/openai-compatible" => {
+            if id.contains("north-mini-code") {
+                vec!["none", "high"]
+            } else {
+                let mut e = WIDELY_SUPPORTED_EFFORTS.to_vec();
+                if id.contains("deepseek-v4") {
+                    e.push("max");
+                }
+                e
+            }
+        }
+        "@ai-sdk/azure" => {
+            if id == "o1-mini" {
+                Vec::new()
+            } else {
+                openai_reasoning_efforts(id, release_date)
+            }
+        }
+        "@ai-sdk/amazon-bedrock/mantle" | "@ai-sdk/openai" => {
+            openai_reasoning_efforts(id, release_date)
+        }
+        "@ai-sdk/anthropic" | "@ai-sdk/google-vertex/anthropic" => {
+            if let Some(mut efforts) = adaptive {
+                if provider_id == "github-copilot" {
+                    if id.contains("opus-4.7") {
+                        efforts = vec!["medium"];
+                    }
+                    // github-copilot currently supports low/medium/high only.
+                    efforts.retain(|v| *v != "max" && *v != "xhigh");
+                }
+                efforts
+            } else if ["opus-4-5", "opus-4.5"].iter().any(|v| id.contains(v)) {
+                WIDELY_SUPPORTED_EFFORTS.to_vec()
+            } else {
+                vec!["high", "max"]
+            }
+        }
+        "@ai-sdk/amazon-bedrock" => {
+            if let Some(efforts) = adaptive {
+                efforts
+            } else if id.contains("anthropic") {
+                vec!["high", "max"]
+            } else {
+                // Amazon Nova.
+                WIDELY_SUPPORTED_EFFORTS.to_vec()
+            }
+        }
+        "@ai-sdk/google-vertex" | "@ai-sdk/google" => google_thinking_variant_keys(id),
+        "@ai-sdk/mistral" => {
+            const MISTRAL_REASONING_IDS: &[&str] = &[
+                "mistral-small-2603",
+                "mistral-small-latest",
+                "mistral-medium-3.5",
+                "mistral-medium-2604",
+            ];
+            if !MISTRAL_REASONING_IDS.iter().any(|m| id.contains(m)) {
+                Vec::new()
+            } else {
+                vec!["high"]
+            }
+        }
+        "@ai-sdk/cohere" => Vec::new(),
+        "@ai-sdk/groq" => vec!["none", "low", "medium", "high"],
+        "@ai-sdk/perplexity" => Vec::new(),
+        "@jerome-benoit/sap-ai-provider-v2" => {
+            if id.contains("anthropic") {
+                adaptive.unwrap_or_else(|| vec!["high", "max"])
+            } else if id.contains("gemini") && id.contains("2.5") {
+                google_thinking_variant_keys(id)
+            } else if id.contains("gpt") || O_SERIES_RE.is_match(id) {
+                openai_reasoning_efforts(id, release_date)
+            } else {
+                vec!["low", "medium", "high"]
+            }
+        }
+        _ => Vec::new(),
+    }
+}
+
+/// The ordered [`EffortLevel`]s a model's opencode `variants()` map exposes,
+/// weakest to strongest. Empty when the model has no reasoning variants (a
+/// non-reasoning model, or a provider whose `variants()` returns `{}`).
+///
+/// `Ultracode` is NOT appended here — that is claurst's always-last workflow
+/// overlay, added by [`crate::effort_support::supported_efforts`].
+pub fn variant_efforts(
+    npm: &str,
+    id: &str,
+    release_date: &str,
+    provider_id: &str,
+    reasoning: bool,
+) -> Vec<EffortLevel> {
+    variant_effort_keys(npm, id, release_date, provider_id, reasoning)
+        .into_iter()
+        .filter_map(effort_key_to_level)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn keys(
+        npm: &str,
+        id: &str,
+        rd: &str,
+        provider_id: &str,
+    ) -> Vec<EffortLevel> {
+        variant_efforts(npm, id, rd, provider_id, true)
+    }
+
+    #[test]
+    fn anthropic_native_ladders() {
+        use EffortLevel::*;
+        // Opus 4.7+ and Sonnet 5+ get the full adaptive ladder incl. xhigh + max.
+        assert_eq!(
+            keys("@ai-sdk/anthropic", "claude-opus-4-8", "2026-06-15", "anthropic"),
+            vec![Low, Medium, High, XHigh, Max]
+        );
+        // 4.6-era opus/sonnet: low/medium/high/max (no xhigh).
+        assert_eq!(
+            keys("@ai-sdk/anthropic", "claude-opus-4-6", "2026-02-05", "anthropic"),
+            vec![Low, Medium, High, Max]
+        );
+        assert_eq!(
+            keys("@ai-sdk/anthropic", "claude-sonnet-4-6", "2026-02-17", "anthropic"),
+            vec![Low, Medium, High, Max]
+        );
+        // Opus 4.5 is the WIDELY special-case: low/medium/high only.
+        assert_eq!(
+            keys("@ai-sdk/anthropic", "claude-opus-4-5", "2025-11-24", "anthropic"),
+            vec![Low, Medium, High]
+        );
+        // Non-adaptive thinking model (haiku 4.5): budget-based high/max.
+        assert_eq!(
+            keys("@ai-sdk/anthropic", "claude-haiku-4-5", "2025-10-15", "anthropic"),
+            vec![High, Max]
+        );
+    }
+
+    #[test]
+    fn openai_modern_gpt5_has_none_and_xhigh() {
+        use EffortLevel::*;
+        // gpt-5.5 (version 5 >= 2): none + xhigh via the versioned path, no minimal.
+        assert_eq!(
+            keys("@ai-sdk/openai", "gpt-5.5", "2026-04-23", "openai"),
+            vec![None, Low, Medium, High, XHigh]
+        );
+        assert_eq!(
+            keys("@ai-sdk/openai", "gpt-5.4", "2026-03-05", "openai"),
+            vec![None, Low, Medium, High, XHigh]
+        );
+    }
+
+    #[test]
+    fn openai_older_gpt5_has_no_none_or_xhigh() {
+        use EffortLevel::*;
+        // Plain "gpt-5" released 2025-08 predates both gates: minimal + widely only.
+        assert_eq!(
+            keys("@ai-sdk/openai", "gpt-5", "2025-08-07", "openai"),
+            vec![Minimal, Low, Medium, High]
+        );
+    }
+
+    #[test]
+    fn openai_chat_pro_codex_special_cases() {
+        use EffortLevel::*;
+        // gpt-5-chat-latest: handled but empty (no effort selector).
+        assert!(keys("@ai-sdk/openai", "gpt-5-chat-latest", "2025-08-07", "openai").is_empty());
+        // gpt-5-pro: "high" only.
+        assert_eq!(keys("@ai-sdk/openai", "gpt-5-pro", "2025-10-06", "openai"), vec![High]);
+        // gpt-5-codex (version-less): WIDELY.
+        assert_eq!(
+            keys("@ai-sdk/openai", "gpt-5-codex", "2025-09-15", "openai"),
+            vec![Low, Medium, High]
+        );
+    }
+
+    #[test]
+    fn non_reasoning_model_has_no_variants() {
+        assert!(variant_efforts("@ai-sdk/openai", "gpt-4o", "2024-05-13", "openai", false).is_empty());
+    }
+
+    #[test]
+    fn openai_release_date_gate_boundaries() {
+        use EffortLevel::*;
+        // `none` gate is `>= 2025-11-13`.
+        assert_eq!(
+            keys("@ai-sdk/openai", "gpt-5", "2025-11-12", "openai"),
+            vec![Minimal, Low, Medium, High]
+        );
+        assert_eq!(
+            keys("@ai-sdk/openai", "gpt-5", "2025-11-13", "openai"),
+            vec![None, Minimal, Low, Medium, High]
+        );
+        // `xhigh` gate is `>= 2025-12-04`.
+        assert_eq!(
+            keys("@ai-sdk/openai", "gpt-5", "2025-12-03", "openai"),
+            vec![None, Minimal, Low, Medium, High]
+        );
+        assert_eq!(
+            keys("@ai-sdk/openai", "gpt-5", "2025-12-04", "openai"),
+            vec![None, Minimal, Low, Medium, High, XHigh]
+        );
+    }
+
+    #[test]
+    fn azure_matches_openai_and_o1_mini_is_empty() {
+        use EffortLevel::*;
+        assert_eq!(
+            keys("@ai-sdk/azure", "gpt-5", "2025-08-07", "azure"),
+            vec![Minimal, Low, Medium, High]
+        );
+        assert!(keys("@ai-sdk/azure", "o1-mini", "2024-09-12", "azure").is_empty());
+    }
+
+    #[test]
+    fn bedrock_ladders() {
+        use EffortLevel::*;
+        // Bedrock anthropic 4.6: adaptive low/medium/high/max.
+        assert_eq!(
+            keys("@ai-sdk/amazon-bedrock", "anthropic.claude-opus-4-6-v1", "2026-02-05", "amazon-bedrock"),
+            vec![Low, Medium, High, Max]
+        );
+        // Bedrock anthropic 4.5 (non-adaptive): budget high/max (NOT the native
+        // opus-4.5 WIDELY special-case, which is anthropic-SDK only).
+        assert_eq!(
+            keys(
+                "@ai-sdk/amazon-bedrock",
+                "anthropic.claude-opus-4-5-20251101-v1:0",
+                "2025-11-24",
+                "amazon-bedrock"
+            ),
+            vec![High, Max]
+        );
+        // Amazon Nova (non-anthropic): WIDELY.
+        assert_eq!(
+            keys("@ai-sdk/amazon-bedrock", "amazon.nova-pro-v1:0", "2024-12-03", "amazon-bedrock"),
+            vec![Low, Medium, High]
+        );
+    }
+
+    #[test]
+    fn google_ladders() {
+        use EffortLevel::*;
+        assert_eq!(
+            keys("@ai-sdk/google", "gemini-2.5-pro", "2025-03-20", "google"),
+            vec![High, Max]
+        );
+        assert_eq!(
+            keys("@ai-sdk/google", "gemini-3-flash-preview", "2025-12-17", "google"),
+            vec![Minimal, Low, Medium, High]
+        );
+        assert_eq!(
+            keys("@ai-sdk/google", "gemini-3-pro-preview", "2025-11-18", "google"),
+            vec![Low, Medium, High]
+        );
+    }
+
+    #[test]
+    fn glm_5_2_special_cases_per_npm() {
+        use EffortLevel::*;
+        // OpenRouter maps xhigh to glm-5.2's native max.
+        assert_eq!(
+            keys("@openrouter/ai-sdk-provider", "z-ai/glm-5.2", "2026-05-01", "openrouter"),
+            vec![High, XHigh]
+        );
+        assert_eq!(
+            keys("@ai-sdk/openai-compatible", "glm-5.2", "2026-05-01", "zai"),
+            vec![High, Max]
+        );
+        assert_eq!(
+            keys("@ai-sdk/anthropic", "glm-5.2", "2026-05-01", "zai"),
+            vec![High, Max]
+        );
+        // Non-5.2 glm is excluded entirely (no reasoning variants).
+        assert!(keys("@ai-sdk/openai-compatible", "glm-5.1", "2026-03-27", "zai").is_empty());
+    }
+
+    #[test]
+    fn grok_and_groq() {
+        use EffortLevel::*;
+        assert_eq!(keys("@ai-sdk/xai", "grok-3-mini", "2025-04-01", "xai"), vec![Low, High]);
+        // Other grok models expose no effort variants.
+        assert!(keys("@ai-sdk/xai", "grok-4", "2025-07-01", "xai").is_empty());
+        // groq prepends `none` to widely.
+        assert_eq!(
+            keys("@ai-sdk/groq", "openai/gpt-oss-120b", "2025-08-05", "groq"),
+            vec![None, Low, Medium, High]
+        );
+    }
+
+    #[test]
+    fn openrouter_openai_uses_compatible_efforts() {
+        use EffortLevel::*;
+        // openrouter "openai/gpt-5" (version-less) → OPENAI_EFFORTS (all six).
+        assert_eq!(
+            keys("@openrouter/ai-sdk-provider", "openai/gpt-5", "2025-08-07", "openrouter"),
+            vec![None, Minimal, Low, Medium, High, XHigh]
+        );
+        // A non-openai openrouter model → widely.
+        assert_eq!(
+            keys("@openrouter/ai-sdk-provider", "meta-llama/llama-3.1-70b", "2024-07-23", "openrouter"),
+            vec![Low, Medium, High]
+        );
+    }
+
+    #[test]
+    fn cohere_and_perplexity_have_no_variants() {
+        assert!(keys("@ai-sdk/cohere", "command-a-03-2025", "2025-03-01", "cohere").is_empty());
+        assert!(keys("@ai-sdk/perplexity", "sonar-reasoning", "2025-01-01", "perplexity").is_empty());
+    }
+}

--- a/src-rust/crates/core/src/effort.rs
+++ b/src-rust/crates/core/src/effort.rs
@@ -22,12 +22,26 @@ use serde::{Deserialize, Serialize};
 
 /// The named effort levels supported by Claurst.
 ///
-/// Ordered from least to most effort. `Ultracode` is the top level: it requests
-/// the model's maximum reasoning *and* activates the ultracode operating
-/// procedure (bounded delegation across native primitives + verification).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+/// Ordered from least to most effort (the enum's *declaration order* is the
+/// canonical ascending order — see the derived [`Ord`]). `None` and `Minimal`
+/// are the two rungs below `Low`, ported from opencode's OpenAI reasoning ladder
+/// (`reasoning_effort: "none" | "minimal"`); `Ultracode` is the top level: it
+/// requests the model's maximum reasoning *and* activates the ultracode
+/// operating procedure (bounded delegation across native primitives +
+/// verification).
+///
+/// IMPORTANT: keep the variants in ascending order — [`Ord`]/[`PartialOrd`] are
+/// derived from declaration order and the picker/effort ladders rely on it.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize,
+)]
 #[serde(rename_all = "lowercase")]
 pub enum EffortLevel {
+    /// No reasoning at all (opencode `reasoning_effort: "none"`). The model
+    /// answers directly with thinking disabled.
+    None,
+    /// The smallest reasoning budget (opencode `reasoning_effort: "minimal"`).
+    Minimal,
     /// Quick, straightforward implementation with minimal overhead.
     Low,
     /// Balanced approach with standard implementation and testing.
@@ -51,10 +65,13 @@ pub enum EffortLevel {
 impl EffortLevel {
     /// Parse an effort level from its string representation (case-insensitive).
     ///
-    /// Accepts: `"low"`, `"medium"` (or `"normal"`), `"high"`, `"xhigh"`,
-    /// `"max"`, `"ultracode"`. Returns `None` for any other value.
+    /// Accepts: `"none"`, `"minimal"`, `"low"`, `"medium"` (or `"normal"`),
+    /// `"high"`, `"xhigh"`, `"max"`, `"ultracode"`. Returns `None` for any other
+    /// value.
     pub fn from_str(s: &str) -> Option<Self> {
         match s.to_ascii_lowercase().as_str() {
+            "none" => Some(Self::None),
+            "minimal" => Some(Self::Minimal),
             "low" => Some(Self::Low),
             "medium" | "normal" => Some(Self::Medium),
             "high" => Some(Self::High),
@@ -70,6 +87,8 @@ impl EffortLevel {
     /// Round-trips with `from_str`.
     pub fn as_str(&self) -> &'static str {
         match self {
+            Self::None => "none",
+            Self::Minimal => "minimal",
             Self::Low => "low",
             Self::Medium => "medium",
             Self::High => "high",
@@ -95,6 +114,8 @@ impl EffortLevel {
     /// `None` if thinking should be disabled.
     ///
     /// Values (ascending):
+    ///   None      → None  (reasoning disabled)
+    ///   Minimal   → 1 024 (the smallest valid Anthropic thinking budget)
     ///   Low       → None  (no thinking)
     ///   Medium    → 5 000
     ///   High      → 10 000
@@ -103,10 +124,15 @@ impl EffortLevel {
     ///   Ultracode → 20 000 (the model's top reasoning budget)
     ///
     /// Low/Medium/High/Max are unchanged from the original mapping and must stay
-    /// that way — they are sent verbatim to the Anthropic API.
+    /// that way — they are sent verbatim to the Anthropic API. `None` maps to no
+    /// thinking (opencode `reasoning_effort: "none"`); `Minimal` maps to the
+    /// smallest budget Anthropic accepts (`1024`). Note these two rungs only ever
+    /// appear on OpenAI-family ladders (where the effort *name* is sent, not the
+    /// budget); no Anthropic model's ladder exposes them.
     pub fn thinking_budget_tokens(&self) -> Option<u32> {
         match self {
-            Self::Low => None,
+            Self::None | Self::Low => None,
+            Self::Minimal => Some(1_024),
             Self::Medium => Some(5_000),
             Self::High => Some(10_000),
             Self::XHigh => Some(16_000),
@@ -122,15 +148,23 @@ impl EffortLevel {
     pub fn temperature(&self) -> Option<f32> {
         match self {
             Self::Low => Some(0.0),
-            Self::Medium | Self::High | Self::XHigh | Self::Max | Self::Ultracode => None,
+            Self::None
+            | Self::Minimal
+            | Self::Medium
+            | Self::High
+            | Self::XHigh
+            | Self::Max
+            | Self::Ultracode => None,
         }
     }
 
     /// A single Unicode glyph used to represent this effort level.
     ///
-    ///   Low ○  Medium ◐  High ●  XHigh ◍  Max ◉  Ultracode ✦
+    ///   None ∅  Minimal ◔  Low ○  Medium ◐  High ●  XHigh ◍  Max ◉  Ultracode ✦
     pub fn glyph(&self) -> &'static str {
         match self {
+            Self::None => "∅",
+            Self::Minimal => "◔",
             Self::Low => "○",
             Self::Medium => "◐",
             Self::High => "●",
@@ -142,9 +176,11 @@ impl EffortLevel {
 
     /// A quarter-circle "fill" symbol used in the TUI pickers/status bar.
     ///
-    ///   Low ○  Medium ◐  High ◕  XHigh ●  Max ◉  Ultracode ✦
+    ///   None ∅  Minimal ◔  Low ○  Medium ◐  High ◕  XHigh ●  Max ◉  Ultracode ✦
     pub fn symbol(&self) -> &'static str {
         match self {
+            Self::None => "\u{2205}",      // ∅  empty set
+            Self::Minimal => "\u{25d4}",   // ◔  quarter
             Self::Low => "\u{25cb}",       // ○  empty
             Self::Medium => "\u{25d0}",    // ◐  half
             Self::High => "\u{25d5}",      // ◕  three-quarter
@@ -157,6 +193,8 @@ impl EffortLevel {
     /// Human-readable description of this effort level.
     pub fn description(&self) -> &'static str {
         match self {
+            Self::None => "No reasoning — answer directly with thinking disabled",
+            Self::Minimal => "The smallest reasoning budget for the quickest thinking",
             Self::Low => "Quick, straightforward implementation with minimal overhead",
             Self::Medium => "Balanced approach with standard implementation and testing",
             Self::High => {
@@ -170,14 +208,19 @@ impl EffortLevel {
         }
     }
 
-    /// Cycle to the next level (used by the /model picker's ←/→ effort selector).
+    /// Cycle to the next level in the legacy fixed Low↔Medium↔High↔Max cycle.
     ///
-    /// Preserves the historical Low↔Medium↔High↔Max cycle: `Max` is only reached
-    /// when the model supports it (`supports_max`). `XHigh`/`Ultracode` are not
-    /// part of this cycle (they are surfaced via `supported_efforts` and the
-    /// ultracode keyword respectively); if somehow current, they wrap to `Low`.
+    /// Historically drove the /model picker's ←/→ effort selector; that selector
+    /// now cycles the model's actual variants ladder (see
+    /// `ModelPickerState::effort_next`). These helpers are retained for the
+    /// effort-picker tests and any caller that still wants the fixed cycle. `Max`
+    /// is only reached when the model supports it (`supports_max`). The
+    /// out-of-cycle rungs (`None`/`Minimal`/`XHigh`/`Ultracode`) fall back to the
+    /// nearest in-cycle level.
     pub fn next(self, supports_max: bool) -> Self {
         match self {
+            Self::None => Self::Minimal,
+            Self::Minimal => Self::Low,
             Self::Low => Self::Medium,
             Self::Medium => Self::High,
             Self::High => {
@@ -196,6 +239,7 @@ impl EffortLevel {
     /// [`next`]: Self::next
     pub fn prev(self, supports_max: bool) -> Self {
         match self {
+            Self::None | Self::Minimal => Self::Low,
             Self::Low => {
                 if supports_max {
                     Self::Max
@@ -396,23 +440,42 @@ pub fn ultracode_system_prompt_addendum() -> String {
 mod tests {
     use super::*;
 
+    /// Every effort level in canonical ascending order — the single list the
+    /// tests iterate so a new rung is covered everywhere at once.
+    const ALL_LEVELS: [EffortLevel; 8] = [
+        EffortLevel::None,
+        EffortLevel::Minimal,
+        EffortLevel::Low,
+        EffortLevel::Medium,
+        EffortLevel::High,
+        EffortLevel::XHigh,
+        EffortLevel::Max,
+        EffortLevel::Ultracode,
+    ];
+
     #[test]
     fn from_str_roundtrips() {
-        for level in [
-            EffortLevel::Low,
-            EffortLevel::Medium,
-            EffortLevel::High,
-            EffortLevel::XHigh,
-            EffortLevel::Max,
-            EffortLevel::Ultracode,
-        ] {
+        for level in ALL_LEVELS {
             let parsed = EffortLevel::from_str(level.as_str());
             assert_eq!(parsed, Some(level), "from_str({:?}) should round-trip", level);
         }
     }
 
     #[test]
+    fn declaration_order_is_ascending() {
+        // Ord is derived from declaration order; the ladders rely on it.
+        for pair in ALL_LEVELS.windows(2) {
+            assert!(pair[0] < pair[1], "{:?} must rank below {:?}", pair[0], pair[1]);
+        }
+        assert_eq!(*ALL_LEVELS.iter().min().unwrap(), EffortLevel::None);
+        assert_eq!(*ALL_LEVELS.iter().max().unwrap(), EffortLevel::Ultracode);
+    }
+
+    #[test]
     fn from_str_case_insensitive_and_aliases() {
+        assert_eq!(EffortLevel::from_str("none"), Some(EffortLevel::None));
+        assert_eq!(EffortLevel::from_str("NONE"), Some(EffortLevel::None));
+        assert_eq!(EffortLevel::from_str("Minimal"), Some(EffortLevel::Minimal));
         assert_eq!(EffortLevel::from_str("LOW"), Some(EffortLevel::Low));
         assert_eq!(EffortLevel::from_str("Medium"), Some(EffortLevel::Medium));
         // "normal" is the legacy TUI spelling for Medium.
@@ -444,12 +507,17 @@ mod tests {
         // XHigh slots between High and Max; Ultracode = top reasoning.
         assert_eq!(EffortLevel::XHigh.thinking_budget_tokens(), Some(16_000));
         assert_eq!(EffortLevel::Ultracode.thinking_budget_tokens(), Some(20_000));
+        // New rungs: None disables thinking, Minimal is the smallest budget.
+        assert_eq!(EffortLevel::None.thinking_budget_tokens(), None);
+        assert_eq!(EffortLevel::Minimal.thinking_budget_tokens(), Some(1_024));
     }
 
     #[test]
     fn temperature_matches_legacy() {
         assert_eq!(EffortLevel::Low.temperature(), Some(0.0));
         for level in [
+            EffortLevel::None,
+            EffortLevel::Minimal,
             EffortLevel::Medium,
             EffortLevel::High,
             EffortLevel::XHigh,
@@ -462,14 +530,7 @@ mod tests {
 
     #[test]
     fn glyph_and_symbol_are_distinct_per_variant() {
-        let levels = [
-            EffortLevel::Low,
-            EffortLevel::Medium,
-            EffortLevel::High,
-            EffortLevel::XHigh,
-            EffortLevel::Max,
-            EffortLevel::Ultracode,
-        ];
+        let levels = ALL_LEVELS;
         let glyphs: std::collections::HashSet<_> = levels.iter().map(|l| l.glyph()).collect();
         let symbols: std::collections::HashSet<_> = levels.iter().map(|l| l.symbol()).collect();
         assert_eq!(glyphs.len(), levels.len(), "glyphs must be unique");
@@ -490,6 +551,8 @@ mod tests {
     fn is_ultracode_only_for_top() {
         assert!(EffortLevel::Ultracode.is_ultracode());
         for level in [
+            EffortLevel::None,
+            EffortLevel::Minimal,
             EffortLevel::Low,
             EffortLevel::Medium,
             EffortLevel::High,
@@ -532,16 +595,22 @@ mod tests {
 
     #[test]
     fn display_matches_as_str() {
-        for level in [
-            EffortLevel::Low,
-            EffortLevel::Medium,
-            EffortLevel::High,
-            EffortLevel::XHigh,
-            EffortLevel::Max,
-            EffortLevel::Ultracode,
-        ] {
+        for level in ALL_LEVELS {
             assert_eq!(format!("{}", level), level.as_str());
         }
+    }
+
+    #[test]
+    fn serde_roundtrips_none_and_minimal() {
+        assert_eq!(serde_json::to_string(&EffortLevel::None).unwrap(), "\"none\"");
+        assert_eq!(
+            serde_json::to_string(&EffortLevel::Minimal).unwrap(),
+            "\"minimal\""
+        );
+        let n: EffortLevel = serde_json::from_str("\"none\"").unwrap();
+        assert_eq!(n, EffortLevel::None);
+        let m: EffortLevel = serde_json::from_str("\"minimal\"").unwrap();
+        assert_eq!(m, EffortLevel::Minimal);
     }
 
     // ---- ultracode keyword + procedure ----------------------------------

--- a/src-rust/crates/query/src/runner/provider_options.rs
+++ b/src-rust/crates/query/src/runner/provider_options.rs
@@ -8,6 +8,11 @@ pub(crate) fn reasoning_effort_for_level(
 ) -> &'static str {
     use claurst_core::effort::EffortLevel;
     match effort_level {
+        // `none`/`minimal` are the two OpenAI reasoning_effort tiers below `low`;
+        // pass them through verbatim (the model's variants ladder only offers
+        // them where the API accepts them).
+        EffortLevel::None => "none",
+        EffortLevel::Minimal => "minimal",
         EffortLevel::Low => "low",
         EffortLevel::Medium => "medium",
         // XHigh/Max/Ultracode collapse to "high" for the generic OpenAI-family
@@ -25,6 +30,10 @@ pub(crate) fn google_thinking_level_for_effort(
 ) -> &'static str {
     use claurst_core::effort::EffortLevel;
     match effort_level.unwrap_or(EffortLevel::High) {
+        // Google's thinkingLevel has no "none"; floor it at "low". "minimal" is a
+        // real gemini-3 thinking level, so pass Minimal through.
+        EffortLevel::None => "low",
+        EffortLevel::Minimal => "minimal",
         EffortLevel::Low => "low",
         EffortLevel::Medium => "medium",
         // Gemini's top thinking level is "high"; XHigh/Max/Ultracode all map onto it.
@@ -229,6 +238,7 @@ pub(crate) fn build_provider_options(
             if provider_id == "deepseek" {
                 match effort_level {
                     None
+                    | Some(claurst_core::effort::EffortLevel::Minimal)
                     | Some(claurst_core::effort::EffortLevel::Medium)
                     | Some(claurst_core::effort::EffortLevel::High) => {
                         options.insert(
@@ -246,7 +256,9 @@ pub(crate) fn build_provider_options(
                         );
                         options.insert("reasoningEffort".to_string(), serde_json::json!("max"));
                     }
-                    Some(claurst_core::effort::EffortLevel::Low) => {
+                    // `none` and `low` both disable DeepSeek's thinking mode.
+                    Some(claurst_core::effort::EffortLevel::None)
+                    | Some(claurst_core::effort::EffortLevel::Low) => {
                         options.insert(
                             "thinking".to_string(),
                             serde_json::json!({"type": "disabled"}),

--- a/src-rust/crates/tui/src/effort_picker.rs
+++ b/src-rust/crates/tui/src/effort_picker.rs
@@ -166,12 +166,14 @@ fn index_for(levels: &[EffortLevel], current: EffortLevel) -> usize {
 /// Ascending ordering rank used for nearest-level selection.
 fn rank(level: EffortLevel) -> u8 {
     match level {
-        EffortLevel::Low => 0,
-        EffortLevel::Medium => 1,
-        EffortLevel::High => 2,
-        EffortLevel::XHigh => 3,
-        EffortLevel::Max => 4,
-        EffortLevel::Ultracode => 5,
+        EffortLevel::None => 0,
+        EffortLevel::Minimal => 1,
+        EffortLevel::Low => 2,
+        EffortLevel::Medium => 3,
+        EffortLevel::High => 4,
+        EffortLevel::XHigh => 5,
+        EffortLevel::Max => 6,
+        EffortLevel::Ultracode => 7,
     }
 }
 
@@ -414,6 +416,13 @@ fn hsv_to_rgb(h: f32, s: f32, v: f32) -> (u8, u8, u8) {
 /// derived from the model's top native effort: "<top> + workflows".
 fn level_description(level: EffortLevel, levels: &[EffortLevel]) -> String {
     match level {
+        EffortLevel::None => {
+            "No reasoning \u{2014} the model answers directly with thinking disabled.".to_string()
+        }
+        EffortLevel::Minimal => {
+            "The smallest reasoning budget \u{2014} a touch of thinking for the quickest tasks."
+                .to_string()
+        }
         EffortLevel::Low => {
             "Fastest, most direct responses. Best for simple edits and quick questions.".to_string()
         }

--- a/src-rust/crates/tui/src/model_picker.rs
+++ b/src-rust/crates/tui/src/model_picker.rs
@@ -26,35 +26,88 @@ pub use claurst_core::effort::EffortLevel;
 
 
 // ---------------------------------------------------------------------------
-// Model capability helpers
+// Model capability helpers — driven by the opencode variants() ladder
 // ---------------------------------------------------------------------------
+//
+// Both the /effort command and this /model picker now derive their effort
+// tiers from the single source of truth, `claurst_api::variant_ladder`
+// (a faithful port of opencode's `ProviderTransform.variants()`), instead of
+// the old name-string heuristics that disagreed between the two surfaces.
 
-/// Returns `true` for models that support extended thinking / effort levels.
+/// A process-wide bundled `ModelRegistry`, built once, used only to resolve the
+/// npm / release_date / reasoning fields that `variant_ladder` keys off.
 ///
-/// Covers Claude's extended-thinking models and the GPT-5 reasoning family
-/// (incl. Codex / ChatGPT models like `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`),
-/// which honour OpenAI's `reasoning_effort` ladder. Lets the picker surface the
-/// ←/→ thinking-level selector for Codex the way opencode does.
+/// The picker owns just a model id string (it does not carry the live registry
+/// the app holds), so the ladder is resolved against the compile-time bundled
+/// snapshot here. The `/effort` command path (`app.rs`) passes the *live*
+/// registry and is therefore exact; both funnel through the same port, so they
+/// agree tier-for-tier for every catalog model.
+fn picker_registry() -> &'static claurst_api::ModelRegistry {
+    static REG: std::sync::OnceLock<claurst_api::ModelRegistry> = std::sync::OnceLock::new();
+    REG.get_or_init(claurst_api::ModelRegistry::new)
+}
+
+/// The reasoning-effort ladder (ascending, no ultracode) a model exposes, per
+/// opencode's `variants()`. Empty for non-reasoning models.
+///
+/// The provider is inferred from the id: a `provider/model` prefix is trusted as
+/// the provider; a bare id is mapped to its canonical provider via the registry
+/// family heuristic. (Gateway upstream prefixes like `openai/…` are the one
+/// approximation — the picker's catalog providers use bare ids and resolve
+/// exactly.)
+fn picker_variant_ladder(id: &str) -> Vec<EffortLevel> {
+    let reg = picker_registry();
+    let provider = match id.split_once('/') {
+        Some((p, _)) => p.to_string(),
+        None => reg
+            .find_provider_for_model(id)
+            .map(|p| p.to_string())
+            .unwrap_or_default(),
+    };
+    claurst_api::variant_ladder(&provider, id, Some(reg))
+}
+
+/// Returns `true` when the model exposes more than one reasoning-effort tier —
+/// i.e. the picker's ←/→ selector has something to cycle through. A model with
+/// zero tiers (non-reasoning) or a single fixed tier (e.g. `gpt-5-pro` → only
+/// `high`) does not surface the selector.
 pub fn model_supports_effort(id: &str) -> bool {
-    id.starts_with("claude-3-7")
-        || id.starts_with("claude-opus-4")
-        || id.starts_with("claude-sonnet-4")
-        || is_gpt5_reasoning_model(id)
+    picker_variant_ladder(id).len() > 1
 }
 
-/// Returns `true` for models that support the maximum effort tier.
-///
-/// For Claude this is Opus-only; for the GPT-5 family the top tier maps to
-/// OpenAI's `xhigh` ("extra high") reasoning effort on the Codex endpoint.
-pub fn model_supports_max_effort(id: &str) -> bool {
-    id.starts_with("claude-opus-4") || is_gpt5_reasoning_model(id)
+/// The index of the ladder rung nearest to `current`: the highest rung `<=`
+/// current, or the lowest rung when `current` sits below the whole ladder.
+/// `ladder` is assumed ascending (as `variant_ladder` returns it).
+fn nearest_ladder_index(ladder: &[EffortLevel], current: EffortLevel) -> usize {
+    let mut best = 0usize;
+    for (i, level) in ladder.iter().enumerate() {
+        if *level <= current {
+            best = i;
+        }
+    }
+    best
 }
 
-/// Whether `id` is a GPT-5 reasoning model (`gpt-5*`), excluding the
-/// non-reasoning chat / pro snapshots that ignore `reasoning_effort`.
-fn is_gpt5_reasoning_model(id: &str) -> bool {
-    let id = id.to_ascii_lowercase();
-    id.starts_with("gpt-5") && !id.contains("-chat") && !id.contains("-pro")
+/// Clamp `effort` onto `ladder`: itself if present, else the nearest rung.
+fn clamp_to_ladder(ladder: &[EffortLevel], effort: EffortLevel) -> EffortLevel {
+    if ladder.contains(&effort) {
+        effort
+    } else {
+        ladder[nearest_ladder_index(ladder, effort)]
+    }
+}
+
+/// Step one rung along `ladder` from `current` (`dir` = +1 / -1), wrapping.
+fn cycle_ladder(ladder: &[EffortLevel], current: EffortLevel, dir: isize) -> EffortLevel {
+    if ladder.is_empty() {
+        return current;
+    }
+    let idx = ladder
+        .iter()
+        .position(|l| *l == current)
+        .unwrap_or_else(|| nearest_ladder_index(ladder, current)) as isize;
+    let n = ladder.len() as isize;
+    ladder[(((idx + dir) % n + n) % n) as usize]
 }
 
 // ---------------------------------------------------------------------------
@@ -562,29 +615,36 @@ impl ModelPickerState {
         self.selected_idx = count.saturating_sub(1);
     }
 
-    /// Cycle effort level forward (→ key).
+    /// The reasoning-effort ladder of the currently highlighted model (ascending,
+    /// no ultracode). Empty when nothing is highlighted or the model is
+    /// non-reasoning.
+    fn selected_ladder(&self) -> Vec<EffortLevel> {
+        let filtered = self.filtered_models();
+        match filtered.get(self.selected_idx) {
+            Some(m) => picker_variant_ladder(&m.id),
+            None => Vec::new(),
+        }
+    }
+
+    /// Cycle effort level forward (→ key) along the model's variants ladder.
     pub fn effort_next(&mut self) {
-        let filtered = self.filtered_models();
-        let id = filtered.get(self.selected_idx).map(|m| m.id.as_str()).unwrap_or("");
-        let supports_max = model_supports_max_effort(id);
-        self.effort_level = self.effort_level.next(supports_max);
+        let ladder = self.selected_ladder();
+        self.effort_level = cycle_ladder(&ladder, self.effort_level, 1);
     }
 
-    /// Cycle effort level backward (← key).
+    /// Cycle effort level backward (← key) along the model's variants ladder.
     pub fn effort_prev(&mut self) {
-        let filtered = self.filtered_models();
-        let id = filtered.get(self.selected_idx).map(|m| m.id.as_str()).unwrap_or("");
-        let supports_max = model_supports_max_effort(id);
-        self.effort_level = self.effort_level.prev(supports_max);
+        let ladder = self.selected_ladder();
+        self.effort_level = cycle_ladder(&ladder, self.effort_level, -1);
     }
 
-    /// Returns the effective effort for the currently highlighted model:
-    /// `None` if the model does not support extended thinking.
+    /// Returns the effective effort for the currently highlighted model, clamped
+    /// onto its variants ladder; `None` if the model exposes no selectable effort
+    /// (a single-tier or non-reasoning model).
     pub fn effective_effort(&self) -> Option<EffortLevel> {
-        let filtered = self.filtered_models();
-        let id = filtered.get(self.selected_idx).map(|m| m.id.as_str()).unwrap_or("");
-        if model_supports_effort(id) {
-            Some(self.effort_level)
+        let ladder = self.selected_ladder();
+        if ladder.len() > 1 {
+            Some(clamp_to_ladder(&ladder, self.effort_level))
         } else {
             None
         }
@@ -610,7 +670,12 @@ impl ModelPickerState {
         }
         let entry = filtered.get(self.selected_idx)?;
         let id = entry.id.clone();
-        let effort = if model_supports_effort(&id) { Some(self.effort_level) } else { None };
+        let ladder = picker_variant_ladder(&id);
+        let effort = if ladder.len() > 1 {
+            Some(clamp_to_ladder(&ladder, self.effort_level))
+        } else {
+            None
+        };
         // If user chose a model other than the fast-mode model while fast mode is
         // active, the caller should turn off fast mode (mirrors TS behaviour).
         self.close();
@@ -865,10 +930,12 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
 
             spans.push(Span::styled(model.display_name.clone(), Style::default().fg(fg).bg(bg)));
 
-            // Effort indicator
+            // Effort indicator — show the effort clamped onto this model's
+            // variants ladder so it never displays a tier the model can't do.
             if supports_effort && is_selected {
+                let shown = state.effective_effort().unwrap_or(state.effort_level);
                 spans.push(Span::styled(
-                    format!("  {} {}", state.effort_level.symbol(), state.effort_level.label()),
+                    format!("  {} {}", shown.symbol(), shown.label()),
                     Style::default().fg(Color::Rgb(200, 255, 200)).bg(bg),
                 ));
             }
@@ -1129,49 +1196,75 @@ mod tests {
         assert!(p.filter.is_empty());
     }
 
-    // 11. effort cycling works for effort-supporting models.
+    // 11. effort cycling follows the model's actual variants ladder.
     #[test]
     fn effort_cycles_correctly() {
+        // sonnet-4-6's ladder is Low/Medium/High/Max (opencode adaptive).
         let mut p = make_picker_with_current("claude-sonnet-4-6");
-        // sonnet-4-6 supports effort but not max
         assert_eq!(p.effort_level, EffortLevel::Medium);
         p.effort_next();
         assert_eq!(p.effort_level, EffortLevel::High);
         p.effort_next();
-        // no max for sonnet → wraps to Low
+        assert_eq!(p.effort_level, EffortLevel::Max);
+        p.effort_next();
+        // wraps back to the bottom of the ladder.
         assert_eq!(p.effort_level, EffortLevel::Low);
     }
 
-    // 12. Opus supports max effort.
+    // 12. The picker ladders match opencode's variants() (single source of
+    //     truth), not the old name heuristic.
     #[test]
-    fn opus_supports_max_effort() {
-        assert!(model_supports_max_effort("claude-opus-4-6"));
-        assert!(!model_supports_max_effort("claude-sonnet-4-6"));
-        assert!(!model_supports_max_effort("claude-haiku-4-5"));
+    fn ladders_match_opencode_for_known_models() {
+        use EffortLevel::*;
+        // 4.6-era opus/sonnet: low/medium/high/max.
+        assert_eq!(picker_variant_ladder("claude-opus-4-6"), vec![Low, Medium, High, Max]);
+        assert_eq!(picker_variant_ladder("claude-sonnet-4-6"), vec![Low, Medium, High, Max]);
+        // Haiku 4.5 is a thinking model: budget-based high/max.
+        assert_eq!(picker_variant_ladder("claude-haiku-4-5"), vec![High, Max]);
+        // gpt-4o is non-reasoning → no ladder, no selector.
+        assert!(picker_variant_ladder("gpt-4o").is_empty());
+        assert!(!model_supports_effort("gpt-4o"));
+        for id in ["claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"] {
+            assert!(model_supports_effort(id), "{id} should support effort");
+        }
     }
 
-    // 12b. GPT-5 codex/reasoning models expose the effort selector (incl. max).
+    // 12b. GPT-5 reasoning models expose the multi-tier effort selector (incl.
+    //      xhigh); a single-tier pro snapshot does not.
     #[test]
-    fn gpt5_codex_models_support_effort() {
+    fn gpt5_reasoning_models_support_effort() {
+        use EffortLevel::*;
         for id in ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark"] {
+            let ladder = picker_variant_ladder(id);
+            assert!(ladder.len() > 1, "{id} should support effort: {ladder:?}");
             assert!(model_supports_effort(id), "{id} should support effort");
-            assert!(model_supports_max_effort(id), "{id} should support max/xhigh");
+            assert!(ladder.contains(&XHigh), "{id} should reach xhigh: {ladder:?}");
         }
-        // Non-reasoning chat / pro snapshots are excluded.
+        // Version-less gpt-5-pro exposes only the fixed `high` tier → no selector.
+        assert_eq!(picker_variant_ladder("gpt-5-pro"), vec![High]);
+        assert!(!model_supports_effort("gpt-5-pro"));
+        // Chat snapshots have no reasoning variants.
         assert!(!model_supports_effort("gpt-5-chat-latest"));
-        assert!(!model_supports_effort("gpt-5.5-pro"));
         // Non-gpt5 stays unaffected.
         assert!(!model_supports_effort("gpt-4o"));
     }
 
-    // 13. Non-effort models return None from effective_effort.
+    // 13. Haiku 4.5 IS a thinking model (opencode high/max), so confirming it
+    //     carries an effort clamped onto its ladder.
     #[test]
-    fn haiku_has_no_effort() {
+    fn haiku_supports_effort() {
+        assert_eq!(
+            picker_variant_ladder("claude-haiku-4-5"),
+            vec![EffortLevel::High, EffortLevel::Max]
+        );
+        assert!(model_supports_effort("claude-haiku-4-5"));
         let mut p = make_picker_with_current("claude-haiku-4-5");
         p.selected_idx = p.models.iter().position(|m| m.id == "claude-haiku-4-5").unwrap();
-        assert!(!model_supports_effort("claude-haiku-4-5"));
-        let effort = p.confirm();
-        assert!(effort.is_some_and(|(_, e)| e.is_none()));
+        let confirmed = p.confirm();
+        assert!(
+            confirmed.is_some_and(|(_, e)| e.is_some()),
+            "haiku should carry a (clamped) effort"
+        );
     }
 
     // 14. render_model_picker does not panic for a default-area call.


### PR DESCRIPTION
Phase 2 of the opencode model-system port: the reasoning-effort ladder.

**`crates/api/src/variants.rs` (new)** — a branch-for-branch port of opencode's `variants()` + `openaiReasoningEfforts` + `openaiCompatibleReasoningEfforts`, keyed off the model's provider npm + `release_date` + id, with the identical date-gate constants: `OPENAI_NONE_EFFORT_RELEASE_DATE = "2025-11-13"`, `OPENAI_XHIGH_EFFORT_RELEASE_DATE = "2025-12-04"` (verified at both boundaries). Every opencode case has a corresponding branch (openai, azure, anthropic, bedrock, google, openrouter, gateway, github-copilot, cerebras/xai/etc., mistral, groq, sap, glm-5.2 specials, …).

**Unified effort detection** — both `/effort` (`effort_support::supported_efforts`) and the `/model` inline selector (`model_picker.rs`) now funnel through the port. **Deleted** the old name-string-matching `model_supports_effort`/`model_supports_max_effort` heuristics (the wrong path). Public `ModelPickerState` method signatures unchanged, so `app.rs` needed no edits.

**`EffortLevel`** — added `None` (thinking off) and `Minimal` (1024-token budget) below `Low`; order is now `None < Minimal < Low < Medium < High < XHigh < Max < Ultracode`. `"normal"`→Medium alias and all existing values still parse; `Ultracode` stays claurst-only and always last. Exhaustive-match fallout handled in `provider_options.rs` and `effort_picker.rs`.

**Honest deviations** (all `// NOTE:`-marked): `model.api.id`↔`model.id` collapsed (exact for models.dev catalog); minimax-m3 `thinking` variant → nearest rung `High`; the picker infers npm from the id against the bundled registry (exact for bare catalog ids; gateway-prefixed ids fall to the native ladder), while `/effort` uses the live registry and is exact. One visible improvement: Haiku 4.5 is a thinking model in opencode, so it now correctly surfaces effort (the old heuristic hid it).

4 commits + tests (per-npm ladders, date-gate boundaries). `cargo check --workspace` + clippy -D warnings green; core/api/tui/query tests pass. CRLF preserved (api/lib.rs).