### PR TITLE
fix(api): echo Gemini thoughtSignature on tool calls (#311)

### DIFF
--- a/src-rust/crates/api/src/lib.rs
+++ b/src-rust/crates/api/src/lib.rs
@@ -1488,7 +1488,7 @@ impl StreamAccumulator {
                         PartialBlock::ToolUse { id, name, json_buf } => {
                             let input = serde_json::from_str(&json_buf)
                                 .unwrap_or(Value::Object(Default::default()));
-                            ContentBlock::ToolUse { id, name, input }
+                            ContentBlock::ToolUse { id, name, input, thought_signature: None }
                         }
                         PartialBlock::Thinking {
                             thinking_buf,

--- a/src-rust/crates/api/src/protocol/openai_chat.rs
+++ b/src-rust/crates/api/src/protocol/openai_chat.rs
@@ -225,6 +225,7 @@ impl OpenAiChatDecoder {
                             id: tc_id.to_string(),
                             name,
                             input: json!({}),
+                            thought_signature: None,
                         },
                     });
                 }

--- a/src-rust/crates/api/src/provider_types.rs
+++ b/src-rust/crates/api/src/provider_types.rs
@@ -204,6 +204,9 @@ enum PartialBlock {
         id: String,
         name: String,
         json_buf: String,
+        /// Opaque provider signature (e.g. Gemini's `thoughtSignature`) captured
+        /// on `ContentBlockStart`; echoed back on the finalized block (#311).
+        thought_signature: Option<String>,
     },
     /// Any block that arrives fully-formed on `ContentBlockStart` and needs no
     /// delta accumulation (e.g. `RedactedThinking`, images).
@@ -225,10 +228,11 @@ impl PartialBlock {
                 thinking_buf: thinking,
                 signature_buf: signature,
             },
-            ContentBlock::ToolUse { id, name, .. } => PartialBlock::ToolUse {
+            ContentBlock::ToolUse { id, name, thought_signature, .. } => PartialBlock::ToolUse {
                 id,
                 name,
                 json_buf: String::new(),
+                thought_signature,
             },
             other => PartialBlock::Passthrough(other),
         }
@@ -244,10 +248,10 @@ impl PartialBlock {
                 thinking: thinking_buf,
                 signature: signature_buf,
             },
-            PartialBlock::ToolUse { id, name, json_buf } => {
+            PartialBlock::ToolUse { id, name, json_buf, thought_signature } => {
                 let input =
                     serde_json::from_str(&json_buf).unwrap_or(Value::Object(Default::default()));
-                ContentBlock::ToolUse { id, name, input }
+                ContentBlock::ToolUse { id, name, input, thought_signature }
             }
             PartialBlock::Passthrough(block) => block,
         }
@@ -519,6 +523,7 @@ mod tests {
                 id: "tool_1".into(),
                 name: "get_weather".into(),
                 input: Value::Null,
+                thought_signature: Some("sig-tool-xyz".into()),
             },
         });
         acc.on_event(&StreamEvent::InputJsonDelta {
@@ -549,13 +554,18 @@ mod tests {
             other => panic!("expected Text block second, got {other:?}"),
         }
         match &blocks[2] {
-            ContentBlock::ToolUse { id, name, input } => {
+            ContentBlock::ToolUse { id, name, input, thought_signature } => {
                 assert_eq!(id, "tool_1");
                 assert_eq!(name, "get_weather");
                 assert_eq!(
                     input.get("city").and_then(Value::as_str),
                     Some("Paris"),
                     "tool_use JSON assembled from partial deltas"
+                );
+                assert_eq!(
+                    thought_signature.as_deref(),
+                    Some("sig-tool-xyz"),
+                    "opaque tool-call signature survives stream assembly"
                 );
             }
             other => panic!("expected ToolUse block third, got {other:?}"),

--- a/src-rust/crates/api/src/providers/azure.rs
+++ b/src-rust/crates/api/src/providers/azure.rs
@@ -377,6 +377,7 @@ impl LlmProvider for AzureProvider {
                                         id: tc_id.to_string(),
                                         name,
                                         input: serde_json::json!({}),
+                                        thought_signature: None,
                                     },
                                 });
                             }

--- a/src-rust/crates/api/src/providers/bedrock.rs
+++ b/src-rust/crates/api/src/providers/bedrock.rs
@@ -373,7 +373,7 @@ impl BedrockProvider {
                     None
                 }
             }
-            ContentBlock::ToolUse { id, name, input } => Some(json!({
+            ContentBlock::ToolUse { id, name, input, .. } => Some(json!({
                 "toolUse": {
                     "toolUseId": id,
                     "name": name,
@@ -595,7 +595,12 @@ impl BedrockProvider {
                         .unwrap_or("")
                         .to_string();
                     let input = tu.get("input").cloned().unwrap_or(json!({}));
-                    return Some(ContentBlock::ToolUse { id, name, input });
+                    return Some(ContentBlock::ToolUse {
+                        id,
+                        name,
+                        input,
+                        thought_signature: None,
+                    });
                 }
                 None
             })
@@ -834,6 +839,7 @@ fn parse_bedrock_event(
                     id,
                     name,
                     input: json!({}),
+                    thought_signature: None,
                 },
             }));
         } else {

--- a/src-rust/crates/api/src/providers/codex.rs
+++ b/src-rust/crates/api/src/providers/codex.rs
@@ -492,7 +492,12 @@ impl CodexProvider {
                         .and_then(|v| v.as_str())
                         .unwrap_or("{}");
                     let input = serde_json::from_str(args).unwrap_or_else(|_| json!({}));
-                    content.push(ContentBlock::ToolUse { id, name, input });
+                    content.push(ContentBlock::ToolUse {
+                        id,
+                        name,
+                        input,
+                        thought_signature: None,
+                    });
                 }
                 _ => {}
             }
@@ -705,6 +710,7 @@ impl LlmProvider for CodexProvider {
                                                         id: call_id,
                                                         name,
                                                         input: json!({}),
+                                                        thought_signature: None,
                                                     },
                                                 });
                                             }

--- a/src-rust/crates/api/src/providers/cohere.rs
+++ b/src-rust/crates/api/src/providers/cohere.rs
@@ -230,7 +230,12 @@ impl CohereProvider {
                         .unwrap_or("{}");
                     let input: Value =
                         serde_json::from_str(input_str).unwrap_or_else(|_| json!({}));
-                    content_blocks.push(ContentBlock::ToolUse { id, name, input });
+                    content_blocks.push(ContentBlock::ToolUse {
+                        id,
+                        name,
+                        input,
+                        thought_signature: None,
+                    });
                 }
             }
         }
@@ -554,6 +559,7 @@ impl LlmProvider for CohereProvider {
                                         id: tc_id,
                                         name: tc_name,
                                         input: json!({}),
+                                        thought_signature: None,
                                     },
                                 });
                             }

--- a/src-rust/crates/api/src/providers/copilot.rs
+++ b/src-rust/crates/api/src/providers/copilot.rs
@@ -371,6 +371,7 @@ impl CopilotProvider {
                                     id,
                                     name,
                                     input: tool_input,
+                                    ..
                                 } => {
                                     flush_assistant_content(&mut input, &mut message_parts);
                                     input.push(json!({
@@ -551,7 +552,12 @@ impl CopilotProvider {
                         .and_then(|value| value.as_str())
                         .unwrap_or("{}");
                     let input = serde_json::from_str(args).unwrap_or_else(|_| json!({}));
-                    content.push(ContentBlock::ToolUse { id, name, input });
+                    content.push(ContentBlock::ToolUse {
+                        id,
+                        name,
+                        input,
+                        thought_signature: None,
+                    });
                 }
                 _ => {}
             }
@@ -660,10 +666,11 @@ impl CopilotProvider {
             for (index, block) in response.content.iter().enumerate() {
                 let start_block = match block {
                     ContentBlock::Text { .. } => ContentBlock::Text { text: String::new() },
-                    ContentBlock::ToolUse { id, name, .. } => ContentBlock::ToolUse {
+                    ContentBlock::ToolUse { id, name, thought_signature, .. } => ContentBlock::ToolUse {
                         id: id.clone(),
                         name: name.clone(),
                         input: json!({}),
+                        thought_signature: thought_signature.clone(),
                     },
                     ContentBlock::Thinking { .. } => ContentBlock::Thinking {
                         thinking: String::new(),
@@ -1051,6 +1058,7 @@ impl LlmProvider for CopilotProvider {
                                         id: tc_id.to_string(),
                                         name,
                                         input: serde_json::json!({}),
+                                        thought_signature: None,
                                     },
                                 });
                             }

--- a/src-rust/crates/api/src/providers/google.rs
+++ b/src-rust/crates/api/src/providers/google.rs
@@ -152,12 +152,27 @@ impl GoogleProvider {
                     })) }
             }
 
-            ContentBlock::ToolUse { name, input, .. } => Some(json!({
-                "functionCall": {
-                    "name": name,
-                    "args": input
+            ContentBlock::ToolUse {
+                name,
+                input,
+                thought_signature,
+                ..
+            } => {
+                let mut part = json!({
+                    "functionCall": {
+                        "name": name,
+                        "args": input
+                    }
+                });
+                // Gemini 3.x thinking models require the exact `thoughtSignature`
+                // captured from the response to be echoed back on the functionCall
+                // part; omitting it yields HTTP 400 (issue #311). REST JSON uses
+                // camelCase. Absent signature → old behaviour (no key emitted).
+                if let (Some(sig), Some(obj)) = (thought_signature, part.as_object_mut()) {
+                    obj.insert("thoughtSignature".to_string(), json!(sig));
                 }
-            })),
+                Some(part)
+            }
 
             // Thinking blocks are not supported by Gemini — drop silently.
             ContentBlock::Thinking { .. } | ContentBlock::RedactedThinking { .. } => None,
@@ -534,6 +549,7 @@ impl GoogleProvider {
                         .unwrap_or("")
                         .to_string();
                     let args = fc.get("args").cloned().unwrap_or(json!({}));
+                    let thought_signature = thought_signature_from_part(part);
                     let occurrence = tool_name_counts
                         .entry(name.clone())
                         .and_modify(|count| *count += 1)
@@ -543,6 +559,7 @@ impl GoogleProvider {
                         id,
                         name,
                         input: args,
+                        thought_signature,
                     });
                 }
             }
@@ -801,6 +818,10 @@ impl LlmProvider for GoogleProvider {
                                             .get("args")
                                             .map(|a| a.to_string())
                                             .unwrap_or_else(|| "{}".to_string());
+                                        // Gemini streams a functionCall part whole, so its
+                                        // thoughtSignature is present on this same part and
+                                        // must ride along on the ToolUse block (#311).
+                                        let thought_signature = thought_signature_from_part(part);
 
                                         let idx = if let Some((existing_idx, _, _)) = open_tool_calls.get(&part_idx) {
                                             *existing_idx
@@ -819,6 +840,7 @@ impl LlmProvider for GoogleProvider {
                                                     id,
                                                     name: name.clone(),
                                                     input: json!({}),
+                                                    thought_signature,
                                                 },
                                             });
                                             idx
@@ -963,6 +985,17 @@ fn uuid_v4_simple() -> String {
     format!("{:032x}", b)
 }
 
+/// Extract Gemini's opaque `thoughtSignature` (camelCase in REST JSON) from a
+/// response `part`. Thinking models attach it as a sibling of `functionCall`;
+/// it must be captured and echoed back verbatim on the next turn or the API
+/// rejects the tool call with HTTP 400 (issue #311). Shared by the streaming
+/// and non-streaming parsers, whose parts have the identical shape.
+fn thought_signature_from_part(part: &Value) -> Option<String> {
+    part.get("thoughtSignature")
+        .and_then(|s| s.as_str())
+        .map(|s| s.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -993,6 +1026,7 @@ mod tests {
                 id: "call_search_2".to_string(),
                 name: "search".to_string(),
                 input: json!({"q": "cats"}),
+                thought_signature: None,
             }]),
             Message::user_blocks(vec![ContentBlock::ToolResult {
                 tool_use_id: "call_search_2".to_string(),
@@ -1063,6 +1097,159 @@ mod tests {
         assert!(matches!(
             &parsed.content[1],
             ContentBlock::ToolUse { id, .. } if id == "call_search_2"
+        ));
+    }
+
+    #[test]
+    fn thought_signature_from_part_captures_streaming_signature() {
+        // The streaming SSE parser lives inside an async network generator with
+        // no test seam, but it extracts the signature through this exact helper.
+        // A streamed functionCall part carries `thoughtSignature` as a sibling of
+        // `functionCall`, identical to the non-streaming shape (#311).
+        let streamed_part = json!({
+            "functionCall": { "name": "read", "args": { "path": "a.rs" } },
+            "thoughtSignature": "SIG_STREAM_1"
+        });
+        assert_eq!(
+            thought_signature_from_part(&streamed_part).as_deref(),
+            Some("SIG_STREAM_1"),
+            "streamed functionCall part's signature is captured"
+        );
+
+        // A part without a signature (older/non-thinking models) yields None.
+        let unsigned_part = json!({
+            "functionCall": { "name": "read", "args": {} }
+        });
+        assert!(
+            thought_signature_from_part(&unsigned_part).is_none(),
+            "absent signature stays None"
+        );
+    }
+
+    #[test]
+    fn parse_response_body_captures_thought_signature() {
+        // Gemini 3.x thinking models attach a camelCase `thoughtSignature` as a
+        // sibling of `functionCall` on the part; it must be captured (#311).
+        let provider = GoogleProvider::new("test".to_string());
+        let response = json!({
+            "candidates": [{
+                "finishReason": "FUNCTION_CALL",
+                "content": {
+                    "parts": [
+                        {
+                            "functionCall": { "name": "read", "args": { "path": "a.rs" } },
+                            "thoughtSignature": "SIG_ABC123"
+                        }
+                    ]
+                }
+            }],
+            "usageMetadata": {}
+        });
+
+        let parsed = provider
+            .parse_response_body(&response, "gemini-3.1-pro-preview")
+            .expect("parsed response");
+
+        match &parsed.content[0] {
+            ContentBlock::ToolUse {
+                name,
+                thought_signature,
+                ..
+            } => {
+                assert_eq!(name, "read");
+                assert_eq!(thought_signature.as_deref(), Some("SIG_ABC123"));
+            }
+            other => panic!("expected ToolUse block, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_response_body_omits_signature_when_absent() {
+        // A functionCall part without a signature (older/non-thinking models)
+        // yields a ToolUse with `thought_signature == None` (old behaviour).
+        let provider = GoogleProvider::new("test".to_string());
+        let response = json!({
+            "candidates": [{
+                "finishReason": "FUNCTION_CALL",
+                "content": {
+                    "parts": [
+                        { "functionCall": { "name": "read", "args": {} } }
+                    ]
+                }
+            }],
+            "usageMetadata": {}
+        });
+
+        let parsed = provider
+            .parse_response_body(&response, "gemini-2.0-flash")
+            .expect("parsed response");
+
+        assert!(matches!(
+            &parsed.content[0],
+            ContentBlock::ToolUse { thought_signature, .. } if thought_signature.is_none()
+        ));
+    }
+
+    #[test]
+    fn build_request_body_round_trips_thought_signature_onto_function_call() {
+        // A captured signature must ride back as a camelCase sibling of the
+        // functionCall part, or Gemini 3.x rejects the turn with HTTP 400 (#311).
+        let provider = GoogleProvider::new("test".to_string());
+        let request = test_request(vec![Message::assistant_blocks(vec![
+            ContentBlock::ToolUse {
+                id: "call_read".to_string(),
+                name: "read".to_string(),
+                input: json!({ "path": "a.rs" }),
+                thought_signature: Some("SIG_ABC123".to_string()),
+            },
+        ])]);
+
+        let body = provider.build_request_body(&request);
+        let contents = body["contents"].as_array().expect("contents array");
+        let part = &contents[0]["parts"][0];
+        assert_eq!(part["functionCall"]["name"], json!("read"));
+        assert_eq!(part["functionCall"]["args"], json!({ "path": "a.rs" }));
+        assert_eq!(part["thoughtSignature"], json!("SIG_ABC123"));
+    }
+
+    #[test]
+    fn build_request_body_without_signature_omits_thought_signature_key() {
+        // Absent signature keeps the old wire shape: no thoughtSignature key.
+        let provider = GoogleProvider::new("test".to_string());
+        let request = test_request(vec![Message::assistant_blocks(vec![
+            ContentBlock::ToolUse {
+                id: "call_read".to_string(),
+                name: "read".to_string(),
+                input: json!({ "path": "a.rs" }),
+                thought_signature: None,
+            },
+        ])]);
+
+        let body = provider.build_request_body(&request);
+        let part = &body["contents"][0]["parts"][0];
+        assert_eq!(part["functionCall"]["name"], json!("read"));
+        assert!(
+            part.get("thoughtSignature").is_none(),
+            "absent signature must not emit a thoughtSignature key"
+        );
+    }
+
+    #[test]
+    fn thought_signature_survives_content_block_serde_round_trip() {
+        // The signature must persist across session save/load (JSON round-trip).
+        let block = ContentBlock::ToolUse {
+            id: "call_read".to_string(),
+            name: "read".to_string(),
+            input: json!({ "path": "a.rs" }),
+            thought_signature: Some("SIG_PERSIST".to_string()),
+        };
+        let encoded = serde_json::to_string(&block).expect("serialize");
+        assert!(encoded.contains("thought_signature"));
+        let decoded: ContentBlock = serde_json::from_str(&encoded).expect("deserialize");
+        assert!(matches!(
+            decoded,
+            ContentBlock::ToolUse { thought_signature, .. }
+                if thought_signature.as_deref() == Some("SIG_PERSIST")
         ));
     }
 }

--- a/src-rust/crates/api/src/providers/message_normalization.rs
+++ b/src-rust/crates/api/src/providers/message_normalization.rs
@@ -122,6 +122,7 @@ mod tests {
                 id: "call:1/abc".to_string(),
                 name: "search".to_string(),
                 input: json!({"q": "test"}),
+                thought_signature: None,
             }]),
             Message::user_blocks(vec![ContentBlock::ToolResult {
                 tool_use_id: "call:1/abc".to_string(),

--- a/src-rust/crates/api/src/providers/minimax.rs
+++ b/src-rust/crates/api/src/providers/minimax.rs
@@ -158,6 +158,7 @@ impl MinimaxProvider {
                             id,
                             name,
                             input: serde_json::Value::Object(Default::default()),
+                            thought_signature: None,
                         }
                     }
                     _ => return None,

--- a/src-rust/crates/api/src/providers/openai.rs
+++ b/src-rust/crates/api/src/providers/openai.rs
@@ -249,7 +249,7 @@ impl OpenAiProvider {
                 ContentBlock::Text { text } => {
                     text_parts.push(text.as_str());
                 }
-                ContentBlock::ToolUse { id, name, input } => {
+                ContentBlock::ToolUse { id, name, input, .. } => {
                     let args = serde_json::to_string(input).unwrap_or_default();
                     tool_calls.push(json!({
                         "id": id,
@@ -492,7 +492,12 @@ impl OpenAiProvider {
                     .unwrap_or("{}");
                 let input: Value =
                     serde_json::from_str(args_str).unwrap_or(json!({}));
-                content_blocks.push(ContentBlock::ToolUse { id, name, input });
+                content_blocks.push(ContentBlock::ToolUse {
+                    id,
+                    name,
+                    input,
+                    thought_signature: None,
+                });
             }
         }
 
@@ -642,6 +647,7 @@ mod tests {
                 id: "call_1".to_string(),
                 name: "search".to_string(),
                 input: json!({ "q": "test" }),
+                thought_signature: None,
             }]),
             Message::user_blocks(vec![ContentBlock::ToolResult {
                 tool_use_id: "call_1".to_string(),
@@ -982,6 +988,7 @@ impl LlmProvider for OpenAiProvider {
                                         id: tc_id.to_string(),
                                         name,
                                         input: json!({}),
+                                        thought_signature: None,
                                     },
                                 });
                             }

--- a/src-rust/crates/api/src/transformers/anthropic.rs
+++ b/src-rust/crates/api/src/transformers/anthropic.rs
@@ -200,6 +200,7 @@ impl MessageTransformer for AnthropicTransformer {
                         id: tool_id,
                         name,
                         input,
+                        thought_signature: None,
                     });
                 }
                 "thinking" => {

--- a/src-rust/crates/commands/src/export.rs
+++ b/src-rust/crates/commands/src/export.rs
@@ -43,7 +43,7 @@ fn export_message_to_markdown(
                     ContentBlock::Text { text } => {
                         text_parts.push(text.as_str());
                     }
-                    ContentBlock::ToolUse { id, name, input } => {
+                    ContentBlock::ToolUse { id, name, input, .. } => {
                         tool_uses.push((id.as_str(), name.as_str(), input));
                     }
                     ContentBlock::Thinking { thinking, .. } => {

--- a/src-rust/crates/commands/src/stats.rs
+++ b/src-rust/crates/commands/src/stats.rs
@@ -1236,6 +1236,7 @@ mod tests {
                 id: format!("tu-{i}"),
                 name: t.to_string(),
                 input: serde_json::json!({}),
+                thought_signature: None,
             });
         }
         TranscriptEntry::Assistant(TranscriptMessage {

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -219,6 +219,13 @@ pub mod types {
             id: String,
             name: String,
             input: Value,
+            /// Opaque, provider-supplied metadata that must be echoed back
+            /// verbatim on subsequent turns for the tool call to be accepted.
+            /// Currently carries Google Gemini's `thoughtSignature` for thinking
+            /// models (issue #311); `None` for every other provider. Persisted
+            /// with the session so it survives save/load.
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            thought_signature: Option<String>,
         },
         ToolResult {
             tool_use_id: String,

--- a/src-rust/crates/query/src/compact.rs
+++ b/src-rust/crates/query/src/compact.rs
@@ -992,7 +992,7 @@ async fn summarise_head(
         if let MessageContent::Blocks(blocks) = &msg.content {
             for block in blocks {
                 match block {
-                    ContentBlock::ToolUse { name, input, id } => {
+                    ContentBlock::ToolUse { name, input, id, .. } => {
                         transcript.push_str(&format!(
                             "[Tool Call: {} (id={})]\nInput: {}\n\n",
                             name, id, input
@@ -1734,6 +1734,7 @@ mod tests {
             id: id.to_string(),
             name: name.to_string(),
             input,
+            thought_signature: None,
         }])
     }
 

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -1001,8 +1001,11 @@ pub async fn run_query_loop(
                     // Accumulate reasoning/thinking content for providers like
                     // DeepSeek that require reasoning_content to be sent back.
                     let mut thinking_chunks: Vec<String> = Vec::new();
-                    // tool_call_blocks: index → (id, name, accumulated_json)
-                    let mut tool_call_blocks: std::collections::HashMap<usize, (String, String, String)> =
+                    // tool_call_blocks: index → (id, name, accumulated_json, thought_signature)
+                    // thought_signature carries Gemini's opaque per-call signature
+                    // through stream assembly so it survives into the persisted
+                    // ToolUse block and is echoed back next turn (#311).
+                    let mut tool_call_blocks: std::collections::HashMap<usize, (String, String, String, Option<String>)> =
                         std::collections::HashMap::new();
                     let mut usage = UsageInfo::default();
                     let mut stop_str = "end_turn".to_string();
@@ -1054,9 +1057,9 @@ pub async fn run_query_loop(
                                             }
                                             claurst_api::StreamEvent::ContentBlockStart {
                                                 index,
-                                                content_block: ContentBlock::ToolUse { id, name, .. },
+                                                content_block: ContentBlock::ToolUse { id, name, thought_signature, .. },
                                             } => {
-                                                tool_call_blocks.insert(*index, (id.clone(), name.clone(), String::new()));
+                                                tool_call_blocks.insert(*index, (id.clone(), name.clone(), String::new(), thought_signature.clone()));
                                             }
                                             claurst_api::StreamEvent::TextDelta { text, .. } => {
                                                 text_chunks.push(text.clone());
@@ -1068,7 +1071,7 @@ pub async fn run_query_loop(
                                                 thinking_chunks.push(reasoning.clone());
                                             }
                                             claurst_api::StreamEvent::InputJsonDelta { index, partial_json } => {
-                                                if let Some((_, _, buf)) = tool_call_blocks.get_mut(index) {
+                                                if let Some((_, _, buf, _)) = tool_call_blocks.get_mut(index) {
                                                     buf.push_str(partial_json);
                                                 }
                                             }
@@ -1177,7 +1180,7 @@ pub async fn run_query_loop(
                     let mut malformed_tool_calls: std::collections::HashSet<String> =
                         std::collections::HashSet::new();
                     for idx in tc_indices {
-                        if let Some((id, name, json_str)) = tool_call_blocks.remove(&idx) {
+                        if let Some((id, name, json_str, thought_signature)) = tool_call_blocks.remove(&idx) {
                             let input = match parse_tool_args(&json_str) {
                                 Ok(v) => v,
                                 Err(e) => {
@@ -1193,7 +1196,7 @@ pub async fn run_query_loop(
                                     serde_json::json!({})
                                 }
                             };
-                            content_blocks.push(ContentBlock::ToolUse { id, name, input });
+                            content_blocks.push(ContentBlock::ToolUse { id, name, input, thought_signature });
                         }
                     }
 
@@ -1216,7 +1219,7 @@ pub async fn run_query_loop(
 
                     // Handle tool-use turn: execute tools and loop.
                     let tool_use_blocks: Vec<_> = content_blocks.iter().filter_map(|b| {
-                        if let ContentBlock::ToolUse { id, name, input } = b {
+                        if let ContentBlock::ToolUse { id, name, input, .. } = b {
                             Some((id.clone(), name.clone(), input.clone()))
                         } else {
                             None
@@ -1857,7 +1860,7 @@ pub async fn run_query_loop(
                 // Phase 1: sequential pre-hook pass.
                 let mut prepared: Vec<PreparedTool> = Vec::with_capacity(tool_blocks.len());
                 for block in tool_blocks {
-                    if let ContentBlock::ToolUse { id, name, input } = block {
+                    if let ContentBlock::ToolUse { id, name, input, .. } = block {
                         // Clone from the references returned by get_tool_use_blocks()
                         let id = id.clone();
                         let name = name.clone();
@@ -2770,6 +2773,7 @@ mod tests {
                             id: tool_id,
                             name: "noop_tool".to_string(),
                             input: serde_json::json!({}),
+                            thought_signature: None,
                         },
                     }),
                     Ok(StreamEvent::InputJsonDelta {

--- a/src-rust/crates/query/src/sanitize.rs
+++ b/src-rust/crates/query/src/sanitize.rs
@@ -209,6 +209,7 @@ mod tests {
             id: id.to_string(),
             name: "Read".to_string(),
             input: serde_json::json!({ "path": "/tmp/x" }),
+            thought_signature: None,
         }
     }
 

--- a/src-rust/crates/query/src/session_memory.rs
+++ b/src-rust/crates/query/src/session_memory.rs
@@ -476,6 +476,7 @@ mod tests {
             id: "tool-123".to_string(),
             name: "bash".to_string(),
             input: serde_json::json!({"command": "ls"}),
+            thought_signature: None,
         }]);
         // Last assistant has tool_use → extraction should be deferred
         assert!(!SessionMemoryExtractor::should_extract(&msgs));

--- a/src-rust/crates/tui/src/lib.rs
+++ b/src-rust/crates/tui/src/lib.rs
@@ -1290,6 +1290,7 @@ mod tests {
                 id: "toolu_1".to_string(),
                 name: "read_file".to_string(),
                 input: serde_json::json!({ "path": "README.md" }),
+                thought_signature: None,
             },
             ContentBlock::Text {
                 text: "Done".to_string(),

--- a/src-rust/crates/tui/src/message_copy.rs
+++ b/src-rust/crates/tui/src/message_copy.rs
@@ -30,7 +30,7 @@ pub fn copy_as_markdown(message: &Message) -> String {
                             signature, thinking
                         ))
                     }
-                    claurst_core::ContentBlock::ToolUse { id, name, input } => {
+                    claurst_core::ContentBlock::ToolUse { id, name, input, .. } => {
                         // Format tool use as code block
                         Some(format!(
                             "```json\n// Tool: {}\n// ID: {}\n{}\n```",
@@ -330,7 +330,7 @@ fn format_block_for_json(block: &claurst_core::ContentBlock) -> String {
     match block {
         claurst_core::ContentBlock::Text { text } => text.clone(),
         claurst_core::ContentBlock::Image { .. } => "[Image content]".to_string(),
-        claurst_core::ContentBlock::ToolUse { id, name, input } => {
+        claurst_core::ContentBlock::ToolUse { id, name, input, .. } => {
             format!(
                 "[Tool: {} (ID: {})]\n{}",
                 name,

--- a/src-rust/crates/tui/src/messages/mod.rs
+++ b/src-rust/crates/tui/src/messages/mod.rs
@@ -1627,7 +1627,7 @@ pub fn render_message(msg: &Message, ctx: &RenderContext) -> Vec<Line<'static>> 
                     ctx.width,
                 ));
             }
-            ContentBlock::ToolUse { id, name, input } => {
+            ContentBlock::ToolUse { id, name, input, .. } => {
                 flush_text(&mut lines, &msg.role, &mut pending_text, ctx);
                 let rendered = render_tool_use_inner(&name, &input);
                 // Silence unused-variable warning on id — kept for symmetry with ToolResult lookup.
@@ -2090,6 +2090,7 @@ mod tests {
                 id: "tool-1".to_string(),
                 name: "read_file".to_string(),
                 input: serde_json::json!({ "path": "README.md" }),
+                thought_signature: None,
             },
             ContentBlock::ToolResult {
                 tool_use_id: "tool-1".to_string(),
@@ -2289,6 +2290,7 @@ mod tests {
             id: "tu-1".to_string(),
             name: "Bash".to_string(),
             input: serde_json::json!({"command": "ls -la"}),
+            thought_signature: None,
         }]);
         let rendered = render_message(&msg, &RenderContext::default())
             .into_iter()
@@ -2306,6 +2308,7 @@ mod tests {
             id: "tu-2".to_string(),
             name: "Read".to_string(),
             input: serde_json::json!({"file_path": "/tmp/foo.txt"}),
+            thought_signature: None,
         }]);
         let rendered = render_message(&msg, &RenderContext::default())
             .into_iter()
@@ -2326,6 +2329,7 @@ mod tests {
                 "subagent_type": "explore",
                 "description": "Trace the auth flow"
             }),
+            thought_signature: None,
         }]);
         let rendered = render_message(&msg, &RenderContext::default())
             .into_iter()


### PR DESCRIPTION
## Problem

Google Gemini 3.x "thinking" models (e.g. `gemini-3.1-pro-preview`) reject **any**
tool call on the next turn with HTTP 400:

> Function call is missing a thought_signature in functionCall parts. This is
> required for tools to work correctly.

Plain chat works; the failure only appears once a tool (Read, etc.) is invoked.

Root cause: these models attach an opaque `thoughtSignature` to each `functionCall`
part in their response. Per Google's rules the client must echo that exact signature
back on the corresponding `functionCall` part when it replays conversation history.
Claurst dropped the field, so every follow-up turn was rejected.

## Approach

- Add a provider-agnostic `thought_signature: Option<String>` passthrough field to
  the internal `ContentBlock::ToolUse` type (`crates/core`). It is
  `#[serde(default, skip_serializing_if = "Option::is_none")]`, so other providers'
  wire formats and persisted sessions are byte-identical to before, and the field
  survives session save/load.
- Capture the camelCase `thoughtSignature` in the Google provider from **both** the
  non-streaming `generateContent` response and the streaming SSE parser (shared
  `thought_signature_from_part` helper).
- Carry it on the `ToolUse` block through stream assembly: the query-loop tool-call
  accumulator and the `StreamBlockAccumulator`.
- Re-emit it as a sibling of the `functionCall` part when serializing history back to
  Gemini `contents`. Absent signature keeps the old wire shape (no key emitted); no
  signature is ever fabricated for calls that never carried one.
- Mechanical fan-out of the new field to every other `ToolUse` construction site
  (all providers pass `None`).

## Verification

- No Gemini API key is available in this environment, so the fix was not exercised
  against the live API. Coverage relies on round-trip unit tests in
  `crates/api/src/providers/google.rs`:
  - `thought_signature_from_part_captures_streaming_signature` — streaming extraction
    (and absent → `None`).
  - `parse_response_body_captures_thought_signature` /
    `parse_response_body_omits_signature_when_absent` — non-streaming capture.
  - `build_request_body_round_trips_thought_signature_onto_function_call` /
    `build_request_body_without_signature_omits_thought_signature_key` — request
    serialization re-attaches the signature as a `functionCall` sibling, and omits the
    key entirely when absent.
  - `thought_signature_survives_content_block_serde_round_trip` — session save/load.
  - `provider_types` stream-accumulator test asserts the signature survives streaming
    assembly.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test --workspace` — all pass (117 in `claurst-api`, full suite green).

Closes #311
