### PR TITLE
feat(api): live Anthropic model discovery via /v1/models (filters the sub list)

### DIFF
--- a/src-rust/crates/api/src/providers/anthropic.rs
+++ b/src-rust/crates/api/src/providers/anthropic.rs
@@ -10,12 +10,12 @@ use std::sync::Arc;
 
 use async_stream::stream;
 use async_trait::async_trait;
-use claurst_core::provider_id::ProviderId;
+use claurst_core::provider_id::{ModelId, ProviderId};
 use claurst_core::types::{ContentBlock, UsageInfo};
 use futures::Stream;
 
 use crate::client::{AnthropicClient, ClientConfig};
-use crate::provider::LlmProvider;
+use crate::provider::{LlmProvider, ModelInfo};
 use crate::provider_error::ProviderError;
 use crate::provider_types::{
     ProviderCapabilities, ProviderRequest, ProviderResponse, ProviderStatus, StopReason,
@@ -280,6 +280,36 @@ impl LlmProvider for AnthropicProvider {
         };
 
         Ok(Box::pin(s))
+    }
+
+    /// Live model discovery via `GET /v1/models`, returning exactly the models
+    /// the active credential can use. For a Claude Pro/Max OAuth token this is
+    /// the curated subscription set (no legacy claude-3.x); for an API key it is
+    /// the org's accessible models. On any failure (offline, expired/absent
+    /// token) returns an empty vec so the picker keeps the models.dev catalog
+    /// projection instead of surfacing an error.
+    async fn discover_models(&self) -> Result<Vec<ModelInfo>, ProviderError> {
+        let available = match self.client.fetch_available_models().await {
+            Ok(m) => m,
+            Err(_) => return Ok(Vec::new()),
+        };
+        let models = available
+            .into_iter()
+            .map(|m| {
+                let name = m.display_name.unwrap_or_else(|| m.id.clone());
+                ModelInfo {
+                    id: ModelId::new(&m.id),
+                    provider_id: self.id.clone(),
+                    name,
+                    // Sensible Claude defaults; the picker overlays richer
+                    // context/cost from the models.dev catalog for known ids.
+                    context_window: 200_000,
+                    max_output_tokens: 64_000,
+                    ..Default::default()
+                }
+            })
+            .collect();
+        Ok(models)
     }
 
     async fn health_check(&self) -> Result<ProviderStatus, ProviderError> {

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -3594,7 +3594,19 @@ async fn run_interactive(
                     // an unreachable endpoint, or a missing entitlement — is a
                     // no-op and never wipes the projection. For copilot the id
                     // IS the api.id, so this is the by-api.id merge.
-                    app.model_picker.merge_models(entries);
+                    //
+                    // Anthropic is the exception: its discovery result is the
+                    // subscription/key set already intersected with the catalog,
+                    // so we REPLACE (dropping legacy claude-3.x the credential
+                    // can't serve). An empty result (discovery failed / offline)
+                    // is a no-op that keeps the full catalog projection.
+                    if provider == "anthropic" {
+                        if !entries.is_empty() {
+                            app.model_picker.set_models(entries);
+                        }
+                    } else {
+                        app.model_picker.merge_models(entries);
+                    }
                     for m in &mut app.model_picker.models {
                         m.is_current = m.id == current;
                     }
@@ -3638,6 +3650,19 @@ async fn run_interactive(
                 .clone()
                 .or_else(|| app.config.provider.clone())
                 .unwrap_or_else(|| "anthropic".to_string());
+            let is_anthropic = provider_id_str == "anthropic";
+            // For Anthropic, live `/v1/models` discovery is the authoritative set
+            // the credential can use; intersect it with the rich catalog
+            // projection so we keep context/cost metadata for known ids but drop
+            // models the subscription/key can't serve (e.g. legacy claude-3.x).
+            let anthropic_catalog: Vec<claurst_tui::model_picker::ModelEntry> = if is_anthropic {
+                claurst_tui::model_picker::models_for_provider_from_registry(
+                    "anthropic",
+                    model_registry.as_ref(),
+                )
+            } else {
+                Vec::new()
+            };
             if let Some(ref registry) = app.provider_registry {
                 let pid = claurst_core::ProviderId::new(&provider_id_str);
                 if let Some(provider) = registry.get(&pid) {
@@ -3648,17 +3673,46 @@ async fn run_interactive(
                     tokio::spawn(async move {
                         match provider.discover_models().await {
                             Ok(models) => {
-                                let entries: Vec<claurst_tui::model_picker::ModelEntry> = models
-                                    .into_iter()
-                                    .map(|m| claurst_tui::model_picker::ModelEntry {
-                                        id: m.id.to_string(),
-                                        display_name: m.name.clone(),
-                                        description: claurst_tui::model_picker::format_context_window(
-                                            m.context_window,
-                                        ),
-                                        is_current: false,
-                                    })
-                                    .collect();
+                                let entries: Vec<claurst_tui::model_picker::ModelEntry> =
+                                    if is_anthropic && !models.is_empty() {
+                                        let by_id: std::collections::HashMap<
+                                            String,
+                                            claurst_tui::model_picker::ModelEntry,
+                                        > = anthropic_catalog
+                                            .into_iter()
+                                            .map(|e| (e.id.clone(), e))
+                                            .collect();
+                                        models
+                                            .into_iter()
+                                            .map(|m| {
+                                                let id = m.id.to_string();
+                                                by_id.get(&id).cloned().unwrap_or_else(|| {
+                                                    claurst_tui::model_picker::ModelEntry {
+                                                        id: id.clone(),
+                                                        display_name: m.name.clone(),
+                                                        description:
+                                                            claurst_tui::model_picker::format_context_window(
+                                                                m.context_window,
+                                                            ),
+                                                        is_current: false,
+                                                    }
+                                                })
+                                            })
+                                            .collect()
+                                    } else {
+                                        models
+                                            .into_iter()
+                                            .map(|m| claurst_tui::model_picker::ModelEntry {
+                                                id: m.id.to_string(),
+                                                display_name: m.name.clone(),
+                                                description:
+                                                    claurst_tui::model_picker::format_context_window(
+                                                        m.context_window,
+                                                    ),
+                                                is_current: false,
+                                            })
+                                            .collect()
+                                    };
                                 let _ = tx.send(Ok(entries)).await;
                             }
                             Err(_) => {

--- a/src-rust/crates/tui/src/model_picker.rs
+++ b/src-rust/crates/tui/src/model_picker.rs
@@ -360,11 +360,18 @@ pub fn default_model_for_provider(
 /// replace the catalog projection. This is what makes a fresh `claude-opus-*`
 /// point-release surface the instant the snapshot ships it.
 ///
-/// Anthropic/OpenAI/Google never had a live endpoint. Azure, Amazon Bedrock,
+/// OpenAI/Google never had a live endpoint. Azure, Amazon Bedrock,
 /// Cohere and MiniMax used to ship a tiny hardcoded `discover_models()` list
 /// that clobbered the far richer catalog (108/85/12/6 rows); that override was
 /// removed, so they are projected from the models.dev catalog here too rather
 /// than fetched.
+///
+/// **Anthropic is intentionally NOT here**: it implements live discovery via
+/// `GET /v1/models`, which returns exactly the models the active credential can
+/// use (for a Claude Pro/Max OAuth token, the curated subscription set — no
+/// legacy claude-3.x). The event loop opens on the catalog projection, then
+/// intersects it with the discovered set (see the anthropic branch in the
+/// discovery spawn), falling back to the full projection if discovery fails.
 ///
 /// Live-endpoint providers (Ollama/LM Studio/llama.cpp, Copilot, the
 /// openai-compatible gateways, …) and curated-list providers (Codex, free) are
@@ -374,13 +381,7 @@ pub fn default_model_for_provider(
 pub fn provider_uses_catalog_projection(provider_id: &str) -> bool {
     matches!(
         provider_id,
-        "anthropic"
-            | "openai"
-            | "google"
-            | "azure"
-            | "amazon-bedrock"
-            | "cohere"
-            | "minimax"
+        "openai" | "google" | "azure" | "amazon-bedrock" | "cohere" | "minimax"
     )
 }
 
@@ -1327,7 +1328,9 @@ mod tests {
         let registry = claurst_api::ModelRegistry::new();
 
         // Catalog-backed providers skip live discovery; live ones do not.
-        assert!(provider_uses_catalog_projection("anthropic"));
+        // Anthropic now discovers via GET /v1/models, so it's on the live side;
+        // its sync projection below is still the pre-discovery/offline fallback.
+        assert!(!provider_uses_catalog_projection("anthropic"));
         assert!(provider_uses_catalog_projection("openai"));
         assert!(provider_uses_catalog_projection("google"));
         assert!(!provider_uses_catalog_projection("ollama"));
@@ -1540,7 +1543,8 @@ mod tests {
             );
         }
         // Live/curated providers must NOT be treated as catalog projections.
-        for pid in ["ollama", "github-copilot", "codex", "free"] {
+        // Anthropic joined this group: it discovers via GET /v1/models.
+        for pid in ["anthropic", "ollama", "github-copilot", "codex", "free"] {
             assert!(
                 !provider_uses_catalog_projection(pid),
                 "{pid} must keep its live/curated discovery"


### PR DESCRIPTION
## What

The Claude Pro/Max model picker showed the **entire models.dev anthropic catalog** — Opus 3, Sonnet 3, the 3.5 line — because models.dev tags no Claude model with a lifecycle status (so the deprecated/alpha filter passes everything), and there was no subscription-aware filter (Codex has `codex_model_allowed`; Anthropic had none).

## Fix — use the authoritative source

Implement `AnthropicProvider::discover_models()` (the only major provider still on the empty trait default) to call **`GET /v1/models`**, which returns exactly what the active credential can use: for a Pro/Max OAuth token, the curated subscription set (verified: 9 models, no claude-3.x); for an API key, the org's accessible models.

The picker opens on the catalog projection (instant/offline), then **intersects** it with the discovered set:
- catalog metadata (context/cost/date) is kept for ids in both,
- served ids missing from the catalog are appended with basic info,
- models the credential can't serve (legacy claude-3.x) are pruned.

Discovery failure/offline is a **no-op** that keeps the full projection.

## Changes
- `anthropic.rs` — `discover_models()` via the existing-but-unused `fetch_available_models()`.
- `model_picker.rs` — drop anthropic from `provider_uses_catalog_projection` so the event loop runs discovery; tests updated.
- `main.rs` — intersect discovery with the catalog in the fetch spawn; **replace** (not additive-merge) for anthropic so non-served models drop.

## Testing
- `cargo clippy -D warnings` + `cargo test --workspace` — green.
- `/v1/models` with the Pro/Max Bearer returns the 9-model subscription set (opus/sonnet/haiku 4.x + sonnet-5/fable-5), no legacy models — confirmed live.
- Picker behavior is best eyeballed; rebuilt binary installed.