### PR TITLE
feat(tui): terminal working indicator via OSC 9;4 progress

### DIFF
--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -2079,6 +2079,14 @@ async fn run_interactive(
     // any flash.
     let mut last_scroll_offset = app.scroll_offset;
     let mut last_auto_scroll = app.auto_scroll;
+    // The terminal progress bar (OSC 9;4) is opt-out via the terminalProgressBar
+    // setting; read it once at startup. `progress_shown` tracks whether we've
+    // told the terminal we're "busy", so the escape is only emitted on an actual
+    // streaming-state edge.
+    let progress_bar_enabled = claurst_core::config::Settings::load_sync()
+        .map(|s| s.terminal_progress_bar)
+        .unwrap_or(true);
+    let mut progress_shown = false;
     'main: loop {
         app.frame_count = app.frame_count.wrapping_add(1);
         app.tick_rustle_pose();
@@ -2114,6 +2122,15 @@ async fn run_interactive(
 
         // Draw the UI
         terminal.draw(|f| render_app(f, &app))?;
+
+        // Level-sync the terminal progress indicator (OSC 9;4) to streaming
+        // state, so supporting terminals (iTerm2, WezTerm, Windows Terminal, …)
+        // show a "working" bar while a turn is active and clear it when idle.
+        let want_progress = app.is_streaming && progress_bar_enabled;
+        if want_progress != progress_shown {
+            claurst_tui::set_terminal_progress(want_progress);
+            progress_shown = want_progress;
+        }
 
         // Poll for crossterm events (keyboard/mouse) with short timeout
         // unless an auto-submit (queued message) is pending — in which case

--- a/src-rust/crates/tui/src/lib.rs
+++ b/src-rust/crates/tui/src/lib.rs
@@ -332,6 +332,8 @@ pub fn setup_terminal(mouse_capture: bool) -> io::Result<Terminal<CrosstermBacke
 /// Restore the terminal to its original state.
 pub fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> io::Result<()> {
     disable_raw_mode()?;
+    // Clear any terminal "busy" progress indicator (OSC 9;4) we may have set.
+    set_terminal_progress(false);
     // Restore the original title by clearing it (terminals fall back to default).
     let _ = execute!(
         terminal.backend_mut(),
@@ -345,6 +347,54 @@ pub fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> io
 /// Set the terminal window title via OSC escape sequence.
 pub fn set_terminal_title(title: &str) {
     let _ = execute!(io::stdout(), crossterm::terminal::SetTitle(title));
+}
+
+/// Whether the current terminal is known to render the OSC 9;4 "progress"
+/// sequence. Most terminals silently ignore an unknown OSC, but a bare
+/// tmux/screen passthrough can leak it as visible text, so we require a real
+/// tty and an allow-listed terminal (iTerm2, WezTerm, Ghostty, Windows
+/// Terminal, ConEmu).
+pub fn supports_progress_osc() -> bool {
+    use std::io::IsTerminal;
+    if !io::stdout().is_terminal() {
+        return false;
+    }
+    // tmux/screen don't forward OSC 9;4 to the outer terminal by default.
+    if std::env::var_os("TMUX").is_some() {
+        return false;
+    }
+    if let Ok(term) = std::env::var("TERM") {
+        if term.starts_with("screen") || term.starts_with("tmux") {
+            return false;
+        }
+    }
+    if std::env::var_os("WT_SESSION").is_some() || std::env::var_os("ConEmuPID").is_some() {
+        return true;
+    }
+    matches!(
+        std::env::var("TERM_PROGRAM").unwrap_or_default().as_str(),
+        "iTerm.app" | "WezTerm" | "ghostty"
+    )
+}
+
+/// Emit the OSC 9;4 progress sequence. `active = true` shows an indeterminate
+/// "busy" indicator (e.g. iTerm2's progress bar, the Windows Terminal taskbar);
+/// `false` clears it. No-op on terminals that don't support it.
+///
+/// Safe alongside the ratatui alternate screen: OSC 9;4 addresses terminal
+/// chrome (title bar / taskbar), not the cell grid, so it doesn't disturb the
+/// rendered frame.
+pub fn set_terminal_progress(active: bool) {
+    if !supports_progress_osc() {
+        return;
+    }
+    use std::io::Write;
+    // state 3 = indeterminate/busy, state 0 = clear; the progress value is
+    // unused for the indeterminate state.
+    let seq: &[u8] = if active { b"\x1b]9;4;3;0\x07" } else { b"\x1b]9;4;0;0\x07" };
+    let mut out = io::stdout();
+    let _ = out.write_all(seq);
+    let _ = out.flush();
 }
 
 /// Update the terminal title to reflect the current session context.


### PR DESCRIPTION
## What

Adds the "working" terminal indicator (Claude Code's iTerm2 "green bar"): while a turn is streaming, claurst emits the **OSC 9;4** progress escape so supporting terminals show a busy/progress indicator, cleared when the turn ends. Completes the second half of #301.

## Details

- **`crates/tui/src/lib.rs`**
  - `supports_progress_osc()` — capability detection: requires a real tty and an allow-listed terminal (iTerm2, WezTerm, Ghostty, Windows Terminal, ConEmu); skips tmux/screen passthrough and unknown terminals so no stray bytes leak as text.
  - `set_terminal_progress(active)` — emits `ESC]9;4;3;0BEL` (indeterminate) / `ESC]9;4;0;0BEL` (clear). OSC 9;4 targets terminal chrome, not the cell grid, so it's safe alongside the ratatui alternate screen.
  - `restore_terminal` now clears the indicator on exit / temporary restores.
- **`crates/cli/src/main.rs`**
  - Level-syncs the indicator to `app.is_streaming` once per frame (edge-triggered emit), gated on the existing `terminalProgressBar` setting (read once at startup).

## Notes

- Wires up the previously-dead `terminalProgressBar` setting (default on; toggle off in settings to disable).
- Escape-sequence behavior is validated by compile + reasoning; live rendering is best-eyeballed in iTerm2. It's fully guarded and opt-out, and degrades to a no-op on unsupported terminals.

## Testing

- `cargo check -p claurst` — clean
- `cargo clippy -p claurst -p claurst-tui --all-targets -- -D warnings` — clean
- `cargo test --workspace` — all green

closes #301