### PR TITLE
fix(cli): activate Claude Pro/Max OAuth credentials in-session (no restart)

### DIFF
--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -1353,6 +1353,49 @@ async fn refresh_provider_runtime_state(
     })
 }
 
+/// Non-destructive counterpart to [`refresh_provider_runtime_state`]: re-resolve
+/// credentials for the CURRENT provider (e.g. right after an in-session OAuth
+/// login) and rebuild the client + provider registry, keeping the active
+/// provider and model. Mirrors the startup resolution so a just-completed
+/// Claude Pro/Max login works without a restart.
+async fn reload_provider_runtime_state(
+    current_config: &Config,
+) -> anyhow::Result<RefreshedProviderRuntime> {
+    let config = current_config.clone();
+
+    let (api_key, use_bearer_auth) = if config.selected_provider_id() == "anthropic" {
+        config
+            .resolve_anthropic_auth_async()
+            .await
+            .unwrap_or((String::new(), false))
+    } else {
+        (config.resolve_api_key().unwrap_or_default(), false)
+    };
+
+    claurst_api::set_request_timeout_secs(config.resolve_request_timeout_secs_active());
+    let client_config = claurst_api::client::ClientConfig {
+        api_key,
+        api_base: config.resolve_anthropic_api_base(),
+        use_bearer_auth,
+        ..Default::default()
+    };
+    let client = Arc::new(
+        claurst_api::AnthropicClient::new(client_config.clone())
+            .context("Failed to rebuild Anthropic client")?,
+    );
+    let provider_registry =
+        Arc::new(claurst_api::ProviderRegistry::from_config(&config, client_config));
+    let model_registry = load_cached_model_registry();
+
+    Ok(RefreshedProviderRuntime {
+        config,
+        client,
+        provider_registry,
+        model_registry,
+        auth_store: claurst_core::AuthStore::default(),
+    })
+}
+
 fn normalize_provider_from_model(config: &mut Config) {
     if let Some(model) = config.model.as_deref() {
         if let Some((provider, _)) = model.split_once('/') {
@@ -3935,6 +3978,42 @@ async fn run_interactive(
                         "MCP auth is unavailable because the MCP runtime is not connected."
                             .to_string(),
                     );
+                }
+            }
+        }
+
+        if !app.is_streaming && current_query.is_none() && app.take_pending_provider_reload() {
+            // A provider was just connected in-session (e.g. a Claude Pro/Max
+            // OAuth login). Re-resolve credentials and swap in a fresh client +
+            // provider registry so the current session can use them immediately,
+            // without a restart. The client built at startup had no credential.
+            // `activate_provider` updated `app.config` (not `cmd_ctx.config`), so
+            // snapshot it as the resolution source — and snapshot up-front so we
+            // don't hold a borrow of `app` across the await.
+            let reload_source = app.config.clone();
+            match reload_provider_runtime_state(&reload_source).await {
+                Ok(refreshed) => {
+                    cmd_ctx.config = refreshed.config.clone();
+                    tool_ctx.config = refreshed.config.clone();
+                    base_query_config.provider_registry =
+                        Some(refreshed.provider_registry.clone());
+                    base_query_config.model_registry = Some(refreshed.model_registry.clone());
+                    base_query_config.model = claurst_api::effective_model_for_config(
+                        &cmd_ctx.config,
+                        refreshed.model_registry.as_ref(),
+                    );
+                    client = refreshed.client;
+                    model_registry = refreshed.model_registry;
+                    session.model = claurst_api::effective_model_for_config(
+                        &cmd_ctx.config,
+                        model_registry.as_ref(),
+                    );
+                    app.provider_registry = Some(refreshed.provider_registry);
+                    app.has_credentials = true;
+                }
+                Err(err) => {
+                    app.status_message =
+                        Some(format!("Could not activate credentials: {}", err));
                 }
             }
         }

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -918,6 +918,11 @@ pub struct App {
     pub mcp_manager: Option<Arc<claurst_mcp::McpManager>>,
     /// Queued request for a real MCP reconnect from the interactive loop.
     pub pending_mcp_reconnect: bool,
+    /// Set after an in-session provider connection (e.g. a Claude Pro/Max OAuth
+    /// login) so the main loop re-resolves credentials and swaps in a fresh
+    /// client + provider registry. Without it the session keeps the client built
+    /// at startup, which for a fresh OAuth login still has no usable credential.
+    pub pending_provider_reload: bool,
     /// Pending MCP panel-auth request for the interactive loop.
     pub pending_mcp_panel_auth: Option<String>,
     /// Shared file-history service used for turn diff reconstruction.
@@ -1319,6 +1324,7 @@ impl App {
             remote_session_url: None,
             mcp_manager: None,
             pending_mcp_reconnect: false,
+            pending_provider_reload: false,
             pending_mcp_panel_auth: None,
             file_history: None,
             current_turn: None,
@@ -2841,6 +2847,12 @@ impl App {
         pending
     }
 
+    pub fn take_pending_provider_reload(&mut self) -> bool {
+        let pending = self.pending_provider_reload;
+        self.pending_provider_reload = false;
+        pending
+    }
+
     /// If a project MCP server is waiting for approval and no approval dialog
     /// is currently open, pop the next one and show the approval dialog for it.
     ///
@@ -3224,6 +3236,10 @@ impl App {
                                 "Anthropic".to_string(),
                                 "Connected to",
                             );
+                            // The live client was built at startup with no
+                            // credential; ask the main loop to re-resolve the
+                            // freshly-saved Bearer and swap in a working client.
+                            self.pending_provider_reload = true;
                             return false;
                         }
                         let credential = if provider_id == "github-copilot" {


### PR DESCRIPTION
## Bug

After logging into **Anthropic (Claude Pro/Max)** via `/connect` (shipped in #302), selecting a model and sending failed with **"No API key for the selected model"** — for every model/effort combo — until claurst was restarted.

## Root cause

The live `AnthropicClient` + `ProviderRegistry` are built **once at startup** from `resolve_anthropic_auth_async()`. For a user who launches with no Anthropic creds, that client has an empty key. An in-session OAuth login persists the Bearer (`save_and_register`) and switches `app.config` to anthropic, but never rebuilds the live client — so it keeps the empty key.

Verified the Bearer itself is fine: `claurst --print --model <m>` returns `PONG` for `claude-opus-4-8`, `claude-sonnet-5`, and `claude-opus-4-7` from a fresh start. So the break was purely in-session staleness.

## Fix

- New `pending_provider_reload` flag (mirrors `pending_mcp_reconnect`): the `anthropic-oauth` success handler sets it.
- The main loop consumes it when idle and calls a new **non-destructive** `reload_provider_runtime_state` — re-resolves `resolve_anthropic_auth_async()` from the now-active `app.config` and swaps in a fresh client + provider registry (unlike `/refresh`, which resets provider/model).

## Testing

- `cargo check`/`clippy -D warnings`/`test --workspace` — green.
- Headless Bearer inference verified for all three models above.
- Note: the interactive in-session login path needs a human to complete the browser step; I've rebuilt/installed the binary so it can be eyeballed.

Follow-up to #302.