### PR TITLE
fix(mcp): fix peer_info clone in rmcp backend

### DIFF
--- a/src-rust/crates/mcp/src/rmcp_backend.rs
+++ b/src-rust/crates/mcp/src/rmcp_backend.rs
@@ -626,7 +626,7 @@ async fn build_snapshot(
     config: &claurst_core::config::McpServerConfig,
     peer: &rmcp::Peer<RoleClient>,
 ) -> anyhow::Result<McpClientSnapshot> {
-    let server_info = peer.peer_info().cloned();
+    let server_info = peer.peer_info().map(|info| (*info).clone());
 
     let (server_info_value, capabilities, instructions) = match server_info {
         Some(info) => (


### PR DESCRIPTION
## Summary
- Corrects how server peer info is cloned when building an MCP client snapshot.

## Changes
- Replace `peer.peer_info().cloned()` with `peer.peer_info().map(|info| (*info).clone())` to properly dereference and clone the referenced value.