### PR TITLE
feat(core): add named workspace roots

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -637,6 +637,10 @@ Grants Claurst read access to an additional directory outside the working direct
 
 Multiple `--add-dir` flags can be combined.
 
+The working directory and additional directories are exposed to the model as named workspace roots. The primary working directory is always `&main`; each additional directory gets a stable root name derived from its directory name, lowercased and sanitized for use in prompts. For example, `_ai-engine` becomes `&_ai-engine`, and `My Project (API)` becomes `&my-project-api`.
+
+Path-based tools accept absolute paths, paths relative to `&main`, and workspace-root paths such as `&main/src/lib.rs` or `&_ai-engine/prd/spec.md`. For `Glob` and `Grep`, omitting `path` searches only `&main`; to search all workspace roots, the model calls the tool once per root, which can run in parallel.
+
 ### Environment variables in config
 
 Environment variables can be set in `.claude/settings.json` under an `env` key. These are injected into tool executions:
@@ -680,7 +684,7 @@ The `LspTool` provides code intelligence by communicating with a Language Server
 ```
 
 - `action` — required, one of the operations above
-- `file` — required, absolute or working-directory-relative path
+- `file` — required, absolute, working-directory-relative, or `&root-name/relative` path
 - `line` — 1-based line number (required for `hover`, `definition`, `references`)
 - `column` — 1-based column number (required for `hover`, `definition`, `references`)
 
@@ -707,4 +711,4 @@ LSP servers must be configured in `settings.json`:
 }
 ```
 
-If no LSP server is configured for the file's language, the tool returns an informative error. Path resolution is relative to the current working directory.
+If no LSP server is configured for the file's language, the tool returns an informative error. Relative paths resolve against `&main`; `&root-name/relative` paths resolve against the named workspace root.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,7 +120,7 @@ prefixed with their server name (`myserver_toolname`).
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `additional_dirs` | array of strings | [] | Additional filesystem paths Claurst is allowed to read and write. Equivalent to passing `--add-dir` on the command line. |
+| `additional_dirs` | array of strings | [] | Additional filesystem paths Claurst is allowed to read and write. Equivalent to passing `--add-dir` on the command line. These directories are also exposed as named workspace roots alongside `&main`, so path-based tools can target them with `&root-name/relative` paths. |
 
 ### MCP servers
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -39,6 +39,12 @@ Every tool in Claurst implements a common `Tool` interface. This interface defin
 
 Tools are loaded eagerly at session start. The model receives tool descriptions and schemas and selects tools to call. Each tool call goes through permission resolution before `call()` is invoked.
 
+### Workspace-root paths
+
+Path-based tools accept absolute paths, paths relative to the main workspace root, and named workspace-root paths. The primary working directory is always available as `&main`; additional directories from `--add-dir` or `additional_dirs` are assigned sanitized names such as `&_ai-engine` or `&my-project-api`.
+
+Use `&root-name` for a root directory itself, or `&root-name/relative/path` for a file or subdirectory under that root. Relative paths without a root prefix resolve against `&main`.
+
 ### Tool Concurrency
 
 Tools marked `isConcurrencySafe` may run in parallel with other tool calls. Most write tools are not concurrency-safe. Read-only tools are generally safe to parallelize.
@@ -103,7 +109,7 @@ Read the contents of a file from the local filesystem. Returns file contents as 
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `file_path` | string | yes | Absolute path to the file |
+| `file_path` | string | yes | Absolute, `&main`-relative, or `&root-name/relative` path to the file |
 | `offset` | integer | no | First line to read (1-indexed) |
 | `limit` | integer | no | Maximum number of lines to read |
 
@@ -121,7 +127,7 @@ Write content to a file. Creates the file and any missing parent directories. Ov
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `file_path` | string | yes | Absolute path to write |
+| `file_path` | string | yes | Absolute, `&main`-relative, or `&root-name/relative` path to write |
 | `content` | string | yes | Full file content |
 
 Requires the file to have been read first (or the file to not exist). The previous content is stored for `/undo` support.
@@ -136,7 +142,7 @@ Perform an exact string replacement within an existing file. Fails if `old_strin
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `file_path` | string | yes | Absolute path to the file |
+| `file_path` | string | yes | Absolute, `&main`-relative, or `&root-name/relative` path to the file |
 | `old_string` | string | yes | Exact text to replace |
 | `new_string` | string | yes | Replacement text |
 | `replace_all` | boolean | no | Replace all occurrences (default: false) |
@@ -153,7 +159,7 @@ Apply multiple `FileEditTool`-style edits in a single tool call. More efficient 
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `edits` | array | yes | Array of `{file_path, old_string, new_string, replace_all}` objects |
+| `edits` | array | yes | Array of `{file_path, old_string, new_string, replace_all}` objects. `file_path` accepts absolute, `&main`-relative, or `&root-name/relative` paths. |
 
 Edits within the same file are applied in order. If any individual edit fails (string not found, not unique), the batch is aborted and no changes are written.
 
@@ -163,7 +169,7 @@ Edits within the same file are applied in order. If any individual edit fails (s
 
 **Permission level:** Write
 
-Apply a unified diff patch to one or more files. Accepts standard `diff -u` / `git diff` format patches.
+Apply a unified diff patch to one or more files. Accepts standard `diff -u` / `git diff` format patches. Patch file paths may be absolute, `&main`-relative, or `&root-name/relative` paths.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -269,12 +275,12 @@ Useful for iterative data exploration or multi-step computations where re-runnin
 
 **Permission level:** ReadOnly
 
-Find files matching a glob pattern. Searches from a specified directory (defaults to the current working directory). Returns matching file paths sorted by modification time.
+Find files matching a glob pattern. Searches from a specified directory; if `path` is omitted, searches only `&main`. Returns matching file paths sorted by modification time.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `pattern` | string | yes | Glob pattern (e.g., `**/*.rs`, `src/**/*.ts`) |
-| `path` | string | no | Directory to search from |
+| `path` | string | no | Directory to search from. Accepts absolute, `&main`-relative, or `&root-name/relative` paths. To search all workspace roots, call `GlobTool` once per root. |
 
 ---
 
@@ -287,7 +293,7 @@ Search file contents using regular expressions, powered by ripgrep. Supports mul
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `pattern` | string | yes | Regular expression pattern |
-| `path` | string | no | Directory or file to search |
+| `path` | string | no | Directory or file to search. Accepts absolute, `&main`-relative, or `&root-name/relative` paths. If omitted, searches only `&main`; to search all workspace roots, call `GrepTool` once per root. |
 | `glob` | string | no | File glob filter (e.g., `*.rs`) |
 | `type` | string | no | File type filter (e.g., `rust`, `py`, `js`) |
 | `output_mode` | string | no | `content`, `files_with_matches`, or `count` |
@@ -587,7 +593,7 @@ Edit a Jupyter notebook (`.ipynb`) by modifying, inserting, or deleting cells. O
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `notebook_path` | string | yes | Absolute path to the notebook |
+| `notebook_path` | string | yes | Absolute, `&main`-relative, or `&root-name/relative` path to the notebook |
 | `cell_index` | integer | no | Cell to edit (0-indexed) |
 | `new_source` | string | no | New cell source content |
 | `cell_type` | string | no | `code`, `markdown`, or `raw` |
@@ -757,7 +763,7 @@ Query a language server for code intelligence actions. Supports hover documentat
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `action` | string | yes | `hover`, `definition`, `references`, `symbols`, or `diagnostics` |
-| `file` | string | yes | Absolute or working-directory-relative path to the source file |
+| `file` | string | yes | Absolute, `&main`-relative, or `&root-name/relative` path to the source file |
 | `line` | integer | no | 1-based line number (required for `hover`, `definition`, `references`) |
 | `column` | integer | no | 1-based column number (required for `hover`, `definition`, `references`) |
 
@@ -790,7 +796,7 @@ Query a language server for code intelligence actions. Supports hover documentat
 }
 ```
 
-If no LSP server is configured for a file's language, the tool returns an informative error. The tool resolves relative paths against the current working directory.
+If no LSP server is configured for a file's language, the tool returns an informative error. Relative paths resolve against `&main`; `&root-name/relative` paths resolve against the named workspace root.
 
 ---
 

--- a/src-rust/crates/acp/src/prompt.rs
+++ b/src-rust/crates/acp/src/prompt.rs
@@ -51,8 +51,13 @@ pub async fn handle(
     // Build per-session ToolContext.
     let permission_handler: Arc<dyn claurst_core::PermissionHandler> =
         Arc::new(AcpPermissionHandler);
+    let workspace_roots = claurst_core::generate_root_names(
+        &session.cwd,
+        &runtime.config.additional_dirs,
+        &runtime.config.workspace_paths,
+    );
     let tool_ctx = ToolContext {
-        working_dir: session.cwd.clone(),
+        workspace_roots,
         permission_mode: runtime.config.permission_mode.clone(),
         permission_handler,
         cost_tracker: runtime.cost_tracker.clone(),
@@ -91,12 +96,20 @@ pub async fn handle(
     ));
 
     // Run the query loop.
+    let mut query_config = runtime.query_config.clone();
+    query_config.working_directory = Some(tool_ctx.main_root().display().to_string());
+    query_config.workspace_roots = tool_ctx
+        .workspace_roots()
+        .iter()
+        .map(|(name, path)| (name.clone(), path.display().to_string()))
+        .collect();
+
     let outcome = claurst_query::run_query_loop(
         runtime.api_client.as_ref(),
         &mut messages,
         runtime.tools.as_slice(),
         &tool_ctx,
-        &runtime.query_config,
+        &query_config,
         runtime.cost_tracker.clone(),
         Some(ev_tx),
         cancel,

--- a/src-rust/crates/acp/src/runtime.rs
+++ b/src-rust/crates/acp/src/runtime.rs
@@ -89,6 +89,14 @@ impl AgentRuntime {
 
         let mut query_config = QueryConfig::from_config(&config);
         query_config.working_directory = Some(working_dir.display().to_string());
+        query_config.workspace_roots = claurst_core::generate_root_names(
+            &working_dir,
+            &config.additional_dirs,
+            &config.workspace_paths,
+        )
+        .into_iter()
+        .map(|(name, path)| (name, path.display().to_string()))
+        .collect();
         query_config.provider_registry = Some(provider_registry.clone());
 
         Ok(Self {

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -48,6 +48,7 @@ use claurst_core::types::ToolDefinition;
 use claurst_tools::{PermissionLevel, Tool, ToolContext, ToolResult};
 use clap::{ArgAction, Parser, ValueEnum};
 use parking_lot::Mutex as ParkingMutex;
+use std::collections::BTreeMap;
 use std::{path::PathBuf, sync::Arc};
 use tracing::{debug, info, warn};
 use tracing_subscriber::EnvFilter;
@@ -109,6 +110,14 @@ impl Tool for McpToolWrapper {
             Err(e) => ToolResult::error(format!("MCP tool '{}' failed: {}", bare_name, e)),
         }
     }
+}
+
+fn workspace_roots_for_prompt(tool_ctx: &ToolContext) -> BTreeMap<String, String> {
+    tool_ctx
+        .workspace_roots()
+        .iter()
+        .map(|(name, path)| (name.clone(), path.display().to_string()))
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -731,8 +740,15 @@ async fn main() -> anyhow::Result<()> {
         tokio::sync::mpsc::unbounded_channel::<claurst_tools::UserQuestionEvent>();
     let user_question_rx = if is_non_interactive { None } else { Some(user_question_rx) };
 
+    // Build workspace roots map: main = cwd, additional from config.
+    let workspace_roots = claurst_core::generate_root_names(
+        &cwd,
+        &config.additional_dirs,
+        &config.workspace_paths,
+    );
+
     let tool_ctx = ToolContext {
-        working_dir: cwd.clone(),
+        workspace_roots,
         permission_mode: config.permission_mode.clone(),
         permission_handler: permission_handler.clone(),
         cost_tracker: cost_tracker.clone(),
@@ -830,6 +846,7 @@ async fn main() -> anyhow::Result<()> {
     query_config.system_prompt = Some(system_prompt);
     query_config.append_system_prompt = None;
     query_config.working_directory = Some(cwd.display().to_string());
+    query_config.workspace_roots = workspace_roots_for_prompt(&tool_ctx);
     if let Some(tokens) = cli.thinking {
         query_config.thinking_budget = Some(tokens);
     }
@@ -1825,7 +1842,7 @@ async fn run_interactive(
                 if let Some(saved_dir) = session.working_dir.as_ref() {
                     let saved_path = std::path::PathBuf::from(saved_dir);
                     if saved_path.exists() {
-                        tool_ctx.working_dir = saved_path;
+                        tool_ctx.workspace_roots.insert("main".to_string(), saved_path);
                     }
                 }
                 tool_ctx.session_id = session.id.clone();
@@ -1838,7 +1855,7 @@ async fn run_interactive(
                         claurst_api::effective_model_for_config(&config, &model_registry),
                     );
                 session.id = tool_ctx.session_id.clone();
-                session.working_dir = Some(tool_ctx.working_dir.display().to_string());
+                session.working_dir = Some(tool_ctx.main_root().display().to_string());
                 session
             }
         }
@@ -1848,11 +1865,12 @@ async fn run_interactive(
                 claurst_api::effective_model_for_config(&config, &model_registry),
             );
         session.id = tool_ctx.session_id.clone();
-        session.working_dir = Some(tool_ctx.working_dir.display().to_string());
+        session.working_dir = Some(tool_ctx.main_root().display().to_string());
         session
     };
     let initial_messages = session.messages.clone();
     let mut base_query_config = query_config;
+    base_query_config.workspace_roots = workspace_roots_for_prompt(&tool_ctx);
     // Goal autonomy is now an in-loop continuation policy (issue #230 / MI-3):
     // run_query_loop itself decides whether to continue toward an active goal
     // after each turn, instead of the REPL re-dispatching a fresh turn. Select
@@ -1915,7 +1933,7 @@ async fn run_interactive(
         app.user_question_rx = Some(rx);
     }
 
-    app.config.project_dir = Some(tool_ctx.working_dir.clone());
+    app.config.project_dir = Some(tool_ctx.main_root().clone());
     app.attach_turn_diff_state(tool_ctx.file_history.clone(), tool_ctx.current_turn.clone());
     if let Some(manager) = tool_ctx.mcp_manager.clone() {
         app.attach_mcp_manager(manager);
@@ -1924,7 +1942,7 @@ async fn run_interactive(
 
     // Home directory warning: mirror TS feedConfigs.tsx warningText
     let home_dir = dirs::home_dir();
-    if home_dir.as_deref() == Some(tool_ctx.working_dir.as_path()) {
+    if home_dir.as_deref() == Some(tool_ctx.main_root().as_path()) {
         app.home_dir_warning = true;
     }
 
@@ -2089,7 +2107,7 @@ async fn run_interactive(
         config: live_config,
         cost_tracker: cost_tracker.clone(),
         messages: messages.clone(),
-        working_dir: tool_ctx.working_dir.clone(),
+        working_dir: tool_ctx.main_root().clone(),
         session_id: session.id.clone(),
         session_title: session.title.clone(),
         remote_session_url: session.remote_session_url.clone(),
@@ -2420,7 +2438,7 @@ async fn run_interactive(
                                     );
                                     session = claurst_commands::build_home_session(
                                         model,
-                                        Some(tool_ctx.working_dir.display().to_string()),
+                                        Some(tool_ctx.main_root().display().to_string()),
                                     );
                                     messages.clear();
                                     app.replace_messages(Vec::new());
@@ -2453,13 +2471,15 @@ async fn run_interactive(
                                     // command; here we repoint every cwd-aware
                                     // surface so tools, the system prompt and the
                                     // saved session all track the new location.
-                                    tool_ctx.working_dir = destination.clone();
+                                    tool_ctx.workspace_roots.insert("main".to_string(), destination.clone());
                                     cmd_ctx.working_dir = destination.clone();
                                     cmd_ctx.config.project_dir = Some(destination.clone());
                                     tool_ctx.config.project_dir = Some(destination.clone());
                                     app.config.project_dir = Some(destination.clone());
                                     base_query_config.working_directory =
                                         Some(destination.display().to_string());
+                                    base_query_config.workspace_roots =
+                                        workspace_roots_for_prompt(&tool_ctx);
                                     session.working_dir =
                                         Some(destination.display().to_string());
                                     session.updated_at = chrono::Utc::now();
@@ -2469,7 +2489,7 @@ async fn run_interactive(
                                     // <system-reminder> prompt after a move. claurst
                                     // re-derives working_directory into every turn's
                                     // system prompt (qcfg.working_directory below),
-                                    // so repointing tool_ctx.working_dir already
+                                    // so repointing tool_ctx.main_root() already
                                     // tells the model on its next turn — we skip the
                                     // dangling user message that would otherwise
                                     // break user/assistant role alternation.
@@ -2539,12 +2559,14 @@ async fn run_interactive(
                                         let saved_path =
                                             std::path::PathBuf::from(saved_dir);
                                         if saved_path.exists() {
-                                            tool_ctx.working_dir = saved_path.clone();
+                                            tool_ctx.workspace_roots.insert("main".to_string(), saved_path.clone());
                                             cmd_ctx.working_dir = saved_path;
                                         }
                                     }
+                                    base_query_config.workspace_roots =
+                                        workspace_roots_for_prompt(&tool_ctx);
                                     app.config.project_dir =
-                                        Some(tool_ctx.working_dir.clone());
+                                        Some(tool_ctx.main_root().clone());
                                     app.attach_turn_diff_state(
                                         tool_ctx.file_history.clone(),
                                         tool_ctx.current_turn.clone(),
@@ -2844,7 +2866,7 @@ async fn run_interactive(
                                 &cmd_ctx.config.hooks,
                                 claurst_core::config::HookEvent::UserPromptSubmit,
                                 &hook_ctx,
-                                &tool_ctx.working_dir,
+                                tool_ctx.main_root(),
                             )
                             .await;
                         }
@@ -2867,7 +2889,7 @@ async fn run_interactive(
                             } else {
                                 app.config.file_injection_max_size
                             };
-                            let (within_limit, mut oversized) = parse_at_refs(&input, &tool_ctx.working_dir, effective_limit);
+                            let (within_limit, mut oversized) = parse_at_refs(&input, &tool_ctx.main_root(), effective_limit);
                             if was_force {
                                 oversized.retain(|f| !matches!(f.issue, Some(claurst_tui::AtFileIssue::IsDirectory)));
                             }
@@ -2890,7 +2912,7 @@ async fn run_interactive(
                                     pending_imgs,
                                     oversized_summaries,
                                     app.config.file_injection_max_size,
-                                    Some(tool_ctx.working_dir.clone()),
+                                    Some(tool_ctx.main_root().clone()),
                                 );
                                 app.set_prompt_text(input);
                                 continue;
@@ -2992,7 +3014,8 @@ async fn run_interactive(
                         qcfg.system_prompt = base_query_config.system_prompt.clone();
                         qcfg.output_style = cmd_ctx.config.effective_output_style();
                         qcfg.output_style_prompt = cmd_ctx.config.resolve_output_style_prompt();
-                        qcfg.working_directory = Some(tool_ctx.working_dir.display().to_string());
+                        qcfg.working_directory = Some(tool_ctx.main_root().display().to_string());
+                        qcfg.workspace_roots = workspace_roots_for_prompt(&tool_ctx);
                         // The active-goal system-prompt addendum is now injected
                         // inside run_query_loop per turn (issue #230 / MI-3), so
                         // it also covers in-loop continuation turns.
@@ -3347,6 +3370,8 @@ async fn run_interactive(
                 let mut qcfg = base_query_config.clone();
                 qcfg.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
                 qcfg.max_tokens = cmd_ctx.config.effective_max_tokens();
+                qcfg.working_directory = Some(tool_ctx.main_root().display().to_string());
+                qcfg.workspace_roots = workspace_roots_for_prompt(&tool_ctx);
                 // Auto-compact is a maintenance turn, not a goal turn: never let
                 // it trigger in-loop goal continuation.
                 qcfg.continuation = claurst_query::ContinuationMode::Default;
@@ -3503,6 +3528,8 @@ async fn run_interactive(
                         let mut qcfg = base_query_config.clone();
                         qcfg.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
                         qcfg.max_tokens = cmd_ctx.config.effective_max_tokens();
+                        qcfg.working_directory = Some(tool_ctx.main_root().display().to_string());
+                        qcfg.workspace_roots = workspace_roots_for_prompt(&tool_ctx);
                         let tracker = cost_tracker.clone();
                         let tx = event_tx.clone();
                         let client_clone = client.clone();
@@ -3611,6 +3638,8 @@ async fn run_interactive(
                 let mut qcfg = base_query_config.clone();
                 qcfg.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
                 qcfg.max_tokens = cmd_ctx.config.effective_max_tokens();
+                qcfg.working_directory = Some(tool_ctx.main_root().display().to_string());
+                qcfg.workspace_roots = workspace_roots_for_prompt(&tool_ctx);
                 let tracker = cost_tracker.clone();
                 let tx = event_tx.clone();
                 let client_clone = client.clone();
@@ -4027,7 +4056,7 @@ async fn run_interactive(
                 session.messages = messages.clone();
                 session.updated_at = chrono::Utc::now();
                 session.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
-                session.working_dir = Some(tool_ctx.working_dir.display().to_string());
+                session.working_dir = Some(tool_ctx.main_root().display().to_string());
                 app.is_streaming = false;
                 app.status_message = None;
                 // Drain one queued message into the prompt and request an

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -83,6 +83,10 @@ pub use update_check::{check_for_updates, UpdateInfo};
 // Self-contained HTML export of a session, used by the `/share` slash command.
 pub mod share_export;
 
+// Named workspace roots (main + --add-dir).
+pub mod workspace;
+pub use workspace::{WorkspaceRoot, ResolvedWorkspacePath, generate_root_names};
+
 // Re-export commonly used types at the crate root
 pub use error::{ClaudeError, Result};
 pub use types::{

--- a/src-rust/crates/core/src/system_prompt.rs
+++ b/src-rust/crates/core/src/system_prompt.rs
@@ -6,7 +6,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::sync::{Mutex, OnceLock};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 // ---------------------------------------------------------------------------
 // Dynamic boundary marker
@@ -207,6 +207,8 @@ pub struct SystemPromptOptions {
     pub custom_output_style_prompt: Option<String>,
     /// Absolute path to the working directory (injected as dynamic section).
     pub working_directory: Option<String>,
+    /// Named workspace roots visible to the model. `main` is the primary root.
+    pub workspace_roots: BTreeMap<String, String>,
     /// Pre-built memory content from memdir (injected as dynamic section).
     pub memory_content: String,
     /// Custom system prompt (--system-prompt flag or settings).
@@ -318,7 +320,12 @@ pub fn build_system_prompt(opts: &SystemPromptOptions) -> String {
         parts.push(format!("\n<working_directory>{}</working_directory>", cwd));
     }
 
-    // 12. Memory injection (from memdir)
+    // 12. Workspace roots (dynamic — can vary per session/worktree)
+    if !opts.workspace_roots.is_empty() {
+        parts.push(build_workspace_roots_section(&opts.workspace_roots));
+    }
+
+    // 13. Memory injection (from memdir)
     if !opts.memory_content.is_empty() {
         parts.push(format!(
             "\n<memory>\n{}\n</memory>",
@@ -326,12 +333,12 @@ pub fn build_system_prompt(opts: &SystemPromptOptions) -> String {
         ));
     }
 
-    // 13. Active goal addendum (dynamic — changes each session)
+    // 14. Active goal addendum (dynamic — changes each session)
     if let Some(goal_text) = &opts.active_goal_addendum {
         parts.push(goal_text.clone());
     }
 
-    // 14. Appended system prompt (--append-system-prompt)
+    // 15. Appended system prompt (--append-system-prompt)
     if let Some(append) = &opts.append_system_prompt {
         parts.push(format!("\n{}", append));
     }
@@ -463,6 +470,21 @@ fn build_env_info_section(working_dir: Option<&str>) -> String {
         shell_line,
         os_note,
     )
+}
+
+fn build_workspace_roots_section(roots: &BTreeMap<String, String>) -> String {
+    let mut out = String::from("\n<workspace_roots>");
+    for (name, path) in roots {
+        out.push_str(&format!("\n<root name=\"{}\">{}</root>", name, path));
+    }
+    out.push_str(
+        "\n</workspace_roots>\nPaths may use workspace root syntax: &<root-name>/<relative-path>. \
+         Use &<root-name> to refer to a root directory itself. Relative paths without & resolve against main. \
+         For Glob and Grep, omitted path searches only main. To search all workspace roots, \
+         call the tool once per root with path=&<root-name>; these independent calls can run in parallel. \
+         When the user asks to find or search something without naming a specific root, search all workspace roots.",
+    );
+    out
 }
 
 // ---------------------------------------------------------------------------
@@ -676,6 +698,25 @@ mod tests {
             mem_pos > boundary_pos,
             "Memory content must appear after the dynamic boundary"
         );
+    }
+
+    #[test]
+    fn test_workspace_roots_in_dynamic_section() {
+        let opts = SystemPromptOptions {
+            workspace_roots: BTreeMap::from([
+                ("main".to_string(), "/repo".to_string()),
+                ("docs".to_string(), "/repo/docs".to_string()),
+            ]),
+            ..Default::default()
+        };
+        let prompt = build_system_prompt(&opts);
+        let boundary_pos = prompt.find(SYSTEM_PROMPT_DYNAMIC_BOUNDARY).unwrap();
+        let roots_pos = prompt.find("<workspace_roots>").unwrap();
+        assert!(roots_pos > boundary_pos);
+        assert!(prompt.contains("<root name=\"main\">/repo</root>"));
+        assert!(prompt.contains("<root name=\"docs\">/repo/docs</root>"));
+        assert!(prompt.contains("&<root-name>/<relative-path>"));
+        assert!(prompt.contains("without naming a specific root, search all workspace roots"));
     }
 
     #[test]

--- a/src-rust/crates/core/src/workspace.rs
+++ b/src-rust/crates/core/src/workspace.rs
@@ -1,0 +1,292 @@
+//! Workspace root types and name generation for named workspace roots.
+//!
+//! A workspace root is a named, absolute directory that Claurst can access.
+//! The primary root is always named `"main"` and corresponds to the session's
+//! working directory. Additional roots come from `--add-dir` CLI flags and
+//! persisted `workspace_paths` in settings.json.
+
+use std::collections::{BTreeMap, HashSet};
+use std::path::PathBuf;
+
+/// A named workspace root.
+#[derive(Debug, Clone)]
+pub struct WorkspaceRoot {
+    /// Stable name (e.g. "main", "report-a", "lib-2")
+    pub name: String,
+    /// Absolute path
+    pub path: PathBuf,
+    /// Whether this is the primary (main) working directory
+    pub is_primary: bool,
+}
+
+/// Result of resolving a path that may use `&root-name` syntax.
+#[derive(Debug, Clone)]
+pub struct ResolvedWorkspacePath {
+    /// The original input string.
+    pub input: String,
+    /// Root name if `&root-name/path` syntax was used.
+    pub root_name: Option<String>,
+    /// Absolute path of the matched root.
+    pub root_path: Option<PathBuf>,
+    /// Path fragment relative to the root.
+    pub relative_path: Option<PathBuf>,
+    /// Final resolved absolute path.
+    pub absolute_path: PathBuf,
+}
+
+/// Parse an input string that may use `&root-name/relative-path` syntax.
+///
+/// Returns `None` when the input is an absolute path, a plain relative path
+/// (no `&` prefix), or when the `&` prefix names an unknown root.
+///
+/// When the input is `&root-name` alone (no slash), returns the root path
+/// itself (empty relative path).
+///
+/// # Resolution order
+/// 1. Absolute path (`C:\...`, `/home/...`) → `None` (not &-syntax)
+/// 2. `&root-name/sub/path` → `Some((root_name, "sub/path"))`
+/// 3. `&root-name` → `Some((root_name, ""))`
+/// 4. Plain relative path → `None`
+pub fn parse_root_ref<'a>(input: &'a str, roots: &BTreeMap<String, PathBuf>) -> Option<(&'a str, &'a str)> {
+    if std::path::Path::new(input).is_absolute() {
+        return None;
+    }
+    if !input.starts_with('&') {
+        return None;
+    }
+    let without_prefix = &input[1..];
+    if let Some(slash_pos) = without_prefix.find(|c| c == '/' || c == '\\') {
+        let candidate_root = &without_prefix[..slash_pos];
+        if roots.contains_key(candidate_root) {
+            let remainder = &without_prefix[slash_pos + 1..];
+            return Some((candidate_root, remainder));
+        }
+    } else if roots.contains_key(without_prefix) {
+        return Some((without_prefix, ""));
+    }
+    None
+}
+
+/// Generate a `BTreeMap<String, PathBuf>` of workspace roots from the primary
+/// working directory and any additional directories.
+///
+/// The primary directory is always named `"main"`. Additional paths are named
+/// after a sanitized version of their last path component, with numeric suffixes
+/// appended for duplicates (e.g. `"lib"`, `"lib-2"`, `"lib-3"`).
+///
+/// # Panics
+/// Panics if `primary` is not an absolute path.
+pub fn generate_root_names(
+    primary: &std::path::Path,
+    additional_dirs: &[PathBuf],
+    workspace_paths: &[PathBuf],
+) -> BTreeMap<String, PathBuf> {
+    assert!(
+        primary.is_absolute(),
+        "workspace primary root must be an absolute path, got: {}",
+        primary.display()
+    );
+
+    let mut result = BTreeMap::new();
+    let mut seen_paths: HashSet<PathBuf> = HashSet::new();
+    let mut seen_names: HashSet<String> = HashSet::new();
+
+    // 1. Primary root — always named "main"
+    result.insert("main".to_string(), primary.to_path_buf());
+    seen_paths.insert(canonicalize_or_raw(primary));
+    seen_names.insert("main".to_string());
+
+    // 2. Additional directories
+    let all_extra: Vec<&PathBuf> = additional_dirs
+        .iter()
+        .chain(workspace_paths.iter())
+        .collect();
+
+    for path in all_extra {
+        let canon = canonicalize_or_raw(path);
+
+        // Skip if this exact path is already registered
+        if seen_paths.contains(&canon) {
+            continue;
+        }
+        seen_paths.insert(canon.clone());
+
+        // Generate a stable, prompt-friendly name from the last path component.
+        let base_name = path
+            .file_name()
+            .map(|n| sanitize_root_name(&n.to_string_lossy()))
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "workspace".to_string());
+
+        let mut name = base_name.clone();
+        let mut counter = 2;
+        while !seen_names.insert(name.clone()) {
+            name = format!("{}-{}", base_name, counter);
+            counter += 1;
+        }
+
+        result.insert(name, path.clone());
+    }
+
+    result
+}
+
+fn canonicalize_or_raw(path: &std::path::Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn sanitize_root_name(name: &str) -> String {
+    let mut out = String::new();
+    let mut previous_dash = false;
+
+    for ch in name.chars().flat_map(|ch| ch.to_lowercase()) {
+        let mapped = if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-') {
+            ch
+        } else {
+            '-'
+        };
+
+        if mapped == '-' {
+            if previous_dash {
+                continue;
+            }
+            previous_dash = true;
+        } else {
+            previous_dash = false;
+        }
+        out.push(mapped);
+    }
+
+    let trimmed = out.trim_matches('-').to_string();
+    if trimmed.is_empty() {
+        "workspace".to_string()
+    } else {
+        trimmed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Return an absolute path suitable for tests on any platform.
+    fn abs_workspace() -> PathBuf {
+        std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/workspace"))
+    }
+
+    #[test]
+    #[should_panic(expected = "workspace primary root must be an absolute path")]
+    fn rejects_relative_primary() {
+        generate_root_names(
+            std::path::Path::new("relative/path"),
+            &[],
+            &[],
+        );
+    }
+
+    #[test]
+    fn primary_is_main() {
+        let base = abs_workspace();
+        let roots = generate_root_names(&base, &[], &[]);
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots.get("main").unwrap(), &base);
+    }
+
+    #[test]
+    fn additional_dirs_get_name_from_component() {
+        let base = abs_workspace();
+        let extra = PathBuf::from(&base).join("report-a");
+        let roots = generate_root_names(&base, &[extra.clone()], &[]);
+        assert_eq!(roots.len(), 2);
+        assert_eq!(roots.get("report-a").unwrap(), &extra);
+    }
+
+    #[test]
+    fn duplicate_names_get_numeric_suffix() {
+        let base = abs_workspace();
+        let dir_a = PathBuf::from(&base).join("projects").join("lib");
+        let dir_b = PathBuf::from(&base).join("extern").join("lib");
+        let roots = generate_root_names(&base, &[dir_a.clone(), dir_b.clone()], &[]);
+        assert_eq!(roots.len(), 3);
+        assert_eq!(roots.get("lib").unwrap(), &dir_a);
+        assert_eq!(roots.get("lib-2").unwrap(), &dir_b);
+    }
+
+    #[test]
+    fn duplicate_paths_are_skipped() {
+        let base = abs_workspace();
+        let lib = PathBuf::from(&base).join("lib");
+        let roots = generate_root_names(&base, &[lib.clone(), lib.clone()], &[]);
+        assert_eq!(roots.len(), 2);
+    }
+
+    #[test]
+    fn path_in_additional_and_workspace_paths_deduped() {
+        let base = abs_workspace();
+        let lib = PathBuf::from(&base).join("lib");
+        let roots = generate_root_names(&base, &[lib.clone()], &[lib.clone()]);
+        assert_eq!(roots.len(), 2);
+    }
+
+    #[test]
+    fn names_are_case_insensitive_for_dedup() {
+        let base = abs_workspace();
+        let lib_a = PathBuf::from(&base).join("Lib");
+        let lib_b = PathBuf::from(&base).join("extern").join("lib");
+        let roots = generate_root_names(&base, &[lib_a.clone(), lib_b.clone()], &[]);
+        assert_eq!(roots.get("lib-2").unwrap(), &lib_b);
+    }
+
+    #[test]
+    fn root_names_are_sanitized_for_prompt_references() {
+        let base = abs_workspace();
+        let fancy = PathBuf::from(&base).join("My Project (API)");
+        let unicode = PathBuf::from(&base).join("剧本创意体系");
+        let roots = generate_root_names(&base, &[fancy.clone(), unicode.clone()], &[]);
+        assert_eq!(roots.get("my-project-api").unwrap(), &fancy);
+        assert_eq!(roots.get("workspace").unwrap(), &unicode);
+    }
+
+    #[test]
+    fn parse_root_ref_absolute_path_returns_none() {
+        let roots = BTreeMap::from([("main".to_string(), PathBuf::from("/workspace"))]);
+        assert!(parse_root_ref("C:\\Users\\test.rs", &roots).is_none());
+        assert!(parse_root_ref("D:\\abs\\path", &roots).is_none());
+    }
+
+    #[test]
+    fn parse_root_ref_plain_relative_returns_none() {
+        let roots = BTreeMap::from([("main".to_string(), PathBuf::from("/workspace"))]);
+        assert!(parse_root_ref("src/main.rs", &roots).is_none());
+    }
+
+    #[test]
+    fn parse_root_ref_with_subpath() {
+        let roots = BTreeMap::from([
+            ("main".to_string(), PathBuf::from("/workspace")),
+            ("lib".to_string(), PathBuf::from("/lib")),
+        ]);
+        let result = parse_root_ref("&lib/src/main.rs", &roots);
+        assert_eq!(result, Some(("lib", "src/main.rs")));
+    }
+
+    #[test]
+    fn parse_root_ref_alone_returns_empty_subpath() {
+        let roots = BTreeMap::from([("main".to_string(), PathBuf::from("/workspace"))]);
+        let result = parse_root_ref("&main", &roots);
+        assert_eq!(result, Some(("main", "")));
+    }
+
+    #[test]
+    fn parse_root_ref_unknown_root_returns_none() {
+        let roots = BTreeMap::from([("main".to_string(), PathBuf::from("/workspace"))]);
+        assert!(parse_root_ref("&unknown/path.rs", &roots).is_none());
+    }
+
+    #[test]
+    fn parse_root_ref_with_backslash_on_windows() {
+        let roots = BTreeMap::from([("lib".to_string(), PathBuf::from("/lib"))]);
+        let result = parse_root_ref("&lib\\src\\main.rs", &roots);
+        assert_eq!(result, Some(("lib", "src\\main.rs")));
+    }
+}

--- a/src-rust/crates/query/src/agent_tool.rs
+++ b/src-rust/crates/query/src/agent_tool.rs
@@ -321,7 +321,7 @@ impl Tool for AgentTool {
 
         let (working_dir_str, worktree_path, git_root): (String, Option<PathBuf>, Option<PathBuf>) =
             if use_isolation {
-                let git_root = find_git_root(&ctx.working_dir);
+                let git_root = find_git_root(&ctx.main_root());
                 if let Some(ref root) = git_root {
                     if let Some(wt) = create_worktree(root, &agent_id).await {
                         let wd = wt.display().to_string();
@@ -331,17 +331,17 @@ impl Tool for AgentTool {
                             agent_id = %agent_id,
                             "Worktree creation failed; running agent in shared working directory"
                         );
-                        (ctx.working_dir.display().to_string(), None, None)
+                        (ctx.main_root().display().to_string(), None, None)
                     }
                 } else {
                     warn!(
                         agent_id = %agent_id,
                         "No git root found; isolation=worktree ignored"
                     );
-                    (ctx.working_dir.display().to_string(), None, None)
+                    (ctx.main_root().display().to_string(), None, None)
                 }
             } else {
-                (ctx.working_dir.display().to_string(), None, None)
+                (ctx.main_root().display().to_string(), None, None)
             };
 
         let query_config = QueryConfig {
@@ -353,6 +353,11 @@ impl Tool for AgentTool {
             output_style: ctx.config.effective_output_style(),
             output_style_prompt: ctx.config.resolve_output_style_prompt(),
             working_directory: Some(working_dir_str),
+            workspace_roots: ctx
+                .workspace_roots()
+                .iter()
+                .map(|(name, path)| (name.clone(), path.display().to_string()))
+                .collect(),
             thinking_budget: None,
             temperature: None,
             tool_result_budget: 50_000,
@@ -636,7 +641,12 @@ pub fn init_team_swarm_runner() {
                     max_tokens: claurst_core::constants::DEFAULT_MAX_TOKENS,
                     max_turns: max_turns.unwrap_or(10),
                     system_prompt: Some(system_prompt),
-                    working_directory: Some(ctx.working_dir.display().to_string()),
+                    working_directory: Some(ctx.main_root().display().to_string()),
+                    workspace_roots: ctx
+                        .workspace_roots()
+                        .iter()
+                        .map(|(name, path)| (name.clone(), path.display().to_string()))
+                        .collect(),
                     output_style: ctx.config.effective_output_style(),
                     output_style_prompt: ctx.config.resolve_output_style_prompt(),
                     provider_registry: Some(Arc::new(provider_registry)),

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -66,6 +66,7 @@ use claurst_core::error::ClaudeError;
 use claurst_core::types::{ContentBlock, Message, Role, ToolResultContent, UsageInfo};
 use claurst_tools::{PermissionLevel, Tool, ToolContext, ToolResult};
 use serde_json::Value;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
@@ -100,6 +101,7 @@ pub struct QueryConfig {
     pub output_style: claurst_core::system_prompt::OutputStyle,
     pub output_style_prompt: Option<String>,
     pub working_directory: Option<String>,
+    pub workspace_roots: BTreeMap<String, String>,
     pub thinking_budget: Option<u32>,
     pub temperature: Option<f32>,
     /// Maximum cumulative character count of all tool results in the message
@@ -179,6 +181,7 @@ impl Default for QueryConfig {
             output_style: claurst_core::system_prompt::OutputStyle::Default,
             output_style_prompt: None,
             working_directory: None,
+            workspace_roots: BTreeMap::new(),
             thinking_budget: None,
             temperature: None,
             tool_result_budget: 50_000,
@@ -447,7 +450,7 @@ pub async fn run_query_loop(
     // can produce a per-turn file-change patch when the turn ends.
     let shadow_snap: Option<std::sync::Arc<claurst_core::snapshot::ShadowSnapshot>> =
         if tool_ctx.config.auto_commits == Some(true) {
-            claurst_core::snapshot::get_or_create(&tool_ctx.working_dir)
+            claurst_core::snapshot::get_or_create(&tool_ctx.main_root())
         } else {
             None
         };
@@ -1673,7 +1676,7 @@ pub async fn run_query_loop(
                     &tool_ctx.config.hooks,
                     claurst_core::config::HookEvent::Stop,
                     &stop_ctx,
-                    &tool_ctx.working_dir,
+                    &tool_ctx.main_root(),
                 )
                 .await;
             }};
@@ -1689,7 +1692,7 @@ pub async fn run_query_loop(
                 let _bg = stop_hooks_with_full_behavior(
                     &assistant_msg,
                     &tool_ctx.config,
-                    tool_ctx.working_dir.clone(),
+                    tool_ctx.main_root().clone(),
                 );
 
                 // Asynchronously extract and persist session memories if warranted.
@@ -1697,7 +1700,7 @@ pub async fn run_query_loop(
                 if session_memory::SessionMemoryExtractor::should_extract(messages) {
                     let model_clone = config.model.clone();
                     let messages_clone = messages.clone();
-                    let working_dir_clone = tool_ctx.working_dir.clone();
+                    let working_dir_clone = tool_ctx.main_root().clone();
 
                     // Build a fresh client using the same API key.  This avoids
                     // requiring an Arc in the existing run_query_loop signature.
@@ -1896,7 +1899,7 @@ pub async fn run_query_loop(
                             hooks,
                             claurst_core::config::HookEvent::PreToolUse,
                             &hook_ctx,
-                            &tool_ctx.working_dir,
+                            &tool_ctx.main_root(),
                         )
                         .await;
 
@@ -1980,7 +1983,7 @@ pub async fn run_query_loop(
                             hooks,
                             claurst_core::config::HookEvent::PostToolUse,
                             &post_ctx,
-                            &tool_ctx.working_dir,
+                            &tool_ctx.main_root(),
                         )
                         .await;
 
@@ -2026,7 +2029,7 @@ pub async fn run_query_loop(
                 let _bg = stop_hooks_with_full_behavior(
                     &assistant_msg,
                     &tool_ctx.config,
-                    tool_ctx.working_dir.clone(),
+                    tool_ctx.main_root().clone(),
                 );
                 if let (Some(ref snap), Some(ref hash)) = (&shadow_snap, &initial_snapshot) {
                     let patch = snap.patch(hash).await;
@@ -2042,7 +2045,7 @@ pub async fn run_query_loop(
                 let _bg = stop_hooks_with_full_behavior(
                     &assistant_msg,
                     &tool_ctx.config,
-                    tool_ctx.working_dir.clone(),
+                    tool_ctx.main_root().clone(),
                 );
                 if let (Some(ref snap), Some(ref hash)) = (&shadow_snap, &initial_snapshot) {
                     let patch = snap.patch(hash).await;
@@ -2132,6 +2135,7 @@ mod tests {
             output_style: claurst_core::system_prompt::OutputStyle::Default,
             output_style_prompt: None,
             working_directory: None,
+            workspace_roots: BTreeMap::new(),
             thinking_budget: None,
             temperature: None,
             tool_result_budget: 50_000,
@@ -2554,8 +2558,9 @@ mod tests {
     }
 
     fn deny_all_context() -> ToolContext {
+        use std::collections::BTreeMap;
         ToolContext {
-            working_dir: std::path::PathBuf::from("/workspace"),
+            workspace_roots: BTreeMap::from([("main".to_string(), std::path::PathBuf::from("/workspace"))]),
             permission_mode: claurst_core::config::PermissionMode::Default,
             permission_handler: Arc::new(DenyAllHandler),
             cost_tracker: claurst_core::cost::CostTracker::new(),

--- a/src-rust/crates/query/src/runner/prompt.rs
+++ b/src-rust/crates/query/src/runner/prompt.rs
@@ -26,6 +26,7 @@ pub(crate) fn build_system_prompt(config: &QueryConfig) -> SystemPrompt {
         output_style: config.output_style,
         custom_output_style_prompt: config.output_style_prompt.clone(),
         working_directory: config.working_directory.clone(),
+        workspace_roots: config.workspace_roots.clone(),
         // Forward the session's enabled tool set so per-tool guideline blocks
         // are only emitted for tools that are actually loaded (issue #233).
         enabled_tools: config.enabled_tools.clone(),

--- a/src-rust/crates/tools/src/apply_patch.rs
+++ b/src-rust/crates/tools/src/apply_patch.rs
@@ -256,8 +256,9 @@ impl Tool for ApplyPatchTool {
 
     fn description(&self) -> &str {
         "Apply a unified diff patch to files. The patch must be in standard unified \
-         diff format (as produced by `git diff` or `diff -u`). Set dry_run=true to \
-         validate the patch without writing any changes."
+         diff format (as produced by `git diff` or `diff -u`). Patch file paths \
+         may be absolute, main-relative, or &root-name/relative paths. Set \
+         dry_run=true to validate the patch without writing any changes."
     }
 
     fn permission_level(&self) -> PermissionLevel {

--- a/src-rust/crates/tools/src/batch_edit.rs
+++ b/src-rust/crates/tools/src/batch_edit.rs
@@ -60,7 +60,7 @@ impl Tool for BatchEditTool {
                         "properties": {
                             "file_path": {
                                 "type": "string",
-                                "description": "Absolute path to the file to modify"
+                                "description": "File to modify. Accepts absolute paths, main-relative paths, or &root-name/relative paths."
                             },
                             "old_string": {
                                 "type": "string",

--- a/src-rust/crates/tools/src/brief.rs
+++ b/src-rust/crates/tools/src/brief.rs
@@ -59,7 +59,7 @@ impl Tool for BriefTool {
                 "attachments": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Optional file paths to attach (images, diffs, logs)"
+                    "description": "Optional file paths to attach (images, diffs, logs). Accepts absolute paths, main-relative paths, or &root-name/relative paths."
                 },
                 "status": {
                     "type": "string",

--- a/src-rust/crates/tools/src/cron.rs
+++ b/src-rust/crates/tools/src/cron.rs
@@ -557,8 +557,9 @@ mod tests {
     }
 
     fn deny_ctx() -> ToolContext {
+        use std::collections::BTreeMap;
         ToolContext {
-            working_dir: std::env::temp_dir(),
+            workspace_roots: BTreeMap::from([("main".to_string(), std::env::temp_dir())]),
             permission_mode: claurst_core::config::PermissionMode::Default,
             permission_handler: Arc::new(DenyHandler),
             cost_tracker: claurst_core::cost::CostTracker::new(),

--- a/src-rust/crates/tools/src/file_edit.rs
+++ b/src-rust/crates/tools/src/file_edit.rs
@@ -44,7 +44,7 @@ impl Tool for FileEditTool {
             "properties": {
                 "file_path": {
                     "type": "string",
-                    "description": "The absolute path to the file to modify"
+                    "description": "The file to modify. Accepts absolute paths, main-relative paths, or &root-name/relative paths."
                 },
                 "old_string": {
                     "type": "string",

--- a/src-rust/crates/tools/src/file_read.rs
+++ b/src-rust/crates/tools/src/file_read.rs
@@ -43,7 +43,7 @@ impl Tool for FileReadTool {
             "properties": {
                 "file_path": {
                     "type": "string",
-                    "description": "The absolute path to the file to read"
+                    "description": "The file to read. Accepts absolute paths, main-relative paths, or &root-name/relative paths."
                 },
                 "offset": {
                     "type": "number",

--- a/src-rust/crates/tools/src/file_write.rs
+++ b/src-rust/crates/tools/src/file_write.rs
@@ -39,7 +39,7 @@ impl Tool for FileWriteTool {
             "properties": {
                 "file_path": {
                     "type": "string",
-                    "description": "The absolute path to the file to write"
+                    "description": "The file to write. Accepts absolute paths, main-relative paths, or &root-name/relative paths."
                 },
                 "content": {
                     "type": "string",

--- a/src-rust/crates/tools/src/glob_tool.rs
+++ b/src-rust/crates/tools/src/glob_tool.rs
@@ -46,7 +46,7 @@ impl Tool for GlobTool {
                 },
                 "path": {
                     "type": "string",
-                    "description": "The directory to search in. Defaults to working directory."
+                    "description": "The directory to search in. Accepts absolute paths, main-relative paths, or &root-name/relative paths. If omitted, searches only main. To search all workspace roots, call Glob once per root with path=&root-name; these calls can run in parallel."
                 }
             },
             "required": ["pattern"]
@@ -63,7 +63,7 @@ impl Tool for GlobTool {
             .path
             .as_ref()
             .map(|p| ctx.resolve_path(p))
-            .unwrap_or_else(|| ctx.working_dir.clone());
+            .unwrap_or_else(|| ctx.main_root().clone());
 
         if let Err(e) = ctx.check_permission_for_path(
             self.name(),

--- a/src-rust/crates/tools/src/grep_tool.rs
+++ b/src-rust/crates/tools/src/grep_tool.rs
@@ -95,7 +95,7 @@ impl Tool for GrepTool {
                 },
                 "path": {
                     "type": "string",
-                    "description": "File or directory to search in. Defaults to working directory."
+                    "description": "File or directory to search in. Accepts absolute paths, main-relative paths, or &root-name/relative paths. If omitted, searches only main. To search all workspace roots, call Grep once per root with path=&root-name; these calls can run in parallel."
                 },
                 "type": {
                     "type": "string",
@@ -145,7 +145,7 @@ impl Tool for GrepTool {
             .path
             .as_ref()
             .map(|p| ctx.resolve_path(p))
-            .unwrap_or_else(|| ctx.working_dir.clone());
+            .unwrap_or_else(|| ctx.main_root().clone());
 
         if let Err(e) = ctx.check_permission_for_path(
             self.name(),

--- a/src-rust/crates/tools/src/lib.rs
+++ b/src-rust/crates/tools/src/lib.rs
@@ -13,8 +13,8 @@ use claurst_core::cost::CostTracker;
 use claurst_core::permissions::{PermissionDecision, PermissionHandler, PermissionRequest};
 use claurst_core::types::ToolDefinition;
 use serde_json::Value;
-use std::collections::{HashMap, VecDeque};
-use std::path::PathBuf;
+use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
@@ -282,7 +282,9 @@ impl CompletionNotifier {
 /// Shared context passed to every tool invocation.
 #[derive(Clone)]
 pub struct ToolContext {
-    pub working_dir: PathBuf,
+    /// Named workspace roots: "main" is the primary working directory,
+    /// additional entries come from --add-dir and workspace_paths.
+    pub workspace_roots: BTreeMap<String, PathBuf>,
     pub permission_mode: PermissionMode,
     pub permission_handler: Arc<dyn PermissionHandler>,
     pub cost_tracker: Arc<CostTracker>,
@@ -316,14 +318,113 @@ pub struct ToolContext {
 }
 
 impl ToolContext {
-    /// Resolve a potentially relative path against the working directory.
+    /// Returns the primary (main) working directory.
+    ///
+    /// Invariant: every production and test `ToolContext` constructor must
+    /// populate the `main` root. This is the replacement for the previous
+    /// single `working_dir` field, so missing `main` indicates a programming
+    /// error at construction time rather than a user-provided path failure.
+    pub fn main_root(&self) -> &PathBuf {
+        self.workspace_roots.get("main")
+            .expect("ToolContext: 'main' root must always exist")
+    }
+
+    /// Returns all named workspace roots as a reference.
+    pub fn workspace_roots(&self) -> &BTreeMap<String, PathBuf> {
+        &self.workspace_roots
+    }
+
+    /// Look up a workspace root by name.
+    pub fn root(&self, name: &str) -> Option<&PathBuf> {
+        self.workspace_roots.get(name)
+    }
+
+    /// Resolve a path that may use `&root-name/relative-path` syntax.
+    ///
+    /// Delegates to `resolve_workspace_path` and returns just the absolute path
+    /// for backward compatibility.
     pub fn resolve_path(&self, path: &str) -> PathBuf {
-        let p = PathBuf::from(path);
-        if p.is_absolute() {
-            p
-        } else {
-            self.working_dir.join(p)
+        self.resolve_workspace_path(path).absolute_path
+    }
+
+    /// Resolve a path that may use `&root-name/relative-path` syntax.
+    ///
+    /// Three cases:
+    /// - Absolute path (`D:\...`, `/home/...`) → returned as-is.
+    /// - `&root-name/path` → resolved against the named root.
+    /// - `&root-name` alone → resolved to the root directory itself.
+    /// - Plain relative path → resolved against `main_root()`.
+    pub fn resolve_workspace_path(&self, path: &str) -> claurst_core::ResolvedWorkspacePath {
+        let input = path.to_string();
+
+        // 1. Absolute path
+        if Path::new(path).is_absolute() {
+            return claurst_core::ResolvedWorkspacePath {
+                input,
+                root_name: None,
+                root_path: None,
+                relative_path: None,
+                absolute_path: PathBuf::from(path),
+            };
         }
+
+        // 2. &root-name[/subpath] syntax
+        if let Some((root_name, remainder)) = claurst_core::workspace::parse_root_ref(path, &self.workspace_roots) {
+            if let Some(root_path) = self.workspace_roots.get(root_name).cloned() {
+                let absolute_path = if remainder.is_empty() {
+                    root_path.clone()
+                } else {
+                    root_path.join(remainder)
+                };
+                let relative = if remainder.is_empty() { None } else { Some(PathBuf::from(remainder)) };
+                return claurst_core::ResolvedWorkspacePath {
+                    input,
+                    root_name: Some(root_name.to_string()),
+                    root_path: Some(root_path),
+                    relative_path: relative,
+                    absolute_path,
+                };
+            }
+        }
+
+        // 3. Plain relative path — default to main
+        let absolute_path = self.main_root().join(path);
+        claurst_core::ResolvedWorkspacePath {
+            input,
+            root_name: None,
+            root_path: None,
+            relative_path: Some(PathBuf::from(path)),
+            absolute_path,
+        }
+    }
+
+    /// Format an absolute path as `&root-name/relative-path` if it falls under
+    /// any registered workspace root.
+    pub fn format_workspace_path(&self, path: &Path) -> Option<String> {
+        let canon = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+        for (name, root_path) in &self.workspace_roots {
+            let canon_root = std::fs::canonicalize(root_path).unwrap_or_else(|_| root_path.clone());
+            if let Ok(relative) = canon.strip_prefix(&canon_root) {
+                let relative_str = relative.to_string_lossy();
+                if relative_str.is_empty() {
+                    return Some(format!("&{}", name));
+                }
+                return Some(format!("&{}/{}", name, relative_str));
+            }
+        }
+        None
+    }
+
+    /// Find which registered workspace root contains the given absolute path.
+    pub fn find_root_for_path(&self, path: &Path) -> Option<&str> {
+        let canon = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+        for (name, root_path) in &self.workspace_roots {
+            let canon_root = std::fs::canonicalize(root_path).unwrap_or_else(|_| root_path.clone());
+            if canon.starts_with(&canon_root) {
+                return Some(name);
+            }
+        }
+        None
     }
 
     fn permission_allowed_roots(&self) -> Vec<PathBuf> {
@@ -346,7 +447,7 @@ impl ToolContext {
             details,
             is_read_only,
             path: path.map(|p| p.display().to_string()),
-            working_dir: Some(self.working_dir.clone()),
+            working_dir: Some(self.main_root().clone()),
             allowed_roots: self.permission_allowed_roots(),
             context_description: None,
         }
@@ -451,7 +552,7 @@ impl ToolContext {
     pub fn path_is_within_workspace(&self, path: &std::path::Path) -> bool {
         let resolved = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
         let mut roots = vec![
-            std::fs::canonicalize(&self.working_dir).unwrap_or_else(|_| self.working_dir.clone()),
+            std::fs::canonicalize(self.main_root()).unwrap_or_else(|_| self.main_root().clone()),
         ];
         roots.extend(
             self.permission_allowed_roots()
@@ -655,9 +756,10 @@ mod tests {
         handler: Arc<dyn claurst_core::permissions::PermissionHandler>,
     ) -> ToolContext {
         use claurst_core::config::Config;
+        use std::collections::BTreeMap;
 
         ToolContext {
-            working_dir: PathBuf::from("/workspace"),
+            workspace_roots: BTreeMap::from([("main".to_string(), PathBuf::from("/workspace"))]),
             permission_mode: claurst_core::config::PermissionMode::Default,
             permission_handler: handler,
             cost_tracker: claurst_core::cost::CostTracker::new(),

--- a/src-rust/crates/tools/src/lsp_tool.rs
+++ b/src-rust/crates/tools/src/lsp_tool.rs
@@ -39,7 +39,7 @@ impl Tool for LspTool {
                 },
                 "file": {
                     "type": "string",
-                    "description": "Absolute or working-directory-relative path to the source file."
+                    "description": "Path to the source file. Accepts absolute paths, main-relative paths, or &root-name/relative paths."
                 },
                 "line": {
                     "type": "integer",
@@ -67,14 +67,7 @@ impl Tool for LspTool {
         };
 
         // Resolve to absolute path
-        let file_path = if std::path::Path::new(&file_raw).is_absolute() {
-            file_raw.clone()
-        } else {
-            ctx.working_dir
-                .join(&file_raw)
-                .to_string_lossy()
-                .into_owned()
-        };
+        let file_path = ctx.resolve_path(&file_raw).to_string_lossy().into_owned();
 
         if let Err(e) = ctx.check_permission_for_path(
             self.name(),
@@ -119,7 +112,7 @@ impl Tool for LspTool {
         // --- Ensure the file is opened on its LSP server --------------------
         {
             let mut manager = lsp_manager_arc.lock().await;
-            if let Err(e) = manager.open_file(&file_path, &ctx.working_dir).await {
+            if let Err(e) = manager.open_file(&file_path, ctx.main_root()).await {
                 return ToolResult::error(format!("Failed to open file in LSP: {}", e));
             }
         }
@@ -130,7 +123,7 @@ impl Tool for LspTool {
                 let result = {
                     let mut manager = lsp_manager_arc.lock().await;
                     manager
-                        .hover(&file_path, &ctx.working_dir, line, column)
+                        .hover(&file_path, ctx.main_root(), line, column)
                         .await
                 };
                 match result {
@@ -147,7 +140,7 @@ impl Tool for LspTool {
                 let result = {
                     let mut manager = lsp_manager_arc.lock().await;
                     manager
-                        .definition(&file_path, &ctx.working_dir, line, column)
+                        .definition(&file_path, ctx.main_root(), line, column)
                         .await
                 };
                 match result {
@@ -164,7 +157,7 @@ impl Tool for LspTool {
                 let result = {
                     let mut manager = lsp_manager_arc.lock().await;
                     manager
-                        .references(&file_path, &ctx.working_dir, line, column)
+                        .references(&file_path, ctx.main_root(), line, column)
                         .await
                 };
                 match result {
@@ -185,7 +178,7 @@ impl Tool for LspTool {
                 let result = {
                     let mut manager = lsp_manager_arc.lock().await;
                     manager
-                        .document_symbols(&file_path, &ctx.working_dir)
+                        .document_symbols(&file_path, ctx.main_root())
                         .await
                 };
                 match result {

--- a/src-rust/crates/tools/src/monitor_tool.rs
+++ b/src-rust/crates/tools/src/monitor_tool.rs
@@ -258,8 +258,9 @@ mod tests {
         let handler = Arc::new(AutoPermissionHandler {
             mode: claurst_core::config::PermissionMode::Default,
         });
+        use std::collections::BTreeMap;
         ToolContext {
-            working_dir: PathBuf::from("."),
+            workspace_roots: BTreeMap::from([("main".to_string(), std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))]),
             permission_mode: claurst_core::config::PermissionMode::Default,
             permission_handler: handler,
             cost_tracker: claurst_core::cost::CostTracker::new(),

--- a/src-rust/crates/tools/src/notebook_edit.rs
+++ b/src-rust/crates/tools/src/notebook_edit.rs
@@ -63,7 +63,7 @@ impl Tool for NotebookEditTool {
             "properties": {
                 "notebook_path": {
                     "type": "string",
-                    "description": "Absolute path to the .ipynb notebook file"
+                    "description": "Path to the .ipynb notebook file. Accepts absolute paths, main-relative paths, or &root-name/relative paths."
                 },
                 "cell_id": {
                     "type": "string",

--- a/src-rust/crates/tools/src/powershell.rs
+++ b/src-rust/crates/tools/src/powershell.rs
@@ -221,7 +221,7 @@ impl Tool for PowerShellTool {
         let mut child = match Command::new(exe)
             .args(&args)
             .arg(&params.command)
-            .current_dir(&ctx.working_dir)
+            .current_dir(ctx.main_root())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .stdin(Stdio::null())

--- a/src-rust/crates/tools/src/pty_bash.rs
+++ b/src-rust/crates/tools/src/pty_bash.rs
@@ -744,7 +744,7 @@ impl Tool for PtyBashTool {
         if params.run_in_background {
             let cwd = {
                 let state = shell_state_arc.lock();
-                state.cwd.clone().unwrap_or_else(|| ctx.working_dir.clone())
+                state.cwd.clone().unwrap_or_else(|| ctx.main_root().clone())
             };
             return run_in_background(params.command, cwd, timeout_ms).await;
         }
@@ -756,7 +756,7 @@ impl Tool for PtyBashTool {
         {
             let effective_cwd = {
                 let state = shell_state_arc.lock();
-                state.cwd.clone().unwrap_or_else(|| ctx.working_dir.clone())
+                state.cwd.clone().unwrap_or_else(|| ctx.main_root().clone())
             };
             return run_windows_fallback(&params.command, &effective_cwd, timeout_dur, timeout_ms)
                 .await;
@@ -770,9 +770,9 @@ impl Tool for PtyBashTool {
             // environment (never its argv) — see `apply_restored_env` (#211).
             let (script, restored_env, working_dir_str) = {
                 let state = shell_state_arc.lock();
-                let script = build_wrapper_script(&params.command, &state, &ctx.working_dir);
+                let script = build_wrapper_script(&params.command, &state, &ctx.main_root());
                 let restored_env = state.env_vars.clone();
-                let wd = ctx.working_dir.to_string_lossy().into_owned();
+                let wd = ctx.main_root().to_string_lossy().into_owned();
                 (script, restored_env, wd)
             };
 
@@ -934,8 +934,9 @@ mod tests {
     }
 
     fn allow_all_context() -> ToolContext {
+        use std::collections::BTreeMap;
         ToolContext {
-            working_dir: std::env::temp_dir(),
+            workspace_roots: BTreeMap::from([("main".to_string(), std::env::temp_dir())]),
             permission_mode: claurst_core::config::PermissionMode::Default,
             permission_handler: std::sync::Arc::new(AllowAllHandler),
             cost_tracker: claurst_core::cost::CostTracker::new(),

--- a/src-rust/crates/tools/src/repl_tool.rs
+++ b/src-rust/crates/tools/src/repl_tool.rs
@@ -344,8 +344,9 @@ mod tests {
         handler: Arc<dyn claurst_core::permissions::PermissionHandler>,
         session_id: &str,
     ) -> ToolContext {
+        use std::collections::BTreeMap;
         ToolContext {
-            working_dir: std::env::temp_dir(),
+            workspace_roots: BTreeMap::from([("main".to_string(), std::env::temp_dir())]),
             permission_mode: claurst_core::config::PermissionMode::Default,
             permission_handler: handler,
             cost_tracker: claurst_core::cost::CostTracker::new(),

--- a/src-rust/crates/tools/src/skill_tool.rs
+++ b/src-rust/crates/tools/src/skill_tool.rs
@@ -132,7 +132,7 @@ impl Tool for SkillTool {
 
 fn skill_search_dirs(ctx: &ToolContext) -> Vec<PathBuf> {
     let mut dirs = vec![
-        ctx.working_dir.join(".claurst").join("commands"),
+        ctx.main_root().join(".claurst").join("commands"),
     ];
     dirs.push(claurst_core::config::Settings::config_dir().join("commands"));
     dirs

--- a/src-rust/crates/tools/src/test_support.rs
+++ b/src-rust/crates/tools/src/test_support.rs
@@ -2,6 +2,7 @@
 //! `ToolContext` rooted at a caller-supplied (usually temp) directory.
 
 use crate::ToolContext;
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -27,7 +28,7 @@ impl claurst_core::permissions::PermissionHandler for AllowAllHandler {
 /// Build a permissive, non-interactive `ToolContext` rooted at `working_dir`.
 pub(crate) fn allow_all_context(working_dir: PathBuf) -> ToolContext {
     ToolContext {
-        working_dir,
+        workspace_roots: BTreeMap::from([("main".to_string(), working_dir)]),
         permission_mode: claurst_core::config::PermissionMode::Default,
         permission_handler: Arc::new(AllowAllHandler),
         cost_tracker: claurst_core::cost::CostTracker::new(),

--- a/src-rust/crates/tools/src/worktree.rs
+++ b/src-rust/crates/tools/src/worktree.rs
@@ -137,13 +137,13 @@ impl Tool for EnterWorktreeTool {
 
         // Determine worktree path
         let worktree_path = if let Some(p) = params.path {
-            ctx.working_dir.join(p)
+            ctx.main_root().join(p)
         } else {
-            ctx.working_dir.join(".worktrees").join(&branch)
+            ctx.main_root().join(".worktrees").join(&branch)
         };
 
         // Verify we are inside a git repository before attempting worktree creation
-        let head_result = run_git(&ctx.working_dir, &["rev-parse", "HEAD"]).await;
+        let head_result = run_git(&ctx.main_root(), &["rev-parse", "HEAD"]).await;
         let original_head = match &head_result {
             Ok(h) => Some(h.trim().to_string()),
             Err(e) => {
@@ -151,7 +151,7 @@ impl Tool for EnterWorktreeTool {
                 if msg.contains("not a git repository") || msg.contains("fatal") {
                     return ToolResult::error(format!(
                         "Cannot create worktree: the current directory '{}' is not inside a git repository.",
-                        ctx.working_dir.display()
+                        ctx.main_root().display()
                     ));
                 }
                 None
@@ -169,7 +169,7 @@ impl Tool for EnterWorktreeTool {
         // Create the worktree
         let worktree_str = worktree_path.to_string_lossy().to_string();
         let result = run_git(
-            &ctx.working_dir,
+            &ctx.main_root(),
             &["worktree", "add", "-b", &branch, &worktree_str],
         )
         .await;
@@ -185,7 +185,7 @@ impl Tool for EnterWorktreeTool {
                 } else if msg.to_lowercase().contains("not a git repository") {
                     format!(
                         "Failed to create worktree: '{}' is not inside a git repository.",
-                        ctx.working_dir.display()
+                        ctx.main_root().display()
                     )
                 } else {
                     format!("Failed to create worktree: {}", msg)
@@ -201,7 +201,7 @@ impl Tool for EnterWorktreeTool {
 
                 // Save session state
                 *WORKTREE_SESSION.write().await = Some(WorktreeSession {
-                    original_cwd: ctx.working_dir.clone(),
+                    original_cwd: ctx.main_root().clone(),
                     worktree_path: worktree_path.clone(),
                     branch: Some(branch.clone()),
                     original_head,
@@ -270,13 +270,13 @@ impl Tool for EnterWorktreeTool {
                     worktree_path.display(),
                     branch,
                     worktree_path.display(),
-                    ctx.working_dir.display(),
+                    ctx.main_root().display(),
                     post_create_output,
                 ))
                 .with_metadata(json!({
                     "worktree_path": worktree_path.to_string_lossy(),
                     "branch": branch,
-                    "original_cwd": ctx.working_dir.to_string_lossy(),
+                    "original_cwd": ctx.main_root().to_string_lossy(),
                 }))
             }
         }

--- a/src-rust/crates/tui/src/render.rs
+++ b/src-rust/crates/tui/src/render.rs
@@ -369,18 +369,57 @@ fn startup_notice_lines(app: &App, width: u16) -> Vec<Line<'static>> {
         ]));
     }
 
-    // Additional directories (from --add-dir)
-    for dir in &app.config.additional_dirs {
-        lines.push(Line::from(vec![
-            Span::styled(" +dir ", Style::default().fg(Color::Cyan)),
-            Span::styled(
-                truncate_end(&dir.display().to_string(), max_width),
-                Style::default().fg(Color::DarkGray),
-            ),
-        ]));
-    }
+    lines.extend(workspace_root_notice_lines(app, max_width));
 
     lines
+}
+
+fn workspace_root_notice_lines(app: &App, max_width: usize) -> Vec<Line<'static>> {
+    if app.config.additional_dirs.is_empty() && app.config.workspace_paths.is_empty() {
+        return Vec::new();
+    }
+
+    let primary = app
+        .config
+        .project_dir
+        .clone()
+        .or_else(|| app.current_dir.as_deref().map(std::path::PathBuf::from));
+    let Some(primary) = primary.filter(|path| path.is_absolute()) else {
+        return Vec::new();
+    };
+
+    let roots = claurst_core::generate_root_names(
+        &primary,
+        &app.config.additional_dirs,
+        &app.config.workspace_paths,
+    );
+
+    let mut ordered_roots = Vec::new();
+    if let Some(main) = roots.get("main") {
+        ordered_roots.push(("main", main));
+    }
+    ordered_roots.extend(
+        roots
+            .iter()
+            .filter(|(name, _)| name.as_str() != "main")
+            .map(|(name, path)| (name.as_str(), path)),
+    );
+
+    ordered_roots
+        .into_iter()
+        .map(|(name, path)| {
+            let root_ref = format!("&{} ", name);
+            let path_width = max_width.saturating_sub(UnicodeWidthStr::width(root_ref.as_str()));
+            Line::from(vec![
+                Span::styled(" root ", Style::default().fg(Color::Cyan)),
+                Span::styled(root_ref, Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+                Span::styled(
+                    truncate_end(&path.display().to_string(), path_width),
+                    Style::default().fg(Color::DarkGray),
+                ),
+            ])
+        })
+        .collect()
 }
 
 fn render_startup_notices(frame: &mut Frame, app: &App, area: Rect) {
@@ -3438,6 +3477,28 @@ mod tool_block_tests {
         }
         // A non-home path is left untouched.
         assert_eq!(shorten_home_path("/etc/hosts"), "/etc/hosts");
+    }
+
+    #[test]
+    fn startup_notices_show_named_workspace_roots() {
+        let temp = tempfile::tempdir().unwrap();
+        let main = temp.path().join("main");
+        let ai_engine = temp.path().join("_ai-engine");
+        let mut config = claurst_core::config::Config::default();
+        config.project_dir = Some(main.clone());
+        config.additional_dirs = vec![ai_engine.clone()];
+        let app = App::new(config, claurst_core::cost::CostTracker::new());
+
+        let lines: Vec<String> = startup_notice_lines(&app, 120)
+            .iter()
+            .map(flatten_line_text)
+            .collect();
+        let joined = lines.join("\n");
+        assert!(joined.contains("root &main"), "{joined}");
+        assert!(joined.contains("root &_ai-engine"), "{joined}");
+        assert!(joined.contains(main.to_string_lossy().as_ref()), "{joined}");
+        assert!(joined.contains(ai_engine.to_string_lossy().as_ref()), "{joined}");
+        assert!(!joined.contains("+dir"), "{joined}");
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`--add-dir` already allowed Claurst to access extra directories, but those directories were mostly anonymous permission roots. In multi-repository workflows, the model had to rely on absolute paths or user reminders to search and edit outside the main working directory.

This change makes the main directory and additional directories visible as named workspace roots, so users and the model can refer to them consistently with `&main` and `&root-name/path`.

`&` is used instead of `@` because `@` is already used by prompt file injection.

## Summary

- Introduce named workspace roots, with `&main` for the primary working directory and stable sanitized names for additional directories from `--add-dir`, `additional_dirs`, and `workspace_paths`.
- Add `&root-name/path` resolution through the shared tool path resolver, so path-based tools can target additional roots without requiring absolute paths.
- Expose the workspace root list to the model prompt, including guidance for searching across roots with parallel `Glob` / `Grep` calls.
- Update the TUI welcome screen to show named roots instead of anonymous `+dir` entries.
- Document workspace-root paths in the advanced guide, configuration reference, and tools reference.

## Test plan

- `cargo check --workspace`
- `cargo test --package claurst-core workspace`
- `cargo test --package claurst-core system_prompt`