### PR TITLE
fix(cli): drop guarded unwrap() on suggestion_index

### DIFF
--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -2320,10 +2320,12 @@ async fn run_interactive(
                     if plain_enter && !app.is_streaming && !any_dialog_open {
                         // If a file-ref suggestion is active, accept it instead of submitting.
                         if !app.prompt_input.suggestions.is_empty()
-                            && app.prompt_input.suggestion_index.is_some()
-                            && app.prompt_input.suggestions.get(app.prompt_input.suggestion_index.unwrap())
-                                .map(|s| s.source == claurst_tui::prompt_input::TypeaheadSource::FileRef)
-                                .unwrap_or(false)
+                            && app.prompt_input.suggestion_index.is_some_and(|index| {
+                                app.prompt_input
+                                    .suggestions
+                                    .get(index)
+                                    .is_some_and(|s| s.source == claurst_tui::prompt_input::TypeaheadSource::FileRef)
+                            })
                         {
                             app.prompt_input.accept_suggestion();
                             app.prompt_input.insert_char(' ');


### PR DESCRIPTION
## Summary

`crates/cli/src/main.rs` had `app.prompt_input.suggestions.get(app.prompt_input.suggestion_index.unwrap())`, guarded by a preceding `suggestion_index.is_some()` check in the same `&&` chain — not a live bug, but `AGENTS.md` bans `.unwrap()`/`.expect()` on fallible operations outright regardless of whether the panic is currently reachable.

## Changes

- Replaced the `is_some()` + `.unwrap()` pair with `is_some_and(...)` composed with `.get(index).is_some_and(...)`. Identical behavior, no unwrap.

## Test plan

- [x] `cargo check -p claurst` — clean.
- [x] `cargo clippy -p claurst --all-targets -- -D warnings` — clean.
- [x] `cargo test --workspace` — all pass except one pre-existing, unrelated failure in `claurst-core` (`test_config_resolve_api_key_none`) that reads this machine's real `~/.claurst` config dir instead of an isolated one; reproduces identically on `main`, so it's a local environment artifact, not something this change touches.