### PR TITLE
fix(config): preserve malformed settings

### DIFF
--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -486,8 +486,23 @@ async fn main() -> anyhow::Result<()> {
 
     debug!(cwd = %cwd.display(), "Starting Claurst");
 
-    // Load settings from disk (hierarchical: global < project)
-    let mut settings = Settings::load_hierarchical(&cwd).await;
+    // Determine mode early (needed for settings error reporting, auth error
+    // handling, and permission handler selection).
+    let is_headless = cli.print || cli.prompt.is_some();
+
+    // Load settings from disk (hierarchical: global < project). A malformed
+    // global file is kept intact; interactive mode displays the error in the
+    // startup dialog, while headless mode reports it on stderr.
+    let (mut settings, settings_load_error) = match Settings::load_hierarchical(&cwd).await {
+        Ok(settings) => (settings, None),
+        Err(error) => {
+            let message = error.to_string();
+            if is_headless {
+                eprintln!("Warning: {}", message);
+            }
+            (Settings::default(), Some(message))
+        }
+    };
     // `--trust-project-mcp` (and automation use cases) flip on the same global
     // trust the user could set via `trustProjectMcpServers`. Folding it into
     // `settings` here keeps a single source of truth for the gate, including
@@ -586,9 +601,6 @@ async fn main() -> anyhow::Result<()> {
         system_parts.push(append.clone());
     }
     let system_prompt = system_parts.join("\n\n");
-
-    // Determine mode early (needed for auth error handling and permission handler selection).
-    let is_headless = cli.print || cli.prompt.is_some();
 
     // Initialize API client.
     // Try config/env first; fall back to saved OAuth tokens.
@@ -892,6 +904,7 @@ async fn main() -> anyhow::Result<()> {
         run_interactive(
             config,
             settings,
+            settings_load_error,
             client,
             tools,
             tool_ctx,
@@ -1758,6 +1771,7 @@ fn permission_request_from_core(
 async fn run_interactive(
     config: Config,
     settings: claurst_core::config::Settings,
+    settings_load_error: Option<String>,
     client: Arc<claurst_api::AnthropicClient>,
     tools: Arc<Vec<Box<dyn claurst_tools::Tool>>>,
     tool_ctx: ToolContext,
@@ -1860,6 +1874,10 @@ async fn run_interactive(
     // Set up terminal
     let mut terminal = setup_terminal(live_config.mouse_capture_enabled())?;
     let mut app = App::new(live_config.clone(), cost_tracker.clone());
+    if let Some(error) = settings_load_error {
+        app.invalid_config_dialog =
+            claurst_tui::InvalidConfigDialogState::show_settings_error(&error);
+    }
     // Gate input shift-normalization on whether the terminal speaks the kitty
     // keyboard protocol (detected in setup_terminal). On terminals that don't —
     // Windows conhost / CMD / legacy PowerShell, etc. — printable keys already

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -613,7 +613,7 @@ pub mod types {
 pub mod config {
     use serde::{Deserialize, Serialize};
     use std::collections::HashMap;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
     // ---- Hook configuration ----------------------------------------------
 
@@ -1710,48 +1710,98 @@ pub mod config {
             Self::config_dir().join("settings.json")
         }
 
-        /// Load settings from disk, returning defaults when the file is missing.
-        pub async fn load() -> anyhow::Result<Self> {
-            let path = Self::global_settings_path();
+        fn parse_file(content: &str, path: &Path) -> anyhow::Result<Self> {
+            serde_json::from_str(content).map_err(|error| {
+                anyhow::anyhow!(
+                    "Failed to parse settings file {}: {}. The file was not modified; fix the JSON and restart Claurst.",
+                    path.display(),
+                    error
+                )
+            })
+        }
+
+        async fn load_from_path(path: &Path) -> anyhow::Result<Self> {
             if path.exists() {
-                let content = tokio::fs::read_to_string(&path).await?;
-                Ok(serde_json::from_str(&content).unwrap_or_default())
+                let content = tokio::fs::read_to_string(path).await?;
+                Self::parse_file(&content, path)
             } else {
                 Ok(Self::default())
             }
         }
 
-        /// Persist settings to disk.
-        pub async fn save(&self) -> anyhow::Result<()> {
-            let path = Self::global_settings_path();
+        fn load_from_path_sync(path: &Path) -> anyhow::Result<Self> {
+            if path.exists() {
+                let content = std::fs::read_to_string(path)?;
+                Self::parse_file(&content, path)
+            } else {
+                Ok(Self::default())
+            }
+        }
+
+        async fn save_to_path(&self, path: &Path) -> anyhow::Result<()> {
+            if path.exists() {
+                let content = tokio::fs::read_to_string(path).await?;
+                Self::parse_file(&content, path).map_err(|error| {
+                    anyhow::anyhow!(
+                        "Refusing to overwrite malformed settings file {}: {}",
+                        path.display(),
+                        error
+                    )
+                })?;
+            }
             if let Some(parent) = path.parent() {
                 tokio::fs::create_dir_all(parent).await?;
             }
             let content = serde_json::to_string_pretty(self)?;
-            tokio::fs::write(&path, content).await?;
+            tokio::fs::write(path, content).await?;
             Ok(())
+        }
+
+        fn save_to_path_sync(&self, path: &Path) -> anyhow::Result<()> {
+            if path.exists() {
+                let content = std::fs::read_to_string(path)?;
+                Self::parse_file(&content, path).map_err(|error| {
+                    anyhow::anyhow!(
+                        "Refusing to overwrite malformed settings file {}: {}",
+                        path.display(),
+                        error
+                    )
+                })?;
+            }
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let content = serde_json::to_string_pretty(self)?;
+            std::fs::write(path, content)?;
+            Ok(())
+        }
+
+        /// Load settings from disk, returning defaults when the file is missing.
+        ///
+        /// A malformed file is returned as an error and is never replaced with
+        /// defaults.
+        pub async fn load() -> anyhow::Result<Self> {
+            let path = Self::global_settings_path();
+            Self::load_from_path(&path).await
+        }
+
+        /// Persist settings to disk without overwriting a malformed file.
+        pub async fn save(&self) -> anyhow::Result<()> {
+            let path = Self::global_settings_path();
+            self.save_to_path(&path).await
         }
 
         /// Synchronous variant used by pre-session commands.
         pub fn load_sync() -> anyhow::Result<Self> {
             let path = Self::global_settings_path();
-            if path.exists() {
-                let content = std::fs::read_to_string(&path)?;
-                Ok(serde_json::from_str(&content).unwrap_or_default())
-            } else {
-                Ok(Self::default())
-            }
+            Self::load_from_path_sync(&path)
         }
 
-        /// Synchronous variant used by pre-session commands.
+        /// Synchronous variant used by pre-session commands. Refuses to
+        /// overwrite a malformed file.
         pub fn save_sync(&self) -> anyhow::Result<()> {
             let path = Self::global_settings_path();
-            if let Some(parent) = path.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
-            let content = serde_json::to_string_pretty(self)?;
-            std::fs::write(&path, content)?;
-            Ok(())
+            self.save_to_path_sync(&path)
         }
 
         /// Return the effective `Config`, merging top-level provider settings
@@ -1818,14 +1868,14 @@ pub mod config {
 
         /// Load settings from all config levels and merge them.
         /// Priority: project > global.
-        pub async fn load_hierarchical(cwd: &std::path::Path) -> Self {
+        pub async fn load_hierarchical(cwd: &std::path::Path) -> anyhow::Result<Self> {
             // 1. Load global settings.
-            let mut merged = Self::load().await.unwrap_or_default();
+            let mut merged = Self::load().await?;
             // 2. Find and merge project settings (project wins).
             if let Some(project_settings) = Self::find_project_settings(cwd).await {
                 merged = Self::merge(merged, project_settings);
             }
-            merged
+            Ok(merged)
         }
 
         /// Walk up from `cwd` looking for `.claurst/settings.json` or
@@ -2053,6 +2103,66 @@ pub mod config {
             }
         }
         result
+    }
+
+    #[cfg(test)]
+    mod settings_io_tests {
+        use super::*;
+
+        const MALFORMED_SETTINGS: &str = r#"{"config":{"model":"test-model",}}"#;
+
+        #[test]
+        fn sync_load_reports_malformed_settings_without_modifying_them() {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("settings.json");
+            std::fs::write(&path, MALFORMED_SETTINGS).unwrap();
+
+            let error = Settings::load_from_path_sync(&path).unwrap_err();
+
+            assert!(error.to_string().contains("Failed to parse settings file"));
+            assert!(error.to_string().contains(&path.display().to_string()));
+            assert!(error.to_string().contains("The file was not modified"));
+            assert_eq!(std::fs::read_to_string(path).unwrap(), MALFORMED_SETTINGS);
+        }
+
+        #[test]
+        fn sync_save_refuses_to_overwrite_malformed_settings() {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("settings.json");
+            std::fs::write(&path, MALFORMED_SETTINGS).unwrap();
+            let mut replacement = Settings::default();
+            replacement.config.model = Some("replacement".to_string());
+
+            let error = replacement.save_to_path_sync(&path).unwrap_err();
+
+            assert!(
+                error
+                    .to_string()
+                    .contains("Refusing to overwrite malformed settings file")
+            );
+            assert_eq!(std::fs::read_to_string(path).unwrap(), MALFORMED_SETTINGS);
+        }
+
+        #[tokio::test]
+        async fn async_load_and_save_preserve_malformed_settings() {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("settings.json");
+            tokio::fs::write(&path, MALFORMED_SETTINGS).await.unwrap();
+
+            let load_error = Settings::load_from_path(&path).await.unwrap_err();
+            assert!(load_error.to_string().contains("Failed to parse settings file"));
+
+            let save_error = Settings::default().save_to_path(&path).await.unwrap_err();
+            assert!(
+                save_error
+                    .to_string()
+                    .contains("Refusing to overwrite malformed settings file")
+            );
+            assert_eq!(
+                tokio::fs::read_to_string(path).await.unwrap(),
+                MALFORMED_SETTINGS
+            );
+        }
     }
 
     #[cfg(test)]
@@ -4567,7 +4677,7 @@ mod tests {
         );
         std::fs::write(claurst.join("settings.json"), json).unwrap();
 
-        let merged = Settings::load_hierarchical(dir.path()).await;
+        let merged = Settings::load_hierarchical(dir.path()).await.unwrap();
         let server = merged
             .config
             .mcp_servers


### PR DESCRIPTION
## Summary

- return malformed settings as an actionable error instead of silently loading defaults
- refuse to overwrite an existing malformed settings file
- surface the parse failure in the startup dialog and headless stderr
- cover synchronous and asynchronous preservation paths

## Tests

- `cargo test --package claurst-core settings_io_tests`
- `cargo test --package claurst-core project_mcp_servers_are_tagged_project_origin`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`

Fixes #321
