### PR TITLE
fix(tui): paste pipeline — stop truncating pastes in the live event loop; click a placeholder to read it

### DIFF
--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -2187,7 +2187,11 @@ async fn run_interactive(
         // Poll for crossterm events (keyboard/mouse) with short timeout
         // unless an auto-submit (queued message) is pending — in which case
         // synthesize an Enter event to dequeue and submit it.
-        let synthetic_event: Option<Event> = if app.pending_auto_submit && !app.is_streaming {
+        let synthetic_event: Option<Event> = if let Some(k) = app.pending_key.take() {
+            // A non-character key swallowed by the paste-burst drain — replay
+            // it so the keystroke that ended a raw-key paste is not lost.
+            Some(Event::Key(k))
+        } else if app.pending_auto_submit && !app.is_streaming {
             app.pending_auto_submit = false;
             Some(Event::Key(crossterm::event::KeyEvent::new(
                 KeyCode::Enter,
@@ -2231,6 +2235,29 @@ async fn run_interactive(
                             break 'main;
                         }
                         continue;
+                    }
+
+                    // ── Paste-burst detection ─────────────────────────────
+                    // Terminals without bracketed paste (notably Windows
+                    // Ctrl+V, some tmux configs) dump the clipboard as raw
+                    // key events: every pasted newline arrives as Enter and
+                    // would submit a truncated prompt. A zero-timeout drain
+                    // right after the first character captures the whole
+                    // flood as one paste (human typing never queues 2+ chars
+                    // in the same instant). Must run BEFORE the Enter/submit
+                    // handling below so pasted newlines can't submit.
+                    if key.modifiers == KeyModifiers::NONE
+                        || key.modifiers == KeyModifiers::SHIFT
+                    {
+                        if let KeyCode::Char(c) = key.code {
+                            if app.paste_burst_allowed() {
+                                if let Some(burst) = app.try_detect_paste_burst(c) {
+                                    app.handle_paste_data(burst);
+                                    app.refresh_prompt_input();
+                                    continue;
+                                }
+                            }
+                        }
                     }
 
                     // Enter => submit input (but NOT when ANY dialog/overlay is open —

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -3096,9 +3096,12 @@ async fn run_interactive(
                     }
                 }
                 Event::Paste(data) => {
-                    // Cmd+V paste on macOS / Ctrl+Shift+V on Linux (via bracketed paste)
-                    if !app.is_streaming
-                        && app.permission_request.is_none()
+                    // Bracketed paste (Cmd+V on macOS, Ctrl+Shift+V on Linux, any
+                    // terminal with bracketed paste). Deliberately NOT gated on
+                    // is_streaming: the prompt stays editable during a turn so a
+                    // follow-up can be composed/queued — dropping the event here
+                    // silently loses the pasted content.
+                    if app.permission_request.is_none()
                         && !app.history_search_overlay.visible
                         && app.history_search.is_none()
                     {
@@ -3108,8 +3111,11 @@ async fn run_interactive(
                                 app.key_input_dialog.insert_char(ch);
                             }
                         } else {
-                            // Paste into main prompt input
-                            app.prompt_input.paste(&data);
+                            // Paste into the main prompt through the shared path
+                            // so file-path/image pastes and the large-paste
+                            // placeholder are handled uniformly.
+                            app.handle_paste_data(data);
+                            app.refresh_prompt_input();
                         }
                     }
                 }

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -1109,8 +1109,6 @@ pub struct App {
     /// A single key event that was drained from the queue during paste-burst
     /// detection but wasn't part of the burst (e.g. a modifier key that stopped
     /// the burst). Replayed at the top of the next loop iteration.
-    /// Non-character key swallowed by the paste-burst drain, replayed at the
-    /// top of the next event-loop iteration (see `try_detect_paste_burst`).
     pub pending_key: Option<crossterm::event::KeyEvent>,
     /// Receiver for model-list results fetched in the background when the
     /// /model picker opens.  Drained each frame so models appear as soon as

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -953,6 +953,8 @@ pub struct App {
     pub agents_menu: AgentsMenuState,
     /// Diff viewer overlay.
     pub diff_viewer: DiffViewerState,
+    /// Read-only viewer for [Pasted text #N ...] placeholders.
+    pub paste_viewer: crate::paste_viewer::PasteViewer,
     /// Session-quality feedback survey overlay.
     pub feedback_survey: crate::feedback_survey::FeedbackSurveyState,
     /// Memory file selector overlay (AGENTS.md browser).
@@ -1339,6 +1341,7 @@ impl App {
             mcp_view: McpViewState::new(),
             agents_menu: AgentsMenuState::new(),
             diff_viewer: DiffViewerState::new(),
+            paste_viewer: crate::paste_viewer::PasteViewer::default(),
             feedback_survey: crate::feedback_survey::FeedbackSurveyState::new(),
             memory_file_selector: crate::memory_file_selector::MemoryFileSelectorState::new(),
             hooks_config_menu: crate::hooks_config_menu::HooksConfigMenuState::new(),
@@ -2325,6 +2328,7 @@ impl App {
             || self.mcp_view.visible
             || self.agents_menu.visible
             || self.diff_viewer.visible
+            || self.paste_viewer.visible
             || self.global_search.visible
             || self.feedback_survey.visible
             || self.memory_file_selector.visible
@@ -3865,6 +3869,11 @@ impl App {
                 KeyCode::Down | KeyCode::Char('j') => self.hooks_config_menu.select_next(),
                 _ => {}
             }
+            return false;
+        }
+
+        if self.paste_viewer.visible {
+            self.handle_paste_viewer_key(key);
             return false;
         }
 
@@ -5865,8 +5874,49 @@ impl App {
         let target_row = scroll + (row - text_start_y) as usize;
         let target_col = col.saturating_sub(rect.x + 2) as usize;
         self.prompt_input.set_cursor_at_visual(target_row, target_col, width);
-        self.prompt_input.expand_paste_ref_at(self.prompt_input.cursor);
+        // Clicking a [Pasted text #N ...] placeholder opens the read-only
+        // viewer so the body can be read without splicing it into the
+        // prompt; Alt+E remains the in-place expansion for editing.
+        if let Some((id, body)) = self.prompt_input.paste_ref_at(self.prompt_input.cursor) {
+            self.paste_viewer.open(id, &body);
+        }
         self.refresh_prompt_input();
+    }
+
+    /// Key handling while the paste viewer modal is open.
+    fn handle_paste_viewer_key(&mut self, key: crossterm::event::KeyEvent) {
+        use crossterm::event::{KeyCode, KeyModifiers};
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => self.paste_viewer.close(),
+            KeyCode::Up | KeyCode::Char('k') => self.paste_viewer.scroll_up(1),
+            KeyCode::Down | KeyCode::Char('j') => self.paste_viewer.scroll_down(1),
+            KeyCode::PageUp => self.paste_viewer.page_up(),
+            KeyCode::PageDown => self.paste_viewer.page_down(),
+            KeyCode::Home | KeyCode::Char('g') => self.paste_viewer.scroll_to_top(),
+            KeyCode::End | KeyCode::Char('G') => self.paste_viewer.scroll_to_bottom(),
+            // Alt+E from inside the viewer: same in-place expansion as on the
+            // placeholder itself, then close (the body now lives in the
+            // prompt buffer).
+            KeyCode::Char('e') if key.modifiers.contains(KeyModifiers::ALT) => {
+                let id = self.paste_viewer.paste_id;
+                self.paste_viewer.close();
+                self.expand_paste_ref_by_id(id);
+            }
+            _ => {}
+        }
+    }
+
+    /// Expand the `[Pasted text #N ...]` placeholder with the given id, if it
+    /// is still present in the prompt buffer with a stored body.
+    fn expand_paste_ref_by_id(&mut self, id: u32) {
+        let target =
+            claurst_core::prompt_history::parse_references_with_positions(&self.prompt_input.text)
+                .into_iter()
+                .find(|(rid, matched, _)| *rid == id && matched.starts_with("[Pasted text #"));
+        if let Some((_, _, start)) = target {
+            self.prompt_input.expand_paste_ref_at(start);
+            self.refresh_prompt_input();
+        }
     }
 
     pub fn handle_mouse_event(&mut self, mouse_event: MouseEvent) {
@@ -5878,6 +5928,17 @@ impl App {
         // Keyboard scrolling (PageUp/PageDown, etc.) is handled elsewhere and is
         // unaffected by this gate.
         if !self.config.mouse_capture_enabled() {
+            return;
+        }
+
+        // The paste viewer modal swallows mouse input: the wheel scrolls its
+        // body, everything else is inert (Esc/q close it).
+        if self.paste_viewer.visible {
+            match mouse_event.kind {
+                MouseEventKind::ScrollUp => self.paste_viewer.scroll_up(3),
+                MouseEventKind::ScrollDown => self.paste_viewer.scroll_down(3),
+                _ => {}
+            }
             return;
         }
 
@@ -6864,10 +6925,10 @@ mod tests {
         assert!(app.scroll_offset <= 50, "scroll stays within max_scroll");
     }
 
-    // ---- click-to-expand paste placeholders ----
+    // ---- click-to-view paste placeholders ----
 
     #[test]
-    fn prompt_click_on_placeholder_expands_it() {
+    fn prompt_click_on_placeholder_opens_viewer() {
         let mut app = make_app();
         // Bottom pane as rendered: 1 status row (height > 2), then the top
         // separator at y=21, text rows from y=22. Prefix "❯ " is 2 cells.
@@ -6878,12 +6939,38 @@ mod tests {
         app.prompt_input.paste("l1\nl2\nl3");
         assert!(app.prompt_input.text.contains("[Pasted text #1"));
 
-        // Click on the separator row: no expansion.
+        // Click on the separator row: nothing opens.
         app.handle_prompt_click(10, 21);
-        assert!(app.prompt_input.text.contains("[Pasted text #1"));
+        assert!(!app.paste_viewer.visible);
 
-        // Click inside the placeholder on the first text row.
+        // Click inside the placeholder on the first text row: the viewer
+        // opens read-only — the placeholder stays in the buffer and the body
+        // stays stored so submit-time expansion is unaffected.
         app.handle_prompt_click(2 + 5, 22);
+        assert!(app.paste_viewer.visible);
+        assert_eq!(app.paste_viewer.paste_id, 1);
+        assert_eq!(app.paste_viewer.line_count(), 3);
+        assert!(app.prompt_input.text.contains("[Pasted text #1"));
+        assert!(!app.prompt_input.paste_contents.is_empty());
+    }
+
+    #[test]
+    fn paste_viewer_alt_e_expands_into_prompt() {
+        let mut app = make_app();
+        app.last_input_area.set(ratatui::layout::Rect { x: 0, y: 20, width: 80, height: 8 });
+        for c in "hi ".chars() {
+            app.prompt_input.insert_char(c);
+        }
+        app.prompt_input.paste("l1\nl2\nl3");
+        app.handle_prompt_click(2 + 5, 22);
+        assert!(app.paste_viewer.visible);
+
+        let alt_e = crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('e'),
+            KeyModifiers::ALT,
+        );
+        app.handle_paste_viewer_key(alt_e);
+        assert!(!app.paste_viewer.visible);
         assert_eq!(app.prompt_input.text, "hi l1\nl2\nl3");
         assert!(app.prompt_input.paste_contents.is_empty());
     }
@@ -6898,10 +6985,11 @@ mod tests {
         app.prompt_input.paste("l1\nl2\nl3");
         let text_before = app.prompt_input.text.clone();
 
-        // Click on "hello " before the placeholder: cursor moves, no expand.
+        // Click on "hello " before the placeholder: cursor moves, no viewer.
         app.handle_prompt_click(2 + 1, 22);
         assert_eq!(app.prompt_input.text, text_before);
         assert_eq!(app.prompt_input.cursor, 1);
+        assert!(!app.paste_viewer.visible);
     }
 
     // ---- scroll_offset clamping (issue #223) ----

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -1107,7 +1107,9 @@ pub struct App {
     /// A single key event that was drained from the queue during paste-burst
     /// detection but wasn't part of the burst (e.g. a modifier key that stopped
     /// the burst). Replayed at the top of the next loop iteration.
-    pending_key: Option<crossterm::event::KeyEvent>,
+    /// Non-character key swallowed by the paste-burst drain, replayed at the
+    /// top of the next event-loop iteration (see `try_detect_paste_burst`).
+    pub pending_key: Option<crossterm::event::KeyEvent>,
     /// Receiver for model-list results fetched in the background when the
     /// /model picker opens.  Drained each frame so models appear as soon as
     /// the fetch completes.
@@ -5727,6 +5729,17 @@ impl App {
             && self.prompt_input.vim_mode == crate::prompt_input::VimMode::Insert
     }
 
+    /// Gate for paste-burst detection in the live CLI event loop: keystrokes
+    /// are currently flowing into the prompt (no modal is capturing input and
+    /// vim is in insert mode). Unlike `prompt_is_accepting_text`, streaming
+    /// does NOT disable it — the prompt stays editable during a turn for
+    /// queued composition, and a raw-key paste flood must be captured there
+    /// too instead of submitting on every pasted newline.
+    pub fn paste_burst_allowed(&self) -> bool {
+        !self.any_modal_open()
+            && self.prompt_input.vim_mode == crate::prompt_input::VimMode::Insert
+    }
+
     /// Drain any immediately-available key events from the crossterm event
     /// queue (zero-timeout poll) and return them alongside `first` as a single
     /// pasted string if the burst is large enough to be a paste.
@@ -5745,7 +5758,7 @@ impl App {
     /// single keystroke.  If a non-character key is encountered while
     /// draining, it is stored in `self.pending_key` and will be replayed at
     /// the top of the next event-loop iteration.
-    fn try_detect_paste_burst(
+    pub fn try_detect_paste_burst(
         &mut self,
         first: char,
     ) -> Option<String> {
@@ -5767,10 +5780,21 @@ impl App {
 
         while let Ok(true) = crossterm::event::poll(std::time::Duration::ZERO) {
             match crossterm::event::read() {
-                Ok(Event::Key(k)) if k.kind == KeyEventKind::Press => {
+                Ok(Event::Key(k)) => {
+                    // Windows emits Press+Release pairs for every keystroke,
+                    // so Release events are interleaved with the flood — skip
+                    // them instead of treating them as end-of-burst (which
+                    // capped every burst at a single character).
+                    if k.kind != KeyEventKind::Press {
+                        continue;
+                    }
                     match k.code {
                         KeyCode::Char(c) => buf.push(c),
                         KeyCode::Enter => buf.push('\n'),
+                        // Raw tabs are indentation in pasted code; ending the
+                        // burst on them would truncate the paste and replay
+                        // Tab as a completion keypress.
+                        KeyCode::Tab => buf.push('\t'),
                         _ => {
                             // Non-character key — save it for replay.
                             self.pending_key = Some(k);

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -5798,8 +5798,20 @@ impl App {
                         continue;
                     }
                     match k.code {
+                        // A raw LF (0x0A) in the flood arrives as Ctrl+J —
+                        // map it back to a newline or Unix pastes lose their
+                        // line breaks (they'd insert a literal 'j').
+                        KeyCode::Char('j')
+                            if k.modifiers.contains(crossterm::event::KeyModifiers::CONTROL) =>
+                        {
+                            buf.push('\n')
+                        }
                         KeyCode::Char(c) => buf.push(c),
-                        KeyCode::Enter => buf.push('\n'),
+                        // A raw CR (0x0D) arrives as Enter. Push '\r', not
+                        // '\n': normalize_newlines() collapses CRLF pairs and
+                        // lone CRs later, so CRLF pastes (Windows) don't end
+                        // up with doubled line breaks.
+                        KeyCode::Enter => buf.push('\r'),
                         // Raw tabs are indentation in pasted code; ending the
                         // burst on them would truncate the paste and replay
                         // Tab as a completion keypress.

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -5677,7 +5677,7 @@ impl App {
     ///
     /// Otherwise the text goes through the normal `prompt_input.paste()` path
     /// which applies the multi-line summary placeholder for large pastes.
-    fn handle_paste_data(&mut self, data: String) {
+    pub fn handle_paste_data(&mut self, data: String) {
         use crate::prompt_input::detect_pasted_path;
         use crate::image_paste::PastedImage;
 

--- a/src-rust/crates/tui/src/lib.rs
+++ b/src-rust/crates/tui/src/lib.rs
@@ -101,6 +101,8 @@ pub mod theme_screen;
 pub mod theme_colors;
 /// Diff viewer dialog (two-pane: file list + unified diff detail).
 pub mod diff_viewer;
+/// Read-only viewer for [Pasted text #N ...] placeholders.
+pub mod paste_viewer;
 /// Virtual scrollable list for efficient message rendering.
 pub mod virtual_list;
 /// Message type renderers (assistant, user, tool use, etc.).

--- a/src-rust/crates/tui/src/paste_viewer.rs
+++ b/src-rust/crates/tui/src/paste_viewer.rs
@@ -1,0 +1,220 @@
+//! Read-only viewer for `[Pasted text #N ...]` placeholders.
+//!
+//! Clicking a placeholder in the prompt opens this scrollable modal so the
+//! full pasted body can be read without splicing hundreds of lines into the
+//! prompt buffer. Alt+E (from the prompt or from inside the viewer) still
+//! performs the in-place expansion for editing.
+
+use std::cell::Cell;
+
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::Style,
+    text::{Line, Span},
+    widgets::{Paragraph, Widget},
+};
+use unicode_width::UnicodeWidthChar;
+
+use crate::overlays::{
+    begin_modal_buf, render_modal_title_buf, CLAURST_MUTED, CLAURST_TEXT,
+};
+
+/// Rows scrolled per PageUp/PageDown press.
+const PAGE_ROWS: usize = 10;
+
+/// Modal state for viewing a stored paste body without expanding it into the
+/// prompt buffer.
+#[derive(Debug, Clone, Default)]
+pub struct PasteViewer {
+    pub visible: bool,
+    /// ID of the `[Pasted text #N ...]` placeholder being viewed.
+    pub paste_id: u32,
+    /// The paste body split into logical lines (tabs pre-expanded).
+    lines: Vec<String>,
+    /// Scroll offset in wrapped visual rows.
+    pub scroll: usize,
+    /// Max meaningful scroll measured by the last render (wrapped rows minus
+    /// viewport rows). Scrolling is clamped to it, mirroring the transcript's
+    /// `last_max_scroll` pattern.
+    last_max_scroll: Cell<usize>,
+}
+
+impl PasteViewer {
+    pub fn open(&mut self, paste_id: u32, body: &str) {
+        self.paste_id = paste_id;
+        // Tabs render with unpredictable widths in a terminal cell grid;
+        // expand them so wrapping arithmetic stays exact.
+        self.lines = body
+            .lines()
+            .map(|l| l.replace('\t', "    "))
+            .collect();
+        if self.lines.is_empty() {
+            self.lines.push(String::new());
+        }
+        self.scroll = 0;
+        self.last_max_scroll.set(0);
+        self.visible = true;
+    }
+
+    pub fn close(&mut self) {
+        self.visible = false;
+        self.lines.clear();
+        self.scroll = 0;
+    }
+
+    /// Number of logical (unwrapped) lines in the paste body.
+    pub fn line_count(&self) -> usize {
+        self.lines.len()
+    }
+
+    pub fn scroll_up(&mut self, rows: usize) {
+        self.scroll = self.scroll.saturating_sub(rows);
+    }
+
+    pub fn scroll_down(&mut self, rows: usize) {
+        self.scroll = (self.scroll + rows).min(self.last_max_scroll.get());
+    }
+
+    pub fn page_up(&mut self) {
+        self.scroll_up(PAGE_ROWS);
+    }
+
+    pub fn page_down(&mut self) {
+        self.scroll_down(PAGE_ROWS);
+    }
+
+    pub fn scroll_to_top(&mut self) {
+        self.scroll = 0;
+    }
+
+    pub fn scroll_to_bottom(&mut self) {
+        self.scroll = self.last_max_scroll.get();
+    }
+
+    /// Hard-wrap every logical line to `width` columns (unicode-width aware)
+    /// so scroll units map 1:1 onto rendered rows.
+    fn wrapped_rows(&self, width: usize) -> Vec<String> {
+        let mut rows = Vec::with_capacity(self.lines.len());
+        for line in &self.lines {
+            let mut row = String::new();
+            let mut used = 0usize;
+            for c in line.chars() {
+                let w = c.width().unwrap_or(0);
+                if used + w > width && !row.is_empty() {
+                    rows.push(std::mem::take(&mut row));
+                    used = 0;
+                }
+                row.push(c);
+                used += w;
+            }
+            rows.push(row);
+        }
+        rows
+    }
+}
+
+/// Render the paste viewer modal into `buf`, clamping the scroll offset to
+/// the measured content height as a side effect.
+pub fn render_paste_viewer_buf(viewer: &PasteViewer, area: Rect, buf: &mut Buffer) {
+    let width = area.width.saturating_sub(6).min(100).max(20);
+    let height = area.height.saturating_sub(4).min(40).max(8);
+    let layout = begin_modal_buf(buf, area, width, height, 2, 1);
+
+    render_modal_title_buf(
+        buf,
+        layout.header_area,
+        &format!("Pasted text #{}", viewer.paste_id),
+        &format!("{} lines", viewer.line_count()),
+    );
+
+    let body = layout.body_area;
+    if body.width == 0 || body.height == 0 {
+        return;
+    }
+    let text_width = body.width.saturating_sub(2) as usize;
+    if text_width == 0 {
+        return;
+    }
+    let rows = viewer.wrapped_rows(text_width);
+    let max_scroll = rows.len().saturating_sub(body.height as usize);
+    viewer.last_max_scroll.set(max_scroll);
+    let scroll = viewer.scroll.min(max_scroll);
+
+    for (i, row) in rows
+        .iter()
+        .skip(scroll)
+        .take(body.height as usize)
+        .enumerate()
+    {
+        let line = Line::from(Span::styled(
+            row.clone(),
+            Style::default().fg(CLAURST_TEXT),
+        ));
+        Paragraph::new(line).render(
+            Rect {
+                x: body.x + 1,
+                y: body.y + i as u16,
+                width: body.width.saturating_sub(2),
+                height: 1,
+            },
+            buf,
+        );
+    }
+
+    let footer = Line::from(Span::styled(
+        " ↑/↓ scroll · PgUp/PgDn page · g/G top/bottom · Alt+E insert into prompt · Esc close",
+        Style::default().fg(CLAURST_MUTED),
+    ));
+    Paragraph::new(footer).render(layout.footer_area, buf);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_splits_lines_and_resets_scroll() {
+        let mut v = PasteViewer::default();
+        v.scroll = 7;
+        v.open(3, "a\nb\tc\nd");
+        assert!(v.visible);
+        assert_eq!(v.paste_id, 3);
+        assert_eq!(v.line_count(), 3);
+        assert_eq!(v.scroll, 0);
+        // Tab expanded so wrap math stays width-exact.
+        assert_eq!(v.lines[1], "b    c");
+    }
+
+    #[test]
+    fn scroll_clamps_to_last_render_measurement() {
+        let mut v = PasteViewer::default();
+        v.open(1, "x\ny\nz");
+        v.last_max_scroll.set(5);
+        v.scroll_down(100);
+        assert_eq!(v.scroll, 5);
+        v.scroll_up(2);
+        assert_eq!(v.scroll, 3);
+        v.scroll_to_bottom();
+        assert_eq!(v.scroll, 5);
+        v.scroll_to_top();
+        assert_eq!(v.scroll, 0);
+    }
+
+    #[test]
+    fn wrapped_rows_hard_wraps_wide_lines() {
+        let mut v = PasteViewer::default();
+        v.open(1, "abcdefghij\nshort");
+        let rows = v.wrapped_rows(4);
+        assert_eq!(rows, vec!["abcd", "efgh", "ij", "shor", "t"]);
+    }
+
+    #[test]
+    fn close_drops_body() {
+        let mut v = PasteViewer::default();
+        v.open(1, "big body");
+        v.close();
+        assert!(!v.visible);
+        assert_eq!(v.line_count(), 0);
+    }
+}

--- a/src-rust/crates/tui/src/paste_viewer.rs
+++ b/src-rust/crates/tui/src/paste_viewer.rs
@@ -117,8 +117,8 @@ impl PasteViewer {
 /// Render the paste viewer modal into `buf`, clamping the scroll offset to
 /// the measured content height as a side effect.
 pub fn render_paste_viewer_buf(viewer: &PasteViewer, area: Rect, buf: &mut Buffer) {
-    let width = area.width.saturating_sub(6).min(100).max(20);
-    let height = area.height.saturating_sub(4).min(40).max(8);
+    let width = area.width.saturating_sub(6).clamp(20, 100);
+    let height = area.height.saturating_sub(4).clamp(8, 40);
     let layout = begin_modal_buf(buf, area, width, height, 2, 1);
 
     render_modal_title_buf(
@@ -175,8 +175,10 @@ mod tests {
 
     #[test]
     fn open_splits_lines_and_resets_scroll() {
-        let mut v = PasteViewer::default();
-        v.scroll = 7;
+        let mut v = PasteViewer {
+            scroll: 7,
+            ..Default::default()
+        };
         v.open(3, "a\nb\tc\nd");
         assert!(v.visible);
         assert_eq!(v.paste_id, 3);

--- a/src-rust/crates/tui/src/prompt_input.rs
+++ b/src-rust/crates/tui/src/prompt_input.rs
@@ -2676,6 +2676,26 @@ impl PromptInputState {
         false
     }
 
+    /// The paste placeholder covering byte offset `offset` (same hit rules as
+    /// `expand_paste_ref_at`) together with its stored body, without mutating
+    /// the buffer — used by the read-only paste viewer.
+    pub fn paste_ref_at(&self, offset: usize) -> Option<(u32, String)> {
+        let refs = claurst_core::prompt_history::parse_references_with_positions(&self.text);
+        for (id, matched, start) in refs {
+            if !matched.starts_with("[Pasted text #") {
+                continue;
+            }
+            let end = start + matched.len();
+            if offset < start || offset > end {
+                continue;
+            }
+            if let Some(body) = self.paste_contents.get(&id) {
+                return Some((id, body.clone()));
+            }
+        }
+        None
+    }
+
     /// Expand the paste placeholder at the cursor; falls back to the first
     /// expandable placeholder in the buffer so the keybinding works without
     /// first navigating onto the reference.

--- a/src-rust/crates/tui/src/render.rs
+++ b/src-rust/crates/tui/src/render.rs
@@ -691,6 +691,10 @@ pub fn render_app(frame: &mut Frame, app: &App) {
         render_diff_dialog(&mut state, size, frame.buffer_mut());
     }
 
+    if app.paste_viewer.visible {
+        crate::paste_viewer::render_paste_viewer_buf(&app.paste_viewer, size, frame.buffer_mut());
+    }
+
     if app.global_search.visible {
         render_global_search(&app.global_search, size, frame.buffer_mut());
     }
@@ -2150,7 +2154,7 @@ fn render_input(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
             // A [Pasted text #N ...] placeholder is in the buffer — tell the
             // user how to view the full pasted body before submitting.
             Line::from(vec![
-                Span::styled("alt+e/click to expand paste", Style::default().fg(dim)),
+                Span::styled("click to view paste · alt+e expands", Style::default().fg(dim)),
             ])
         } else {
             Line::from(Vec::<Span>::new())


### PR DESCRIPTION
## Problem

Large pastes kept arriving truncated or empty at the model (reported again in #314: *"pasted text is not expanded and it is seen as empty"*), even after the earlier placeholder-expansion fix (45a775c).

**Root cause:** every paste fix so far went into `App::run` in `tui/app.rs` — an event loop **nothing calls**. The real binary runs `run_interactive` in `cli/main.rs`, which has its own loop that:

1. had **no paste-burst detection** — on terminals without bracketed paste (Windows Ctrl+V, some tmux setups) the clipboard floods in as raw key events, every pasted newline acts as Enter, and a truncated first line gets submitted while the rest sprays into follow-up messages;
2. **silently dropped `Event::Paste` during streaming**, even though the prompt stays editable to compose queued follow-ups;
3. bypassed `handle_paste_data`, skipping file-path/image paste detection.

## Fix

- Run the burst drain in the live loop *before* Enter/submit handling; replay the drain's leftover key as a synthetic event.
- Repair the drain itself: skip Windows Press/Release Release events (they previously capped every burst at one char), map Ctrl+J (raw LF) back to a newline, push Enter as `\r` so `normalize_newlines` collapses CRLF pairs, and keep literal tabs.
- Deliver bracketed pastes while streaming, routed through the shared `handle_paste_data` path.
- **Click a `[Pasted text #N +X lines]` placeholder to read it**: opens a read-only scrollable modal (wheel/arrows/PgUp/PgDn/g/G, Esc closes) instead of destructively splicing hundreds of lines into a 3-row prompt. Alt+E — from the prompt or inside the viewer — still expands in place for editing.

## Verification

- `cargo test -p claurst-tui`: 657 passed (new viewer/click tests included; click-to-expand tests updated to click-to-view).
- Manual, against the built binary in tmux: raw 4-line key flood → one placeholder, zero premature submits, line breaks intact; bracketed paste → placeholder; click → viewer shows full body; Esc keeps placeholder; Alt+E expands in place.
- Submit-time expansion (placeholder → real body) covered by existing `take()` unit tests.

Fixes the paste-truncation half of #314 (the cache-counter half is addressed separately).