### PR TITLE
feat(core): crab wordplay for spinner + completion verbs (Carapaced for…)

### DIFF
--- a/src-rust/crates/core/src/spinner.rs
+++ b/src-rust/crates/core/src/spinner.rs
@@ -32,12 +32,28 @@ pub const SPINNER_VERBS: &[&str] = &[
     "Unravelling", "Vibing", "Waddling", "Wandering", "Warping", "Whatchamacalliting",
     "Whirlpooling", "Whirring", "Whisking", "Wibbling", "Working", "Wrangling", "Zesting",
     "Zigzagging",
+    // Crab wordplay (Rustle) — cohesive with the completion verbs below.
+    "Carapacing", "Scuttling", "Molting", "Clawing", "Pinching", "Snipping",
+    "Sidling", "Skittering", "Chelating", "Crabwalking", "Clacking", "Scrabbling",
+    "Shelling", "Nipping", "Beachcombing", "Pincering", "Barnacling", "Reef-crawling",
+    "Tide-pooling",
 ];
 
 /// Past-tense verbs shown in the status row after a turn completes.
+///
+/// A mix of the neutral originals and a big pile of crab / crustacean wordplay,
+/// in honour of Rustle (claurst's crab mascot) — so "Carapaced for 2m 5s" and
+/// friends scuttle by when a turn finishes.
 pub const TURN_COMPLETION_VERBS: &[&str] = &[
+    // Neutral.
     "Baked", "Brewed", "Churned", "Cogitated", "Cooked", "Crunched",
     "Pondered", "Processed", "Worked",
+    // Crab wordplay (Rustle).
+    "Carapaced", "Scuttled", "Molted", "Clawed", "Pinched", "Snipped",
+    "Sidled", "Skittered", "Burrowed", "Chelated", "Crabwalked", "Clacked",
+    "Scrabbled", "Shelled", "Nipped", "Beachcombed", "Scurried", "Pincered",
+    "Barnacled", "Tide-pooled", "Crustaceated", "Molt-hopped", "Clam-baked",
+    "Shell-shocked", "Low-tided", "Reef-crawled",
 ];
 
 /// Select a random spinner verb.


### PR DESCRIPTION
Rustle is a crab 🦀, so the status line should scuttle. Adds a pile of crab/crustacean past-tense verbs to `TURN_COMPLETION_VERBS` so completions read like **"Carapaced for 2m 5s"** (also Scuttled, Molted, Clawed, Pinched, Chelated, Crabwalked, Barnacled, Tide-pooled, Beachcombed, …), and matching gerunds to `SPINNER_VERBS` so in-progress work is themed too (Scuttling, Carapacing, Chelating, Reef-crawling, …). The neutral originals stay in the pool. clippy clean, LF preserved.