### PR TITLE
feat(install): GitHub auth, Git Bash support, aligned Windows paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ curl -fsSL https://github.com/kuberwastaken/claurst/releases/latest/download/ins
 irm https://github.com/kuberwastaken/claurst/releases/latest/download/install.ps1 | iex
 ```
 
-This drops `claurst` into `~/.claurst/bin` (or `%USERPROFILE%\.claurst\bin` on Windows) and adds it to your `PATH` automatically. Open a new terminal and run `claurst`.
+This drops `claurst` into `~/.local/bin` (or `%LOCALAPPDATA%\Programs\claurst` on Windows; Git Bash uses the same Windows path) and adds it to your `PATH` automatically. Open a new terminal and run `claurst`.
 
 ## Via npm / bun
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,8 +2,9 @@
 
 Claurst is a Rust reimplementation of the Claude Code CLI. The fastest way
 to install it is via the one-liner installers below. They drop the binary
-into `~/.claurst/bin` (or `%USERPROFILE%\.claurst\bin` on Windows) and add
-that directory to your `PATH` automatically.
+into `~/.local/bin` (or `%LOCALAPPDATA%\Programs\claurst` on Windows; Git Bash
+uses that same Windows default) and add that directory to your `PATH`
+automatically.
 
 ---
 
@@ -36,13 +37,26 @@ curl -fsSL https://github.com/Kuberwastaken/claurst/releases/latest/download/ins
 irm https://github.com/Kuberwastaken/claurst/releases/latest/download/install.ps1 | iex
 ```
 
+### Windows (Git Bash / MSYS / Cygwin)
+
+`install.sh` also works under Git Bash. It downloads the Windows zip
+(`claurst-windows-x86_64.zip`), installs `claurst.exe` into the **same**
+default directory as `install.ps1` (`%LOCALAPPDATA%\Programs\claurst`), and
+updates the Windows user `PATH` (not only bashrc):
+
+```bash
+curl -fsSL https://github.com/Kuberwastaken/claurst/releases/latest/download/install.sh | bash
+```
+
 Both installers:
 
 1. Detect your platform and architecture.
 2. Download the matching archive from the latest GitHub release.
-3. Extract `claurst` into `~/.claurst/bin/` (Windows: `%USERPROFILE%\.claurst\bin\`).
+3. Extract `claurst` into `~/.local/bin/` on Linux/macOS, or
+   `%LOCALAPPDATA%\Programs\claurst` on Windows (`install.sh` under Git Bash
+   uses this same Windows default).
 4. Append that directory to your shell config (`.bashrc`, `.zshrc`,
-   `.config/fish/config.fish`) or to your Windows user `PATH`.
+   `.config/fish/config.fish`) on Unix, or to your Windows user `PATH`.
 5. On macOS, strip the quarantine attribute so Gatekeeper does not block the
    unsigned binary.
 
@@ -330,12 +344,14 @@ the [Upgrading](#upgrading) section above.
 
 ## Uninstalling
 
-If you used the install script, remove the install directory:
+If you used the install script, remove the binary (or install directory):
 
 ```bash
-rm -rf ~/.claurst/bin                    # Linux / macOS
-# Windows (PowerShell):
-Remove-Item -Recurse -Force "$env:USERPROFILE\.claurst\bin"
+rm -f ~/.local/bin/claurst               # Linux / macOS
+# Windows (PowerShell / default install.ps1 path):
+Remove-Item -Force "$env:LOCALAPPDATA\Programs\claurst\claurst.exe"
+# Optional: remove the empty install dir
+Remove-Item -Recurse -Force "$env:LOCALAPPDATA\Programs\claurst" -ErrorAction SilentlyContinue
 ```
 
 For manual installs:
@@ -352,4 +368,5 @@ rm -rf ~/.claurst
 ```
 
 You may also want to remove the `# claurst` PATH line that the installer
-appended to your shell config (`.bashrc`, `.zshrc`, etc.).
+appended to your shell config (`.bashrc`, `.zshrc`, etc.), or the Windows
+user PATH entry for `%LOCALAPPDATA%\Programs\claurst`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -58,10 +58,40 @@ Both scripts accept the same flags:
 | `--version 0.1.0` | `-Version 0.1.0` | Install a specific version |
 | `--binary <path>` | `-Binary <path>` | Install from a local file (skip download) |
 | `--install-dir <path>` | `-InstallDir <path>` | Override the install directory |
+| `--token <token>` | `-Token <token>` | GitHub token for API/downloads |
 | `--no-modify-path` | `-NoModifyPath` | Don't touch shell config / user PATH |
 | `--help` | `-Help` | Show usage |
 
 Example: `curl -fsSL https://.../install.sh | bash -s -- --version 0.1.0`
+
+### GitHub authentication
+
+If GitHub rate-limits unauthenticated requests, or you install from a private
+fork/release, set a token via env or flag. The installer also accepts
+`GH_TOKEN` (GitHub CLI convention):
+
+```bash
+# Linux / macOS
+export GITHUB_TOKEN=ghp_...   # or GH_TOKEN
+curl -fsSL https://github.com/Kuberwastaken/claurst/releases/latest/download/install.sh | bash
+
+# Or pass the token as a flag when running the script locally:
+./install.sh --token ghp_...
+```
+
+```powershell
+# Windows
+$env:GITHUB_TOKEN = 'ghp_...'   # or $env:GH_TOKEN
+irm https://github.com/Kuberwastaken/claurst/releases/latest/download/install.ps1 | iex
+
+# Or:
+.\install.ps1 -Token ghp_...
+```
+
+The token is sent as `Authorization: Bearer …` on the GitHub API call that
+resolves the latest version and on asset/checksum downloads. A fine-grained
+or classic PAT with `contents: read` (public repos need no scopes beyond
+rate-limit relief) is enough.
 
 ---
 

--- a/install.ps1
+++ b/install.ps1
@@ -258,16 +258,20 @@ function Install-FromBinary {
 
 function Install-Binary($source) {
     $target = Join-Path $InstallDir 'claurst.exe'
+    $stale = "$target.old"
 
     # The currently running claurst.exe (if any) holds an exclusive file lock on
-    # Windows.  Try to swap by renaming the old one first.
+    # Windows.  Swap by renaming the old one aside, then remove it after the
+    # new binary is in place (the lock is on the path that was open).
     if (Test-Path $target) {
-        $stale = "$target.old"
         if (Test-Path $stale) { Remove-Item -Force $stale -ErrorAction SilentlyContinue }
         try { Move-Item -Force $target $stale } catch { }
     }
 
     Copy-Item -Force $source $target
+    if (Test-Path $stale) {
+        Remove-Item -Force $stale -ErrorAction SilentlyContinue
+    }
     Write-Success "Installed: $target"
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -12,6 +12,7 @@ param(
     [string]$Version = "",
     [string]$Binary = "",
     [string]$InstallDir = "",
+    [string]$Token = "",
     [switch]$NoModifyPath,
     [switch]$Help
 )
@@ -38,16 +39,38 @@ Options:
     -Version <version>      Install a specific version (e.g., 0.1.0)
     -Binary <path>          Install from a local binary instead of downloading
     -InstallDir <path>      Override install location (default: %LOCALAPPDATA%\Programs\claurst)
+    -Token <token>          GitHub token for API/downloads (or set GITHUB_TOKEN / GH_TOKEN)
     -NoModifyPath           Don't add the install dir to user PATH
 
 Examples:
     irm https://github.com/Kuberwastaken/claurst/releases/latest/download/install.ps1 | iex
     .\install.ps1 -Version 0.1.0
     .\install.ps1 -Binary C:\path\to\claurst.exe
+    `$env:GITHUB_TOKEN = 'ghp_...'; .\install.ps1
 "@
 }
 
 if ($Help) { Show-Usage; exit 0 }
+
+# Prefer -Token; otherwise GITHUB_TOKEN, then GH_TOKEN (gh CLI convention).
+if ([string]::IsNullOrEmpty($Token)) {
+    if (-not [string]::IsNullOrEmpty($env:GITHUB_TOKEN)) {
+        $Token = $env:GITHUB_TOKEN
+    } elseif (-not [string]::IsNullOrEmpty($env:GH_TOKEN)) {
+        $Token = $env:GH_TOKEN
+    }
+}
+
+function Get-GitHubHeaders {
+    $headers = @{
+        'User-Agent' = 'claurst-installer'
+        'Accept'     = 'application/vnd.github+json'
+    }
+    if (-not [string]::IsNullOrEmpty($script:Token)) {
+        $headers['Authorization'] = "Bearer $($script:Token)"
+    }
+    return $headers
+}
 
 # ----- Detect architecture -----
 function Get-Arch {
@@ -88,12 +111,17 @@ function Resolve-Version {
         return ($script:Version -replace '^v', '')
     }
     try {
-        $resp = Invoke-RestMethod -UseBasicParsing -Uri "https://api.github.com/repos/$Repo/releases/latest" -Headers @{ 'User-Agent' = 'claurst-installer' }
+        $resp = Invoke-RestMethod -UseBasicParsing `
+            -Uri "https://api.github.com/repos/$Repo/releases/latest" `
+            -Headers (Get-GitHubHeaders)
         $tag = $resp.tag_name
         if ([string]::IsNullOrEmpty($tag)) { throw "no tag_name in response" }
         return ($tag -replace '^v', '')
     } catch {
         Write-Err "Failed to fetch latest version from GitHub API: $_"
+        if ([string]::IsNullOrEmpty($script:Token)) {
+            Write-Info "If you hit rate limits or need a private release, set GITHUB_TOKEN or pass -Token."
+        }
         exit 1
     }
 }
@@ -129,16 +157,23 @@ function Download-And-Install($desiredVersion, $arch) {
 
     Write-Info "Installing claurst v$desiredVersion (windows-$arch)"
     Write-Muted "Downloading $url"
+    if (-not [string]::IsNullOrEmpty($script:Token)) {
+        Write-Muted "Using GitHub authentication."
+    }
+    $ghHeaders = Get-GitHubHeaders
     try {
         # Disable progress UI for a faster, less noisy download.
         $oldPref = $ProgressPreference
         $ProgressPreference = 'SilentlyContinue'
-        Invoke-WebRequest -UseBasicParsing -Uri $url -OutFile $zipPath
+        Invoke-WebRequest -UseBasicParsing -Uri $url -OutFile $zipPath -Headers $ghHeaders
         $ProgressPreference = $oldPref
     } catch {
         Write-Err "Download failed: $_"
         Write-Info ("Check that release v$desiredVersion exists for windows-" + $arch + ":")
         Write-Info "  https://github.com/$Repo/releases/tag/v$desiredVersion"
+        if ([string]::IsNullOrEmpty($script:Token)) {
+            Write-Info "Private releases require GITHUB_TOKEN / GH_TOKEN or -Token."
+        }
         Remove-Item -Recurse -Force $tmpRoot -ErrorAction SilentlyContinue
         exit 1
     }
@@ -154,7 +189,7 @@ function Download-And-Install($desiredVersion, $arch) {
     try {
         $oldPref2 = $ProgressPreference
         $ProgressPreference = 'SilentlyContinue'
-        Invoke-WebRequest -UseBasicParsing -Uri $sumsUrl -OutFile $sumsPath
+        Invoke-WebRequest -UseBasicParsing -Uri $sumsUrl -OutFile $sumsPath -Headers $ghHeaders
         $ProgressPreference = $oldPref2
         $haveSums = $true
     } catch {

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Claurst installer for Linux and macOS.
+# Claurst installer for Linux, macOS, and Windows (Git Bash / MSYS / Cygwin).
 #
 # Usage (one-liner):
 #   curl -fsSL https://github.com/Kuberwastaken/claurst/releases/latest/download/install.sh | bash
@@ -33,7 +33,9 @@ Options:
     -b, --binary <path>     Install from a local binary instead of downloading
         --token <token>     GitHub token for API/downloads (or set GITHUB_TOKEN / GH_TOKEN)
         --no-modify-path    Don't modify shell config files (.zshrc, .bashrc, etc.)
-        --install-dir <dir> Override install location (default: ${XDG_BIN_HOME:-~/.local/bin})
+        --install-dir <dir> Override install location
+                            (default: ${XDG_BIN_HOME:-~/.local/bin}; on Windows:
+                            %LOCALAPPDATA%\\Programs\\claurst)
 
 Examples:
     curl -fsSL https://github.com/Kuberwastaken/claurst/releases/latest/download/install.sh | bash
@@ -124,7 +126,43 @@ if [[ -n "$github_token" ]]; then
     github_curl_args+=(-H "Authorization: Bearer ${github_token}")
 fi
 
-INSTALL_DIR="${install_dir_override:-${XDG_BIN_HOME:-$HOME/.local/bin}}"
+# True when running under Git Bash / MSYS / Cygwin on Windows.
+is_windows_shell() {
+    case "$(uname -s 2>/dev/null || echo unknown)" in
+        MINGW*|MSYS*|CYGWIN*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Convert a Windows path (C:\foo or C:/foo) to a Unix path when cygpath exists.
+to_unix_path() {
+    local p="$1"
+    if command -v cygpath >/dev/null 2>&1; then
+        cygpath -u "$p"
+    else
+        # MSYS/Git Bash often accept mixed paths after normalizing slashes.
+        echo "${p//\\//}"
+    fi
+}
+
+# Default install dir matches install.ps1 on Windows:
+#   %LOCALAPPDATA%\Programs\claurst  (fallback: %USERPROFILE%\.local\bin)
+# Unix: ${XDG_BIN_HOME:-~/.local/bin}
+default_install_dir() {
+    if is_windows_shell; then
+        if [[ -n "${LOCALAPPDATA:-}" ]]; then
+            echo "$(to_unix_path "$LOCALAPPDATA")/Programs/claurst"
+        elif [[ -n "${USERPROFILE:-}" ]]; then
+            echo "$(to_unix_path "$USERPROFILE")/.local/bin"
+        else
+            echo "${HOME}/.local/bin"
+        fi
+    else
+        echo "${XDG_BIN_HOME:-$HOME/.local/bin}"
+    fi
+}
+
+INSTALL_DIR="${install_dir_override:-$(default_install_dir)}"
 mkdir -p "$INSTALL_DIR"
 
 # ----- Detect platform & arch -----
@@ -134,12 +172,7 @@ detect_target() {
     case "$raw_os" in
         Darwin*)              os="macos" ;;
         Linux*)               os="linux" ;;
-        MINGW*|MSYS*|CYGWIN*)
-            print_message error "Detected Windows-like environment ($raw_os)."
-            print_message info "Run install.ps1 in PowerShell instead:"
-            print_message info "  irm https://github.com/${REPO}/releases/latest/download/install.ps1 | iex"
-            exit 1
-            ;;
+        MINGW*|MSYS*|CYGWIN*) os="windows" ;;
         *)
             print_message error "Unsupported OS: $raw_os"
             exit 1
@@ -164,14 +197,33 @@ detect_target() {
         fi
     fi
 
+    # Windows releases currently ship x86_64 only (same as install.ps1).
+    if [ "$os" = "windows" ] && [ "$arch" != "x86_64" ]; then
+        print_message warning "Windows ${arch} is not currently supported in releases. Falling back to x86_64."
+        arch="x86_64"
+    fi
+
     target="${os}-${arch}"
+    if [ "$os" = "windows" ]; then
+        archive_ext="zip"
+        binary_name="${APP}.exe"
+    else
+        archive_ext="tar.gz"
+        binary_name="$APP"
+    fi
 }
 
 # ----- Pre-flight: required tools -----
 check_required_tools() {
     local missing=()
-    command -v curl >/dev/null 2>&1 || missing+=("curl")
-    command -v tar  >/dev/null 2>&1 || missing+=("tar")
+    if [[ -z "$binary_path" ]]; then
+        command -v curl >/dev/null 2>&1 || missing+=("curl")
+        if is_windows_shell; then
+            command -v unzip >/dev/null 2>&1 || missing+=("unzip")
+        else
+            command -v tar >/dev/null 2>&1 || missing+=("tar")
+        fi
+    fi
     if [ "${#missing[@]}" -gt 0 ]; then
         print_message error "Missing required tools: ${missing[*]}"
         print_message info "Please install them and try again."
@@ -216,10 +268,12 @@ check_existing_install() {
 
 # ----- Download & extract -----
 download_and_install() {
-    local archive="${APP}-${target}.tar.gz"
+    local archive="${APP}-${target}.${archive_ext}"
     local url="https://github.com/${REPO}/releases/download/v${specific_version}/${archive}"
     local tmp_dir
-    tmp_dir=$(mktemp -d -t claurst-install-XXXXXX)
+    # mktemp -t is GNU-style; fall back for older / BSD layouts (and Git Bash).
+    tmp_dir=$(mktemp -d -t claurst-install-XXXXXX 2>/dev/null \
+        || mktemp -d "${TMPDIR:-/tmp}/claurst-install.XXXXXX")
     trap "rm -rf '$tmp_dir'" EXIT
 
     print_message info "${MUTED}Installing ${NC}${APP} ${MUTED}v${NC}${specific_version} ${MUTED}(${target})${NC}"
@@ -282,16 +336,24 @@ download_and_install() {
     fi
 
     print_message info "${MUTED}Extracting...${NC}"
-    tar -xzf "$tmp_dir/$archive" -C "$tmp_dir"
+    if [[ "$archive_ext" == "zip" ]]; then
+        # Quiet extract; -o overwrites without prompting (Windows zip layout).
+        if ! unzip -o -q "$tmp_dir/$archive" -d "$tmp_dir"; then
+            print_message error "Extract failed."
+            exit 1
+        fi
+    else
+        tar -xzf "$tmp_dir/$archive" -C "$tmp_dir"
+    fi
 
-    if [[ ! -f "$tmp_dir/$APP" ]]; then
-        print_message error "Archive did not contain expected binary '$APP'"
+    if [[ ! -f "$tmp_dir/$binary_name" ]]; then
+        print_message error "Archive did not contain expected binary '$binary_name'"
         print_message info "Contents:"
         ls -la "$tmp_dir"
         exit 1
     fi
 
-    install_binary "$tmp_dir/$APP"
+    install_binary "$tmp_dir/$binary_name"
 }
 
 install_from_binary() {
@@ -305,7 +367,20 @@ install_from_binary() {
 
 install_binary() {
     local source="$1"
-    local target_path="${INSTALL_DIR}/${APP}"
+    # Prefer binary_name from detect_target; local --binary installs may not set it.
+    local dest_name="${binary_name:-$APP}"
+    if is_windows_shell && [[ "$dest_name" != *.exe ]]; then
+        dest_name="${dest_name}.exe"
+    fi
+    local target_path="${INSTALL_DIR}/${dest_name}"
+
+    # Windows holds an exclusive lock on a running .exe — rename the old binary
+    # aside first (same approach as install.ps1).
+    if is_windows_shell && [[ -f "$target_path" ]]; then
+        local stale="${target_path}.old"
+        rm -f "$stale" 2>/dev/null || true
+        mv -f "$target_path" "$stale" 2>/dev/null || true
+    fi
 
     cp "$source" "$target_path"
     chmod 755 "$target_path"
@@ -319,11 +394,63 @@ install_binary() {
 }
 
 # ----- PATH modification -----
-add_to_path_if_needed() {
-    if [[ "$no_modify_path" == "true" ]]; then
-        return
+# On Windows, match install.ps1: update the user PATH env var (inherited by
+# PowerShell, cmd, and Git Bash). On Unix, append to shell config files.
+add_to_windows_user_path() {
+    local win_dir
+    if command -v cygpath >/dev/null 2>&1; then
+        win_dir=$(cygpath -w "$INSTALL_DIR")
+    else
+        # Best-effort: turn /c/Users/... into C:\Users\...
+        win_dir="$INSTALL_DIR"
+        if [[ "$win_dir" =~ ^/([a-zA-Z])/(.*) ]]; then
+            win_dir="${BASH_REMATCH[1]^}:\\${BASH_REMATCH[2]//\//\\}"
+        else
+            win_dir="${win_dir//\//\\}"
+        fi
     fi
 
+    # Use PowerShell so we only touch the User scope (same as install.ps1).
+    local ps_script
+    ps_script=$(cat <<'PSEOF'
+$ErrorActionPreference = 'Stop'
+$installDir = $env:CLAURST_INSTALL_DIR_WIN
+$current = [Environment]::GetEnvironmentVariable('Path', 'User')
+if ($null -eq $current) { $current = '' }
+$paths = $current -split ';' | Where-Object { $_ -ne '' }
+foreach ($p in $paths) {
+    if ($p.TrimEnd('\') -ieq $installDir.TrimEnd('\')) {
+        Write-Output 'already'
+        exit 0
+    }
+}
+if ([string]::IsNullOrEmpty($current)) {
+    $newPath = $installDir
+} else {
+    $newPath = $installDir + ';' + $current
+}
+[Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+Write-Output 'added'
+PSEOF
+)
+
+    local result
+    if ! result=$(CLAURST_INSTALL_DIR_WIN="$win_dir" powershell.exe -NoProfile -NonInteractive -Command "$ps_script" 2>/dev/null); then
+        print_message warning "Could not update Windows user PATH. Add manually: $win_dir"
+        return
+    fi
+    result=$(echo "$result" | tr -d '\r' | tail -n 1)
+    # Visible in this Git Bash session immediately.
+    export PATH="$INSTALL_DIR:$PATH"
+    if [[ "$result" == "already" ]]; then
+        print_message info "${MUTED}Install dir already on user PATH: ${NC}$win_dir"
+    else
+        print_message success "Added $win_dir to user PATH"
+        print_message info "${MUTED}Open a new terminal for the change to take effect everywhere.${NC}"
+    fi
+}
+
+add_to_unix_path() {
     if [[ ":$PATH:" == *":$INSTALL_DIR:"* ]]; then
         return  # already on PATH for this session
     fi
@@ -383,6 +510,18 @@ add_to_path_if_needed() {
     } >> "$config_file"
     print_message success "Added $INSTALL_DIR to PATH in $config_file"
     print_message info "${MUTED}Restart your shell or run:${NC} source $config_file"
+}
+
+add_to_path_if_needed() {
+    if [[ "$no_modify_path" == "true" ]]; then
+        return
+    fi
+
+    if is_windows_shell; then
+        add_to_windows_user_path
+    else
+        add_to_unix_path
+    fi
 }
 
 # ----- GitHub Actions environment hint -----

--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,7 @@ Options:
     -h, --help              Display this help message
     -v, --version <version> Install a specific version (e.g., 0.1.0 or v0.1.0)
     -b, --binary <path>     Install from a local binary instead of downloading
+        --token <token>     GitHub token for API/downloads (or set GITHUB_TOKEN / GH_TOKEN)
         --no-modify-path    Don't modify shell config files (.zshrc, .bashrc, etc.)
         --install-dir <dir> Override install location (default: ${XDG_BIN_HOME:-~/.local/bin})
 
@@ -38,6 +39,7 @@ Examples:
     curl -fsSL https://github.com/Kuberwastaken/claurst/releases/latest/download/install.sh | bash
     ./install.sh --version 0.1.0
     ./install.sh --binary /path/to/claurst
+    GITHUB_TOKEN=ghp_... ./install.sh
 EOF
 }
 
@@ -59,6 +61,8 @@ requested_version=${VERSION:-}
 no_modify_path=false
 binary_path=""
 install_dir_override=""
+# Prefer explicit --token; otherwise GITHUB_TOKEN, then GH_TOKEN (gh CLI convention).
+github_token="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -84,6 +88,15 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             ;;
+        --token)
+            if [[ -n "${2:-}" ]]; then
+                github_token="$2"
+                shift 2
+            else
+                print_message error "Error: --token requires a token argument"
+                exit 1
+            fi
+            ;;
         --no-modify-path)
             no_modify_path=true
             shift
@@ -103,6 +116,13 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+# Build curl args for GitHub (API + asset downloads). Auth avoids rate limits
+# and enables private-release installs when a token is available.
+github_curl_args=(-fsSL -H "User-Agent: claurst-installer" -H "Accept: application/vnd.github+json")
+if [[ -n "$github_token" ]]; then
+    github_curl_args+=(-H "Authorization: Bearer ${github_token}")
+fi
 
 INSTALL_DIR="${install_dir_override:-${XDG_BIN_HOME:-$HOME/.local/bin}}"
 mkdir -p "$INSTALL_DIR"
@@ -166,11 +186,15 @@ resolve_version() {
         specific_version="$requested_version"
     else
         # Fetch latest version from GitHub API.  Use sed instead of jq for portability.
-        specific_version=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+        specific_version=$(curl "${github_curl_args[@]}" \
+            "https://api.github.com/repos/${REPO}/releases/latest" \
             | sed -n 's/.*"tag_name": *"v\{0,1\}\([^"]*\)".*/\1/p' \
             | head -n 1)
         if [[ -z "$specific_version" ]]; then
             print_message error "Failed to fetch latest version from GitHub API"
+            if [[ -z "$github_token" ]]; then
+                print_message info "If you hit rate limits or need a private release, set GITHUB_TOKEN or pass --token."
+            fi
             exit 1
         fi
     fi
@@ -200,11 +224,22 @@ download_and_install() {
 
     print_message info "${MUTED}Installing ${NC}${APP} ${MUTED}v${NC}${specific_version} ${MUTED}(${target})${NC}"
     print_message info "${MUTED}Downloading ${NC}${url}"
+    if [[ -n "$github_token" ]]; then
+        print_message info "${MUTED}Using GitHub authentication.${NC}"
+    fi
 
-    if ! curl -fL --progress-bar -o "$tmp_dir/$archive" "$url"; then
+    # Progress bar is optional; keep -f so HTTP errors fail the install.
+    local -a dl_args=(-fL --progress-bar -H "User-Agent: claurst-installer")
+    if [[ -n "$github_token" ]]; then
+        dl_args+=(-H "Authorization: Bearer ${github_token}")
+    fi
+    if ! curl "${dl_args[@]}" -o "$tmp_dir/$archive" "$url"; then
         print_message error "Download failed."
         print_message info "Check that release v${specific_version} exists for ${target}:"
         print_message info "  https://github.com/${REPO}/releases/tag/v${specific_version}"
+        if [[ -z "$github_token" ]]; then
+            print_message info "Private releases require GITHUB_TOKEN / GH_TOKEN or --token."
+        fi
         exit 1
     fi
 
@@ -214,7 +249,7 @@ download_and_install() {
     # case we warn and continue so existing installs keep working.  But if the
     # file IS present and the hash does NOT match, we abort hard.
     local sums_url="https://github.com/${REPO}/releases/download/v${specific_version}/SHA256SUMS"
-    if curl -fsSL -o "$tmp_dir/SHA256SUMS" "$sums_url" 2>/dev/null; then
+    if curl "${github_curl_args[@]}" -o "$tmp_dir/SHA256SUMS" "$sums_url" 2>/dev/null; then
         # sha256sum emits "<hash>  <filename>" (two spaces); awk collapses the
         # whitespace so $1=hash, $2=bare filename.  Match on the bare archive
         # name (not the full temp path).

--- a/install.sh
+++ b/install.sh
@@ -375,15 +375,20 @@ install_binary() {
     local target_path="${INSTALL_DIR}/${dest_name}"
 
     # Windows holds an exclusive lock on a running .exe — rename the old binary
-    # aside first (same approach as install.ps1).
+    # aside first, then remove it after the new binary is in place (same as
+    # install.ps1). The lock is on the open handle, not the new path name.
+    local stale="${target_path}.old"
     if is_windows_shell && [[ -f "$target_path" ]]; then
-        local stale="${target_path}.old"
         rm -f "$stale" 2>/dev/null || true
         mv -f "$target_path" "$stale" 2>/dev/null || true
     fi
 
     cp "$source" "$target_path"
     chmod 755 "$target_path"
+
+    if [[ -f "$stale" ]]; then
+        rm -f "$stale" 2>/dev/null || true
+    fi
 
     # On macOS, strip the quarantine attribute so Gatekeeper doesn't block the unsigned binary.
     if [[ "$(uname -s)" == "Darwin" ]]; then


### PR DESCRIPTION
## Summary

- **GitHub auth** for `install.sh` / `install.ps1`: `GITHUB_TOKEN`, `GH_TOKEN`, or `--token` / `-Token` on release API + asset/checksum downloads (rate limits / private releases).
- **Git Bash / MSYS / Cygwin**: `install.sh` installs the Windows zip (`claurst-windows-x86_64.zip` → `claurst.exe`) instead of erroring out.
- **Aligned Windows defaults** with `install.ps1`: install dir `%LOCALAPPDATA%\Programs\claurst`, update Windows **user** `PATH` (via PowerShell), lock-safe `.exe` replace.
- Docs (`README.md`, `docs/installation.md`) updated for current install paths and Git Bash usage.

## Test plan

- [x] Linux/macOS: `bash install.sh --help` and dry path resolution; optional `bash install.sh --version <tag> --no-modify-path`
- [x] Windows PowerShell: `.\install.ps1 -Help`; optional install with `-NoModifyPath`
- [x] Git Bash: `bash install.sh --version <tag> --no-modify-path` → binary at `%LOCALAPPDATA%/Programs/claurst/claurst.exe`
- [x] With `GITHUB_TOKEN` set, latest-version API call succeeds under rate-limit pressure / private fork if applicable
- [x] Unauthenticated public install still works (token optional)
