### PR TITLE
feat(tui): add configurable external status line

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,15 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    cargo rustc rustfmt clippy
+    gcc cmake pkg-config gnumake perl
+    openssl.dev alsa-lib.dev
+    clang libclang.lib libclang.dev
+    python3
+    libxkbcommon wayland
+  ];
+
+  LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+  PKG_CONFIG_PATH = "${pkgs.alsa-lib.dev}/lib/pkgconfig";
+}

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -1977,32 +1977,49 @@ async fn run_interactive(
         }
     }
 
-    // CLAUDE_STATUS_COMMAND: optional external command whose stdout replaces the
-    // left-side status bar text. Polled every 500ms (debounced) in the main loop.
-    // The command is run in a background task; results flow through a channel.
-    let status_cmd_str = std::env::var("CLAUDE_STATUS_COMMAND").ok();
+    // Status line: optional external command whose stdout is shown in a status
+    // bar row. Configured via settings.json `statusLine`. The command receives
+    // session data as JSON on stdin and is polled at `pollIntervalMs` (default 5s).
+    // Backward compat: CLAUDE_STATUS_COMMAND env var is also checked.
+    let status_cmd_cfg = live_config.status_line.as_ref().map(|s| {
+        (s.command.clone(), s.poll_interval_ms.unwrap_or(5000))
+    }).or_else(|| {
+        std::env::var("CLAUDE_STATUS_COMMAND").ok().map(|c| (c, 500u16 as u64))
+    });
     let (status_cmd_tx, mut status_cmd_rx) = mpsc::channel::<String>(4);
-    if let Some(ref cmd_str) = status_cmd_str {
+    // Shared session data for the polling task (updated from the main loop).
+    let session_data: Arc<std::sync::Mutex<Option<String>>> = Arc::default();
+    if let Some((ref cmd_str, poll_ms)) = status_cmd_cfg {
         let cmd_str = cmd_str.clone();
         let tx = status_cmd_tx.clone();
+        let sd = session_data.clone();
         tokio::spawn(async move {
             loop {
-                tokio::time::sleep(Duration::from_millis(500)).await;
-                // Run via shell so pipes/redirects in the command string work.
+                tokio::time::sleep(Duration::from_millis(poll_ms)).await;
+                let input = sd.lock().unwrap().clone().unwrap_or_default();
                 let output = if cfg!(target_os = "windows") {
                     tokio::process::Command::new("cmd")
                         .args(["/C", &cmd_str])
-                        .output()
-                        .await
+                        .stdin(std::process::Stdio::piped())
+                        .stdout(std::process::Stdio::piped())
+                        .spawn()
                 } else {
                     tokio::process::Command::new("sh")
                         .args(["-c", &cmd_str])
-                        .output()
-                        .await
+                        .stdin(std::process::Stdio::piped())
+                        .stdout(std::process::Stdio::piped())
+                        .spawn()
                 };
-                if let Ok(out) = output {
-                    let text = String::from_utf8_lossy(&out.stdout).trim().to_string();
-                    let _ = tx.try_send(text);
+                if let Ok(mut child) = output {
+                    use tokio::io::AsyncWriteExt;
+                    if let Some(mut stdin) = child.stdin.take() {
+                        stdin.write_all(input.as_bytes()).await.ok();
+                        drop(stdin);
+                    }
+                    if let Ok(out) = child.wait_with_output().await {
+                        let text = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                        let _ = tx.try_send(text);
+                    }
                 }
             }
         });
@@ -3618,8 +3635,42 @@ async fn run_interactive(
             }
         }
 
-        // Drain CLAUDE_STATUS_COMMAND results (most recent wins)
-        if status_cmd_str.is_some() {
+        // Update shared session data for status line polling task.
+        if status_cmd_cfg.is_some() {
+            let elapsed = app.session_start.elapsed().as_secs();
+            let total_in = app.token_count as u64;
+            let ctx_size = app.context_window_size;
+            let used_pct = if ctx_size > 0 {
+                Some(app.context_used_tokens as f64 / ctx_size as f64 * 100.0)
+            } else {
+                None
+            };
+            let json = serde_json::json!({
+                "session_id": "",
+                "model": {
+                    "display_name": app.model_name,
+                    "id": app.model_name,
+                },
+                "workspace": {
+                    "current_dir": app.current_dir,
+                },
+                "context_window": {
+                    "total_input_tokens": total_in,
+                    "total_output_tokens": 0u64,
+                    "context_window_size": ctx_size,
+                    "current_usage": null,
+                    "used_percentage": used_pct,
+                    "remaining_percentage": used_pct.map(|p| 100.0 - p),
+                },
+                "cost": {
+                    "total_cost_usd": app.cost_usd,
+                },
+                "elapsed_seconds": elapsed,
+            });
+            *session_data.lock().unwrap() = Some(serde_json::to_string(&json).unwrap_or_default());
+        }
+        // Drain status line results (most recent wins)
+        if status_cmd_cfg.is_some() {
             while let Ok(text) = status_cmd_rx.try_recv() {
                 app.status_line_override = if text.is_empty() { None } else { Some(text) };
             }

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -1013,6 +1013,7 @@ pub mod config {
 
     /// Top-level configuration values, merged from CLI args + settings file + env.
     #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+    #[serde(default)]
     pub struct Config {
         pub api_key: Option<String>,
         pub model: Option<String>,
@@ -1114,6 +1115,48 @@ pub mod config {
         /// Keyboard scrolling (PageUp/PageDown, etc.) is unaffected either way.
         #[serde(default, rename = "mouseCapture", skip_serializing_if = "Option::is_none")]
         pub mouse_capture: Option<bool>,
+        /// External status line command configuration. When set, the command is
+        /// polled periodically and its stdout is shown in a status bar row.
+        #[serde(default, rename = "statusLine", alias = "status_line", skip_serializing_if = "Option::is_none")]
+        pub status_line: Option<StatusLineConfig>,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct StatusLineConfig {
+        /// Shell command to execute. Receives session JSON on stdin.
+        pub command: String,
+        /// Poll interval in milliseconds (default: 5000, minimum: 1000).
+        #[serde(
+            default,
+            rename = "pollIntervalMs",
+            alias = "poll_interval_ms",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub poll_interval_ms: Option<u64>,
+        /// Horizontal padding (in spaces) around the status text (default: 0).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub padding: Option<u16>,
+    }
+
+    #[cfg(test)]
+    mod status_line_tests {
+        use super::*;
+        #[test]
+        fn deserialize_status_line_config() {
+            let json = r#"{"command": "date", "pollIntervalMs": 1000, "padding": 1}"#;
+            let sl: StatusLineConfig = serde_json::from_str(json).unwrap();
+            assert_eq!(sl.command, "date");
+            assert_eq!(sl.poll_interval_ms, Some(1000));
+            assert_eq!(sl.padding, Some(1));
+        }
+        #[test]
+        fn deserialize_status_line_in_settings() {
+            let json = r#"{"config": {"statusLine": {"command": "date '+%H:%M:%S'", "pollIntervalMs": 1000, "padding": 1}}}"#;
+            let settings: Settings = serde_json::from_str(json).unwrap();
+            let sl = settings.config.status_line.unwrap();
+            assert_eq!(sl.command, "date '+%H:%M:%S'");
+            assert_eq!(sl.poll_interval_ms, Some(1000));
+        }
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -1932,6 +1975,7 @@ pub mod config {
                 file_injection_enabled: over.config.file_injection_enabled || base.config.file_injection_enabled,
                 file_injection_max_size: if over.config.file_injection_max_size != 0 { over.config.file_injection_max_size } else { base.config.file_injection_max_size },
                 request_timeout_secs: over.config.request_timeout_secs.or(base.config.request_timeout_secs),
+                status_line: over.config.status_line.or(base.config.status_line),
             };
             Self {
                 config: merged_config,

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -2130,6 +2130,24 @@ impl App {
                 self.status_message = Some(format!("Fast mode {}.", status));
                 true
             }
+            "cc-statusline" | "cc-status-line" => {
+                match &self.config.status_line {
+                    Some(sl) => {
+                        let interval = sl.poll_interval_ms.unwrap_or(5000);
+                        let padding = sl.padding.unwrap_or(0);
+                        self.status_message = Some(format!(
+                            "External statusLine active · command: {} · interval: {}ms · padding: {}",
+                            sl.command, interval, padding,
+                        ));
+                    }
+                    None => {
+                        self.status_message = Some(
+                            "No external statusLine configured. Set \"statusLine\": { \"command\": \"...\" } in ~/.claurst/settings.json".to_string(),
+                        );
+                    }
+                }
+                true
+            }
             "plan" => {
                 use claurst_core::config::PermissionMode;
                 self.plan_mode = !self.plan_mode;
@@ -7309,6 +7327,13 @@ mod tests {
         }
         assert_eq!(app.prompt_input.text, "line1\nline2");
         assert!(app.handle_key_event(press_key(KeyCode::Enter, KeyModifiers::NONE)));
+    }
+
+    #[test]
+    fn test_cc_statusline_slash_command() {
+        let mut app = make_app();
+        assert!(app.intercept_slash_command("cc-statusline"));
+        assert!(app.status_message.as_deref().map_or(false, |m| m.contains("No external statusLine configured")));
     }
 
     #[test]

--- a/src-rust/crates/tui/src/render.rs
+++ b/src-rust/crates/tui/src/render.rs
@@ -590,6 +590,7 @@ pub fn render_app(frame: &mut Frame, app: &App) {
         input_height(&app.prompt_input, prompt_text_width) + 1 // +1 for model/mode status line
     };
 
+    let status_line_height: u16 = if app.status_line_override.is_some() { 1 } else { 0 };
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -598,6 +599,7 @@ pub fn render_app(frame: &mut Frame, app: &App) {
             Constraint::Length(status_height),
             Constraint::Length(prompt_height),
             Constraint::Length(suggestions_height),
+            Constraint::Length(status_line_height),
             Constraint::Length(1),
         ])
         .split(size);
@@ -624,7 +626,10 @@ pub fn render_app(frame: &mut Frame, app: &App) {
     if suggestions_height > 0 {
         render_prompt_suggestions(frame, app, chunks[4]);
     }
-    render_footer(frame, app, chunks[5]);
+    if status_line_height > 0 {
+        render_status_line_override(frame, app, chunks[5]);
+    }
+    render_footer(frame, app, chunks[6]);
 
     // Overlays (rendered on top in Z-order)
 
@@ -2787,19 +2792,6 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
             ));
         }
 
-        // External status line override
-        if let Some(ref override_text) = app.status_line_override {
-            if !parts.is_empty() {
-                parts.push(Span::raw("  "));
-            }
-            // Strip any ANSI escapes for terminal rendering (plain text)
-            let clean: String = override_text
-                .chars()
-                .filter(|c| c.is_ascii_graphic() || *c == ' ')
-                .collect();
-            parts.push(Span::styled(clean, Style::default().fg(Color::DarkGray)));
-        }
-
         // 8. Bridge badge
         if let Some(badge) = app.bridge_state.status_badge(app.frame_count) {
             if !parts.is_empty() {
@@ -2842,6 +2834,42 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
         height: footer_area.height,
     };
     frame.render_widget(Paragraph::new(vec![Line::from(spans)]), padded_area);
+}
+
+fn render_status_line_override(frame: &mut Frame, app: &App, area: Rect) {
+    if area.height == 0 {
+        return;
+    }
+    let text = app.status_line_override.as_deref().unwrap_or("");
+    // Strip ANSI escape sequences (e.g. \x1b[32m) for plain-text rendering.
+    let clean: String = {
+        let mut out = String::with_capacity(text.len());
+        let mut in_esc = false;
+        for c in text.chars() {
+            if in_esc {
+                if c == 'm' { in_esc = false; }
+                continue;
+            }
+            if c == '\x1b' { in_esc = true; continue; }
+            out.push(c);
+        }
+        out
+    };
+    let padding = app.config.status_line.as_ref().and_then(|s| s.padding).unwrap_or(0);
+    let padded = Rect {
+        x: area.x + padding,
+        y: area.y,
+        width: area.width.saturating_sub(padding * 2),
+        height: 1,
+    };
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            clean.as_str(),
+            Style::default().fg(Color::DarkGray),
+        )))
+        .wrap(ratatui::widgets::Wrap { trim: false }),
+        padded,
+    );
 }
 
 fn render_prompt_suggestions(frame: &mut Frame, app: &App, area: Rect) {


### PR DESCRIPTION
## Summary

Adds a configurable external status line feature to Claurst, analogous to Claude Code's `statusLine`. The status line runs a user-defined command periodically and displays its stdout in a dedicated row between the prompt input and the footer.

## Changes

### Core (settings.json)
- New `statusLine` config block under `config`: `command`, `pollIntervalMs`, `padding`
- `#[serde(default)]` on `Config` to allow partial deserialization (minimal settings files)
- Backward compatible: `CLAUDE_STATUS_COMMAND` env var continues to work

### CLI/TUI
- Background task polls the command at the configured interval, passes session JSON on stdin
- Session data includes model, context window usage, cost, workspace info
- Rendered as a separate layout row (not inline in the footer)
- ANSI escape sequences stripped for clean display
- `/cc-statusline` slash command shows current external status line config
- Padding support via `statusLine.padding`

### Dev UX
- `shell.nix` for NixOS builds (includes all native dependencies)

## Testing
- Unit tests for `StatusLineConfig` deserialization
- Test for `/cc-statusline` command
- All existing tests pass (657 TUI, 500 core)
