### PR TITLE
feat(tui): expose Claude Pro/Max subscription login in /connect

### DIFF
--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -3669,16 +3669,30 @@ async fn run_interactive(
                         }
                     });
                 }
-                "anthropic" => {
+                "anthropic-oauth" => {
                     let tx2 = device_auth_tx.clone();
-                    // Anthropic OAuth requires a registered application.
-                    // Claurst does not have its own registered OAuth app with Anthropic.
-                    // Users should use an API key from console.anthropic.com instead.
+                    // Claude Pro/Max subscription login: claude.ai OAuth (Bearer).
+                    // Runs the loopback flow in the background and surfaces the URL
+                    // to the dialog; the flow persists the tokens itself
+                    // (save_and_register), so the success handler only switches to
+                    // the anthropic provider. Usage draws from the account's
+                    // extra-usage pool, not subscription quota.
                     tokio::spawn(async move {
-                        let _ = tx2.send(DeviceAuthEvent::Error(
-                            "Anthropic OAuth requires a registered application.\n\
-                             Use an API key instead: console.anthropic.com/settings/keys".to_string()
-                        )).await;
+                        match oauth_flow::run_oauth_login_flow_tui(tx2.clone(), true, None).await {
+                            Ok(_) => {
+                                let _ = tx2
+                                    .send(DeviceAuthEvent::TokenReceived("connected".to_string()))
+                                    .await;
+                            }
+                            Err(e) => {
+                                let _ = tx2
+                                    .send(DeviceAuthEvent::Error(format!(
+                                        "Anthropic login failed: {}",
+                                        e
+                                    )))
+                                    .await;
+                            }
+                        }
                     });
                 }
                 "codex" | "openai-codex" => {

--- a/src-rust/crates/cli/src/oauth_flow.rs
+++ b/src-rust/crates/cli/src/oauth_flow.rs
@@ -21,10 +21,12 @@
 
 use anyhow::{bail, Context};
 use claurst_core::oauth::{self, OAuthTokens};
+use claurst_tui::DeviceAuthEvent;
 use serde::Deserialize;
 use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpListener;
+use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 #[allow(unused_imports)]
 use url::Url;
@@ -119,6 +121,69 @@ pub async fn run_oauth_login_flow_with_label(
         .await
         .context("Token exchange failed")?;
 
+    finalize_login(token_resp, label).await
+}
+
+/// Run the OAuth PKCE login flow from inside the TUI (no stdout / stdin use).
+///
+/// Mirrors [`run_oauth_login_flow_with_label`] but surfaces the authorize URL
+/// to the device-auth dialog through `event_tx` instead of printing it, and
+/// captures the authorization code solely from the loopback redirect — there
+/// is no pasted-code fallback because the alternate screen owns stdin. Tokens
+/// are persisted exactly as the CLI flow does (`save_and_register`), so the
+/// runtime picks up the new credentials (Claude Pro/Max Bearer for the
+/// claude.ai flow). Headless users who cannot complete the browser redirect
+/// can still fall back to `claurst auth login`.
+pub async fn run_oauth_login_flow_tui(
+    event_tx: mpsc::Sender<DeviceAuthEvent>,
+    login_with_claude_ai: bool,
+    label: Option<&str>,
+) -> anyhow::Result<LoginResult> {
+    // 1. PKCE
+    let code_verifier = oauth::generate_code_verifier();
+    let code_challenge = oauth::generate_code_challenge(&code_verifier);
+    let state = oauth::generate_state();
+
+    // 2. Bind random localhost port for the callback server
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("Failed to bind OAuth callback server")?;
+    let port = listener.local_addr()?.port();
+
+    // 3. Build the automatic (loopback-redirect) auth URL, surface it to the
+    //    dialog, and try to open it directly.
+    let authorize_base = if login_with_claude_ai {
+        oauth::CLAUDE_AI_AUTHORIZE_URL
+    } else {
+        oauth::CONSOLE_AUTHORIZE_URL
+    };
+    let automatic_url = oauth::build_auth_url(authorize_base, &code_challenge, &state, port, false);
+    let _ = event_tx
+        .send(DeviceAuthEvent::GotBrowserUrl { url: automatic_url.clone() })
+        .await;
+    try_open_browser(&automatic_url);
+
+    // 4. Capture the authorization code from the browser redirect (loopback
+    //    only — the TUI owns stdin, so there is no paste fallback here).
+    let auth_code = run_callback_server(listener, &state)
+        .await
+        .context("OAuth callback failed")?;
+
+    // 5. Exchange the code (loopback redirect) and persist via the shared tail.
+    let token_resp = exchange_code_for_tokens(&auth_code, &state, &code_verifier, port, false)
+        .await
+        .context("Token exchange failed")?;
+    finalize_login(token_resp, label).await
+}
+
+/// Shared tail of the login flows: derive account metadata from the token
+/// response, mint an API key for the Console flow, persist the tokens, and
+/// return the usable credential. Called by both the interactive CLI flow and
+/// the in-TUI flow.
+async fn finalize_login(
+    token_resp: TokenExchangeResponse,
+    label: Option<&str>,
+) -> anyhow::Result<LoginResult> {
     let expires_at_ms = chrono::Utc::now().timestamp_millis()
         + (token_resp.expires_in as i64 * 1000);
 
@@ -142,7 +207,7 @@ pub async fn run_oauth_login_flow_with_label(
 
     let uses_bearer = scopes.iter().any(|s| s == oauth::CLAUDE_AI_INFERENCE_SCOPE);
 
-    // 7. For Console flow, exchange the access token for an API key
+    // For the Console flow, exchange the access token for an API key.
     let api_key = if !uses_bearer {
         match create_api_key(&token_resp.access_token).await {
             Ok(key) => {
@@ -158,7 +223,7 @@ pub async fn run_oauth_login_flow_with_label(
         None
     };
 
-    // 8. Build and persist tokens
+    // Build and persist tokens.
     let tokens = OAuthTokens {
         access_token: token_resp.access_token.clone(),
         refresh_token: token_resp.refresh_token.clone(),

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -248,6 +248,7 @@ fn provider_picker_items() -> Vec<SelectItem> {
         SelectItem { id: "github-copilot".into(), title: "GitHub Copilot".into(), description: "(GitHub subscription or token)".into(), category: "Popular".into(), badge: None },
         SelectItem { id: "google".into(), title: "Google".into(), description: "(API key)".into(), category: "Popular".into(), badge: None },
         SelectItem { id: "anthropic".into(), title: "Anthropic".into(), description: "(API key)".into(), category: "Popular".into(), badge: None },
+        SelectItem { id: "anthropic-oauth".into(), title: "Anthropic (Claude Pro/Max)".into(), description: "(subscription — browser login; draws from extra-usage)".into(), category: "Popular".into(), badge: None },
         SelectItem { id: "custom-openai".into(), title: "Custom OpenAI-Compatible".into(), description: "Custom URL + API key".into(), category: "Advanced".into(), badge: None },
         SelectItem { id: "openrouter".into(), title: "OpenRouter".into(), description: "100+ models with one key".into(), category: "Popular".into(), badge: None },
         SelectItem { id: "vercel".into(), title: "Vercel AI Gateway".into(), description: "Gateway for AI SDK models".into(), category: "Popular".into(), badge: None },
@@ -3211,6 +3212,20 @@ impl App {
                         let provider_id = self.device_auth_dialog.provider_id.clone();
                         let provider_name = self.device_auth_dialog.provider_name.clone();
                         let token = token.clone();
+                        if provider_id == "anthropic-oauth" {
+                            // The claude.ai OAuth flow already persisted the Bearer
+                            // tokens via save_and_register; the anthropic provider
+                            // reads them directly. Switch to the real "anthropic"
+                            // provider without re-storing the token as an API key.
+                            self.device_auth_pending = None;
+                            self.device_auth_dialog.close();
+                            self.activate_provider(
+                                "anthropic".to_string(),
+                                "Anthropic".to_string(),
+                                "Connected to",
+                            );
+                            return false;
+                        }
                         let credential = if provider_id == "github-copilot" {
                             claurst_core::StoredCredential::OAuthToken {
                                 access: token.clone(),
@@ -3450,9 +3465,16 @@ impl App {
                                 self.free_mode_dialog.open(&existing);
                             }
                             "anthropic" => {
-                                // Anthropic: use API key from console.anthropic.com
-                                // (OAuth requires a registered app which Claurst doesn't have)
+                                // Anthropic: API key from console.anthropic.com.
                                 self.key_input_dialog.open(selected.id.clone(), selected.title.clone());
+                            }
+                            "anthropic-oauth" => {
+                                // Claude Pro/Max subscription: claude.ai OAuth via
+                                // the browser (loopback capture), spawned by the
+                                // main loop. Note: usage draws from the account's
+                                // extra-usage pool, not subscription quota.
+                                self.device_auth_dialog.open(selected.id.clone(), selected.title.clone());
+                                self.device_auth_pending = Some("anthropic-oauth".to_string());
                             }
                             "custom-openai" => {
                                 let current_url = Settings::load_sync()


### PR DESCRIPTION
## What

Exposes **Claude Pro/Max subscription login** in the interactive `/connect` picker. The claude.ai OAuth (Bearer) flow already existed and worked from the CLI (`claurst auth login`), but the TUI only offered Anthropic via API key, and the wired-but-dead `anthropic` device-auth arm returned a bogus "requires a registered application" error.

## Changes

- **`crates/tui/src/app.rs`**
  - New picker entry "Anthropic (Claude Pro/Max)" (`anthropic-oauth`) that opens the device-auth dialog and sets `device_auth_pending`.
  - Success handler special-cases `anthropic-oauth`: switches to the real `anthropic` provider **without** re-storing the Bearer token as an `ApiKey` (the flow already persisted proper OAuth tokens).
- **`crates/cli/src/oauth_flow.rs`**
  - New `run_oauth_login_flow_tui`: surfaces the authorize URL via `DeviceAuthEvent::GotBrowserUrl` and captures the code from the loopback redirect (no stdin paste — the alt screen owns stdin).
  - Extracted the shared tail into `finalize_login`, reused by both the CLI and TUI flows, so token persistence (`save_and_register`) is identical.
- **`crates/cli/src/main.rs`**
  - Replaced the dead `anthropic` stub in the `device_auth_pending` consumer with an `anthropic-oauth` arm that runs `run_oauth_login_flow_tui` in the background (mirrors the Codex arm).

## Why this is safe

The in-TUI flow reuses the exact persistence path (`save_and_register`) as the proven `claurst auth login`, and the automatic redirect is a dynamic-port loopback (`http://localhost:{port}/callback`) — the same primary path the CLI already relies on. Headless users who cannot complete the browser redirect can still fall back to `claurst auth login`.

## Note

Claude Pro/Max usage through third-party clients draws from the account's **extra-usage** pool (not subscription quota) and is outside Anthropic's officially supported clients — the picker copy and dialog make this visible. This mirrors how opencode surfaces the same flow.

## Testing

- `cargo check -p claurst` — clean
- `cargo clippy -p claurst -p claurst-tui --all-targets -- -D warnings` — clean
- `cargo test --workspace` — all green

closes #300
