### PR TITLE
fix(tui): theme the streaming spinner claurst red (not yellow)

### DIFF
--- a/src-rust/crates/tui/src/render.rs
+++ b/src-rust/crates/tui/src/render.rs
@@ -61,10 +61,34 @@ use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph, Widget, Wra
 use ratatui::Frame;
 use unicode_width::UnicodeWidthStr;
 
+// Spinner frames matching the TypeScript SpinnerGlyph: platform-specific base
+// characters mirrored (forward + reverse) for a smooth pulse effect.
+// Windows uses '*' instead of '✳'/'✽' for better font coverage.
+#[cfg(target_os = "windows")]
+const SPINNER: &[char] = &['\u{00b7}', '\u{2722}', '*', '\u{2736}', '\u{273b}', '\u{273d}',
+                            '\u{273d}', '\u{273b}', '\u{2736}', '*', '\u{2722}', '\u{00b7}'];
+#[cfg(not(target_os = "windows"))]
+const SPINNER: &[char] = &['\u{00b7}', '\u{2722}', '\u{2733}', '\u{2736}', '\u{273b}', '\u{273d}',
+                            '\u{273d}', '\u{273b}', '\u{2736}', '\u{2733}', '\u{2722}', '\u{00b7}'];
 const CLAUDE_ORANGE: Color = Color::Rgb(233, 30, 99);
 const WELCOME_BOX_HEIGHT: u16 = 9;
 const STATUS_THINKING: &str = "thinking";
 const STATUS_THINKING_ELLIPSIS: &str = "thinking\u{2026}";
+
+fn spinner_char(frame_count: u64) -> char {
+    SPINNER[(frame_count as usize) % SPINNER.len()]
+}
+
+/// Returns the colour to use for the streaming spinner: claurst red normally,
+/// brightening to a hot red when no stream data has arrived for over 3 seconds.
+fn spinner_color(app: &App) -> Color {
+    if let Some(start) = app.stall_start {
+        if start.elapsed() > std::time::Duration::from_secs(3) {
+            return Color::Rgb(255, 70, 70);
+        }
+    }
+    CLAUDE_ORANGE
+}
 
 fn is_modal_open(app: &App) -> bool {
     app.any_modal_open()
@@ -2204,10 +2228,15 @@ fn render_status_row(frame: &mut Frame, app: &App, area: Rect) {
             .or(app.spinner_verb.as_deref())
             .unwrap_or("Thinking");
 
-        // No leading ASCII-star spinner glyph — the shimmering label is the
-        // motion. (The transcript already shows a spinner for the active tool.)
+        let mut s = vec![Span::styled(
+            spinner_char(app.frame_count).to_string(),
+            Style::default().fg(spinner_color(app)).add_modifier(Modifier::BOLD),
+        )];
         let label = format!("{}…", raw_label.trim_end_matches('…'));
-        shimmer_spans(&label, app.frame_count)
+
+        s.push(Span::raw(" "));
+        s.extend(shimmer_spans(&label, app.frame_count));
+        s
     } else if let (Some(verb), Some(elapsed)) = (app.last_turn_verb, app.last_turn_elapsed.as_deref()) {
         // "✽ Worked for 2m 5s" — mirrors TS TeammateSpinnerLine idle state
         vec![Span::styled(


### PR DESCRIPTION
Restores the status-row spinner glyph (I wrongly deleted it in #298) and recolors it from **yellow → claurst red** (`CLAUDE_ORANGE`); the >3s stall state now brightens to a hot red instead of plain red. This is what the request meant — re-theme the yellow spinner, not remove it. 644 tui tests pass, clippy clean, LF preserved.