### PR TITLE
fix(mcp): reject path traversal in MCP token file names

### DIFF
--- a/src-rust/crates/mcp/src/oauth.rs
+++ b/src-rust/crates/mcp/src/oauth.rs
@@ -195,7 +195,7 @@ pub async fn begin_mcp_auth(
     let redirect_port = oauth_port_alloc()
         .map_err(|e| anyhow::anyhow!("Failed to allocate OAuth redirect port: {}", e))?;
     let redirect_uri = format!("http://127.0.0.1:{}/callback", redirect_port);
-    let verifier = pkce_verifier();
+    let verifier = pkce_verifier().map_err(|e| anyhow::anyhow!("Failed to generate PKCE verifier: {}", e))?;
     let auth_url = build_mcp_auth_url(
         &metadata.authorization_endpoint,
         &redirect_uri,
@@ -373,12 +373,12 @@ pub async fn get_valid_mcp_access_token(
 // ---------------------------------------------------------------------------
 
 /// Generate a PKCE code verifier (43 URL-safe random chars per RFC 7636).
-pub fn pkce_verifier() -> String {
+pub fn pkce_verifier() -> std::io::Result<String> {
     use base64::Engine as _;
     let mut bytes = [0u8; 32];
-    getrandom::getrandom(&mut bytes).expect("getrandom failed");
+    getrandom::getrandom(&mut bytes).map_err(std::io::Error::other)?;
     // base64url-encode → 43 chars (256 bits of entropy, no padding)
-    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+    Ok(base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes))
 }
 
 /// Derive a PKCE code challenge from a verifier (S256 method).
@@ -424,7 +424,7 @@ pub fn initiate_xaa_login(
     idp_url: &str,
 ) -> std::io::Result<XaaLoginState> {
     let port = oauth_port_alloc()?;
-    let verifier = pkce_verifier();
+    let verifier = pkce_verifier()?;
     let challenge = pkce_challenge(&verifier);
     let redirect_uri = format!("http://127.0.0.1:{}/callback", port);
 
@@ -584,6 +584,12 @@ mod tests {
 
         let normal = token_path("my-server");
         assert_eq!(normal.file_name().unwrap(), "my-server.json");
+    }
+
+    #[test]
+    fn pkce_verifier_is_43_chars() {
+        let v = pkce_verifier().expect("getrandom should succeed in tests");
+        assert_eq!(v.len(), 43);
     }
 
     #[test]

--- a/src-rust/crates/mcp/src/oauth.rs
+++ b/src-rust/crates/mcp/src/oauth.rs
@@ -52,8 +52,16 @@ fn token_store_dir() -> PathBuf {
 }
 
 /// Path to the token store for a given MCP server.
+///
+/// `server_name` is untrusted (it comes from MCP server config), so it is
+/// reduced to its file-name component before joining — this rejects path
+/// separators and `..` traversal instead of trusting the raw string.
 fn token_path(server_name: &str) -> PathBuf {
-    token_store_dir().join(format!("{}.json", server_name))
+    let safe_name = std::path::Path::new(server_name)
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    token_store_dir().join(format!("{}.json", safe_name))
 }
 
 /// Persist an MCP OAuth token to disk.
@@ -567,6 +575,16 @@ pub async fn refresh_mcp_token(server_name: &str, token_endpoint: &str) -> anyho
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn token_path_strips_path_traversal() {
+        let traversal = token_path("../../etc/passwd");
+        assert_eq!(traversal.file_name().unwrap(), "passwd.json");
+        assert_eq!(traversal.parent().unwrap(), token_store_dir());
+
+        let normal = token_path("my-server");
+        assert_eq!(normal.file_name().unwrap(), "my-server.json");
+    }
 
     #[test]
     fn pkce_challenge_length() {


### PR DESCRIPTION
## Summary

Fixes #203.

`token_path()` in `src-rust/crates/mcp/src/oauth.rs` joined the raw `server_name` (untrusted, comes from MCP server config) directly into a file path: `token_store_dir().join(format!("{}.json", server_name))`. A `server_name` containing `../../etc/passwd` could escape the token store directory.

Also fixes a related issue in the same file: `pkce_verifier()` called `.expect("getrandom failed")`, which would crash the whole process on a rare RNG failure during OAuth login — house style (`AGENTS.md`) bans `.expect()` on fallible ops in production paths.

## Changes

- `token_path()` now reduces `server_name` to its file-name component via `Path::file_name()` before joining, stripping traversal segments instead of trusting the raw string.
- `pkce_verifier()` now returns `std::io::Result<String>` and both call sites propagate the error instead of panicking.

## Test plan

- [x] Added `token_path_strips_path_traversal` — asserts `../../etc/passwd` resolves to `passwd.json` inside the token store dir.
- [x] Added `pkce_verifier_is_43_chars` covering the new `Result`-returning signature.
- [x] `cargo test -p claurst-mcp` — all tests pass.
- [x] `cargo clippy -p claurst-mcp --all-targets -- -D warnings` — clean.
- [x] `cargo check --workspace` — clean.