### PR TITLE
fix(tui): stop pinning the idle spinner glyph after the first turn

### DIFF
--- a/src-rust/crates/tui/src/render.rs
+++ b/src-rust/crates/tui/src/render.rs
@@ -2198,8 +2198,12 @@ fn should_render_status_row(app: &App) -> bool {
         })
         .unwrap_or(false);
 
+    // Note: a completed turn's "Worked for Xs" summary (`last_turn_elapsed`) is
+    // intentionally NOT a reason to keep the status row on — it stays set until
+    // the next submit, so gating on it pinned the idle spinner glyph on screen
+    // permanently after the first turn. The row now shows only while actually
+    // active (voice, streaming, or an idle status message).
     app.voice_recording
-        || app.last_turn_elapsed.is_some()
         || (!app.is_streaming && app.status_message.is_some())
         || (app.is_streaming && interesting_stream_status)
 }


### PR DESCRIPTION
## What

The status-bar spinner glyph (`✽`) stayed on screen permanently once the first turn completed, regardless of whether the agent was working — the "cog always shown" behavior.

## Root cause

`should_render_status_row` (`crates/tui/src/render.rs`) gated on `app.last_turn_elapsed.is_some()`. That field is set on every `TurnComplete` and cleared only on the *next* submit, so after turn one it is always `Some`, keeping the idle `✽ Worked for Xs` line rendered forever.

## Fix

Drop `last_turn_elapsed` as a render trigger. The status row now renders only while genuinely active: voice recording, streaming, or an idle status message. The glyph appears while the model works and disappears when idle.

## Testing

- `cargo check/clippy -p claurst-tui --all-targets -- -D warnings` — clean
- `cargo test --workspace` — all green

Part of #301. The OSC 9;4 terminal progress bar (the iTerm2 "green bar") is a separate follow-up; leaving #301 open for it.