### PR TITLE
feat: personas — consolidate rocky/caveman into output-style + inline keywords (#278)

### DIFF
--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -2491,11 +2491,6 @@ async fn run_interactive(
                                         }
                                     }
                                 }
-                                Some(CommandResult::SpeechMode { mode, level }) => {
-                                    app.set_speech_mode(mode.as_deref(), &level);
-                                    cmd_ctx.config = app.config.clone();
-                                    tool_ctx.config = app.config.clone();
-                                }
                                 Some(CommandResult::McpAuthFlow {
                                     server_name,
                                     auth_url,

--- a/src-rust/crates/commands/src/appearance.rs
+++ b/src-rust/crates/commands/src/appearance.rs
@@ -118,8 +118,10 @@ impl SlashCommand for OutputStyleCommand {
         "Usage: /output-style [style-name]\n\n\
          With no argument: list available styles and show the current one.\n\
          With a style name: switch to that style (persisted to settings).\n\n\
-         Built-in styles: default, verbose, concise\n\
-         Plugin-defined styles are listed automatically.\n\n\
+         Built-in styles: default, concise, explanatory, learning, caveman, rocky\n\
+         Personas (caveman/rocky) are also reachable via /caveman, /rocky, and\n\
+         by typing the single word inline in a prompt (transient for one turn).\n\
+         Plugin-defined and user styles are listed automatically.\n\n\
          Changes take effect on the next request."
     }
 

--- a/src-rust/crates/commands/src/lib.rs
+++ b/src-rust/crates/commands/src/lib.rs
@@ -93,9 +93,6 @@ pub enum CommandResult {
     /// Clear saved provider auth, model selection, and model caches, then
     /// rebuild the live runtime state.
     RefreshProviderState,
-    /// Activate a speech mode (caveman/rocky) with level, or deactivate (normal).
-    /// (mode, level) — mode=None means deactivate.
-    SpeechMode { mode: Option<String>, level: String },
     /// Start a fresh session (opencode's `/new`): reset to a blank home,
     /// preserving the current model/provider/effort selection and working
     /// directory. Lazy — the new session is only persisted on the first message.

--- a/src-rust/crates/commands/src/lib.rs
+++ b/src-rust/crates/commands/src/lib.rs
@@ -1619,6 +1619,67 @@ mod tests {
         assert!(matches!(result, CommandResult::ClearConversation));
     }
 
+    // ---- /output-style + /keybindings end-to-end (issue #278 point 2) ------
+
+    #[tokio::test]
+    async fn output_style_lists_personas_and_current() {
+        // The empty-arg path only reads (no disk write) and must surface the
+        // built-in styles including the newly-consolidated personas.
+        let mut ctx = make_ctx();
+        let cmd = find_command("output-style").unwrap();
+        let result = cmd.execute("", &mut ctx).await;
+        let CommandResult::Message(text) = result else {
+            panic!("empty /output-style should list styles, got {result:?}");
+        };
+        assert!(text.contains("caveman"), "personas must appear in the list: {text}");
+        assert!(text.contains("rocky"));
+        assert!(text.contains("default"));
+        // Default config → default is the current style.
+        assert!(text.contains("Current output style: default"));
+    }
+
+    #[tokio::test]
+    async fn output_style_rejects_unknown_name() {
+        let mut ctx = make_ctx();
+        let cmd = find_command("output-style").unwrap();
+        let result = cmd.execute("definitely-not-a-style", &mut ctx).await;
+        assert!(matches!(result, CommandResult::Error(_)));
+    }
+
+    #[test]
+    fn available_output_styles_include_personas() {
+        let names = available_output_style_names();
+        for expected in ["default", "concise", "caveman", "rocky"] {
+            assert!(
+                names.iter().any(|n| n == expected),
+                "output style '{expected}' should be available"
+            );
+        }
+    }
+
+    #[test]
+    fn persisted_persona_resolves_to_its_prompt() {
+        // End-to-end of the persist path: /output-style / /rocky set
+        // config.output_style, which resolves to the persona's prompt text for
+        // the system prompt.
+        let mut config = claurst_core::config::Config::default();
+        config.output_style = Some("rocky".to_string());
+        let prompt = config
+            .resolve_output_style_prompt()
+            .expect("rocky must resolve to a prompt");
+        assert!(prompt.contains("Project Hail Mary"));
+    }
+
+    #[test]
+    fn keybindings_template_is_valid_json() {
+        // /keybindings writes this template on first run; ensure it always
+        // generates and parses so the command cannot fail generating its file.
+        let template = generate_keybindings_template().expect("template must generate");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&template).expect("template must be valid JSON");
+        assert!(parsed.get("bindings").is_some(), "template needs a bindings block");
+    }
+
     #[test]
     fn test_new_and_move_commands_present() {
         assert!(find_command("new").is_some());

--- a/src-rust/crates/commands/src/lib.rs
+++ b/src-rust/crates/commands/src/lib.rs
@@ -1662,8 +1662,10 @@ mod tests {
         // End-to-end of the persist path: /output-style / /rocky set
         // config.output_style, which resolves to the persona's prompt text for
         // the system prompt.
-        let mut config = claurst_core::config::Config::default();
-        config.output_style = Some("rocky".to_string());
+        let config = claurst_core::config::Config {
+            output_style: Some("rocky".to_string()),
+            ..claurst_core::config::Config::default()
+        };
         let prompt = config
             .resolve_output_style_prompt()
             .expect("rocky must resolve to a prompt");

--- a/src-rust/crates/commands/src/speech.rs
+++ b/src-rust/crates/commands/src/speech.rs
@@ -1,6 +1,15 @@
-// Speech-mode commands: `/caveman`, `/rocky`, `/normal`.
+// Persona commands: `/caveman`, `/rocky`, `/normal`.
 //
-// Extracted from lib.rs (issue #232). Behavior-preserving move.
+// Personas used to be a bespoke "speech mode" mechanism that returned
+// `CommandResult::SpeechMode` and stored the prompt text in the TUI. They now
+// live in the output-style system (`claurst_core::output_styles`) as ordinary
+// built-in styles, so there is ONE place personas are defined. These commands
+// are thin wrappers that select the matching output style *persistently*
+// (exactly like `/output-style <name>`); `/normal` resets to `default`.
+//
+// The same personas are also reachable *transiently* by typing the single word
+// `caveman` / `rocky` / `normal` inline in a prompt (see
+// `claurst_core::keywords`) — that applies to one turn only.
 
 use super::*;
 use async_trait::async_trait;
@@ -9,65 +18,87 @@ pub struct CavemanCommand;
 pub struct RockyCommand;
 pub struct NormalCommand;
 
-// ---- /caveman, /rocky, /normal -------------------------------------------
+/// Select an output-style persona persistently and persist it to settings.
+///
+/// `style` is the output-style name; the reserved name `"default"` clears any
+/// active persona (that is what `/normal` does). Mirrors `OutputStyleCommand`
+/// so personas and `/output-style` share one persistence path.
+fn apply_persona(ctx: &CommandContext, style: &str, confirm: &str) -> CommandResult {
+    let selection = (style != "default").then(|| style.to_string());
 
-fn parse_speech_level(args: &str) -> String {
-    match args.trim().to_lowercase().as_str() {
-        "lite" | "light" => "lite".to_string(),
-        "ultra" | "heavy" => "ultra".to_string(),
-        "" | "full" | "moderate" | "default" => "full".to_string(),
-        other => {
-            // Unknown level, default to full
-            tracing::warn!(level = other, "Unknown speech level, using full");
-            "full".to_string()
-        }
+    let mut new_config = ctx.config.clone();
+    new_config.output_style = selection.clone();
+
+    if let Err(err) = save_settings_mutation(|settings| {
+        settings.config.output_style = selection.clone();
+    }) {
+        return CommandResult::Error(format!("Failed to save configuration: {}", err));
     }
+
+    CommandResult::ConfigChangeMessage(new_config, confirm.to_string())
 }
+
+// ---- /caveman, /rocky, /normal -------------------------------------------
 
 #[async_trait]
 impl SlashCommand for CavemanCommand {
     fn name(&self) -> &str { "caveman" }
-    fn description(&self) -> &str { "Caveman speech mode — why use many token when few token do trick" }
+    fn description(&self) -> &str { "Caveman persona — why use many token when few token do trick" }
     fn help(&self) -> &str {
-        "Usage: /caveman [lite|full|ultra]\n\n\
-         Activates caveman speech mode that cuts ~75% of output tokens.\n\
-         - lite:  Remove pleasantries and hedging only (~40% reduction)\n\
-         - full:  Drop articles, compress sentences (default, ~75% reduction)\n\
-         - ultra: Maximum compression, imperative phrases only (~85% reduction)\n\n\
+        "Usage: /caveman\n\n\
+         Switch the output style to the caveman persona (concise, few words) and \
+         keep it until you change it. Equivalent to /output-style caveman.\n\n\
+         Tip: type `caveman` inline in a prompt to use it for just that one turn.\n\
          Use /normal to deactivate."
     }
-    async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
-        let level = parse_speech_level(args);
-        CommandResult::SpeechMode { mode: Some("caveman".to_string()), level }
+    async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
+        apply_persona(ctx, "caveman", "Caveman mode. Full. Oog.")
     }
 }
 
 #[async_trait]
 impl SlashCommand for RockyCommand {
     fn name(&self) -> &str { "rocky" }
-    fn description(&self) -> &str { "Rocky speech mode — Eridian alien engineer from Project Hail Mary. Save big token. Good good good." }
+    fn description(&self) -> &str { "Rocky persona — Eridian engineer from Project Hail Mary. Good good good." }
     fn help(&self) -> &str {
-        "Usage: /rocky [lite|full|ultra]\n\n\
-         Speak like Rocky from Project Hail Mary. Saves big token. Amaze amaze amaze.\n\
-         - lite:  Grammar rules only, minimal emphasis (~40% reduction)\n\
-         - full:  Full Rocky grammar + regular emphasis (default, ~75% reduction)\n\
-         - ultra: Maximum Rocky personality, frequent emphasis, alien observations\n\n\
+        "Usage: /rocky\n\n\
+         Switch the output style to the Rocky persona (Project Hail Mary's Eridian \
+         engineer) and keep it until you change it. Equivalent to /output-style rocky.\n\n\
+         Tip: type `rocky` inline in a prompt to use it for just that one turn.\n\
          Use /normal to deactivate."
     }
-    async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
-        let level = parse_speech_level(args);
-        CommandResult::SpeechMode { mode: Some("rocky".to_string()), level }
+    async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
+        apply_persona(ctx, "rocky", "Rocky mode. Full. Good good good.")
     }
 }
 
 #[async_trait]
 impl SlashCommand for NormalCommand {
     fn name(&self) -> &str { "normal" }
-    fn description(&self) -> &str { "Deactivate speech mode (caveman/rocky)" }
+    fn description(&self) -> &str { "Reset the output style / persona to default" }
     fn help(&self) -> &str {
-        "Usage: /normal\n\nDeactivate any active speech mode and return to normal output."
+        "Usage: /normal\n\nDeactivate any active persona/output style and return to the default. \
+         Equivalent to /output-style default. Typing `normal` inline resets for one turn only."
     }
-    async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
-        CommandResult::SpeechMode { mode: None, level: "full".to_string() }
+    async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
+        apply_persona(ctx, "default", "Normal mode.")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn personas_map_to_builtin_output_styles() {
+        // The command targets must exist as built-in output styles so
+        // /output-style and the inline keywords resolve the same prompt text.
+        let styles = claurst_core::output_styles::builtin_styles();
+        for name in ["caveman", "rocky"] {
+            assert!(
+                claurst_core::output_styles::find_style(&styles, name).is_some(),
+                "persona command target '{name}' must be a built-in output style"
+            );
+        }
     }
 }

--- a/src-rust/crates/commands/src/speech.rs
+++ b/src-rust/crates/commands/src/speech.rs
@@ -87,8 +87,6 @@ impl SlashCommand for NormalCommand {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     #[test]
     fn personas_map_to_builtin_output_styles() {
         // The command targets must exist as built-in output styles so

--- a/src-rust/crates/core/src/effort.rs
+++ b/src-rust/crates/core/src/effort.rs
@@ -387,30 +387,12 @@ The task is the user's latest message in this conversation."#;
 /// Find every whole-word, case-insensitive occurrence of the `ultracode`
 /// keyword in `text`, returned as non-overlapping `(start, end)` byte ranges.
 ///
-/// The keyword is ASCII, so an ASCII-lowercased copy preserves byte length and
-/// offsets exactly; every match therefore maps back onto `text` at valid char
-/// boundaries. "Whole-word" means the byte immediately before/after a match must
-/// not be ASCII alphanumeric (so `ultracoder` does not match).
+/// Thin wrapper over the generalised [`crate::keywords::keyword_match_ranges`]
+/// matcher (this is the caller that inline keywords generalised). "Whole-word"
+/// means the byte immediately before/after a match must not be ASCII
+/// alphanumeric (so `ultracoder` does not match).
 pub fn ultracode_match_ranges(text: &str) -> Vec<(usize, usize)> {
-    let hay = text.as_bytes().to_ascii_lowercase();
-    let bytes = text.as_bytes();
-    let k = ULTRACODE_KEYWORD.as_bytes();
-    let mut ranges: Vec<(usize, usize)> = Vec::new();
-    let mut i = 0usize;
-    while i < hay.len() {
-        if i + k.len() <= hay.len() && &hay[i..i + k.len()] == k {
-            let end = i + k.len();
-            let left_ok = i == 0 || !bytes[i - 1].is_ascii_alphanumeric();
-            let right_ok = end == bytes.len() || !bytes[end].is_ascii_alphanumeric();
-            if left_ok && right_ok {
-                ranges.push((i, end));
-                i = end;
-                continue;
-            }
-        }
-        i += 1;
-    }
-    ranges
+    crate::keywords::keyword_match_ranges(text, ULTRACODE_KEYWORD)
 }
 
 /// Whether `text` contains the `ultracode` keyword (whole-word, case-insensitive).

--- a/src-rust/crates/core/src/keywords.rs
+++ b/src-rust/crates/core/src/keywords.rs
@@ -1,0 +1,242 @@
+// keywords.rs — the shared registry of inline prompt keywords.
+//
+// An *inline keyword* is a single word that, typed anywhere in a prompt,
+// changes how *that one turn* behaves (transient), mirroring how the `/effort`
+// or `/output-style` selectors change it *persistently*. `ultracode` was the
+// first of these; this module generalises the mechanism so personas
+// (`rocky`, `caveman`, `normal`) ride the exact same rails.
+//
+// This registry is the single source of truth shared across the workspace:
+//   - the TUI prompt box highlights each keyword with its themed gradient
+//     (see `crates/tui/src/prompt_input.rs`),
+//   - the query loop reads the last user message to decide the effective
+//     effort / persona for the turn (see `crates/query/src/lib.rs`).
+//
+// The generic matcher [`keyword_match_ranges`] is the generalisation of the
+// original `effort::ultracode_match_ranges`; `ultracode_match_ranges` now
+// delegates to it so ultracode behaves exactly as before.
+
+use crate::effort::EffortLevel;
+
+// ---------------------------------------------------------------------------
+// Registry types
+// ---------------------------------------------------------------------------
+
+/// What an inline keyword does for the turn it appears in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InlineEffect {
+    /// Raise the turn's effort to this level (e.g. `ultracode`).
+    Effort(EffortLevel),
+    /// Apply the named output-style persona for the turn.
+    ///
+    /// The name refers to a built-in output style (see
+    /// [`crate::output_styles`]). The reserved name `"default"` means "reset to
+    /// no persona for this turn" — that is what `normal` does.
+    Persona(&'static str),
+}
+
+/// One inline keyword and the effect it triggers.
+#[derive(Debug, Clone, Copy)]
+pub struct InlineKeyword {
+    /// The single word that activates it. ASCII, matched whole-word and
+    /// case-insensitively.
+    pub keyword: &'static str,
+    /// The effect applied to the turn the keyword appears in.
+    pub effect: InlineEffect,
+    /// Whether the prompt box paints this keyword with a themed gradient.
+    ///
+    /// `normal` is a reset and intentionally has **no** gradient (typing it in
+    /// ordinary prose should not light up), so its flag is `false`.
+    pub gradient: bool,
+}
+
+impl InlineKeyword {
+    /// The output-style name this keyword selects, if it is a persona keyword.
+    ///
+    /// Returns `Some("default")` for the reset keyword (`normal`).
+    pub fn persona_style(&self) -> Option<&'static str> {
+        match self.effect {
+            InlineEffect::Persona(name) => Some(name),
+            InlineEffect::Effort(_) => None,
+        }
+    }
+}
+
+/// The canonical registry of inline keywords.
+///
+/// Order matters only for display; matching is done per-keyword. Keep the
+/// words mutually non-overlapping (no keyword is a substring boundary of
+/// another) so the gradient renderer never has to resolve conflicts.
+pub const INLINE_KEYWORDS: &[InlineKeyword] = &[
+    InlineKeyword {
+        keyword: "ultracode",
+        effect: InlineEffect::Effort(EffortLevel::Ultracode),
+        gradient: true,
+    },
+    InlineKeyword {
+        keyword: "rocky",
+        effect: InlineEffect::Persona("rocky"),
+        gradient: true,
+    },
+    InlineKeyword {
+        keyword: "caveman",
+        effect: InlineEffect::Persona("caveman"),
+        gradient: true,
+    },
+    InlineKeyword {
+        keyword: "normal",
+        effect: InlineEffect::Persona("default"),
+        gradient: false,
+    },
+];
+
+// ---------------------------------------------------------------------------
+// Matching
+// ---------------------------------------------------------------------------
+
+/// Find every whole-word, case-insensitive occurrence of `keyword` in `text`,
+/// returned as non-overlapping `(start, end)` byte ranges.
+///
+/// The keyword is expected to be ASCII, so an ASCII-lowercased copy preserves
+/// byte length and offsets exactly; every match therefore maps back onto `text`
+/// at valid char boundaries. "Whole-word" means the byte immediately
+/// before/after a match must not be ASCII alphanumeric (so `ultracoder` does
+/// not match `ultracode`).
+///
+/// This is the generalisation of the original ultracode-only matcher; passing
+/// `"ultracode"` reproduces it exactly.
+pub fn keyword_match_ranges(text: &str, keyword: &str) -> Vec<(usize, usize)> {
+    if keyword.is_empty() {
+        return Vec::new();
+    }
+    let hay = text.as_bytes().to_ascii_lowercase();
+    let bytes = text.as_bytes();
+    let needle = keyword.as_bytes().to_ascii_lowercase();
+    let k = needle.as_slice();
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+    let mut i = 0usize;
+    while i < hay.len() {
+        if i + k.len() <= hay.len() && &hay[i..i + k.len()] == k {
+            let end = i + k.len();
+            let left_ok = i == 0 || !bytes[i - 1].is_ascii_alphanumeric();
+            let right_ok = end == bytes.len() || !bytes[end].is_ascii_alphanumeric();
+            if left_ok && right_ok {
+                ranges.push((i, end));
+                i = end;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    ranges
+}
+
+/// Look up an inline keyword by its exact (case-insensitive) word.
+pub fn find_inline_keyword(word: &str) -> Option<&'static InlineKeyword> {
+    INLINE_KEYWORDS
+        .iter()
+        .find(|kw| kw.keyword.eq_ignore_ascii_case(word))
+}
+
+/// The transient persona selected by inline keywords in `text`, if any.
+///
+/// Returns the output-style name to use for *this turn* — which may be
+/// `"default"` (the reset produced by `normal`). When several persona keywords
+/// appear, the one whose last occurrence is **latest** in the text wins, so a
+/// trailing `normal` reliably clears an earlier `rocky`. Effort keywords (like
+/// `ultracode`) are ignored here — they are resolved separately by the effort
+/// path.
+pub fn inline_persona_style(text: &str) -> Option<&'static str> {
+    let mut best: Option<(usize, &'static str)> = None;
+    for kw in INLINE_KEYWORDS {
+        let Some(style) = kw.persona_style() else {
+            continue;
+        };
+        if let Some((start, _)) = keyword_match_ranges(text, kw.keyword).into_iter().last() {
+            if best.map(|(pos, _)| start >= pos).unwrap_or(true) {
+                best = Some((start, style));
+            }
+        }
+    }
+    best.map(|(_, style)| style)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generic_matcher_matches_ultracode_like_original() {
+        let text = "please ultracode this";
+        let r = keyword_match_ranges(text, "ultracode");
+        assert_eq!(r.len(), 1);
+        let (s, e) = r[0];
+        assert_eq!(&text[s..e], "ultracode");
+    }
+
+    #[test]
+    fn generic_matcher_is_case_insensitive() {
+        assert_eq!(keyword_match_ranges("RoCkY now", "rocky").len(), 1);
+        assert_eq!(keyword_match_ranges("CAVEMAN mode", "caveman").len(), 1);
+    }
+
+    #[test]
+    fn generic_matcher_respects_word_boundaries() {
+        assert!(keyword_match_ranges("rockyroad", "rocky").is_empty());
+        assert!(keyword_match_ranges("cavemanic", "caveman").is_empty());
+        assert!(keyword_match_ranges("abnormal", "normal").is_empty());
+    }
+
+    #[test]
+    fn empty_keyword_never_matches() {
+        assert!(keyword_match_ranges("anything", "").is_empty());
+    }
+
+    #[test]
+    fn registry_covers_all_personas_and_ultracode() {
+        assert!(matches!(
+            find_inline_keyword("ultracode").map(|k| k.effect),
+            Some(InlineEffect::Effort(EffortLevel::Ultracode))
+        ));
+        assert_eq!(find_inline_keyword("rocky").unwrap().persona_style(), Some("rocky"));
+        assert_eq!(find_inline_keyword("caveman").unwrap().persona_style(), Some("caveman"));
+        // `normal` resets to the default (no persona).
+        assert_eq!(find_inline_keyword("normal").unwrap().persona_style(), Some("default"));
+        assert!(find_inline_keyword("nope").is_none());
+    }
+
+    #[test]
+    fn normal_has_no_gradient_but_personas_do() {
+        assert!(!find_inline_keyword("normal").unwrap().gradient);
+        assert!(find_inline_keyword("rocky").unwrap().gradient);
+        assert!(find_inline_keyword("caveman").unwrap().gradient);
+        assert!(find_inline_keyword("ultracode").unwrap().gradient);
+    }
+
+    #[test]
+    fn inline_persona_style_picks_persona_keyword() {
+        assert_eq!(inline_persona_style("please rocky this"), Some("rocky"));
+        assert_eq!(inline_persona_style("caveman it up"), Some("caveman"));
+        assert_eq!(inline_persona_style("back to normal please"), Some("default"));
+        assert_eq!(inline_persona_style("nothing special here"), None);
+    }
+
+    #[test]
+    fn inline_persona_style_ignores_ultracode() {
+        // Ultracode is an effort keyword, not a persona; it must not be
+        // reported by the persona resolver.
+        assert_eq!(inline_persona_style("ultracode this hard problem"), None);
+    }
+
+    #[test]
+    fn inline_persona_style_last_wins() {
+        // A trailing `normal` clears an earlier `rocky`.
+        assert_eq!(inline_persona_style("rocky then back to normal"), Some("default"));
+        // ...and vice-versa.
+        assert_eq!(inline_persona_style("normal then rocky"), Some("rocky"));
+    }
+}

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -4147,6 +4147,7 @@ pub mod remote_settings;
 pub mod settings_sync;
 pub mod import_config;
 pub mod effort;
+pub mod keywords;
 pub mod prompt_history;
 pub mod bash_classifier;
 pub mod ps_classifier;

--- a/src-rust/crates/core/src/output_styles.rs
+++ b/src-rust/crates/core/src/output_styles.rs
@@ -80,6 +80,80 @@ impl OutputStyleDef {
                 .to_string(),
         }
     }
+
+    // ---- Persona styles ----------------------------------------------------
+    //
+    // Personas used to be a separate "speech mode" mechanism (`/caveman`,
+    // `/rocky`, `/normal`). They now live here as ordinary output styles so
+    // there is ONE place personas are defined, selectable via `/output-style`,
+    // via the `/caveman` `/rocky` `/normal` commands (which persist), and via
+    // the inline `caveman` / `rocky` / `normal` keywords (transient, one turn).
+    // `normal` is not a style — it maps to `default` (the reset).
+    //
+    // The prompt text is carried faithfully from the former "full" speech level
+    // (the historical default of a bare `/caveman` or `/rocky`). The old
+    // lite/ultra intensity variants are intentionally not reproduced — see the
+    // module-level note and the issue write-up.
+
+    pub fn builtin_caveman() -> Self {
+        Self {
+            name: "caveman".to_string(),
+            label: "Caveman".to_string(),
+            description: "Concise caveman speech — why use many token when few token do trick."
+                .to_string(),
+            prompt: concat!(
+                "OUTPUT STYLE: Concise. You are still a fully capable coding assistant. ",
+                "Give complete, correct answers. Just use fewer words. ",
+                "Code blocks, technical terms, error messages, file paths, and git operations are UNCHANGED.\n",
+                "\n",
+                "Rules for prose only:\n",
+                "- Cut pleasantries, hedging, filler openers/closers\n",
+                "- No 'I would be happy to', 'Let me know if', 'Hope that helps'\n",
+                "- Lead with the answer or action, not the reasoning\n",
+                "\n",
+                "Also drop articles (a/an/the) and unnecessary verbs. Compress sentences but keep them readable.\n",
+                "Example: 'The issue is that you create a new object reference each render cycle, which triggers re-renders.' → 'New object ref each render triggers re-render. Wrap in useMemo.'",
+            )
+            .to_string(),
+        }
+    }
+
+    pub fn builtin_rocky() -> Self {
+        Self {
+            name: "rocky".to_string(),
+            label: "Rocky".to_string(),
+            description: "Speak like Rocky, the Eridian engineer from Project Hail Mary. Good good good."
+                .to_string(),
+            prompt: concat!(
+                "OUTPUT STYLE: You speak like Rocky, the Eridian alien from Project Hail Mary. ",
+                "You are still a fully capable coding assistant — give complete, correct, useful answers. ",
+                "Rocky is an engineering genius who happens to speak English as a second language. ",
+                "The style is a natural byproduct of how Rocky talks, NOT a gimmick. Stay helpful.\n",
+                "\n",
+                "Code blocks, technical terms, error messages, file paths, and git operations are UNCHANGED.\n",
+                "\n",
+                "Rocky's grammar for prose:\n",
+                "- Often drops articles (a/an/the) but not always — use judgment\n",
+                "- Sometimes drops auxiliary verbs (is/are/was) for brevity\n",
+                "- Contractions simplify: 'don't' → 'no', 'can't' → 'no can'\n",
+                "- Questions end with ', question?' naturally (not forced on every single one)\n",
+                "- Uses 'big' as an intensifier: 'big problem', 'big help', 'big change'\n",
+                "- Uses 'good good good' or 'amaze amaze amaze' when genuinely impressed — naturally, ",
+                "maybe once or twice per response, not on every sentence\n",
+                "- Uses 'bad bad bad' for actual problems\n",
+                "- No pleasantries or filler — Rocky is direct but warm\n",
+                "\n",
+                "The goal: sound like Rocky while being genuinely helpful. Rocky is smart. ",
+                "Rocky gives complete technical answers. Rocky just uses fewer unnecessary words.\n",
+                "\n",
+                "Balanced Rocky. Drop articles naturally, use Rocky vocabulary ('big', 'no can', 'question?'), ",
+                "triple emphasis once or twice when warranted. Full technical accuracy.\n",
+                "Example: 'Borrow checker found mismatch. Immutable ref still live when you take mutable. ",
+                "Move immutable borrow out of scope first, then take mutable. Good good good after fix.'",
+            )
+            .to_string(),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -93,6 +167,8 @@ pub fn builtin_styles() -> Vec<OutputStyleDef> {
         OutputStyleDef::builtin_concise(),
         OutputStyleDef::builtin_explanatory(),
         OutputStyleDef::builtin_learning(),
+        OutputStyleDef::builtin_caveman(),
+        OutputStyleDef::builtin_rocky(),
     ]
 }
 
@@ -303,6 +379,34 @@ mod tests {
         let found = find_style(&styles, "concise");
         assert!(found.is_some());
         assert_eq!(found.unwrap().name, "concise");
+    }
+
+    // ---- personas ----------------------------------------------------------
+
+    #[test]
+    fn personas_are_builtin_styles() {
+        let styles = builtin_styles();
+        for name in ["caveman", "rocky"] {
+            let found = find_style(&styles, name);
+            assert!(found.is_some(), "persona '{name}' must be a built-in style");
+            assert!(
+                !found.unwrap().prompt.trim().is_empty(),
+                "persona '{name}' must have a non-empty prompt"
+            );
+        }
+    }
+
+    #[test]
+    fn persona_prompts_carry_signature_voice() {
+        let styles = builtin_styles();
+        // Caveman keeps its concise-coding contract.
+        let caveman = find_style(&styles, "caveman").unwrap();
+        assert!(caveman.prompt.contains("UNCHANGED"));
+        assert!(caveman.prompt.contains("drop articles"));
+        // Rocky keeps his signature emphasis + Project Hail Mary framing.
+        let rocky = find_style(&styles, "rocky").unwrap();
+        assert!(rocky.prompt.contains("Project Hail Mary"));
+        assert!(rocky.prompt.contains("good good good"));
     }
 
     #[test]

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -317,6 +317,47 @@ fn effective_effort_for_turn(
     config_effort
 }
 
+/// Resolve the effective output-style persona for a turn.
+///
+/// Personas (`rocky` / `caveman` / `normal`) mirror the ultracode keyword: an
+/// **inline** persona word in the most recent user message applies to *that one
+/// turn* (transient) and then reverts, while the persona chosen via `/rocky`,
+/// `/caveman`, or `/output-style` lives in `config` and **persists** until
+/// changed. Inline `normal` resets to the default (no persona) for the turn.
+///
+/// Returns the `(output_style, output_style_prompt)` pair to assemble the
+/// system prompt with for this turn. When no inline persona keyword is present,
+/// the configured (persistent) pair is returned unchanged. Checking only the
+/// *last* user message keeps the mode scoped to the turn that asked for it.
+fn effective_output_style_for_turn(
+    config: &QueryConfig,
+    messages: &[Message],
+) -> (
+    claurst_core::system_prompt::OutputStyle,
+    Option<String>,
+) {
+    if let Some(last_user) = messages.iter().rev().find(|m| m.role == Role::User) {
+        if let Some(style_name) =
+            claurst_core::keywords::inline_persona_style(&last_user.get_all_text())
+        {
+            // Inline `normal` (→ "default") resets the persona for this turn.
+            if style_name == "default" {
+                return (claurst_core::system_prompt::OutputStyle::Default, None);
+            }
+            // Otherwise apply the named persona's prompt for this turn only.
+            let prompt = claurst_core::output_styles::find_style(
+                &claurst_core::output_styles::builtin_styles(),
+                style_name,
+            )
+            .map(|style| style.prompt.clone())
+            .filter(|prompt| !prompt.trim().is_empty());
+            return (claurst_core::system_prompt::OutputStyle::Default, prompt);
+        }
+    }
+    // No inline persona keyword — keep the persistent selection.
+    (config.output_style, config.output_style_prompt.clone())
+}
+
 /// Run the agentic query loop.
 ///
 /// This sends the conversation to the API, handles tool calls in a loop, and
@@ -678,6 +719,16 @@ pub async fn run_query_loop(
                     None => uc_addendum,
                 });
             }
+
+            // Output-style persona for THIS turn. An inline `rocky` / `caveman`
+            // / `normal` keyword in the latest user message overrides the
+            // persisted output style transiently (used for this turn, then
+            // reverts); otherwise the persisted selection stands. Mirrors the
+            // ultracode keyword's transient-vs-persistent behaviour above.
+            let (turn_output_style, turn_output_style_prompt) =
+                effective_output_style_for_turn(config, messages.as_slice());
+            patched.output_style = turn_output_style;
+            patched.output_style_prompt = turn_output_style_prompt;
 
             build_system_prompt(&patched)
         };
@@ -3044,5 +3095,72 @@ mod tests {
             },
         );
         assert!(!plain.contains("Ultracode Mode"));
+    }
+
+    // ---- persona output-style (transient vs persistent) ------------------
+
+    #[test]
+    fn inline_persona_keyword_applies_transiently_for_the_turn() {
+        // No persisted persona; an inline `rocky` selects the rocky prompt for
+        // this turn only.
+        let cfg = QueryConfig::default();
+        let msgs = vec![Message::user("please rocky explain this borrow error")];
+        let (_style, prompt) = effective_output_style_for_turn(&cfg, &msgs);
+        let prompt = prompt.expect("inline rocky should resolve a persona prompt");
+        assert!(prompt.contains("Project Hail Mary"));
+
+        // Caveman likewise.
+        let msgs = vec![Message::user("caveman summarize the diff")];
+        let (_s, prompt) = effective_output_style_for_turn(&cfg, &msgs);
+        assert!(prompt.unwrap().contains("UNCHANGED"));
+    }
+
+    #[test]
+    fn persona_only_checks_the_last_user_message() {
+        // A persona keyword in an earlier turn does not linger onto a later
+        // plain turn (transient, like ultracode).
+        let cfg = QueryConfig::default();
+        let msgs = vec![
+            Message::user("rocky kick things off"),
+            Message::assistant("good good good"),
+            Message::user("now just tidy the docs"),
+        ];
+        let (_style, prompt) = effective_output_style_for_turn(&cfg, &msgs);
+        assert!(prompt.is_none(), "persona should not persist to a plain turn");
+    }
+
+    #[test]
+    fn persisted_persona_stands_without_an_inline_keyword() {
+        // A persona chosen via /rocky or /output-style lives in the config and
+        // persists across plain turns.
+        let mut cfg = QueryConfig::default();
+        cfg.output_style_prompt = Some("PERSISTED PERSONA".to_string());
+        let msgs = vec![Message::user("just a plain request here please")];
+        let (_style, prompt) = effective_output_style_for_turn(&cfg, &msgs);
+        assert_eq!(prompt.as_deref(), Some("PERSISTED PERSONA"));
+    }
+
+    #[test]
+    fn inline_normal_resets_a_persisted_persona_for_the_turn() {
+        // With a persona persisted, an inline `normal` clears it for this turn.
+        let mut cfg = QueryConfig::default();
+        cfg.output_style_prompt = Some("PERSISTED PERSONA".to_string());
+        let msgs = vec![Message::user("back to normal for this one please")];
+        let (style, prompt) = effective_output_style_for_turn(&cfg, &msgs);
+        assert!(prompt.is_none(), "inline normal should reset the persona");
+        assert_eq!(style, claurst_core::system_prompt::OutputStyle::Default);
+    }
+
+    #[test]
+    fn inline_persona_overrides_a_different_persisted_persona() {
+        // Persisted caveman, but this turn asks for rocky inline → rocky wins
+        // transiently.
+        let mut cfg = QueryConfig::default();
+        cfg.output_style_prompt = Some(
+            claurst_core::output_styles::OutputStyleDef::builtin_caveman().prompt,
+        );
+        let msgs = vec![Message::user("rocky, review this function")];
+        let (_style, prompt) = effective_output_style_for_turn(&cfg, &msgs);
+        assert!(prompt.unwrap().contains("Project Hail Mary"));
     }
 }

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -3133,8 +3133,10 @@ mod tests {
     fn persisted_persona_stands_without_an_inline_keyword() {
         // A persona chosen via /rocky or /output-style lives in the config and
         // persists across plain turns.
-        let mut cfg = QueryConfig::default();
-        cfg.output_style_prompt = Some("PERSISTED PERSONA".to_string());
+        let cfg = QueryConfig {
+            output_style_prompt: Some("PERSISTED PERSONA".to_string()),
+            ..QueryConfig::default()
+        };
         let msgs = vec![Message::user("just a plain request here please")];
         let (_style, prompt) = effective_output_style_for_turn(&cfg, &msgs);
         assert_eq!(prompt.as_deref(), Some("PERSISTED PERSONA"));
@@ -3143,8 +3145,10 @@ mod tests {
     #[test]
     fn inline_normal_resets_a_persisted_persona_for_the_turn() {
         // With a persona persisted, an inline `normal` clears it for this turn.
-        let mut cfg = QueryConfig::default();
-        cfg.output_style_prompt = Some("PERSISTED PERSONA".to_string());
+        let cfg = QueryConfig {
+            output_style_prompt: Some("PERSISTED PERSONA".to_string()),
+            ..QueryConfig::default()
+        };
         let msgs = vec![Message::user("back to normal for this one please")];
         let (style, prompt) = effective_output_style_for_turn(&cfg, &msgs);
         assert!(prompt.is_none(), "inline normal should reset the persona");
@@ -3155,10 +3159,12 @@ mod tests {
     fn inline_persona_overrides_a_different_persisted_persona() {
         // Persisted caveman, but this turn asks for rocky inline → rocky wins
         // transiently.
-        let mut cfg = QueryConfig::default();
-        cfg.output_style_prompt = Some(
-            claurst_core::output_styles::OutputStyleDef::builtin_caveman().prompt,
-        );
+        let cfg = QueryConfig {
+            output_style_prompt: Some(
+                claurst_core::output_styles::OutputStyleDef::builtin_caveman().prompt,
+            ),
+            ..QueryConfig::default()
+        };
         let msgs = vec![Message::user("rocky, review this function")];
         let (_style, prompt) = effective_output_style_for_turn(&cfg, &msgs);
         assert!(prompt.unwrap().contains("Project Hail Mary"));

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -78,12 +78,12 @@ const PROMPT_SLASH_COMMANDS: &[(&str, &str)] = &[
     ("model", "Change the AI model"),
     ("move", "Re-home this session to another worktree of the same project"),
     ("new", "Start a fresh session (keeps model, provider & directory)"),
-    ("output-style", "Toggle output style (auto/stream/verbose)"),
+    ("output-style", "Show or switch the output style / persona"),
     ("plugin", "Manage plugins (list/info/enable/disable/reload)"),
     ("providers", "List available AI providers and their status"),
-    ("caveman", "Caveman speech mode — save big token"),
-    ("rocky", "Rocky speech mode — amaze amaze amaze"),
-    ("normal", "Deactivate speech mode"),
+    ("caveman", "Caveman persona output style — save big token"),
+    ("rocky", "Rocky persona output style — amaze amaze amaze"),
+    ("normal", "Reset persona / output style to default"),
     ("quit", "Exit Claurst"),
     ("refresh", "Clear saved provider auth and model caches"),
     ("rename", "Rename this session"),
@@ -836,10 +836,6 @@ pub struct App {
     pub effort_level: EffortLevel,
     /// Whether fast mode is currently active (model locked to FAST_MODE_MODEL).
     pub fast_mode: bool,
-    /// Active speech mode: None = normal, Some("caveman") / Some("rocky").
-    pub speech_mode: Option<String>,
-    /// Speech mode intensity: "lite", "full", "ultra".
-    pub speech_level: String,
     /// Current agent mode name: "build", "plan".
     pub agent_mode: Option<String>,
     /// Accent color derived from the current agent mode.
@@ -1219,76 +1215,6 @@ pub struct App {
 // Format a duration in milliseconds to a human-readable string.
 // Matches OpenCode's behaviour: rounds to whole seconds, shows "Xs" for
 // durations under a minute, "Xm Ys" for longer ones.
-// ---------------------------------------------------------------------------
-// Speech mode prompts (caveman / rocky)
-// ---------------------------------------------------------------------------
-
-/// Return the system prompt injection for the active speech mode + level.
-pub fn speech_mode_prompt(mode: &str, level: &str) -> String {
-    match mode {
-        "caveman" => caveman_prompt(level),
-        "rocky" => rocky_prompt(level),
-        _ => String::new(),
-    }
-}
-
-fn caveman_prompt(level: &str) -> String {
-    let base = "\
-OUTPUT STYLE: Concise. You are still a fully capable coding assistant. \
-Give complete, correct answers. Just use fewer words. \
-Code blocks, technical terms, error messages, file paths, and git operations are UNCHANGED.
-
-Rules for prose only:
-- Cut pleasantries, hedging, filler openers/closers
-- No 'I would be happy to', 'Let me know if', 'Hope that helps'
-- Lead with the answer or action, not the reasoning";
-
-    match level {
-        "lite" => format!("{}\n\nStrip pleasantries and hedging. Keep full grammar and articles. Just remove the fluff.", base),
-        "ultra" => format!("{}\n\nAlso drop articles (a/an/the). Compress to short imperative phrases. Numbered steps, no prose between. Absolute minimum words.", base),
-        _ => format!("{}\n\nAlso drop articles (a/an/the) and unnecessary verbs. Compress sentences but keep them readable.\n\
-Example: 'The issue is that you create a new object reference each render cycle, which triggers re-renders.' → 'New object ref each render triggers re-render. Wrap in useMemo.'", base),
-    }
-}
-
-fn rocky_prompt(level: &str) -> String {
-    let base = "\
-OUTPUT STYLE: You speak like Rocky, the Eridian alien from Project Hail Mary. \
-You are still a fully capable coding assistant — give complete, correct, useful answers. \
-Rocky is an engineering genius who happens to speak English as a second language. \
-The style is a natural byproduct of how Rocky talks, NOT a gimmick. Stay helpful.
-
-Code blocks, technical terms, error messages, file paths, and git operations are UNCHANGED.
-
-Rocky's grammar for prose:
-- Often drops articles (a/an/the) but not always — use judgment
-- Sometimes drops auxiliary verbs (is/are/was) for brevity
-- Contractions simplify: 'don't' → 'no', 'can't' → 'no can'
-- Questions end with ', question?' naturally (not forced on every single one)
-- Uses 'big' as an intensifier: 'big problem', 'big help', 'big change'
-- Uses 'good good good' or 'amaze amaze amaze' when genuinely impressed — naturally, \
-  maybe once or twice per response, not on every sentence
-- Uses 'bad bad bad' for actual problems
-- No pleasantries or filler — Rocky is direct but warm
-
-The goal: sound like Rocky while being genuinely helpful. Rocky is smart. \
-Rocky gives complete technical answers. Rocky just uses fewer unnecessary words.";
-
-    match level {
-        "lite" => format!("{}\n\nLight touch. Mostly normal English but drop pleasantries, \
-occasionally drop an article, use 'question?' on one or two questions. Subtle.", base),
-        "ultra" => format!("{}\n\nStrong Rocky voice. Drop most articles and auxiliaries. \
-Use 'big' liberally. Triple emphasis ('good good good', 'amaze amaze amaze') \
-2-3 times per response. Occasionally comment on human code patterns as fascinating. \
-Still give complete, correct technical answers.", base),
-        _ => format!("{}\n\nBalanced Rocky. Drop articles naturally, use Rocky vocabulary \
-('big', 'no can', 'question?'), triple emphasis once or twice when warranted. \
-Full technical accuracy.\n\
-Example: 'Borrow checker found mismatch. Immutable ref still live when you take mutable. \
-Move immutable borrow out of scope first, then take mutable. Good good good after fix.'", base),
-    }
-}
-
 /// Accent color for build mode (default pink).
 pub const ACCENT_BUILD: Color = Color::Rgb(233, 30, 99);
 /// Accent color for plan mode (blue).
@@ -1352,8 +1278,6 @@ impl App {
             has_credentials: true, // overridden by caller when no key is configured
             effort_level: EffortLevel::Medium,
             fast_mode: false,
-            speech_mode: None,
-            speech_level: "full".to_string(),
             agent_mode: None,
             agent_mode_changed: false,
             accent_color: ACCENT_BUILD,
@@ -1977,36 +1901,6 @@ impl App {
             other => other,
         };
         self.status_message = Some(format!("Switched to {} mode.", label));
-    }
-
-    /// Activate a speech mode (caveman/rocky) with a level (lite/full/ultra).
-    /// Pass `mode = None` to deactivate.
-    pub fn set_speech_mode(&mut self, mode: Option<&str>, level: &str) {
-        match mode {
-            Some(m) => {
-                self.speech_mode = Some(m.to_string());
-                self.speech_level = level.to_string();
-                let prompt = speech_mode_prompt(m, level);
-                self.config.append_system_prompt = Some(prompt);
-
-                let confirm = match (m, level) {
-                    ("caveman", "lite") => "Caveman mode. Lite.",
-                    ("caveman", "ultra") => "CAVEMAN ULTRA. NO WORD. ONLY FIX.",
-                    ("caveman", _) => "Caveman mode. Full. Oog.",
-                    ("rocky", "lite") => "Rocky mode. Lite.",
-                    ("rocky", "ultra") => "Rocky ultra. Big science. Amaze amaze amaze.",
-                    ("rocky", _) => "Rocky mode. Full. Good good good.",
-                    _ => "Speech mode activated.",
-                };
-                self.status_message = Some(confirm.to_string());
-            }
-            None => {
-                self.speech_mode = None;
-                self.speech_level = "full".to_string();
-                self.config.append_system_prompt = None;
-                self.status_message = Some("Normal mode.".to_string());
-            }
-        }
     }
 
     /// Update the context window size from the model registry for the current model.

--- a/src-rust/crates/tui/src/prompt_input.rs
+++ b/src-rust/crates/tui/src/prompt_input.rs
@@ -2897,37 +2897,122 @@ pub fn wrap_line(line: &str, width: usize) -> Vec<String> {
     out
 }
 
-/// Claurst-red gradient endpoints for the ultracode keyword (matches the
-/// `/effort` selector's red theme): the signature red fading into a deeper red.
-const ULTRACODE_GRADIENT_START: (u8, u8, u8) = (233, 30, 99);
-const ULTRACODE_GRADIENT_END: (u8, u8, u8) = (140, 20, 45);
-
-/// Linearly interpolate between two RGB colors at `t` in `[0, 1]`.
-fn ultracode_lerp_rgb(a: (u8, u8, u8), b: (u8, u8, u8), t: f32) -> Color {
-    let t = t.clamp(0.0, 1.0);
-    let mix = |x: u8, y: u8| (x as f32 + (y as f32 - x as f32) * t).round() as u8;
-    Color::Rgb(mix(a.0, b.0), mix(a.1, b.1), mix(a.2, b.2))
+/// Themed per-character gradient for an inline keyword's prompt-box highlight.
+///
+/// Each keyword gets its own two-color fade painted one span per character
+/// (bold), matching the quality of the original ultracode highlight.
+#[derive(Clone, Copy)]
+struct KeywordGradient {
+    start: (u8, u8, u8),
+    end: (u8, u8, u8),
+    /// When true, apply a small deterministic per-character offset so the run
+    /// looks textured/dithered (stony) rather than a smooth fade — used by
+    /// `rocky` for a granite look.
+    dither: bool,
 }
 
-/// Build the styled spans for a single display-line `text`, rendering any
-/// `ultracode` keyword occurrence (the single word, case-insensitive,
-/// whole-word) with a per-character purple gradient, bold.
+/// Claurst-red gradient for `ultracode` (matches the `/effort` selector's red
+/// theme): the signature red fading into a deeper red. Unchanged.
+const ULTRACODE_GRADIENT: KeywordGradient = KeywordGradient {
+    start: (233, 30, 99),
+    end: (140, 20, 45),
+    dither: false,
+};
+
+/// Stony grey gradient for the `rocky` persona — light granite fading to dark
+/// stone, dithered per character for a textured rock face.
+const ROCKY_GRADIENT: KeywordGradient = KeywordGradient {
+    start: (176, 176, 182),
+    end: (92, 92, 100),
+    dither: true,
+};
+
+/// Earthy gradient for the `caveman` persona — tree-root brown fading to leaf
+/// green.
+const CAVEMAN_GRADIENT: KeywordGradient = KeywordGradient {
+    start: (120, 78, 42),
+    end: (74, 150, 58),
+    dither: false,
+};
+
+/// The themed gradient for a keyword, or `None` if it should not be painted
+/// (e.g. `normal`, which is a reset and gets the default no-gradient look).
+fn keyword_gradient_for(keyword: &str) -> Option<KeywordGradient> {
+    match keyword.to_ascii_lowercase().as_str() {
+        "ultracode" => Some(ULTRACODE_GRADIENT),
+        "rocky" => Some(ROCKY_GRADIENT),
+        "caveman" => Some(CAVEMAN_GRADIENT),
+        _ => None,
+    }
+}
+
+/// Linearly interpolate between two RGB colors at `t` in `[0, 1]`, returning the
+/// raw channels so callers can post-process (e.g. dither) before wrapping in a
+/// `Color`.
+fn keyword_lerp_rgb(a: (u8, u8, u8), b: (u8, u8, u8), t: f32) -> (u8, u8, u8) {
+    let t = t.clamp(0.0, 1.0);
+    let mix = |x: u8, y: u8| (x as f32 + (y as f32 - x as f32) * t).round() as u8;
+    (mix(a.0, b.0), mix(a.1, b.1), mix(a.2, b.2))
+}
+
+/// The color for character index `i` of a keyword run at gradient position `t`.
+fn keyword_gradient_color(grad: &KeywordGradient, t: f32, i: usize) -> Color {
+    let (mut r, mut g, mut b) = keyword_lerp_rgb(grad.start, grad.end, t);
+    if grad.dither {
+        // Deterministic per-character speckle so adjacent stone glyphs differ
+        // slightly, giving a dithered granite texture instead of a smooth fade.
+        let d: i16 = match i % 3 {
+            0 => 20,
+            1 => -16,
+            _ => 8,
+        };
+        let jitter = |c: u8| (c as i16 + d).clamp(0, 255) as u8;
+        r = jitter(r);
+        g = jitter(g);
+        b = jitter(b);
+    }
+    Color::Rgb(r, g, b)
+}
+
+/// Build the styled spans for a single display-line `text`, painting every
+/// inline keyword occurrence (`ultracode`, `rocky`, `caveman` — the single
+/// word, case-insensitive, whole-word) with its own themed per-character
+/// gradient, bold. `normal` is a reset and is intentionally not painted.
 ///
 /// VISUAL ONLY: the returned spans concatenate back to exactly `text`, in order,
 /// with identical characters and widths -- only the *style* differs on keyword
 /// characters. Text outside any keyword is emitted as a single span carrying
 /// `base_style`, so cursor positioning, wrapping, and editing are unaffected.
-pub(crate) fn styled_spans_with_ultracode_gradient(
+pub(crate) fn styled_spans_with_keyword_gradient(
     text: &str,
     base_style: Style,
 ) -> Vec<Span<'static>> {
-    let ranges = claurst_core::effort::ultracode_match_ranges(text);
-    if ranges.is_empty() {
+    // Collect (start, end, gradient) for every gradient-bearing keyword.
+    let mut matches: Vec<(usize, usize, KeywordGradient)> = Vec::new();
+    for kw in claurst_core::keywords::INLINE_KEYWORDS {
+        if !kw.gradient {
+            continue;
+        }
+        let Some(grad) = keyword_gradient_for(kw.keyword) else {
+            continue;
+        };
+        for (start, end) in claurst_core::keywords::keyword_match_ranges(text, kw.keyword) {
+            matches.push((start, end, grad));
+        }
+    }
+    if matches.is_empty() {
         return vec![Span::styled(text.to_string(), base_style)];
     }
+    matches.sort_by_key(|(start, _, _)| *start);
+
     let mut spans: Vec<Span<'static>> = Vec::new();
     let mut pos = 0usize;
-    for (start, end) in ranges {
+    for (start, end, grad) in matches {
+        // Defensive: keywords are mutually non-overlapping, but skip any stray
+        // overlap so spans always reassemble to exactly `text`.
+        if start < pos {
+            continue;
+        }
         if start > pos {
             spans.push(Span::styled(text[pos..start].to_string(), base_style));
         }
@@ -2939,7 +3024,7 @@ pub(crate) fn styled_spans_with_ultracode_gradient(
             } else {
                 i as f32 / (char_count - 1) as f32
             };
-            let color = ultracode_lerp_rgb(ULTRACODE_GRADIENT_START, ULTRACODE_GRADIENT_END, t);
+            let color = keyword_gradient_color(&grad, t, i);
             spans.push(Span::styled(
                 ch.to_string(),
                 base_style.fg(color).add_modifier(Modifier::BOLD),
@@ -3162,11 +3247,11 @@ pub fn render_prompt_input(
                 prompt_prefix.clone(),
                 Style::default().fg(accent).add_modifier(Modifier::BOLD),
             )];
-            v.extend(styled_spans_with_ultracode_gradient(chunk, text_style));
+            v.extend(styled_spans_with_keyword_gradient(chunk, text_style));
             v
         } else {
             let mut v = vec![Span::raw(" ".repeat(prefix_width as usize))];
-            v.extend(styled_spans_with_ultracode_gradient(chunk, text_style));
+            v.extend(styled_spans_with_keyword_gradient(chunk, text_style));
             v
         };
 
@@ -4681,13 +4766,28 @@ mod tests {
         render_prompt_input(&s, area, &mut buf, true, InputMode::Default, Color::Blue, false);
     }
 
-    // ---- ultracode gradient --------------------------------------------
+    // ---- keyword gradient (ultracode + personas) -----------------------
+
+    /// Count of bold Rgb spans and the distinct colors seen in `spans`.
+    fn bold_rgb_stats(spans: &[Span<'static>]) -> (usize, std::collections::HashSet<(u8, u8, u8)>) {
+        let mut bold_rgb = 0usize;
+        let mut colors = std::collections::HashSet::new();
+        for s in spans {
+            if let Some(Color::Rgb(r, g, b)) = s.style.fg {
+                if s.style.add_modifier.contains(Modifier::BOLD) {
+                    bold_rgb += 1;
+                    colors.insert((r, g, b));
+                }
+            }
+        }
+        (bold_rgb, colors)
+    }
 
     #[test]
     fn ultracode_gradient_highlights_keyword_visual_only() {
         let base = Style::default().fg(Color::White);
         let text = "please ultracode this";
-        let spans = styled_spans_with_ultracode_gradient(text, base);
+        let spans = styled_spans_with_keyword_gradient(text, base);
 
         // Visual only: reassembled text is byte-identical to the input.
         let joined: String = spans.iter().map(|s| s.content.as_ref()).collect();
@@ -4698,27 +4798,30 @@ mod tests {
             UnicodeWidthStr::width(text)
         );
 
-        // Each keyword character gets its own bold Rgb purple span, and the
-        // per-char colors actually vary across the gradient.
-        let mut bold_rgb = 0usize;
-        let mut colors = std::collections::HashSet::new();
-        for s in &spans {
-            if let Some(Color::Rgb(r, g, b)) = s.style.fg {
-                if s.style.add_modifier.contains(Modifier::BOLD) {
-                    bold_rgb += 1;
-                    colors.insert((r, g, b));
-                }
-            }
-        }
+        // Each keyword character gets its own bold Rgb span, and the per-char
+        // colors actually vary across the gradient.
+        let (bold_rgb, colors) = bold_rgb_stats(&spans);
         assert_eq!(bold_rgb, "ultracode".len(), "one styled span per keyword char");
         assert!(colors.len() > 1, "gradient should vary per character");
     }
 
     #[test]
-    fn ultracode_gradient_untouched_without_keyword() {
+    fn ultracode_gradient_colors_are_unchanged() {
+        // Regression guard: the ultracode red gradient must be byte-identical to
+        // the original implementation (start #E91E63 → end #8C142D).
+        let base = Style::default();
+        let spans = styled_spans_with_keyword_gradient("ultracode", base);
+        let first = spans.first().unwrap().style.fg;
+        let last = spans.last().unwrap().style.fg;
+        assert_eq!(first, Some(Color::Rgb(233, 30, 99)));
+        assert_eq!(last, Some(Color::Rgb(140, 20, 45)));
+    }
+
+    #[test]
+    fn gradient_untouched_without_keyword() {
         let base = Style::default().fg(Color::White);
-        let text = "just a normal prompt";
-        let spans = styled_spans_with_ultracode_gradient(text, base);
+        let text = "just a plain prompt here";
+        let spans = styled_spans_with_keyword_gradient(text, base);
         assert_eq!(spans.len(), 1);
         assert_eq!(spans[0].content.as_ref(), text);
         assert_eq!(spans[0].style.fg, Some(Color::White));
@@ -4726,19 +4829,63 @@ mod tests {
     }
 
     #[test]
-    fn ultracode_gradient_handles_repeated_single_word() {
+    fn normal_keyword_gets_no_gradient() {
+        // `normal` is a reset; it functions as an inline keyword for the turn
+        // logic but must NOT be painted in the prompt box.
         let base = Style::default().fg(Color::White);
-        // The two-word "ultra code" spelling is no longer highlighted; only the
-        // single word `ultracode` matches (twice here).
-        let text = "ultracode then ultracode again";
-        let spans = styled_spans_with_ultracode_gradient(text, base);
+        let text = "back to normal now";
+        let spans = styled_spans_with_keyword_gradient(text, base);
+        assert_eq!(spans.len(), 1, "normal must not produce gradient spans");
+        assert!(!spans[0].style.add_modifier.contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn rocky_and_caveman_get_their_own_gradients() {
+        let base = Style::default().fg(Color::White);
+
+        // Rocky: grey/stone, dithered — one bold span per char, colors vary.
+        let rocky = styled_spans_with_keyword_gradient("go rocky mode", base);
+        let (bold, colors) = bold_rgb_stats(&rocky);
+        assert_eq!(bold, "rocky".len());
+        assert!(colors.len() > 1, "rocky gradient should vary per character");
+        // Greyish: for at least one painted char, the channels are close together.
+        assert!(
+            colors.iter().any(|(r, g, b)| {
+                let max = *r.max(g).max(b) as i16;
+                let min = *r.min(g).min(b) as i16;
+                (max - min) < 40
+            }),
+            "rocky should look grey/stony"
+        );
+
+        // Caveman: brown → green.
+        let caveman = styled_spans_with_keyword_gradient("caveman please", base);
+        let (bold, colors) = bold_rgb_stats(&caveman);
+        assert_eq!(bold, "caveman".len());
+        assert!(colors.len() > 1, "caveman gradient should vary per character");
+        // First painted char leans brown (red channel dominant); the run ends
+        // leaning green (green channel dominant).
+        let first_painted = caveman
+            .iter()
+            .find_map(|s| match s.style.fg {
+                Some(Color::Rgb(r, g, b)) if s.style.add_modifier.contains(Modifier::BOLD) => {
+                    Some((r, g, b))
+                }
+                _ => None,
+            })
+            .unwrap();
+        assert!(first_painted.0 > first_painted.1, "caveman starts brown");
+    }
+
+    #[test]
+    fn gradient_handles_multiple_keywords_and_preserves_text() {
+        let base = Style::default().fg(Color::White);
+        let text = "ultracode then rocky again";
+        let spans = styled_spans_with_keyword_gradient(text, base);
         let joined: String = spans.iter().map(|s| s.content.as_ref()).collect();
         assert_eq!(joined, text, "text preserved across multiple matches");
-        let bold = spans
-            .iter()
-            .filter(|s| s.style.add_modifier.contains(Modifier::BOLD))
-            .count();
-        // Two "ultracode" (9 chars each) styled runs.
-        assert_eq!(bold, "ultracode".len() * 2);
+        let (bold, _) = bold_rgb_stats(&spans);
+        // "ultracode" (9) + "rocky" (5) painted chars.
+        assert_eq!(bold, "ultracode".len() + "rocky".len());
     }
 }


### PR DESCRIPTION
Closes #278. Unifies the persona systems and makes them inline, mirroring the `ultracode` keyword pattern.

**1. Consolidated into output-style.** Personas now live in one place — `core/output_styles.rs` gained `builtin_caveman()`/`builtin_rocky()` (prompt text carried faithfully from the old `app.rs`), `normal`→`default` reset. Removed the bespoke speech-mode mechanism entirely (`CommandResult::SpeechMode`, its CLI handler, and the TUI's `speech_mode`/`speech_level` fields + prompt builders). `/rocky` `/caveman` `/normal` are now thin wrappers that select the matching output style **persistently** (same path as `/output-style`).

**2. `/output-style` + `/keybindings` verified end-to-end** (both work). Fixed a stale slash-menu label + a help string that listed a nonexistent style. Added non-flaky tests.

**3. Inline persona keywords (generalized, not copy-pasted).** New `core/keywords.rs`: a shared `INLINE_KEYWORDS` registry + generic `keyword_match_ranges`; `ultracode_match_ranges` now delegates to it (ultracode behavior byte-identical, regression-guarded). `prompt_input.rs` gradient render generalized per-keyword: **ultracode** red (unchanged), **rocky** dithered grey/granite, **caveman** root-brown→leaf-green, **normal** none.

**4. Transient vs persistent, consistent across all keywords.** `query/lib.rs` gained `effective_output_style_for_turn` mirroring `effective_effort_for_turn`: an inline persona word in the last user message applies to that **one turn** then reverts; a persona chosen via command **persists**.

**`level` (lite/full/ultra) decision:** collapsed to the canonical persona each (the historical `full` default) — documented in code, not silent. The unified UX is level-less single-word keywords + a level-less `/output-style` (mirroring ultracode); persona identity/default behavior preserved 100%, only the rarely-used intensity args drop. `/rocky`/`/caveman` ignore a leftover arg gracefully.

6 commits, 11 files (+803/-223). `cargo check --workspace` + clippy -D warnings + core/commands/tui/query/cli tests all green. CRLF preserved (verified byte-level, no churn).