### PR TITLE
fix: honest cache accounting for OpenAI-compatible providers + local-models docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -487,6 +487,10 @@
       <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="8" cy="8" r="6"/><path d="M8 2a5 5 0 010 12M2 8h12"/></svg>
       Providers
     </a>
+    <a class="sidebar-link" data-page="local-models" onclick="loadPage('local-models')">
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="12" height="7" rx="1"/><path d="M5 13h6M8 10v3"/></svg>
+      Local Models
+    </a>
     <a class="sidebar-link" data-page="mcp" onclick="loadPage('mcp')">
       <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="2" y="6" width="5" height="4" rx="1"/><rect x="9" y="6" width="5" height="4" rx="1"/><path d="M7 8h2"/></svg>
       MCP Integration
@@ -551,6 +555,7 @@ const PAGES = [
   { id: 'tools',         title: 'Tools Reference' },
   { id: 'keybindings',   title: 'Keybindings' },
   { id: 'providers',     title: 'Providers' },
+  { id: 'local-models',  title: 'Local Models' },
   { id: 'mcp',           title: 'MCP Integration' },
   { id: 'plugins',       title: 'Plugins' },
   { id: 'agents',        title: 'Agents' },

--- a/docs/index.md
+++ b/docs/index.md
@@ -134,7 +134,9 @@ claurst --provider ollama --model llama3.2
 OPENAI_API_KEY=sk-... claurst --provider openai --model gpt-4o
 ```
 
-See [Providers](providers) for setup instructions for every supported provider.
+See [Providers](providers) for setup instructions for every supported provider,
+or the [Local Models](local-models) guide for running against llama.cpp,
+LM Studio, Ollama, or any OpenAI-compatible server on your own machine.
 
 ---
 
@@ -192,6 +194,7 @@ See [Slash Commands](commands) for the complete reference.
 - [Slash Commands](commands) — all 70+ commands
 - [Tools Reference](tools) — all 40+ tools and permission levels
 - [Providers](providers) — configuring each LLM provider
+- [Local Models](local-models) — llama.cpp, LM Studio, Ollama, and other OpenAI-compatible servers
 - [MCP Integration](mcp) — Model Context Protocol servers
 - [Plugins](plugins) — building and using plugins
 - [Agents](agents) — multi-agent orchestration

--- a/docs/local-models.md
+++ b/docs/local-models.md
@@ -1,0 +1,294 @@
+# Running Claurst against local models
+
+Claurst can drive any server that speaks the **OpenAI-compatible chat
+completions API** (`POST /v1/chat/completions`). That includes:
+
+- **llama.cpp** (`llama-server`) — provider id `llamacpp`
+- **LM Studio** — provider id `lmstudio`
+- **Ollama** (via its `/v1` OpenAI shim) — provider id `ollama`
+- **vLLM**, **text-generation-webui**, **LocalAI**, and anything else that
+  exposes `/v1/chat/completions` — use the generic `openai` provider with a
+  custom base URL
+
+No API key is required for a local server. The rest of this page focuses on
+`llama-server` because it exposes the most tuning knobs, but the caching and
+model guidance apply to every OpenAI-compatible backend.
+
+For the short per-provider reference (env vars, default ports), see
+[Providers](providers). This page is the practical guide to getting an
+agentic loop working locally.
+
+---
+
+## Connecting
+
+### llama.cpp (`llama-server`)
+
+Start the server, then point Claurst at it. The built-in `llamacpp` provider
+reads `LLAMA_CPP_HOST` (default `http://localhost:8080`) and appends `/v1`:
+
+```bash
+# Terminal 1 — start the model server
+llama-server -m ./models/your-model.gguf --host 127.0.0.1 --port 8080 --jinja
+
+# Terminal 2 — run Claurst against it
+claurst --provider llamacpp --model your-model "add a health-check endpoint"
+```
+
+If your server runs elsewhere:
+
+```bash
+LLAMA_CPP_HOST=http://192.168.1.50:8080 claurst --provider llamacpp --model your-model
+```
+
+Or persist it in `~/.claurst/settings.json`:
+
+```json
+{
+  "provider": "llamacpp",
+  "providers": {
+    "llamacpp": {
+      "api_base": "http://localhost:8080/v1"
+    }
+  }
+}
+```
+
+`--model` is the label the server advertises at `/v1/models`; llama-server
+usually reports the GGUF filename. Any non-empty string works if the server
+ignores it.
+
+### Any other OpenAI-compatible server
+
+LM Studio and Ollama have dedicated provider ids (`lmstudio`, `ollama`) — see
+[Providers](providers). For everything else, use the generic `openai` provider
+and override the base URL:
+
+```bash
+OPENAI_BASE_URL=http://localhost:8000/v1 \
+  claurst --provider openai --model my-model "..."
+```
+
+Claurst posts to `{base_url}/v1/chat/completions`, so set the base URL to the
+host root (Claurst appends `/v1`) or to a value already ending in `/v1`
+depending on the provider — match the examples above.
+
+---
+
+## Recommended `llama-server` flags for agentic use
+
+Agentic coding is more demanding than chat: the model has to plan across turns
+and emit **valid tool calls** every step. These flags matter most.
+
+### `--jinja` — required for tool calling
+
+```bash
+llama-server -m model.gguf --jinja
+```
+
+`--jinja` tells llama-server to render the **chat template embedded in the
+GGUF** instead of a generic fallback. Tool calling only works when that
+template knows how to format the `tools` list and parse the model's
+`tool_calls` back out. Without `--jinja` most models will either ignore the
+tools Claurst sends or emit tool calls as plain text that never get executed —
+which looks like "the model thinks forever but never edits any files."
+
+If a model's built-in template lacks tool support, pass a template that has it
+with `--chat-template <name>` or `--chat-template-file <path>`.
+
+### Context size and the `--parallel` gotcha
+
+```bash
+llama-server -m model.gguf --ctx-size 32768 --parallel 1
+```
+
+- `--ctx-size` / `-c` is the **total** KV context across all slots. The default
+  (often 4096) is too small for agentic work — a single file read plus the
+  system prompt can blow past it. Give it as much as your VRAM/RAM allows.
+- `--parallel` / `-np` is the number of concurrent slots, and **the context is
+  divided evenly among them**. `--ctx-size 32768 --parallel 4` gives each
+  request only **8192** tokens, not 32768. For a single interactive Claurst
+  session use `--parallel 1` (or size `--ctx-size` as `N × per-request-window`).
+  Setting a big parallel count with a modest ctx-size is a common cause of "the
+  model keeps losing context" and of a tiny effective prompt cache.
+
+Claurst also auto-compacts the conversation as it approaches the window (see
+`auto_compact` / `compact_threshold` in [Configuration](configuration)), so
+you generally want the server window comfortably larger than a couple of tool
+round-trips.
+
+### Prompt caching (prefix reuse)
+
+Prompt caching is what makes multi-turn agentic loops affordable: each turn
+Claurst re-sends the whole growing conversation, and the server should reuse
+the KV cache for the unchanged prefix instead of recomputing it.
+
+- llama-server reuses the cached prompt prefix **by default** (the `cache_prompt`
+  request field, which Claurst relies on) — you usually don't have to enable
+  anything. The `--cache-prompt` flag some guides mention is accepted but not
+  required.
+- `--cache-reuse N` (a.k.a. `-cru`) lets the server reuse cached chunks even
+  after a small divergence of at least `N` tokens. This helps when an edit
+  changes text in the middle of the conversation; without it, everything after
+  the first changed token is recomputed.
+- **Recent builds (llama.cpp >= b4600) report the reused count** as
+  `usage.prompt_tokens_details.cached_tokens`. Claurst reads that field, so
+  cache hits show up in `/usage` and `/extra-usage`. Older builds don't emit
+  it — caching may still be working, the server just isn't reporting numbers
+  (see [Cache accounting](#cache-accounting-what-the-numbers-mean) below).
+
+Verify the server is reporting cache hits with two identical requests:
+
+```bash
+curl -s http://localhost:8080/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"m","messages":[{"role":"user","content":"hi"}]}' | \
+  python -c 'import sys,json; print(json.load(sys.stdin)["usage"])'
+```
+
+On the second call, `prompt_tokens_details.cached_tokens` should be non-zero.
+If the key is absent, your build predates cache-usage reporting.
+
+### `--no-context-shift` — understand the tradeoff
+
+By default, when a request exceeds a slot's context, llama-server **shifts** the
+window: it drops the oldest tokens and keeps going. For an agent that is bad in
+two ways — it silently discards earlier reasoning/instructions, and it changes
+the prompt prefix, which **invalidates the prompt cache** from that point on.
+
+`--no-context-shift` disables shifting: instead of dropping tokens the server
+returns an error when the context is full. That keeps the cache prefix stable
+and never silently forgets context, but it means you must keep `--ctx-size`
+large enough and let Claurst's compaction manage history. Recommended for
+agentic use, paired with a generous context and `auto_compact` enabled.
+
+### Performance flags
+
+These don't affect correctness but help throughput and memory:
+
+```bash
+llama-server -m model.gguf \
+  --jinja --ctx-size 32768 --parallel 1 --no-context-shift \
+  --flash-attn on \
+  --cache-type-k q8_0 --cache-type-v q8_0 \
+  --n-gpu-layers 999 --mlock \
+  --host 127.0.0.1 --port 8080 --no-webui
+```
+
+- `--flash-attn on` (`-fa`) — lower KV memory, usually faster.
+- `--cache-type-k` / `--cache-type-v` — quantize the KV cache (`q8_0` is a good
+  memory/quality balance; `f16` is full precision).
+- `--n-gpu-layers` (`-ngl`) — offload as many layers to GPU as fit.
+- `--mlock` — keep weights resident in RAM.
+- `--no-webui` — skip the bundled web UI.
+
+---
+
+## Why tool calling needs a tool-aware chat template
+
+Claurst is agentic: it sends the model a list of `tools` and expects structured
+`tool_calls` back so it can read files, run shell commands, and edit code. That
+handshake depends on the model's **chat template** encoding tool definitions and
+tool-call syntax. Two things have to line up:
+
+1. The model was **trained** for tool/function calling.
+2. The GGUF ships a **chat template that implements it**, and you enabled it
+   with `--jinja` (or supplied one via `--chat-template`).
+
+If either is missing, the model may narrate what it "would" do instead of
+emitting a real tool call — the classic "runs for a long time thinking but never
+changes any files" symptom. Base/completion models (no instruct/chat tuning)
+don't do tool calling at all.
+
+---
+
+## Model guidance
+
+There is no single "best" local model — it depends on your hardware — but for
+agentic coding, prioritize **reliable tool calling** over raw benchmark scores.
+General, hardware-agnostic guidance (not benchmarks):
+
+- **Use an instruct/chat model with native tool calling**, not a base model.
+  Families that ship tool-aware templates and generally handle function calling
+  include Qwen2.5 / Qwen2.5-Coder Instruct, Qwen3 Instruct, Llama 3.1 / 3.3
+  Instruct, Mistral-Small and Devstral (coding/agent focused), Hermes 3, and
+  Functionary. Confirm the specific GGUF you download has a tool-capable
+  template.
+- **Bigger dense or coder-tuned models are steadier.** Multi-step tool loops are
+  hard; 30B-class-and-up dense instruct models, or coder-specialized ones, tend
+  to loop less than very small models.
+- **Watch MoE models with tiny active parameter counts.** A model advertised as
+  "A3B" activates ~3B parameters per token; those can over-think or loop on
+  agentic tasks even if the total parameter count is large. If a model spends
+  every turn "thinking" and never calls a tool, it may simply not be strong
+  enough at agentic tool use, or its template's reasoning handling isn't
+  compatible — try a different model or a coder-tuned variant.
+- **Don't over-quantize.** Q4_K_M and up is a common sweet spot; Q2/Q3 quants
+  noticeably degrade tool-call reliability.
+
+Community fine-tunes vary a lot: two GGUFs of the "same" base model can behave
+very differently depending on whose template and tuning they ship. When in
+doubt, start from an official instruct release to confirm the loop works, then
+swap in fine-tunes.
+
+---
+
+## Cache accounting: what the numbers mean
+
+A few UI details confuse people running local models:
+
+- **The `0k/262k` counter in the status bar is the _context window_ counter, not
+  a cache counter.** It shows `tokens-in-context / model-context-window`. It
+  advances as the conversation grows and resets/drops when you `/compact`. If it
+  is stuck at `0k`, no real turns have completed — commonly because prompts
+  aren't reaching the model (for example a separate pasted-text bug, fixed on
+  its own), not because caching is off.
+- **Cache read/write live in `/usage` and `/extra-usage`.** Claurst populates
+  them from `usage.prompt_tokens_details.cached_tokens` when the server reports
+  it. If your server never reports cache info, those lines show **`n/a`** rather
+  than a permanent `0`, so you can tell "no cache data reported" apart from "zero
+  cache hits." Upgrade to a recent llama.cpp build (>= b4600) to get real
+  numbers.
+- Local models are priced at `$0.00`, so the cost line stays at zero regardless
+  of cache activity — that's expected, not a bug.
+
+---
+
+## Is `CLAURST_COORDINATOR_MODE=1` a real thing?
+
+Short answer: **the name exists in the source, but setting it currently does
+nothing — don't cargo-cult it for local models (or any models).**
+
+Details, from grepping this repository:
+
+- The string `CLAURST_COORDINATOR_MODE` appears exactly once in the Rust
+  runtime, as a constant in `crates/query/src/coordinator.rs`. There is a
+  `coordinator` module (multi-worker orchestration) and a [Agents](agents) doc
+  page describing a coordinator/worker model.
+- **But nothing in the live agent loop reads it.** `is_coordinator_mode()` (the
+  function that would check the env var) has no callers outside the module's own
+  unit tests, and the system-prompt builder hardcodes `coordinator_mode: false`.
+  So exporting `CLAURST_COORDINATOR_MODE=1` before launching Claurst has no
+  observable effect in this version.
+- **You don't need it anyway.** Claurst is agentic by default — it plans and
+  calls tools on every run. There is no separate "enable agentic mode" switch to
+  flip. If an assistant told you to set `CLAURST_COORDINATOR_MODE=1` to "turn on
+  agentic workflows," that advice was wrong.
+
+If you specifically want parallel sub-agent orchestration, see
+[Agents](agents) and [`/managed-agents`](commands) for what is actually wired
+up today. Note that orchestration multiplies context and demands strong,
+reliable tool calling, so it is generally a poor fit for small local models.
+
+---
+
+## Quick troubleshooting
+
+| Symptom | Likely cause / fix |
+|---------|--------------------|
+| Model "thinks" forever, never edits files | Missing `--jinja`, or the model/template doesn't support tool calls. Try a tool-capable instruct model. |
+| Context fills almost immediately | `--parallel N` is dividing `--ctx-size` across slots. Use `--parallel 1` or raise `--ctx-size`. |
+| Cache read shows `n/a` in `/usage` | Server isn't reporting `cached_tokens`. Upgrade llama.cpp (>= b4600); caching may still be working. |
+| `0k/262k` never moves | No completed turns — check that prompts actually reach the model, not a caching problem. |
+| Errors when context fills (with `--no-context-shift`) | Expected — raise `--ctx-size` and enable Claurst `auto_compact`. |
+| Tool calls arrive as plain text | Template isn't tool-aware; pass `--chat-template`/`--chat-template-file` or pick another model. |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -2,6 +2,10 @@
 
 Claurst supports a wide range of LLM providers through a unified provider abstraction. Every provider implements the same `LlmProvider` trait, so switching between them requires only a configuration change.
 
+> Running a model on your own machine (llama.cpp, LM Studio, Ollama, vLLM)? See
+> the dedicated [Local Models](local-models) guide for recommended server flags,
+> tool-calling setup, model guidance, and cache accounting.
+
 ---
 
 ## Selecting a Provider
@@ -397,6 +401,10 @@ Connects to a locally running llama.cpp HTTP server. No API key required.
 ```
 
 Start llama.cpp with the `--server` flag before use.
+
+For recommended `llama-server` flags (tool calling, context sizing, prompt
+caching), model guidance, and cache-accounting details, see the
+[Local Models](local-models) guide.
 
 ---
 

--- a/src-rust/crates/api/src/providers/openai.rs
+++ b/src-rust/crates/api/src/providers/openai.rs
@@ -532,17 +532,31 @@ impl OpenAiProvider {
             Some(v) => v,
             None => return UsageInfo::default(),
         };
+        let prompt_tokens = u
+            .get("prompt_tokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        // OpenAI-compatible servers report prompt-cache hits under
+        // `prompt_tokens_details.cached_tokens` (OpenAI spec; llama.cpp >= b4600
+        // mirrors it when prompt caching is enabled). Unlike Anthropic, whose
+        // `input_tokens` excludes cached tokens, OpenAI's `prompt_tokens` is
+        // *inclusive* of the cached count, so we split it back out to keep the
+        // additive convention (`input_tokens + cache_read_input_tokens ==
+        // prompt_tokens`) used by the cost tracker and context accounting.
+        let cache_read = u
+            .get("prompt_tokens_details")
+            .and_then(|v| v.get("cached_tokens"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0)
+            .min(prompt_tokens);
         UsageInfo {
-            input_tokens: u
-                .get("prompt_tokens")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(0),
+            input_tokens: prompt_tokens.saturating_sub(cache_read),
             output_tokens: u
                 .get("completion_tokens")
                 .and_then(|v| v.as_u64())
                 .unwrap_or(0),
             cache_creation_input_tokens: 0,
-            cache_read_input_tokens: 0,
+            cache_read_input_tokens: cache_read,
         }
     }
 
@@ -662,6 +676,69 @@ mod tests {
         assert_eq!(wire[0].get("role").and_then(|v| v.as_str()), Some("user"));
         assert_eq!(wire[1].get("role").and_then(|v| v.as_str()), Some("tool"));
         assert_eq!(wire[1].get("tool_call_id").and_then(|v| v.as_str()), Some("call_2"));
+    }
+
+    #[test]
+    fn parse_usage_none_is_all_zero() {
+        let usage = OpenAiProvider::parse_usage(None);
+        assert_eq!(usage.input_tokens, 0);
+        assert_eq!(usage.output_tokens, 0);
+        assert_eq!(usage.cache_creation_input_tokens, 0);
+        assert_eq!(usage.cache_read_input_tokens, 0);
+    }
+
+    #[test]
+    fn parse_usage_without_cache_details_reports_zero_cache() {
+        let usage = OpenAiProvider::parse_usage(Some(&json!({
+            "prompt_tokens": 1000,
+            "completion_tokens": 42,
+        })));
+        assert_eq!(usage.input_tokens, 1000);
+        assert_eq!(usage.output_tokens, 42);
+        assert_eq!(usage.cache_read_input_tokens, 0);
+    }
+
+    #[test]
+    fn parse_usage_reads_cached_tokens_from_prompt_details() {
+        // OpenAI spec / llama.cpp: prompt_tokens is inclusive of cached_tokens.
+        let usage = OpenAiProvider::parse_usage(Some(&json!({
+            "prompt_tokens": 1000,
+            "completion_tokens": 50,
+            "prompt_tokens_details": { "cached_tokens": 800 },
+        })));
+        assert_eq!(usage.cache_read_input_tokens, 800);
+        // input_tokens is the non-cached remainder so the two never double-count.
+        assert_eq!(usage.input_tokens, 200);
+        assert_eq!(
+            usage.input_tokens + usage.cache_read_input_tokens,
+            1000,
+            "input + cache_read must reconstruct the reported prompt_tokens"
+        );
+        assert_eq!(usage.output_tokens, 50);
+    }
+
+    #[test]
+    fn parse_usage_cache_details_present_but_zero() {
+        let usage = OpenAiProvider::parse_usage(Some(&json!({
+            "prompt_tokens": 1000,
+            "completion_tokens": 10,
+            "prompt_tokens_details": { "cached_tokens": 0 },
+        })));
+        assert_eq!(usage.input_tokens, 1000);
+        assert_eq!(usage.cache_read_input_tokens, 0);
+    }
+
+    #[test]
+    fn parse_usage_cached_tokens_clamped_to_prompt_tokens() {
+        // Defensive: a malformed server that reports cached > prompt must not
+        // underflow input_tokens.
+        let usage = OpenAiProvider::parse_usage(Some(&json!({
+            "prompt_tokens": 100,
+            "completion_tokens": 5,
+            "prompt_tokens_details": { "cached_tokens": 999 },
+        })));
+        assert_eq!(usage.cache_read_input_tokens, 100);
+        assert_eq!(usage.input_tokens, 0);
     }
 }
 

--- a/src-rust/crates/commands/src/usage.rs
+++ b/src-rust/crates/commands/src/usage.rs
@@ -29,6 +29,13 @@ impl SlashCommand for UsageCommand {
         let total = ctx.cost_tracker.total_tokens();
         let cost = ctx.cost_tracker.total_cost_usd();
 
+        // Some providers (notably local OpenAI-compatible servers that don't
+        // report `prompt_tokens_details.cached_tokens`) never surface cache
+        // usage. Show "n/a" rather than a permanent 0, which reads as if
+        // caching were broken. See docs/local-models.md.
+        let cache_creation_disp = display_cache_count(cache_creation, cache_read);
+        let cache_read_disp = display_cache_count(cache_read, cache_creation);
+
         // Try to get account tier from OAuth tokens
         let account_info = match claurst_core::oauth::OAuthTokens::load().await {
             Some(tokens) => {
@@ -62,8 +69,8 @@ impl SlashCommand for UsageCommand {
             model = ctx.config.effective_model(),
             input = input,
             output = output,
-            cache_creation = cache_creation,
-            cache_read = cache_read,
+            cache_creation = cache_creation_disp,
+            cache_read = cache_read_disp,
             total = total,
             cost = cost,
         ))
@@ -125,7 +132,7 @@ impl SlashCommand for ExtraUsageCommand {
                Cache read:        {cache_read:>10}\n\
                Total tokens:      {total:>10}\n\n\
              Cache Performance:\n\
-               Cache hit rate:    {cache_hit_pct:.1}%\n\
+               Cache hit rate:    {cache_hit_disp}\n\
                Cache efficiency:  {cache_eff}\n\n\
              Cost:\n\
                Total cost:        ${cost:.4}\n\
@@ -134,10 +141,14 @@ impl SlashCommand for ExtraUsageCommand {
             cost_per_call = cost_per_call,
             input = input,
             output = output,
-            cache_creation = cache_creation,
-            cache_read = cache_read,
+            cache_creation = display_cache_count(cache_creation, cache_read),
+            cache_read = display_cache_count(cache_read, cache_creation),
             total = total,
-            cache_hit_pct = cache_hit_pct,
+            cache_hit_disp = if cache_total > 0 {
+                format!("{:.1}%", cache_hit_pct)
+            } else {
+                "n/a".to_string()
+            },
             cache_eff = if cache_hit_pct > 70.0 {
                 "Excellent"
             } else if cache_hit_pct > 40.0 {
@@ -150,5 +161,40 @@ impl SlashCommand for ExtraUsageCommand {
             cost = cost,
             cost_per_k = if total > 0 { cost / (total as f64 / 1000.0) } else { 0.0 },
         ))
+    }
+}
+
+/// Render a cache token count for display. When neither the read nor the write
+/// counter recorded any activity this session, the provider almost certainly
+/// does not report cache usage at all (e.g. a local OpenAI-compatible server
+/// without prompt caching), so show `n/a` instead of a flat `0` that reads as
+/// if caching were broken.
+fn display_cache_count(value: u64, other: u64) -> String {
+    if value == 0 && other == 0 {
+        "n/a".to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::display_cache_count;
+
+    #[test]
+    fn cache_count_zero_both_is_na() {
+        assert_eq!(display_cache_count(0, 0), "n/a");
+    }
+
+    #[test]
+    fn cache_count_nonzero_shows_number() {
+        assert_eq!(display_cache_count(1234, 0), "1234");
+    }
+
+    #[test]
+    fn cache_count_zero_read_but_nonzero_write_shows_zero() {
+        // Anthropic can report cache_creation on the first turn with no reads
+        // yet; that is real activity, so the zero read count is honest, not n/a.
+        assert_eq!(display_cache_count(0, 500), "0");
     }
 }


### PR DESCRIPTION
## Problem

Reported in #314: running a local `llama-server` (OpenAI-compatible endpoint),
the cache accounting never reflects any activity, and there was no documentation
for driving Claurst against local models. The reporter also asked whether
`CLAURST_COORDINATOR_MODE=1` (suggested to them by an AI) is a real setting.

Two concrete issues under the hood:

1. The OpenAI-compatible provider hardcoded `cache_read_input_tokens` /
   `cache_creation_input_tokens` to `0` in `parse_usage`, so prompt-cache hits
   were thrown away even when the server reported them. OpenAI, LM Studio, vLLM,
   and llama.cpp (>= b4600 with prompt caching) all report reuse under
   `usage.prompt_tokens_details.cached_tokens`.
2. When a provider never reports cache info, `/usage` and `/extra-usage` showed a
   permanent `0`, which reads as "caching is broken" rather than "no data."

## Approach

**Cache parsing (`crates/api/src/providers/openai.rs`)**
- Parse `usage.prompt_tokens_details.cached_tokens` into `cache_read_input_tokens`.
- OpenAI's `prompt_tokens` is *inclusive* of cached tokens (unlike Anthropic,
  whose `input_tokens` excludes them), so the cached count is split back out of
  `input_tokens`, keeping the additive invariant
  `input_tokens + cache_read_input_tokens == prompt_tokens` that the cost tracker
  and context accounting rely on (no double counting). Clamped defensively so a
  malformed `cached > prompt` can't underflow.
- Both streaming and non-streaming paths go through `parse_usage`, so both are
  fixed. Added 5 unit tests.

**Honest counters (`crates/commands/src/usage.rs`)**
- `/usage` and `/extra-usage` now show `n/a` (and `n/a` cache-hit rate) when a
  session recorded zero cache activity, so "provider reports no cache info" is
  distinguishable from a real zero. Added 3 unit tests.

**Documentation (`docs/local-models.md`, new)**
- Connecting via llama.cpp and any OpenAI-compatible server (LM Studio, Ollama,
  vLLM).
- Recommended `llama-server` flags for agentic use: `--jinja` (required for
  tool-call templates), context sizing and the `--parallel` / `--ctx-size` split
  gotcha, prompt caching and `cached_tokens` reporting, the `--no-context-shift`
  tradeoff, and performance flags.
- Why tool calling needs a tool-aware chat template; conservative model guidance
  (no invented benchmarks).
- What the `0k/262k` status counter actually is (context window, not a cache
  counter) and how cache read/write surface in `/usage`.
- Wired into the docs sidebar/registry and cross-linked from the overview and
  providers pages.

**`CLAURST_COORDINATOR_MODE` — the honest answer (documented in the guide)**

Grepping the tree: the string exists **only** as a constant in
`crates/query/src/coordinator.rs`. `is_coordinator_mode()` (which reads it) has
**no callers in the live agent loop**, and `crates/query/src/runner/prompt.rs`
hardcodes `coordinator_mode: false`. So setting `CLAURST_COORDINATOR_MODE=1`
currently has no observable effect, and it is not needed — Claurst is agentic by
default. The docs say this plainly so nobody cargo-cults it.

## Verification

- `cargo check --workspace` — clean.
- `cargo clippy -p claurst-api -p claurst-commands --all-targets` — no warnings.
- `cargo test -p claurst-api -p claurst-commands --lib` — 107 + 66 pass,
  including the new `parse_usage_*` and `display_cache_count` tests.
- Docs loader confirmed to resolve `local-models` -> `local-models.md`.

## Notes

- The reporter's other symptom — pasted text arriving empty ("every prompt starts
  from the beginning, I have to repeat myself") — is a separate TUI paste bug
  being fixed in its own PR, not addressed here. That bug is the more likely
  reason the `0k/262k` context counter appeared stuck, since empty prompts never
  advance the context.

Closes #314
