### PR TITLE
feat: support local model metadata overrides (context window, etc.)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,6 +41,7 @@ values. Keys absent from the project file fall back to the global value.
   "provider": "anthropic",
   "config": { ... },
   "providers": { ... },
+  "modelOverrides": { ... },
   "projects": { ... },
   "commands": { ... },
   "formatter": { ... },
@@ -54,7 +55,9 @@ values. Keys absent from the project file fall back to the global value.
 ```
 
 Most day-to-day options live inside the `config` object. Provider credentials
-live in the `providers` map.
+live in the `providers` map. Corrected model metadata for self-hosted or
+unknown models lives in the `modelOverrides` map — see
+[Model metadata overrides](providers.md#overriding-model-metadata).
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -629,6 +629,16 @@ matches. They are defined in the `formatter` map:
     }
   },
 
+  // Correct metadata for self-hosted / unknown models (keyed by provider/model).
+  // Overrides win over the models.dev catalog.
+  "modelOverrides": {
+    "custom-openai/my-local-llm": {
+      "contextWindow": 32768,
+      "maxOutputTokens": 4096,
+      "name": "My Local LLM"
+    }
+  },
+
   // Custom slash commands
   "commands": {
     "test": {

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -711,3 +711,51 @@ The above example allows only `gpt-4o` (whitelist minus blacklist).
 Claurst ships a bundled snapshot of models for Anthropic, OpenAI, and Google. At runtime it optionally refreshes from the public `https://models.dev/api.json` API (cached to `~/.claurst/models_cache.json`, refreshed at most every 5 minutes). Network failures are swallowed silently; the bundled snapshot is always sufficient for normal operation.
 
 When no model is explicitly set, Claurst scores available models by priority patterns to pick the best default. Well-known model prefixes (`claude-*`, `gpt-*`, `gemini-*`, etc.) are always routed to their canonical provider regardless of gateway entries in the remote cache.
+
+### Overriding model metadata
+
+Self-hosted endpoints (the `custom-openai` / Ollama / LM Studio / llama.cpp
+providers) and model aliases that models.dev does not know can end up with the
+wrong context window or max-output size — either because the alias is matched to
+an unrelated catalog entry, or because there is no catalog entry at all. The
+`modelOverrides` map lets you supply or correct that metadata. **User overrides
+take precedence over the models.dev catalog and over the built-in defaults.**
+
+Add it at the top level of `~/.claurst/settings.json` (or inside the `config`
+object), keyed by the fully-qualified `"provider/model"` id:
+
+```json
+{
+  "modelOverrides": {
+    "custom-openai/my-local-llm": {
+      "contextWindow": 32768,
+      "maxOutputTokens": 4096,
+      "name": "My Local LLM",
+      "releaseDate": "2026-01-01",
+      "status": "beta"
+    },
+    "ollama/qwen3-coder-30b": {
+      "contextWindow": 262144
+    }
+  }
+}
+```
+
+**Fields** (all optional — an unset field keeps the catalog value):
+
+| Field | Type | Description |
+|---|---|---|
+| `contextWindow` | integer | Total context window size in tokens |
+| `maxOutputTokens` | integer | Maximum tokens the model can emit in one response |
+| `name` | string | Human-readable display name shown in the model picker |
+| `releaseDate` | string | ISO 8601 date; drives newest-first ordering in the picker |
+| `status` | string | Lifecycle status (`active`, `beta`, `alpha`, `deprecated`) |
+
+Field names accept both camelCase (`contextWindow`) and snake_case
+(`context_window`). The key **must** contain a `/` — a bare model id is ignored,
+because the registry is keyed by `provider/model`.
+
+When the keyed model exists in the catalog, the override patches it in place.
+When it does not (a self-hosted alias), Claurst materialises a synthetic entry
+so the corrected values flow everywhere the metadata is read: the `/model`
+picker, the token-usage warnings, and the auto-compact thresholds.

--- a/src-rust/crates/api/src/model_registry.rs
+++ b/src-rust/crates/api/src/model_registry.rs
@@ -772,6 +772,10 @@ pub struct ModelRegistry {
     cache_path: Option<PathBuf>,
     /// Minimum age before a network refresh is attempted again (mtime-based).
     refresh_interval: Duration,
+    /// User-supplied metadata overrides, keyed by `"provider/model"`. Re-applied
+    /// after every catalog merge so they stay authoritative across cache reloads
+    /// and network refreshes (issue #309).
+    overrides: HashMap<String, claurst_core::config::ModelOverride>,
 }
 
 impl ModelRegistry {
@@ -782,6 +786,7 @@ impl ModelRegistry {
             providers: HashMap::new(),
             cache_path: None,
             refresh_interval: Duration::from_secs(5 * 60),
+            overrides: HashMap::new(),
         };
         registry.load_bundled_snapshot();
         registry
@@ -1110,6 +1115,8 @@ impl ModelRegistry {
                 if let Some(parsed) = parse_snapshot_str(&text) {
                     self.merge_entries(parsed.models);
                     self.providers.extend(parsed.providers);
+                    // Re-assert user overrides over the freshly fetched catalog.
+                    self.reapply_overrides();
                     if let Some(ref path) = self.cache_path.clone() {
                         // Write the raw response so future loads can re-parse
                         // it identically.  Best-effort; ignore I/O errors.
@@ -1154,6 +1161,8 @@ impl ModelRegistry {
             if !parsed.models.is_empty() {
                 self.merge_entries(parsed.models);
                 self.providers.extend(parsed.providers);
+                // Re-assert user overrides over the freshly merged catalog.
+                self.reapply_overrides();
                 return;
             }
         }
@@ -1161,6 +1170,7 @@ impl ModelRegistry {
         // Legacy: our own serialized HashMap<String, ModelEntry> format.
         if let Ok(entries) = serde_json::from_str::<HashMap<String, ModelEntry>>(&data) {
             self.merge_entries(entries);
+            self.reapply_overrides();
         }
     }
 
@@ -1193,6 +1203,144 @@ impl ModelRegistry {
             }
             self.entries.insert(key, entry);
         }
+    }
+
+    /// Register user-supplied [`ModelOverride`]s and layer them onto the catalog.
+    ///
+    /// Precedence is **user override > models.dev > built-in defaults**: each
+    /// `Some` field replaces the catalog value for the keyed `"provider/model"`,
+    /// leaving unset fields untouched. A key with no catalog entry — a
+    /// self-hosted alias, or an id models.dev does not know — is materialised
+    /// into a synthetic entry so context-window-dependent logic (the model
+    /// picker, token warnings, auto-compact thresholds) sizes it from the
+    /// override instead of mismatching it to an unrelated catalog model.
+    ///
+    /// The overrides are retained and automatically re-applied after every
+    /// later cache reload ([`Self::load_cache`]) and network refresh
+    /// ([`Self::refresh_from_models_dev`]) so a fresh catalog merge can never
+    /// silently clobber them.
+    ///
+    /// Keys without a `'/'` separator are skipped: the registry is keyed by
+    /// `"provider/model"` and a bare id cannot be placed unambiguously.
+    ///
+    /// [`ModelOverride`]: claurst_core::config::ModelOverride
+    pub fn apply_model_overrides(
+        &mut self,
+        overrides: &HashMap<String, claurst_core::config::ModelOverride>,
+    ) {
+        for (key, ov) in overrides {
+            self.overrides.insert(key.clone(), ov.clone());
+        }
+        apply_overrides_to_entries(&mut self.entries, &self.overrides);
+    }
+
+    /// Re-apply the retained overrides after a catalog merge, so a cache reload
+    /// or refresh never wipes out user-corrected metadata. No-op when no
+    /// overrides are registered.
+    fn reapply_overrides(&mut self) {
+        if self.overrides.is_empty() {
+            return;
+        }
+        apply_overrides_to_entries(&mut self.entries, &self.overrides);
+    }
+}
+
+/// Layer `overrides` onto `entries`: patch existing catalog rows in place and
+/// synthesize a minimal entry for any `"provider/model"` key the catalog lacks.
+/// Malformed keys (no `'/'`, or an empty half) and empty overrides are skipped.
+fn apply_overrides_to_entries(
+    entries: &mut HashMap<String, ModelEntry>,
+    overrides: &HashMap<String, claurst_core::config::ModelOverride>,
+) {
+    for (key, ov) in overrides {
+        if ov.is_empty() {
+            continue;
+        }
+        let Some((provider, model)) = key.split_once('/') else {
+            tracing::warn!(key = %key, "model override key must be \"provider/model\"; skipping");
+            continue;
+        };
+        if provider.is_empty() || model.is_empty() {
+            tracing::warn!(key = %key, "model override key must be \"provider/model\"; skipping");
+            continue;
+        }
+
+        let registry_key = format!("{}/{}", provider, model);
+        match entries.get_mut(&registry_key) {
+            Some(entry) => {
+                // Patch: each Some field wins over the catalog value.
+                if let Some(cw) = ov.context_window {
+                    entry.info.context_window = cw;
+                }
+                if let Some(mo) = ov.max_output_tokens {
+                    entry.info.max_output_tokens = mo;
+                }
+                if let Some(name) = &ov.name {
+                    entry.info.name = name.clone();
+                }
+                if let Some(rd) = &ov.release_date {
+                    entry.release_date = Some(rd.clone());
+                    entry.info.release_date = Some(rd.clone());
+                }
+                if let Some(st) = &ov.status {
+                    entry.status = model_status_from_str(st);
+                    entry.info.status = Some(st.clone());
+                }
+            }
+            None => {
+                // Materialise a synthetic entry for an id the catalog lacks.
+                let entry = ModelEntry {
+                    info: ModelInfo {
+                        id: ModelId::new(model),
+                        provider_id: ProviderId::new(provider),
+                        name: ov.name.clone().unwrap_or_else(|| model.to_string()),
+                        context_window: ov.context_window.unwrap_or(0),
+                        max_output_tokens: ov.max_output_tokens.unwrap_or(0),
+                        release_date: ov.release_date.clone(),
+                        status: ov.status.clone(),
+                    },
+                    family: None,
+                    status: ov
+                        .status
+                        .as_deref()
+                        .map(model_status_from_str)
+                        .unwrap_or_default(),
+                    release_date: ov.release_date.clone(),
+                    last_updated: None,
+                    knowledge: None,
+                    open_weights: false,
+                    tool_calling: true,
+                    reasoning: false,
+                    structured_output: false,
+                    temperature: true,
+                    attachment: false,
+                    interleaved: None,
+                    modalities_input: vec![Modality::Text],
+                    modalities_output: vec![Modality::Text],
+                    cost_input: None,
+                    cost_output: None,
+                    cost_cache_read: None,
+                    cost_cache_write: None,
+                    cost: CostBreakdown::default(),
+                    provider_override: None,
+                    experimental_modes: HashMap::new(),
+                    options: HashMap::new(),
+                    headers: HashMap::new(),
+                };
+                entries.insert(registry_key, entry);
+            }
+        }
+    }
+}
+
+/// Parse a models.dev lifecycle status string into [`ModelStatus`], defaulting
+/// to `Active` for anything unrecognised.
+fn model_status_from_str(s: &str) -> ModelStatus {
+    match s.to_ascii_lowercase().as_str() {
+        "beta" => ModelStatus::Beta,
+        "alpha" => ModelStatus::Alpha,
+        "deprecated" => ModelStatus::Deprecated,
+        _ => ModelStatus::Active,
     }
 }
 
@@ -1851,5 +1999,116 @@ mod tests {
                 );
             }
         }
+    }
+
+    // ---- model overrides (issue #309) --------------------------------------
+
+    use claurst_core::config::ModelOverride;
+
+    fn overrides(pairs: Vec<(&str, ModelOverride)>) -> HashMap<String, ModelOverride> {
+        pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect()
+    }
+
+    #[test]
+    fn override_patches_existing_catalog_entry() {
+        let mut reg = ModelRegistry::new();
+        // Pick a real catalog model and prove the override wins over models.dev.
+        let model = reg
+            .list_by_provider("anthropic")
+            .iter()
+            .find(|m| (*m.info.id).contains("opus"))
+            .map(|m| m.info.id.to_string())
+            .expect("anthropic must have an opus model in the bundled snapshot");
+        let key = format!("anthropic/{model}");
+
+        let original = reg.get("anthropic", &model).unwrap();
+        assert_ne!(original.info.context_window, 12_345, "test value must differ");
+
+        reg.apply_model_overrides(&overrides(vec![(
+            key.as_str(),
+            ModelOverride {
+                context_window: Some(12_345),
+                max_output_tokens: Some(6_789),
+                name: Some("My Patched Opus".to_string()),
+                ..Default::default()
+            },
+        )]));
+
+        let patched = reg.get("anthropic", &model).unwrap();
+        assert_eq!(patched.info.context_window, 12_345);
+        assert_eq!(patched.info.max_output_tokens, 6_789);
+        assert_eq!(patched.info.name, "My Patched Opus");
+    }
+
+    #[test]
+    fn override_partial_leaves_other_fields_intact() {
+        let mut reg = ModelRegistry::new();
+        let model = reg
+            .list_by_provider("anthropic")
+            .iter()
+            .find(|m| (*m.info.id).contains("opus"))
+            .map(|m| m.info.id.to_string())
+            .expect("anthropic opus model present");
+        let original_max = reg.get("anthropic", &model).unwrap().info.max_output_tokens;
+        let original_name = reg.get("anthropic", &model).unwrap().info.name.clone();
+
+        // Only context_window is set; max_output_tokens and name must survive.
+        reg.apply_model_overrides(&overrides(vec![(
+            format!("anthropic/{model}").as_str(),
+            ModelOverride { context_window: Some(500_000), ..Default::default() },
+        )]));
+
+        let patched = reg.get("anthropic", &model).unwrap();
+        assert_eq!(patched.info.context_window, 500_000);
+        assert_eq!(patched.info.max_output_tokens, original_max);
+        assert_eq!(patched.info.name, original_name);
+    }
+
+    #[test]
+    fn override_synthesizes_entry_for_unknown_alias() {
+        let mut reg = ModelRegistry::new();
+        // A self-hosted alias models.dev never heard of.
+        assert!(reg.get("custom-openai", "my-local-llm").is_none());
+
+        reg.apply_model_overrides(&overrides(vec![(
+            "custom-openai/my-local-llm",
+            ModelOverride {
+                context_window: Some(32_768),
+                max_output_tokens: Some(4_096),
+                name: Some("My Local LLM".to_string()),
+                status: Some("beta".to_string()),
+                ..Default::default()
+            },
+        )]));
+
+        let entry = reg
+            .get("custom-openai", "my-local-llm")
+            .expect("synthetic entry must be inserted for an unknown alias");
+        assert_eq!(entry.info.context_window, 32_768);
+        assert_eq!(entry.info.max_output_tokens, 4_096);
+        assert_eq!(entry.info.name, "My Local LLM");
+        assert_eq!(entry.status, ModelStatus::Beta);
+        // And it surfaces in the provider listing the picker reads.
+        assert!(reg
+            .list_by_provider("custom-openai")
+            .iter()
+            .any(|m| &*m.info.id == "my-local-llm"));
+    }
+
+    #[test]
+    fn override_empty_or_malformed_keys_are_ignored() {
+        let mut reg = ModelRegistry::new();
+        let before = reg.len();
+        reg.apply_model_overrides(&overrides(vec![
+            // Empty override — nothing to apply.
+            ("custom-openai/noop", ModelOverride::default()),
+            // No provider/model separator — cannot be placed.
+            ("bare-id", ModelOverride { context_window: Some(1_000), ..Default::default() }),
+            // Empty provider / model halves.
+            ("/model", ModelOverride { context_window: Some(1_000), ..Default::default() }),
+            ("provider/", ModelOverride { context_window: Some(1_000), ..Default::default() }),
+        ]));
+        assert_eq!(reg.len(), before, "malformed/empty overrides must not add entries");
+        assert!(reg.get("custom-openai", "noop").is_none());
     }
 }

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -809,7 +809,7 @@ async fn main() -> anyhow::Result<()> {
     // Build model registry for dynamic model/provider resolution.
     // The registry is pre-populated with a hardcoded snapshot and enriched
     // from the models.dev cache if available.
-    let model_registry = load_cached_model_registry();
+    let model_registry = load_cached_model_registry(&config);
 
     // Build query config
     let mut query_config = claurst_query::QueryConfig::from_config_with_registry(&config, &model_registry);
@@ -1154,7 +1154,7 @@ async fn run_models_command(args: &[String]) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn load_cached_model_registry() -> Arc<claurst_api::ModelRegistry> {
+fn load_cached_model_registry(config: &Config) -> Arc<claurst_api::ModelRegistry> {
     let mut reg = claurst_api::ModelRegistry::new();
     // CLAURST_MODELS_PATH wins outright — useful for offline dev where you
     // pin a known-good api.json on disk.
@@ -1168,6 +1168,9 @@ fn load_cached_model_registry() -> Arc<claurst_api::ModelRegistry> {
             reg.load_cache(&models_dev_cache_path());
         }
     }
+    // Layer user metadata overrides on top of the catalog (issue #309). Stored
+    // in the registry, so any later cache reload re-asserts them automatically.
+    reg.apply_model_overrides(&config.model_overrides);
     Arc::new(reg)
 }
 
@@ -1340,7 +1343,7 @@ async fn refresh_provider_runtime_state(
     );
     let provider_registry =
         Arc::new(claurst_api::ProviderRegistry::from_config(&config, client_config));
-    let model_registry = load_cached_model_registry();
+    let model_registry = load_cached_model_registry(&config);
 
     spawn_models_cache_refresh();
 
@@ -1385,7 +1388,7 @@ async fn reload_provider_runtime_state(
     );
     let provider_registry =
         Arc::new(claurst_api::ProviderRegistry::from_config(&config, client_config));
-    let model_registry = load_cached_model_registry();
+    let model_registry = load_cached_model_registry(&config);
 
     Ok(RefreshedProviderRuntime {
         config,
@@ -3685,10 +3688,29 @@ async fn run_interactive(
                 let pid = claurst_core::ProviderId::new(&provider_id_str);
                 if let Some(provider) = registry.get(&pid) {
                     let provider = provider.clone();
+                    // Layer user metadata overrides (issue #309) onto the
+                    // live-discovered list too, so self-hosted / openai-compatible
+                    // endpoints show the corrected context window in the picker.
+                    let overrides = app.config.model_overrides.clone();
+                    let provider_key = provider_id_str.clone();
                     let (tx, rx) = tokio::sync::mpsc::channel(1);
                     app.model_fetch_rx = Some(rx);
                     app.model_picker.loading_models = true;
                     tokio::spawn(async move {
+                        // Effective context window for a discovered model:
+                        // the user override wins, else the discovered value.
+                        let ctx_for = |id: &str, discovered: u32| -> u32 {
+                            overrides
+                                .get(&format!("{}/{}", provider_key, id))
+                                .and_then(|o| o.context_window)
+                                .unwrap_or(discovered)
+                        };
+                        let name_for = |id: &str, discovered: &str| -> String {
+                            overrides
+                                .get(&format!("{}/{}", provider_key, id))
+                                .and_then(|o| o.name.clone())
+                                .unwrap_or_else(|| discovered.to_string())
+                        };
                         match provider.discover_models().await {
                             Ok(models) => {
                                 let entries: Vec<claurst_tui::model_picker::ModelEntry> =
@@ -3707,10 +3729,10 @@ async fn run_interactive(
                                                 by_id.get(&id).cloned().unwrap_or_else(|| {
                                                     claurst_tui::model_picker::ModelEntry {
                                                         id: id.clone(),
-                                                        display_name: m.name.clone(),
+                                                        display_name: name_for(&id, &m.name),
                                                         description:
                                                             claurst_tui::model_picker::format_context_window(
-                                                                m.context_window,
+                                                                ctx_for(&id, m.context_window),
                                                             ),
                                                         is_current: false,
                                                     }
@@ -3720,14 +3742,17 @@ async fn run_interactive(
                                     } else {
                                         models
                                             .into_iter()
-                                            .map(|m| claurst_tui::model_picker::ModelEntry {
-                                                id: m.id.to_string(),
-                                                display_name: m.name.clone(),
-                                                description:
-                                                    claurst_tui::model_picker::format_context_window(
-                                                        m.context_window,
-                                                    ),
-                                                is_current: false,
+                                            .map(|m| {
+                                                let id = m.id.to_string();
+                                                claurst_tui::model_picker::ModelEntry {
+                                                    display_name: name_for(&id, &m.name),
+                                                    description:
+                                                        claurst_tui::model_picker::format_context_window(
+                                                            ctx_for(&id, m.context_window),
+                                                        ),
+                                                    id,
+                                                    is_current: false,
+                                                }
                                             })
                                             .collect()
                                     };

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -1030,6 +1030,13 @@ async fn run_models_command(args: &[String]) -> anyhow::Result<()> {
         registry.load_cache(&models_cache_path());
     }
 
+    // Layer user metadata overrides on top of the catalog (issue #309) so the
+    // listing matches what the TUI picker and context logic use.
+    let overrides = claurst_core::config::Settings::load_sync()
+        .map(|s| s.effective_config().model_overrides)
+        .unwrap_or_default();
+    registry.apply_model_overrides(&overrides);
+
     let mut entries: Vec<&claurst_api::ModelEntry> = match &provider_filter {
         Some(pid) => registry.list_by_provider(pid),
         None => registry.list_all(),

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -2120,6 +2120,54 @@ pub mod config {
         }
 
         #[test]
+        fn effective_config_merges_top_level_model_overrides() {
+            let mut settings = Settings::default();
+            // Nested `config` block wins for a key present in both.
+            settings.config.model_overrides.insert(
+                "custom-openai/a".to_string(),
+                ModelOverride { context_window: Some(111), ..Default::default() },
+            );
+            settings.model_overrides.insert(
+                "custom-openai/a".to_string(),
+                ModelOverride { context_window: Some(999), ..Default::default() },
+            );
+            // Top-level-only key is folded in.
+            settings.model_overrides.insert(
+                "custom-openai/b".to_string(),
+                ModelOverride { context_window: Some(222), ..Default::default() },
+            );
+            let config = settings.effective_config();
+            assert_eq!(config.model_overrides["custom-openai/a"].context_window, Some(111));
+            assert_eq!(config.model_overrides["custom-openai/b"].context_window, Some(222));
+        }
+
+        #[test]
+        fn model_override_accepts_camel_and_snake_case() {
+            // Top-level camelCase key `modelOverrides`, camelCase fields.
+            let camel = r#"{
+                "modelOverrides": {
+                    "custom-openai/x": { "contextWindow": 32768, "maxOutputTokens": 4096, "name": "X" }
+                }
+            }"#;
+            let s: Settings = serde_json::from_str(camel).unwrap();
+            let ov = &s.model_overrides["custom-openai/x"];
+            assert_eq!(ov.context_window, Some(32768));
+            assert_eq!(ov.max_output_tokens, Some(4096));
+            assert_eq!(ov.name.as_deref(), Some("X"));
+
+            // snake_case top-level alias `model_overrides` and snake_case fields.
+            let snake = r#"{
+                "model_overrides": {
+                    "ollama/y": { "context_window": 262144, "status": "beta" }
+                }
+            }"#;
+            let s: Settings = serde_json::from_str(snake).unwrap();
+            let ov = &s.model_overrides["ollama/y"];
+            assert_eq!(ov.context_window, Some(262144));
+            assert_eq!(ov.status.as_deref(), Some("beta"));
+        }
+
+        #[test]
         fn zero_is_treated_as_unset() {
             let config = Config { request_timeout_secs: Some(0), ..Default::default() };
             assert_eq!(

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -941,6 +941,67 @@ pub mod config {
         }
     }
 
+    // ---- ModelOverride ---------------------------------------------------
+
+    /// User-supplied metadata override for a single model, keyed by the
+    /// `"provider/model"` string in [`Config::model_overrides`].
+    ///
+    /// Every field is optional: a `Some` value takes precedence over the
+    /// models.dev catalog entry (and over any built-in default), while a `None`
+    /// leaves the catalog value untouched. When the keyed model is absent from
+    /// the catalog entirely (a self-hosted alias, or an id models.dev does not
+    /// know), the override is materialised into a synthetic registry entry so
+    /// the model picker, token warnings, and auto-compact thresholds size it
+    /// correctly instead of mismatching it to an unrelated catalog model.
+    ///
+    /// Field names accept both camelCase (`contextWindow`) and snake_case
+    /// (`context_window`) so the override reads naturally whether it lives at the
+    /// top level of `settings.json` or under the nested `config` block.
+    #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+    pub struct ModelOverride {
+        /// Total context window size in tokens.
+        #[serde(
+            default,
+            rename = "contextWindow",
+            alias = "context_window",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub context_window: Option<u32>,
+        /// Maximum tokens the model can emit in a single response.
+        #[serde(
+            default,
+            rename = "maxOutputTokens",
+            alias = "max_output_tokens",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub max_output_tokens: Option<u32>,
+        /// Human-readable display name shown in the model picker.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub name: Option<String>,
+        /// First public availability (ISO 8601 date), drives date-DESC listing.
+        #[serde(
+            default,
+            rename = "releaseDate",
+            alias = "release_date",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub release_date: Option<String>,
+        /// Lifecycle status string (`"active"`, `"beta"`, …).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub status: Option<String>,
+    }
+
+    impl ModelOverride {
+        /// Whether this override carries no data (every field is `None`).
+        pub fn is_empty(&self) -> bool {
+            self.context_window.is_none()
+                && self.max_output_tokens.is_none()
+                && self.name.is_none()
+                && self.release_date.is_none()
+                && self.status.is_none()
+        }
+    }
+
     // ---- Config ----------------------------------------------------------
 
     /// Top-level configuration values, merged from CLI args + settings file + env.
@@ -982,6 +1043,11 @@ pub mod config {
         /// Per-provider configurations
         #[serde(default)]
         pub provider_configs: HashMap<String, ProviderConfig>,
+        /// User-supplied model metadata overrides, keyed by `"provider/model"`.
+        /// Take precedence over the models.dev catalog (copied from Settings on
+        /// load; see [`ModelOverride`]).
+        #[serde(default, rename = "modelOverrides", alias = "model_overrides")]
+        pub model_overrides: HashMap<String, ModelOverride>,
         /// Formatter configurations (copied from Settings on load).
         #[serde(default)]
         pub formatter: HashMap<String, FormatterConfig>,
@@ -1179,6 +1245,12 @@ pub mod config {
         /// Per-provider configurations stored in settings.json.
         #[serde(default)]
         pub providers: HashMap<String, ProviderConfig>,
+        /// User-supplied model metadata overrides stored in settings.json,
+        /// keyed by `"provider/model"`. Merged into
+        /// [`Config::model_overrides`] by [`Settings::effective_config`] and
+        /// take precedence over the models.dev catalog.
+        #[serde(default, rename = "modelOverrides", alias = "model_overrides")]
+        pub model_overrides: HashMap<String, ModelOverride>,
         /// User-defined slash command templates.
         #[serde(default)]
         pub commands: HashMap<String, CommandTemplate>,
@@ -1691,6 +1763,11 @@ pub mod config {
             for (id, pc) in &self.providers {
                 config.provider_configs.entry(id.clone()).or_insert_with(|| pc.clone());
             }
+            // Merge top-level `modelOverrides` into config.model_overrides
+            // (nested `config` block wins for keys present in both).
+            for (id, ov) in &self.model_overrides {
+                config.model_overrides.entry(id.clone()).or_insert_with(|| ov.clone());
+            }
             // Copy top-level formatters and commands into config.
             for (k, v) in &self.formatter {
                 config.formatter.entry(k.clone()).or_insert_with(|| v.clone());
@@ -1828,6 +1905,7 @@ pub mod config {
                 hooks: merge_map(base.config.hooks, over.config.hooks),
                 provider: over.config.provider.or(base.config.provider),
                 provider_configs: merge_map(base.config.provider_configs, over.config.provider_configs),
+                model_overrides: merge_map(base.config.model_overrides, over.config.model_overrides),
                 formatter: merge_map(base.config.formatter, over.config.formatter),
                 commands: merge_map(base.config.commands, over.config.commands),
                 agents: merge_map(base.config.agents, over.config.agents),
@@ -1872,6 +1950,7 @@ pub mod config {
                 last_seen_version: over.last_seen_version.or(base.last_seen_version),
                 provider: over.provider.or(base.provider),
                 providers: merge_map(base.providers, over.providers),
+                model_overrides: merge_map(base.model_overrides, over.model_overrides),
                 commands: merge_map(base.commands, over.commands),
                 formatter: merge_map(base.formatter, over.formatter),
                 agents: merge_map(base.agents, over.agents),

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -1255,6 +1255,19 @@ impl App {
     pub fn new(config: Config, cost_tracker: Arc<CostTracker>) -> Self {
         let model_name = config.effective_model().to_string();
         let user_keybindings = UserKeybindings::load(&Settings::config_dir());
+        // Build the model registry up front so user metadata overrides
+        // (issue #309) are layered on before the struct owns `config`.
+        let model_registry = {
+            let mut reg = claurst_api::ModelRegistry::new();
+            // Try to load cached models.dev data from disk.
+            let cache_path = dirs::cache_dir()
+                .unwrap_or_else(|| std::path::PathBuf::from("."))
+                .join("claurst")
+                .join("models.json");
+            reg.load_cache(&cache_path);
+            reg.apply_model_overrides(&config.model_overrides);
+            reg
+        };
         Self {
             config,
             cost_tracker,
@@ -1370,16 +1383,7 @@ impl App {
             device_auth_dialog: crate::device_auth_dialog::DeviceAuthDialogState::new(),
             device_auth_pending: None,
             provider_registry: None,
-            model_registry: {
-                let mut reg = claurst_api::ModelRegistry::new();
-                // Try to load cached models.dev data from disk.
-                let cache_path = dirs::cache_dir()
-                    .unwrap_or_else(|| std::path::PathBuf::from("."))
-                    .join("claurst")
-                    .join("models.json");
-                reg.load_cache(&cache_path);
-                reg
-            },
+            model_registry,
             model_picker_fetch_pending: false,
             model_picker_provider_id: None,
             session_list_pending: false,
@@ -1971,6 +1975,8 @@ impl App {
         self.config = config;
         self.provider_registry = provider_registry;
         self.model_registry = claurst_api::ModelRegistry::new();
+        // Re-layer user metadata overrides (issue #309) onto the fresh registry.
+        self.model_registry.apply_model_overrides(&self.config.model_overrides);
         self.auth_store = auth_store;
         self.connect_dialog = DialogSelectState::new("Connect a provider", provider_picker_items());
         self.import_config_picker = DialogSelectState::new("Import config", import_config_picker_items());


### PR DESCRIPTION
## Problem

When users connect self-hosted endpoints via the OpenAI-compatible provider
(or use model aliases models.dev does not know), claurst's metadata lookup can
mismatch the alias to an unrelated models.dev entry — or find nothing at all —
so the model picker, token-usage warnings, and auto-compact thresholds size the
model with the wrong context window / max output tokens.

Closes #309.

## Approach

Add a local, user-editable metadata override that layers cleanly:
**user override > models.dev > built-in defaults.**

- **`ModelOverride` config type** (`crates/core`): optional `contextWindow`,
  `maxOutputTokens`, `name`, `releaseDate`, `status`. Keyed by
  `"provider/model"` in a `modelOverrides` map on both the top level of
  `settings.json` and the nested `config` block (mirrors the existing
  `providers` / `provider_configs` convention). Field names accept camelCase or
  snake_case. `Settings::effective_config()` and `Settings::merge()` fold the map
  in.

- **Registry layering** (`crates/api`): `ModelRegistry` retains the overrides and
  applies them over the catalog — existing entries are patched in place, and any
  `"provider/model"` key the catalog lacks (a self-hosted alias) is materialised
  into a synthetic entry. Because every context-window consumer funnels through
  `ModelRegistry::get()` / `list_*_by_provider()`
  (`App::refresh_context_window_size`, `compact::resolve_context_window` for
  auto-compact + token warnings, and the picker's catalog projection), correcting
  the registry corrects all of them at once. Overrides are re-asserted after
  every `load_cache()` and `refresh_from_models_dev()` so a later catalog merge
  can't clobber them.

- **Wiring**: overrides are applied in `App::new`, `App::apply_provider_refresh`,
  and the CLI's `load_cached_model_registry`. The live-discovery picker path
  (self-hosted / openai-compatible endpoints) also honours the override when
  rendering the discovered list.

## Config syntax

Add to `~/.claurst/settings.json` (top level, or under `config`), keyed by the
fully-qualified `provider/model` id:

```json
{
  "modelOverrides": {
    "custom-openai/my-local-llm": {
      "contextWindow": 32768,
      "maxOutputTokens": 4096,
      "name": "My Local LLM",
      "releaseDate": "2026-01-01",
      "status": "beta"
    },
    "ollama/qwen3-coder-30b": { "contextWindow": 262144 }
  }
}
```

All fields are optional (an unset field keeps the catalog value); field names
accept camelCase (`contextWindow`) or snake_case (`context_window`). The key must
contain a `/` — a bare model id is ignored because the registry is keyed by
`provider/model`. Documented in `docs/providers.md`
(**Overriding model metadata**) and cross-referenced from
`docs/configuration.md`.

## Verification

- `cargo check --workspace` — clean.
- New unit tests, all passing:
  - `crates/api` — `model_registry::tests::override_*` (4): patch existing
    catalog entry, partial-patch leaves other fields intact, synthesize entry
    for unknown alias, malformed/empty keys ignored.
  - `crates/core` — `config::tests::effective_config_merges_top_level_model_overrides`
    and `config::tests::model_override_accepts_camel_and_snake_case`.
