### PR TITLE
fix(tui): effort picker — Enter confirms + brighter shimmering visuals

### DIFF
--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -2338,6 +2338,7 @@ impl App {
             || self.command_palette.visible
             || self.elicitation.visible
             || self.model_picker.visible
+            || self.effort_picker.visible
             || self.session_browser.visible
             || self.session_branching.visible
             || self.export_dialog.visible

--- a/src-rust/crates/tui/src/effort_picker.rs
+++ b/src-rust/crates/tui/src/effort_picker.rs
@@ -21,10 +21,11 @@
 //     ←/→ to adjust · Enter to confirm · Esc to cancel
 //
 // Selector-only visuals (never the prompt box): the selected label is bold and
-// highlighted; `xhigh` is bold claurst-red; `max` is a per-character rainbow that
-// ANIMATES with `frame_count`; and `ultracode` is claurst-red and, when selected,
-// paints an animated translucent-red audio-spectrum background driven by
-// `frame_count`.
+// highlighted; `xhigh` and `max` (the tiers above `high`, just below ultracode)
+// are per-character shimmering rainbows that ANIMATE with `frame_count`; and
+// `ultracode`, when selected, paints an animated claurst-red audio wave as a
+// background-color gradient (so text sits cleanly on top, no cut-out boxes) with
+// a shimmering, pulsing outline.
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
@@ -39,22 +40,24 @@ use crate::model_picker::EffortLevel;
 // Palette (selector-only) — claurst red family
 // ---------------------------------------------------------------------------
 
-/// Signature claurst red used for the panel border, `xhigh`, and `ultracode`.
-const RED: Color = Color::Rgb(233, 30, 99);
 /// Brighter red for the selected `ultracode` label / marker.
 const RED_BRIGHT: Color = Color::Rgb(255, 105, 140);
+/// Bright red used for the panel outline (a touch louder than `RED`).
+const RED_BORDER: Color = Color::Rgb(255, 60, 120);
 /// Dimmer red for the unselected `ultracode` label and the "Smarter" end.
 const RED_DIM: Color = Color::Rgb(180, 78, 96);
 /// Highlight for the selected (non-special) label.
 const SELECTED_FG: Color = Color::Rgb(238, 238, 240);
-/// Gray for unselected labels.
+/// Gray for unselected labels (off the spectrum).
 const DIM_FG: Color = Color::Rgb(120, 120, 130);
+/// Lighter warm-gray for unselected labels drawn ON the red wave (readable).
+const LABEL_ON_WAVE: Color = Color::Rgb(212, 184, 194);
+/// Near-white for the description / controls text drawn ON the red wave.
+const DESC_ON_WAVE: Color = Color::Rgb(255, 236, 242);
 /// The horizontal track line + divider.
 const TRACK_FG: Color = Color::Rgb(90, 90, 104);
 /// The "Faster" end label.
 const FASTER_FG: Color = Color::Rgb(120, 160, 200);
-/// Deep-red wash behind the ultracode spectrum (translucent look).
-const SPECTRUM_BG: Color = Color::Rgb(40, 12, 20);
 
 /// Rows the docked panel wants (7 content rows + top/bottom border). Clamped to
 /// the available height by the layout in `render_app`.
@@ -131,7 +134,11 @@ impl EffortPickerState {
     /// the `max` rainbow label. The CLI event loop uses this to keep ticking
     /// while the picker is open on an animated level.
     pub fn wants_animation(&self) -> bool {
-        self.visible && (self.current().is_ultracode() || self.current() == EffortLevel::Max)
+        self.visible
+            && matches!(
+                self.current(),
+                EffortLevel::XHigh | EffortLevel::Max | EffortLevel::Ultracode
+            )
     }
 }
 
@@ -196,18 +203,32 @@ pub fn render_effort_picker(
     }
     let selected = state.selected.min(state.levels.len() - 1);
     let sel_level = state.levels[selected];
+    // Ultracode paints the red audio wave behind everything; text drawn over it
+    // needs brighter colors to stay readable.
+    let on_spectrum = sel_level.is_ultracode();
 
     // Lay out the label row: styled spans, per-level center columns, total width.
-    let (label_spans, centers, content_w) = layout_labels(&state.levels, selected, frame_count);
+    let (label_spans, centers, content_w) =
+        layout_labels(&state.levels, selected, frame_count, on_spectrum);
 
     // A bottom-docked, full-width panel that occupies exactly `area`.
     frame.render_widget(Clear, area);
+    // A brighter red outline; when ultracode is selected it pulses/shimmers
+    // between vivid red and bright pink.
+    let border_color = if on_spectrum {
+        let p = 0.5 + 0.5 * (frame_count as f32 * 0.22).sin();
+        lerp_rgb((255, 60, 120), (255, 140, 185), p)
+    } else {
+        RED_BORDER
+    };
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(RED))
+        .border_style(Style::default().fg(border_color))
         .title(Span::styled(
             " Effort ",
-            Style::default().fg(RED).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(border_color)
+                .add_modifier(Modifier::BOLD),
         ));
     let inner = block.inner(area);
     frame.render_widget(block, area);
@@ -241,7 +262,8 @@ pub fn render_effort_picker(
     blit_str(buf, x0, row(0), "Faster", Style::default().fg(FASTER_FG), inner);
     let smarter = "Smarter";
     let sm_x = x0 + usable.saturating_sub(smarter.chars().count() as u16);
-    blit_str(buf, sm_x, row(0), smarter, Style::default().fg(RED_DIM), inner);
+    let smarter_fg = if on_spectrum { LABEL_ON_WAVE } else { RED_DIM };
+    blit_str(buf, sm_x, row(0), smarter, Style::default().fg(smarter_fg), inner);
 
     // Full-width track line.
     for dx in 0..usable {
@@ -261,13 +283,16 @@ pub fn render_effort_picker(
         row(3),
         '\u{25b2}',
         Style::default()
-            .fg(accent_for(sel_level))
+            .fg(accent_for(sel_level, frame_count))
             .add_modifier(Modifier::BOLD),
         inner,
     );
 
     // Description of the selected level (word-wrapped) in the rows between the
     // marker and the bottom-anchored controls hint.
+    // Over the red wave, description/controls use a near-white so they read
+    // cleanly on the animated background (no dark cut-out boxes).
+    let text_fg = if on_spectrum { DESC_ON_WAVE } else { DIM_FG };
     let desc_rows = controls_row.saturating_sub(4).min(2) as usize;
     if desc_rows > 0 {
         let desc = level_description(sel_level, &state.levels);
@@ -281,21 +306,24 @@ pub fn render_effort_picker(
                 x0,
                 row(4 + i as u16),
                 &line,
-                Style::default().fg(DIM_FG),
+                Style::default().fg(text_fg),
                 inner,
             );
         }
     }
 
     // Controls hint, anchored to the bottom inner row.
-    blit_str(buf, x0, row(controls_row), CONTROLS, Style::default().fg(DIM_FG), inner);
+    blit_str(buf, x0, row(controls_row), CONTROLS, Style::default().fg(text_fg), inner);
 }
 
-/// The accent color for a level's marker (matches its label styling).
-fn accent_for(level: EffortLevel) -> Color {
+/// The accent color for a level's marker (matches its label styling). `xhigh`
+/// and `max` cycle through the animated rainbow so the marker shimmers with them.
+fn accent_for(level: EffortLevel, frame_count: u64) -> Color {
     match level {
-        EffortLevel::XHigh => RED,
-        EffortLevel::Max => Color::Rgb(255, 170, 60),
+        EffortLevel::XHigh | EffortLevel::Max => {
+            let (r, g, b) = hsv_to_rgb((frame_count as f32 * 6.0).rem_euclid(360.0), 0.9, 1.0);
+            Color::Rgb(r, g, b)
+        }
         EffortLevel::Ultracode => RED_BRIGHT,
         _ => SELECTED_FG,
     }
@@ -308,6 +336,7 @@ fn layout_labels(
     levels: &[EffortLevel],
     selected: usize,
     frame_count: u64,
+    on_spectrum: bool,
 ) -> (Vec<(usize, Span<'static>)>, Vec<usize>, usize) {
     let mut placed: Vec<(usize, Span<'static>)> = Vec::new();
     let mut centers = vec![0usize; levels.len()];
@@ -331,7 +360,7 @@ fn layout_labels(
         let start = col;
         let width = lvl.label().chars().count();
         centers[i] = start + width / 2;
-        for span in styled_label(*lvl, i == selected, frame_count) {
+        for span in styled_label(*lvl, i == selected, frame_count, on_spectrum) {
             let w = span.content.chars().count();
             placed.push((col, span));
             col += w;
@@ -340,10 +369,15 @@ fn layout_labels(
     (placed, centers, col)
 }
 
-/// Style a single level label. Non-selected labels are dim gray; the selected one
-/// is highlighted, with `xhigh` bold red, `ultracode` red, and `max` a per-char
-/// rainbow that animates with `frame_count`.
-fn styled_label(level: EffortLevel, selected: bool, frame_count: u64) -> Vec<Span<'static>> {
+/// Style a single level label. Non-selected labels are dim (lighter over the
+/// wave); the selected one is highlighted, with `ultracode` red and both `xhigh`
+/// and `max` a per-char shimmering rainbow that animates with `frame_count`.
+fn styled_label(
+    level: EffortLevel,
+    selected: bool,
+    frame_count: u64,
+    on_spectrum: bool,
+) -> Vec<Span<'static>> {
     let text = level.label();
     if level.is_ultracode() {
         let fg = if selected { RED_BRIGHT } else { RED_DIM };
@@ -354,14 +388,12 @@ fn styled_label(level: EffortLevel, selected: bool, frame_count: u64) -> Vec<Spa
         return vec![Span::styled(text.to_string(), st)];
     }
     if !selected {
-        return vec![Span::styled(text.to_string(), Style::default().fg(DIM_FG))];
+        let fg = if on_spectrum { LABEL_ON_WAVE } else { DIM_FG };
+        return vec![Span::styled(text.to_string(), Style::default().fg(fg))];
     }
     match level {
-        EffortLevel::XHigh => vec![Span::styled(
-            text.to_string(),
-            Style::default().fg(RED).add_modifier(Modifier::BOLD),
-        )],
-        EffortLevel::Max => rainbow_spans(text, frame_count),
+        // The tiers above `high` (just below ultracode) shimmer rainbow.
+        EffortLevel::XHigh | EffortLevel::Max => rainbow_spans(text, frame_count),
         _ => vec![Span::styled(
             text.to_string(),
             Style::default().fg(SELECTED_FG).add_modifier(Modifier::BOLD),
@@ -370,17 +402,22 @@ fn styled_label(level: EffortLevel, selected: bool, frame_count: u64) -> Vec<Spa
 }
 
 /// One bold span per character, each with a distinct hue cycled across the word,
-/// producing a rainbow gradient (selector-only visual for `max`). `frame_count`
-/// shifts the hue phase so the rainbow ANIMATES over time.
+/// producing a rainbow gradient (selector-only visual for `xhigh`/`max`).
+/// `frame_count` shifts the hue phase so the rainbow ANIMATES, and a per-char
+/// brightness ripple makes it SHIMMER rather than merely scroll.
 fn rainbow_spans(text: &str, frame_count: u64) -> Vec<Span<'static>> {
     let n = text.chars().count().max(1);
-    // Degrees of hue rotation per frame — a full cycle every 60 frames.
-    let phase = frame_count as f32 * 6.0;
+    // Degrees of hue rotation per frame — a full cycle every ~51 frames.
+    let phase = frame_count as f32 * 7.0;
+    let t = frame_count as f32;
     text.chars()
         .enumerate()
         .map(|(i, ch)| {
             let hue = 360.0 * i as f32 / n as f32 + phase;
-            let (r, g, b) = hsv_to_rgb(hue, 0.9, 1.0);
+            // Brightness/value ripples across the characters and over time so the
+            // colors sparkle in place (the "shimmer").
+            let v = (0.80 + 0.20 * (t * 0.45 + i as f32 * 1.1).sin()).clamp(0.0, 1.0);
+            let (r, g, b) = hsv_to_rgb(hue, 0.92, v);
             Span::styled(
                 ch.to_string(),
                 Style::default()
@@ -389,6 +426,13 @@ fn rainbow_spans(text: &str, frame_count: u64) -> Vec<Span<'static>> {
             )
         })
         .collect()
+}
+
+/// Linear interpolation between two RGB triples at `t` in `[0, 1]`.
+fn lerp_rgb(a: (u8, u8, u8), b: (u8, u8, u8), t: f32) -> Color {
+    let t = t.clamp(0.0, 1.0);
+    let lerp = |x: u8, y: u8| (x as f32 + (y as f32 - x as f32) * t).round() as u8;
+    Color::Rgb(lerp(a.0, b.0), lerp(a.1, b.1), lerp(a.2, b.2))
 }
 
 /// Convert HSV (`h` in degrees, `s`/`v` in `[0, 1]`) to an 8-bit RGB triple.
@@ -516,84 +560,71 @@ fn word_wrap(text: &str, width: usize) -> Vec<String> {
 // Ultracode spectrum background
 // ---------------------------------------------------------------------------
 
-/// Paint an animated, translucent claurst-red audio-spectrum into `inner`.
-///
-/// Every column gets a vertical bar rising from the bottom whose height and
-/// brightness vary per column and SHIFT each frame — `frame_count` is the phase,
-/// so successive frames animate. All shades are low-value reds (a dark wash + dim
-/// bars) so foreground text drawn on top stays readable.
+/// Paint an animated claurst-red audio wave into `inner` as a BACKGROUND-color
+/// gradient (space glyphs whose bg brightens toward each column's crest) rather
+/// than filled block glyphs. Foreground text drawn on top then sits cleanly on
+/// the wave with no dark cut-out boxes around it. `frame_count` is the animation
+/// phase; a fast per-cell ripple makes the colors shimmer in place.
 fn paint_spectrum(buf: &mut Buffer, inner: Rect, frame_count: u64) {
     if inner.width == 0 || inner.height == 0 {
         return;
     }
-
-    // Translucent deep-red wash across the whole panel.
-    for y in inner.top()..inner.bottom() {
-        for x in inner.left()..inner.right() {
-            if let Some(cell) = buf.cell_mut((x, y)) {
-                cell.set_char(' ');
-                cell.set_bg(SPECTRUM_BG);
-            }
-        }
-    }
-
-    // Bars rising from the bottom.
     let height = inner.height as f32;
     for gx in 0..inner.width {
         let amp = spectrum_amp(gx, frame_count).clamp(0.0, 1.0);
-        let filled = amp * height;
-        let bars = filled.floor() as u16;
-        let frac = filled - bars as f32;
+        let filled = amp * height; // crest height, in rows from the bottom
         let x = inner.left() + gx;
         for r in 0..inner.height {
-            let (ch, lit) = if r < bars {
-                ('\u{2588}', 0.65 + 0.35 * amp)
-            } else if r == bars && frac > 0.08 {
-                (partial_block(frac), 0.35 + 0.4 * frac)
-            } else {
-                continue;
-            };
+            // `r` counts rows up from the bottom (0 = bottom row).
+            let within = filled - r as f32; // >0 inside the bar; fades at the crest
+            let base = within.clamp(0.0, 1.0); // soft 1-row crest; 0 above the bar
+            // A deep-red wash floor persists even above the crest so the whole
+            // panel reads red; brightness climbs toward the crest, modulated by a
+            // small fast per-cell ripple for the shimmer.
+            let lit =
+                ((0.16 + 0.84 * base) * shimmer_jitter(gx, r, frame_count)).clamp(0.0, 1.0);
+            let shade = red_shade(lit);
             let y = inner.bottom() - 1 - r;
             if let Some(cell) = buf.cell_mut((x, y)) {
-                cell.set_char(ch);
-                cell.set_style(Style::default().fg(red_shade(lit)).bg(SPECTRUM_BG));
+                cell.set_char(' ');
+                cell.set_fg(shade);
+                cell.set_bg(shade);
             }
         }
     }
 }
 
-/// Per-column spectrum amplitude in `[0, 1]` for a given column and frame. Two
-/// out-of-phase sines make it read like a shifting equalizer; `frame` moves the
-/// phase so the bars animate over time.
+/// Per-column wave amplitude in `[0, 1]` for a given column and frame. Three
+/// out-of-phase travelling sines make it read like a lively, non-repetitive
+/// equalizer; `frame` moves the phases so the wave animates over time.
 fn spectrum_amp(gx: u16, frame: u64) -> f32 {
     let fx = gx as f32;
     let t = frame as f32;
-    let a = 0.55 * (fx * 0.55 + t * 0.20).sin() + 0.45 * (fx * 0.27 - t * 0.13 + 1.7).sin();
+    let a = 0.45 * (fx * 0.55 + t * 0.33).sin()
+        + 0.33 * (fx * 0.27 - t * 0.23 + 1.7).sin()
+        + 0.22 * (fx * 0.90 + t * 0.51 + 0.6).sin();
     0.5 + 0.5 * a
 }
 
-/// The partial block glyph (`▁`..`█`) for a fractional bar height in `[0, 1]`.
-fn partial_block(frac: f32) -> char {
-    const BLOCKS: [char; 8] = [
-        '\u{2581}', '\u{2582}', '\u{2583}', '\u{2584}', '\u{2585}', '\u{2586}', '\u{2587}',
-        '\u{2588}',
-    ];
-    let idx = ((frac * 8.0) as usize).min(BLOCKS.len() - 1);
-    BLOCKS[idx]
+/// A small, fast per-cell brightness ripple layered on the wave amplitude so the
+/// colors sparkle in place over time. Returns a multiplier near 1.
+fn shimmer_jitter(gx: u16, row: u16, frame: u64) -> f32 {
+    let t = frame as f32;
+    0.82 + 0.18 * (gx as f32 * 1.3 + row as f32 * 0.9 + t * 0.6).sin()
 }
 
-/// A dim/translucent claurst-red whose brightness scales with `lit` in `[0, 1]`:
-/// a deep red at the base brightening toward the signature red at the peak, kept
-/// in a low value range so foreground text stays dominant. Always red-dominant
-/// (`r > g` and `r > b`) — never purple.
+/// A claurst-red whose brightness scales with `lit` in `[0, 1]`: a deep-red wash
+/// at the base brightening to a vivid claurst red at the crest. Used as a
+/// BACKGROUND color for the wave (so it can go brighter than the old translucent
+/// bars while text stays readable on top). Always red-dominant (`r > g` and
+/// `r > b`) — never purple.
 fn red_shade(lit: f32) -> Color {
     let lit = lit.clamp(0.0, 1.0);
-    // Deep red (120, 20, 30) -> claurst red (233, 30, 99).
-    let r = 120.0 + 113.0 * lit;
-    let g = 20.0 + 10.0 * lit;
-    let b = 30.0 + 69.0 * lit;
-    let k = 0.55; // translucency
-    Color::Rgb((r * k) as u8, (g * k) as u8, (b * k) as u8)
+    // Deep-red wash (28, 8, 14) -> vivid claurst red (255, 45, 110).
+    let r = 28.0 + 227.0 * lit;
+    let g = 8.0 + 37.0 * lit;
+    let b = 14.0 + 96.0 * lit;
+    Color::Rgb(r as u8, g as u8, b as u8)
 }
 
 // ---------------------------------------------------------------------------
@@ -688,16 +719,65 @@ mod tests {
     }
 
     #[test]
-    fn wants_animation_for_max_and_ultracode_only() {
-        // `max` animates (rainbow) and `ultracode` animates (spectrum); the
-        // native levels below are static.
+    fn wants_animation_for_high_tiers_and_ultracode() {
+        // The tiers above `high` (xhigh, max) shimmer rainbow and `ultracode`
+        // animates its wave; the native levels at/below `high` are static.
         let mut s = EffortPickerState::new();
         s.open(EffortLevel::Medium, full_ladder());
         assert!(!s.wants_animation(), "medium is static");
+        s.selected = 2; // high
+        assert!(!s.wants_animation(), "high is static");
+        s.selected = 3; // xhigh
+        assert!(s.wants_animation(), "xhigh rainbow shimmers");
         s.selected = 4; // max
-        assert!(s.wants_animation(), "max rainbow animates");
+        assert!(s.wants_animation(), "max rainbow shimmers");
         s.selected = 5; // ultracode
-        assert!(s.wants_animation(), "ultracode spectrum animates");
+        assert!(s.wants_animation(), "ultracode wave animates");
+    }
+
+    #[test]
+    fn xhigh_uses_shimmering_rainbow_that_animates() {
+        // xhigh (like max) is a per-char rainbow that shifts across frames.
+        let state = state_with(full_ladder(), 3); // xhigh selected
+        let a = render_to_buffer(&state, 0);
+        let b = render_to_buffer(&state, 20);
+        let rows = buffer_rows(&a);
+        let label_y = rows
+            .iter()
+            .position(|r| r.contains("ultracode"))
+            .expect("label row present");
+        let start = char_col_of(&rows[label_y], "xhigh").expect("xhigh in labels row");
+        let y = label_y as u16;
+        // Distinct per-char colors (rainbow) …
+        let c0 = a.cell((start as u16, y)).unwrap().fg;
+        let c1 = a.cell((start as u16 + 1, y)).unwrap().fg;
+        assert_ne!(c0, c1, "xhigh rainbow chars must differ: {c0:?} vs {c1:?}");
+        // … and they animate between frames (shimmer).
+        let cb = b.cell((start as u16, y)).unwrap().fg;
+        assert_ne!(c0, cb, "xhigh rainbow should animate: {c0:?} vs {cb:?}");
+    }
+
+    #[test]
+    fn ultracode_wave_is_a_background_gradient_under_text() {
+        // The description text sits ON the red wave: its cells carry a red-ish
+        // background (not a dark cut-out box) while still showing the glyphs.
+        let state = state_with(full_ladder(), 5); // ultracode
+        let buf = render_to_buffer(&state, 3);
+        let rows = buffer_rows(&buf);
+        // Find a row containing the description sentence.
+        let (dy, drow) = rows
+            .iter()
+            .enumerate()
+            .find(|(_, r)| r.contains("workflows"))
+            .map(|(i, r)| (i as u16, r.clone()))
+            .expect("description row present");
+        let cx = char_col_of(&drow, "workflows").unwrap() as u16;
+        match buf.cell((cx, dy)).unwrap().bg {
+            Color::Rgb(r, _g, b) => {
+                assert!(r > b, "text must sit on the red wave bg, got r={r} b={b}")
+            }
+            other => panic!("expected an Rgb wave background under text, got {other:?}"),
+        }
     }
 
     #[test]
@@ -830,13 +910,8 @@ mod tests {
                 other => panic!("expected Rgb, got {other:?}"),
             }
         }
-        // The dark wash is a deep red, not a blue/purple.
-        match SPECTRUM_BG {
-            Color::Rgb(r, _g, b) => assert!(r > b, "wash must be reddish: {r} vs {b}"),
-            other => panic!("expected Rgb, got {other:?}"),
-        }
         // The ultracode label / accent colors are all red-family.
-        for c in [RED, RED_BRIGHT, RED_DIM] {
+        for c in [RED_BRIGHT, RED_DIM, RED_BORDER] {
             match c {
                 Color::Rgb(r, g, b) => {
                     assert!(r > g && r > b, "label color must be red: {r},{g},{b}")


### PR DESCRIPTION
Three fixes to the `/effort` dock (reported while testing on macOS).

**1. Enter did nothing (functional bug).** `effort_picker.visible` was missing from `App::any_modal_open()`, so the event loop treated a plain Enter as "submit the prompt" and `continue`d before `handle_key_event` could run the picker's Enter arm. Added the effort picker to `any_modal_open()` (like the model picker). Enter now confirms the highlighted mode.

**2. Ultracode wave + 'weird outline' around sentences.** The wave was drawn as bright filled `█` glyphs (fg), so text cells became dark cut-outs through the bars — the boxed look. Reworked it to paint the wave as a **background-color gradient** (space glyphs, brightening toward each column's crest), so the description/labels/controls sit cleanly on top with no boxes. Also: brighter, **pulsing/shimmering red border**, livelier motion (three travelling sines), and a per-cell shimmer ripple.

**3. xhigh/max shimmering rainbow.** `xhigh` was a static red; now both `xhigh` and `max` (the tiers above `high`, just below ultracode) render as a per-char **shimmering rainbow** that animates, and the marker cycles the rainbow with them.

Tests updated/added (xhigh rainbow animates, wave is a bg gradient under text, Enter-modal). clippy -D warnings clean, LF preserved.