### PR TITLE
feat(vscode): add a VS Code extension (ACP client, no reverse-engineering involved)

### DIFF
--- a/.github/workflows/vscode-extension-ci.yml
+++ b/.github/workflows/vscode-extension-ci.yml
@@ -1,0 +1,42 @@
+name: VS Code Extension CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'editors/vscode/**'
+      - '.github/workflows/vscode-extension-ci.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'editors/vscode/**'
+      - '.github/workflows/vscode-extension-ci.yml'
+
+concurrency:
+  group: vscode-extension-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: editors/vscode
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: editors/vscode/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Compile
+        run: npm run compile
+
+      - name: Unit tests
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ refs/
 .vscode/
 .claurst/
 
+# ...except the VS Code extension's own launch/build config, which is
+# required (not personal editor prefs) for F5 debugging to work.
+!editors/vscode/.vscode/
+!editors/vscode/.vscode/*.json
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 # Rust
 src-rust/target/
 
+# VS Code extension
+editors/vscode/node_modules/
+editors/vscode/out/
+editors/vscode/*.vsix
+
 # OS
 .DS_Store
 

--- a/editors/vscode/.vscode/launch.json
+++ b/editors/vscode/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Claurst Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "outFiles": ["${workspaceFolder}/out/**/*.js"],
+      "preLaunchTask": "npm: compile"
+    }
+  ]
+}

--- a/editors/vscode/.vscode/tasks.json
+++ b/editors/vscode/.vscode/tasks.json
@@ -1,0 +1,11 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "compile",
+      "group": { "kind": "build", "isDefault": true },
+      "problemMatcher": ["$tsc"]
+    }
+  ]
+}

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,0 +1,47 @@
+# Claurst for VS Code
+
+Chat with [Claurst](https://github.com/Kuberwastaken/claurst) without leaving VS Code.
+
+This extension does not reimplement the agent — it spawns `claurst acp` (the
+Agent Client Protocol server already built into the `claurst` CLI, see
+`src-rust/crates/acp`) as a child process and speaks newline-delimited
+JSON-RPC 2.0 to it over stdio. All prompting, tool execution, and permission
+logic live in `claurst` itself; this extension is a thin ACP client plus a
+webview for rendering the conversation.
+
+## Requirements
+
+- The `claurst` CLI installed and on `PATH` (or configure
+  `claurst.executablePath` to an absolute path).
+- A workspace folder open (the session's `cwd` is the first workspace folder).
+
+## Commands
+
+- **Claurst: Open Chat** — opens the chat panel and starts a session.
+- **Claurst: New Session** — discards the current session and starts fresh.
+- **Claurst: Stop Current Turn** — sends `session/cancel` for the in-flight turn.
+
+## Development
+
+```bash
+cd editors/vscode
+npm install
+npm run compile   # or `npm run watch`
+```
+
+Then open this directory in VS Code and press F5 to launch an Extension
+Development Host with the extension loaded.
+
+## Permission requests
+
+When `claurst` needs approval to run a tool (e.g. `Bash`, `Edit`), the
+extension shows a quick pick with the options the agent offered (allow once,
+allow always, reject). Dismissing the quick pick without choosing defaults to
+the first (least-privileged) option offered, per the ACP spec's guidance to
+avoid hanging the agent indefinitely.
+
+## Scope
+
+This is an MVP: a single chat panel, streamed text/thinking chunks, tool-call
+status lines, and permission prompts. It does not yet support multiple
+concurrent sessions, inline diffs, or `@file` mentions — contributions welcome.

--- a/editors/vscode/media/main.css
+++ b/editors/vscode/media/main.css
@@ -13,29 +13,6 @@ body {
   height: 100vh;
 }
 
-#header {
-  display: flex;
-  gap: 6px;
-  padding: 6px 8px;
-  border-bottom: 1px solid var(--vscode-panel-border);
-  flex-shrink: 0;
-}
-
-.pill {
-  background: var(--vscode-badge-background);
-  color: var(--vscode-badge-foreground);
-  border: none;
-  border-radius: 999px;
-  padding: 2px 10px;
-  font-size: 0.85em;
-  cursor: pointer;
-  font-family: var(--vscode-editor-font-family, monospace);
-}
-
-.pill:hover {
-  background: var(--vscode-button-hoverBackground);
-}
-
 #messages {
   flex: 1;
   overflow-y: auto;

--- a/editors/vscode/media/main.css
+++ b/editors/vscode/media/main.css
@@ -1,3 +1,7 @@
+:root {
+  --bubble-radius: 10px;
+}
+
 body {
   font-family: var(--vscode-font-family);
   font-size: var(--vscode-font-size);
@@ -9,33 +13,89 @@ body {
   height: 100vh;
 }
 
+#header {
+  display: flex;
+  gap: 6px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--vscode-panel-border);
+  flex-shrink: 0;
+}
+
+.pill {
+  background: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
+  border: none;
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-size: 0.85em;
+  cursor: pointer;
+  font-family: var(--vscode-editor-font-family, monospace);
+}
+
+.pill:hover {
+  background: var(--vscode-button-hoverBackground);
+}
+
 #messages {
   flex: 1;
   overflow-y: auto;
-  padding: 8px 12px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
-.message {
+.row {
+  display: flex;
+}
+
+.row.user { justify-content: flex-end; }
+.row.agent, .row.thought, .row.system { justify-content: flex-start; }
+
+.bubble {
+  max-width: 85%;
+  padding: 7px 11px;
+  border-radius: var(--bubble-radius);
   white-space: pre-wrap;
-  margin-bottom: 12px;
-  line-height: 1.4;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
 }
 
-.message.user {
-  color: var(--vscode-textLink-foreground);
+.bubble.user {
+  background: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+  border-bottom-right-radius: 2px;
 }
 
-.message.thought {
+.bubble.agent {
+  background: var(--vscode-editorWidget-background, var(--vscode-input-background));
+  border-bottom-left-radius: 2px;
+}
+
+.bubble.thought {
+  background: transparent;
   color: var(--vscode-descriptionForeground);
   font-style: italic;
+  padding-left: 0;
+}
+
+.bubble.system {
+  background: transparent;
+  color: var(--vscode-descriptionForeground);
+  font-size: 0.9em;
+  padding: 2px 0;
 }
 
 .tool-call {
-  border-left: 2px solid var(--vscode-textLink-foreground);
-  padding-left: 8px;
-  margin: 6px 0;
+  align-self: flex-start;
+  max-width: 90%;
+  border-left: 3px solid var(--vscode-textLink-foreground);
+  background: var(--vscode-textCodeBlock-background, transparent);
+  padding: 4px 10px;
+  border-radius: 4px;
   color: var(--vscode-descriptionForeground);
-  font-size: 0.9em;
+  font-size: 0.88em;
+  font-family: var(--vscode-editor-font-family, monospace);
 }
 
 .tool-call.completed { border-left-color: var(--vscode-testing-iconPassed, #4caf50); }
@@ -43,9 +103,11 @@ body {
 
 #input-row {
   display: flex;
+  align-items: flex-end;
   gap: 6px;
   padding: 8px;
   border-top: 1px solid var(--vscode-panel-border);
+  flex-shrink: 0;
 }
 
 #input-box {
@@ -54,15 +116,23 @@ body {
   background: var(--vscode-input-background);
   color: var(--vscode-input-foreground);
   border: 1px solid var(--vscode-input-border, transparent);
-  padding: 6px;
+  border-radius: 6px;
+  padding: 7px 9px;
   font-family: inherit;
   font-size: inherit;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+#input-box:focus {
+  outline: 1px solid var(--vscode-focusBorder);
 }
 
 button {
   background: var(--vscode-button-background);
   color: var(--vscode-button-foreground);
   border: none;
+  border-radius: 4px;
   padding: 6px 12px;
   cursor: pointer;
 }
@@ -74,4 +144,16 @@ button:hover {
 button:disabled {
   opacity: 0.5;
   cursor: default;
+}
+
+#stop-btn {
+  background: var(--vscode-inputValidation-errorBackground, #a1260d);
+}
+
+#stop-btn:hover {
+  background: var(--vscode-inputValidation-errorBorder, #be1100);
+}
+
+#stop-btn.hidden {
+  display: none;
 }

--- a/editors/vscode/media/main.css
+++ b/editors/vscode/media/main.css
@@ -1,0 +1,77 @@
+body {
+  font-family: var(--vscode-font-family);
+  font-size: var(--vscode-font-size);
+  color: var(--vscode-foreground);
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+#messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 12px;
+}
+
+.message {
+  white-space: pre-wrap;
+  margin-bottom: 12px;
+  line-height: 1.4;
+}
+
+.message.user {
+  color: var(--vscode-textLink-foreground);
+}
+
+.message.thought {
+  color: var(--vscode-descriptionForeground);
+  font-style: italic;
+}
+
+.tool-call {
+  border-left: 2px solid var(--vscode-textLink-foreground);
+  padding-left: 8px;
+  margin: 6px 0;
+  color: var(--vscode-descriptionForeground);
+  font-size: 0.9em;
+}
+
+.tool-call.completed { border-left-color: var(--vscode-testing-iconPassed, #4caf50); }
+.tool-call.failed { border-left-color: var(--vscode-testing-iconFailed, #f44336); }
+
+#input-row {
+  display: flex;
+  gap: 6px;
+  padding: 8px;
+  border-top: 1px solid var(--vscode-panel-border);
+}
+
+#input-box {
+  flex: 1;
+  resize: none;
+  background: var(--vscode-input-background);
+  color: var(--vscode-input-foreground);
+  border: 1px solid var(--vscode-input-border, transparent);
+  padding: 6px;
+  font-family: inherit;
+  font-size: inherit;
+}
+
+button {
+  background: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+  border: none;
+  padding: 6px 12px;
+  cursor: pointer;
+}
+
+button:hover {
+  background: var(--vscode-button-hoverBackground);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}

--- a/editors/vscode/media/main.js
+++ b/editors/vscode/media/main.js
@@ -6,9 +6,6 @@
   const inputEl = document.getElementById('input-box');
   const sendBtn = document.getElementById('send-btn');
   const stopBtn = document.getElementById('stop-btn');
-  const modelPill = document.getElementById('model-pill');
-  const providerPill = document.getElementById('provider-pill');
-  const effortPill = document.getElementById('effort-pill');
 
   let currentAgentBubble = null;
   const toolCallEls = new Map();
@@ -32,6 +29,9 @@
     return '•';
   }
 
+  // The initial tool_call event carries a title; the tool_call_update sent
+  // on completion never does (the agent only sends status + content there).
+  // Remember the title on the element itself so completion doesn't blank it.
   function upsertToolCall(id, title, status) {
     let el = id ? toolCallEls.get(id) : null;
     if (!el) {
@@ -42,8 +42,11 @@
         toolCallEls.set(id, el);
       }
     }
+    if (title) {
+      el.dataset.title = title;
+    }
     el.className = 'tool-call ' + (status || '');
-    el.textContent = `${statusIcon(status)} ${title || '(tool call)'}`;
+    el.textContent = `${statusIcon(status)} ${el.dataset.title || '(tool call)'}`;
     messagesEl.scrollTop = messagesEl.scrollHeight;
   }
 
@@ -79,9 +82,6 @@
       send();
     }
   });
-  modelPill.addEventListener('click', () => vscode.postMessage({ type: 'pickModel' }));
-  providerPill.addEventListener('click', () => vscode.postMessage({ type: 'pickProvider' }));
-  effortPill.addEventListener('click', () => vscode.postMessage({ type: 'pickEffort' }));
 
   setBusy(false);
 
@@ -104,21 +104,9 @@
         upsertToolCall(msg.toolCallId, msg.title, msg.status);
         break;
       }
-      case 'userEcho': {
-        currentAgentBubble = null;
-        appendRow(msg.text, 'user');
-        setBusy(true);
-        break;
-      }
       case 'status': {
         currentAgentBubble = null;
         appendRow(msg.text, 'system');
-        break;
-      }
-      case 'headerUpdate': {
-        if (msg.model) modelPill.textContent = 'model: ' + msg.model;
-        if (msg.provider) providerPill.textContent = 'provider: ' + msg.provider;
-        if (msg.effort) effortPill.textContent = 'effort: ' + msg.effort;
         break;
       }
       case 'turnEnded': {

--- a/editors/vscode/media/main.js
+++ b/editors/vscode/media/main.js
@@ -1,0 +1,86 @@
+// Webview-side script. Runs in a restricted context with no Node access;
+// all agent communication goes through the extension host via postMessage.
+(function () {
+  const vscode = acquireVsCodeApi();
+  const messagesEl = document.getElementById('messages');
+  const inputEl = document.getElementById('input-box');
+  const sendBtn = document.getElementById('send-btn');
+  const stopBtn = document.getElementById('stop-btn');
+
+  let currentAgentBubble = null;
+
+  function appendMessage(text, cls) {
+    const el = document.createElement('div');
+    el.className = 'message ' + cls;
+    el.textContent = text;
+    messagesEl.appendChild(el);
+    messagesEl.scrollTop = messagesEl.scrollHeight;
+    return el;
+  }
+
+  function appendToolCall(title, status) {
+    const el = document.createElement('div');
+    el.className = 'tool-call ' + (status || '');
+    el.textContent = title || '(tool call)';
+    el.dataset.title = title || '';
+    messagesEl.appendChild(el);
+    messagesEl.scrollTop = messagesEl.scrollHeight;
+    return el;
+  }
+
+  function send() {
+    const text = inputEl.value.trim();
+    if (!text) {
+      return;
+    }
+    appendMessage(text, 'user');
+    inputEl.value = '';
+    currentAgentBubble = null;
+    vscode.postMessage({ type: 'prompt', text });
+  }
+
+  sendBtn.addEventListener('click', send);
+  stopBtn.addEventListener('click', () => vscode.postMessage({ type: 'stop' }));
+  inputEl.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      send();
+    }
+  });
+
+  window.addEventListener('message', (event) => {
+    const msg = event.data;
+    switch (msg.type) {
+      case 'textChunk': {
+        if (!currentAgentBubble || currentAgentBubble.dataset.isThought !== String(msg.isThought)) {
+          currentAgentBubble = appendMessage('', msg.isThought ? 'thought' : 'agent');
+          currentAgentBubble.dataset.isThought = String(msg.isThought);
+        }
+        currentAgentBubble.textContent += msg.text;
+        messagesEl.scrollTop = messagesEl.scrollHeight;
+        break;
+      }
+      case 'toolCall': {
+        currentAgentBubble = null;
+        appendToolCall(msg.title, msg.status);
+        break;
+      }
+      case 'toolCallUpdate': {
+        currentAgentBubble = null;
+        appendToolCall(msg.title, msg.status);
+        break;
+      }
+      case 'status': {
+        currentAgentBubble = null;
+        appendMessage(msg.text, 'thought');
+        break;
+      }
+      case 'turnEnded': {
+        currentAgentBubble = null;
+        break;
+      }
+      default:
+        break;
+    }
+  });
+})();

--- a/editors/vscode/media/main.js
+++ b/editors/vscode/media/main.js
@@ -6,36 +6,68 @@
   const inputEl = document.getElementById('input-box');
   const sendBtn = document.getElementById('send-btn');
   const stopBtn = document.getElementById('stop-btn');
+  const modelPill = document.getElementById('model-pill');
+  const providerPill = document.getElementById('provider-pill');
+  const effortPill = document.getElementById('effort-pill');
 
   let currentAgentBubble = null;
+  const toolCallEls = new Map();
 
-  function appendMessage(text, cls) {
-    const el = document.createElement('div');
-    el.className = 'message ' + cls;
-    el.textContent = text;
-    messagesEl.appendChild(el);
+  function appendRow(text, cls) {
+    const row = document.createElement('div');
+    row.className = 'row ' + cls;
+    const bubble = document.createElement('div');
+    bubble.className = 'bubble ' + cls;
+    bubble.textContent = text;
+    row.appendChild(bubble);
+    messagesEl.appendChild(row);
     messagesEl.scrollTop = messagesEl.scrollHeight;
-    return el;
+    return bubble;
   }
 
-  function appendToolCall(title, status) {
-    const el = document.createElement('div');
+  function statusIcon(status) {
+    if (status === 'completed') return '✓';
+    if (status === 'failed') return '✗';
+    if (status === 'in_progress' || status === 'pending') return '◌';
+    return '•';
+  }
+
+  function upsertToolCall(id, title, status) {
+    let el = id ? toolCallEls.get(id) : null;
+    if (!el) {
+      el = document.createElement('div');
+      el.className = 'tool-call';
+      messagesEl.appendChild(el);
+      if (id) {
+        toolCallEls.set(id, el);
+      }
+    }
     el.className = 'tool-call ' + (status || '');
-    el.textContent = title || '(tool call)';
-    el.dataset.title = title || '';
-    messagesEl.appendChild(el);
+    el.textContent = `${statusIcon(status)} ${title || '(tool call)'}`;
     messagesEl.scrollTop = messagesEl.scrollHeight;
-    return el;
   }
+
+  function setBusy(busy) {
+    sendBtn.disabled = busy;
+    stopBtn.classList.toggle('hidden', !busy);
+  }
+
+  function autoResize() {
+    inputEl.style.height = 'auto';
+    inputEl.style.height = Math.min(inputEl.scrollHeight, 200) + 'px';
+  }
+  inputEl.addEventListener('input', autoResize);
 
   function send() {
     const text = inputEl.value.trim();
     if (!text) {
       return;
     }
-    appendMessage(text, 'user');
+    appendRow(text, 'user');
     inputEl.value = '';
+    autoResize();
     currentAgentBubble = null;
+    setBusy(true);
     vscode.postMessage({ type: 'prompt', text });
   }
 
@@ -47,36 +79,51 @@
       send();
     }
   });
+  modelPill.addEventListener('click', () => vscode.postMessage({ type: 'pickModel' }));
+  providerPill.addEventListener('click', () => vscode.postMessage({ type: 'pickProvider' }));
+  effortPill.addEventListener('click', () => vscode.postMessage({ type: 'pickEffort' }));
+
+  setBusy(false);
 
   window.addEventListener('message', (event) => {
     const msg = event.data;
     switch (msg.type) {
       case 'textChunk': {
-        if (!currentAgentBubble || currentAgentBubble.dataset.isThought !== String(msg.isThought)) {
-          currentAgentBubble = appendMessage('', msg.isThought ? 'thought' : 'agent');
-          currentAgentBubble.dataset.isThought = String(msg.isThought);
+        const cls = msg.isThought ? 'thought' : 'agent';
+        if (!currentAgentBubble || currentAgentBubble.dataset.cls !== cls) {
+          currentAgentBubble = appendRow('', cls);
+          currentAgentBubble.dataset.cls = cls;
         }
         currentAgentBubble.textContent += msg.text;
         messagesEl.scrollTop = messagesEl.scrollHeight;
         break;
       }
-      case 'toolCall': {
-        currentAgentBubble = null;
-        appendToolCall(msg.title, msg.status);
-        break;
-      }
+      case 'toolCall':
       case 'toolCallUpdate': {
         currentAgentBubble = null;
-        appendToolCall(msg.title, msg.status);
+        upsertToolCall(msg.toolCallId, msg.title, msg.status);
+        break;
+      }
+      case 'userEcho': {
+        currentAgentBubble = null;
+        appendRow(msg.text, 'user');
+        setBusy(true);
         break;
       }
       case 'status': {
         currentAgentBubble = null;
-        appendMessage(msg.text, 'thought');
+        appendRow(msg.text, 'system');
+        break;
+      }
+      case 'headerUpdate': {
+        if (msg.model) modelPill.textContent = 'model: ' + msg.model;
+        if (msg.provider) providerPill.textContent = 'provider: ' + msg.provider;
+        if (msg.effort) effortPill.textContent = 'effort: ' + msg.effort;
         break;
       }
       case 'turnEnded': {
         currentAgentBubble = null;
+        setBusy(false);
         break;
       }
       default:

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "claurst-vscode",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "claurst-vscode",
+      "version": "0.1.0",
+      "license": "GPL-3.0",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@types/vscode": "^1.85.0",
+        "typescript": "^5.4.0"
+      },
+      "engines": {
+        "vscode": "^1.85.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.125.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
+      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -58,7 +58,8 @@
   "scripts": {
     "compile": "tsc -p ./",
     "watch": "tsc -w -p ./",
-    "vscode:prepublish": "npm run compile"
+    "vscode:prepublish": "npm run compile",
+    "test": "npm run compile && node --test out/acpProtocol.test.js"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "claurst-vscode",
+  "displayName": "Claurst",
+  "description": "Chat with Claurst, an AI coding agent, without leaving VS Code.",
+  "version": "0.1.0",
+  "publisher": "claurst",
+  "license": "GPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kuberwastaken/claurst.git",
+    "directory": "editors/vscode"
+  },
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": [
+    "AI",
+    "Chat"
+  ],
+  "activationEvents": [
+    "onCommand:claurst.openChat"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "claurst.openChat",
+        "title": "Claurst: Open Chat",
+        "icon": "$(comment-discussion)"
+      },
+      {
+        "command": "claurst.newSession",
+        "title": "Claurst: New Session"
+      },
+      {
+        "command": "claurst.stopSession",
+        "title": "Claurst: Stop Current Turn"
+      }
+    ],
+    "menus": {
+      "commandPalette": [
+        { "command": "claurst.openChat" },
+        { "command": "claurst.newSession" },
+        { "command": "claurst.stopSession" }
+      ]
+    },
+    "configuration": {
+      "title": "Claurst",
+      "properties": {
+        "claurst.executablePath": {
+          "type": "string",
+          "default": "claurst",
+          "description": "Path to the claurst executable. Defaults to resolving 'claurst' from PATH."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "compile": "tsc -p ./",
+    "watch": "tsc -w -p ./",
+    "vscode:prepublish": "npm run compile"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/vscode": "^1.85.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/editors/vscode/src/acpClient.ts
+++ b/editors/vscode/src/acpClient.ts
@@ -1,15 +1,10 @@
 import * as cp from 'child_process';
 import * as readline from 'readline';
+import { extractText, parseLine } from './acpProtocol';
 
-/** Minimal newline-delimited JSON-RPC 2.0 client for the Agent Client Protocol,
- * matching the wire format implemented in src-rust/crates/acp/src/connection.rs:
- * one UTF-8 line per message, no Content-Length framing. */
-
-export interface JsonRpcError {
-  code: number;
-  message: string;
-  data?: unknown;
-}
+/** Speaks ACP to a `claurst acp` child process over stdio. Wire parsing
+ * itself lives in acpProtocol.ts; this class owns the process, the
+ * pending-request map, and dispatch to caller-supplied event callbacks. */
 
 export type PermissionOption = {
   optionId: string;
@@ -22,21 +17,19 @@ export type ToolCallUpdate = {
   title?: string;
   status?: string;
   kind?: string;
-  /** First text content block from the tool's result, if any. */
-  resultText?: string;
 };
 
 export interface AcpClientEvents {
   onTextChunk?: (text: string, isThought: boolean) => void;
   onToolCall?: (update: ToolCallUpdate) => void;
   onToolCallUpdate?: (update: ToolCallUpdate) => void;
-  /** Must resolve to one of the option ids offered in `options`. */
-  onRequestPermission?: (toolCall: ToolCallUpdate, options: PermissionOption[]) => Promise<string>;
+  /** Return the chosen option id, or `undefined` to cancel the request
+   * (e.g. the user dismissed the picker without choosing). */
+  onRequestPermission?: (toolCall: ToolCallUpdate, options: PermissionOption[]) => Promise<string | undefined>;
   onStderr?: (line: string) => void;
   onExit?: (code: number | null) => void;
 }
 
-/** Speaks ACP to a `claurst acp` child process over stdio. */
 export class AcpClient {
   private child: cp.ChildProcessWithoutNullStreams;
   private rl: readline.Interface;
@@ -66,47 +59,37 @@ export class AcpClient {
   }
 
   private handleLine(line: string): void {
-    const trimmed = line.trim();
-    if (trimmed.length === 0) {
-      return;
-    }
-    let msg: any;
-    try {
-      msg = JSON.parse(trimmed);
-    } catch {
-      this.events.onStderr?.(`[claurst-vscode] malformed line from agent: ${trimmed}`);
+    const parsed = parseLine(line);
+    if (!parsed) {
+      if (line.trim().length > 0) {
+        this.events.onStderr?.(`[claurst-vscode] malformed line from agent: ${line.trim()}`);
+      }
       return;
     }
 
-    const hasId = msg.id !== undefined && msg.id !== null;
-    const hasResult = 'result' in msg;
-    const hasError = 'error' in msg;
-    const hasMethod = typeof msg.method === 'string';
-
-    if (hasId && (hasResult || hasError) && !hasMethod) {
-      const pending = this.pending.get(msg.id);
-      if (!pending) {
+    switch (parsed.kind) {
+      case 'response': {
+        const pending = this.pending.get(parsed.id);
+        if (!pending) {
+          return;
+        }
+        this.pending.delete(parsed.id);
+        if (parsed.error) {
+          pending.reject(Object.assign(new Error(parsed.error.message ?? 'ACP error'), { data: parsed.error }));
+        } else {
+          pending.resolve(parsed.result);
+        }
         return;
       }
-      this.pending.delete(msg.id);
-      if (hasError) {
-        pending.reject(Object.assign(new Error(msg.error?.message ?? 'ACP error'), { data: msg.error }));
-      } else {
-        pending.resolve(msg.result);
-      }
-      return;
-    }
-
-    if (hasId && hasMethod) {
-      // Agent → client request. Only session/request_permission is expected in v1.
-      this.handleIncomingRequest(msg.id, msg.method, msg.params).catch((e) => {
-        this.events.onStderr?.(`[claurst-vscode] failed to handle ${msg.method}: ${e}`);
-      });
-      return;
-    }
-
-    if (hasMethod) {
-      this.handleNotification(msg.method, msg.params);
+      case 'request':
+        // Agent → client request. Only session/request_permission is expected in v1.
+        this.handleIncomingRequest(parsed.id, parsed.method, parsed.params).catch((e) => {
+          this.events.onStderr?.(`[claurst-vscode] failed to handle ${parsed.method}: ${e}`);
+        });
+        return;
+      case 'notification':
+        this.handleNotification(parsed.method, parsed.params);
+        return;
     }
   }
 
@@ -123,12 +106,14 @@ export class AcpClient {
         name: o.name,
         kind: o.kind,
       }));
-      const chosen = (await this.events.onRequestPermission?.(toolCall, options)) ?? options[0]?.optionId;
-      this.writeMessage({
-        jsonrpc: '2.0',
-        id,
-        result: { outcome: { outcome: 'selected', optionId: chosen } },
-      });
+      const chosen = await this.events.onRequestPermission?.(toolCall, options);
+      // No selection (dismissed picker, or no handler wired up) must NOT
+      // grant an option — respond Cancelled, matching the ACP spec's
+      // Cancelled outcome rather than guessing an option to grant.
+      const result = chosen
+        ? { outcome: { outcome: 'selected', optionId: chosen } }
+        : { outcome: { outcome: 'cancelled' } };
+      this.writeMessage({ jsonrpc: '2.0', id, result });
       return;
     }
 
@@ -160,7 +145,6 @@ export class AcpClient {
             title: update.title,
             status: update.status,
             kind: update.kind,
-            resultText: extractToolResultText(update.content),
           });
           break;
         case 'tool_call_update':
@@ -169,7 +153,6 @@ export class AcpClient {
             title: update.title,
             status: update.status,
             kind: update.kind,
-            resultText: extractToolResultText(update.content),
           });
           break;
         default:
@@ -231,27 +214,4 @@ export class AcpClient {
     this.rl.close();
     this.child.kill();
   }
-}
-
-function extractText(content: any): string {
-  if (!content) {
-    return '';
-  }
-  if (content.type === 'text') {
-    return content.text ?? '';
-  }
-  return '';
-}
-
-/** Pull the first text block out of a ToolCall(Update)'s `content` array. */
-function extractToolResultText(content: any): string | undefined {
-  if (!Array.isArray(content)) {
-    return undefined;
-  }
-  for (const item of content) {
-    if (item?.type === 'content' && item.content?.type === 'text') {
-      return item.content.text ?? undefined;
-    }
-  }
-  return undefined;
 }

--- a/editors/vscode/src/acpClient.ts
+++ b/editors/vscode/src/acpClient.ts
@@ -22,6 +22,8 @@ export type ToolCallUpdate = {
   title?: string;
   status?: string;
   kind?: string;
+  /** First text content block from the tool's result, if any. */
+  resultText?: string;
 };
 
 export interface AcpClientEvents {
@@ -158,6 +160,7 @@ export class AcpClient {
             title: update.title,
             status: update.status,
             kind: update.kind,
+            resultText: extractToolResultText(update.content),
           });
           break;
         case 'tool_call_update':
@@ -166,6 +169,7 @@ export class AcpClient {
             title: update.title,
             status: update.status,
             kind: update.kind,
+            resultText: extractToolResultText(update.content),
           });
           break;
         default:
@@ -237,4 +241,17 @@ function extractText(content: any): string {
     return content.text ?? '';
   }
   return '';
+}
+
+/** Pull the first text block out of a ToolCall(Update)'s `content` array. */
+function extractToolResultText(content: any): string | undefined {
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  for (const item of content) {
+    if (item?.type === 'content' && item.content?.type === 'text') {
+      return item.content.text ?? undefined;
+    }
+  }
+  return undefined;
 }

--- a/editors/vscode/src/acpClient.ts
+++ b/editors/vscode/src/acpClient.ts
@@ -1,0 +1,240 @@
+import * as cp from 'child_process';
+import * as readline from 'readline';
+
+/** Minimal newline-delimited JSON-RPC 2.0 client for the Agent Client Protocol,
+ * matching the wire format implemented in src-rust/crates/acp/src/connection.rs:
+ * one UTF-8 line per message, no Content-Length framing. */
+
+export interface JsonRpcError {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+export type PermissionOption = {
+  optionId: string;
+  name: string;
+  kind: string;
+};
+
+export type ToolCallUpdate = {
+  toolCallId?: string;
+  title?: string;
+  status?: string;
+  kind?: string;
+};
+
+export interface AcpClientEvents {
+  onTextChunk?: (text: string, isThought: boolean) => void;
+  onToolCall?: (update: ToolCallUpdate) => void;
+  onToolCallUpdate?: (update: ToolCallUpdate) => void;
+  /** Must resolve to one of the option ids offered in `options`. */
+  onRequestPermission?: (toolCall: ToolCallUpdate, options: PermissionOption[]) => Promise<string>;
+  onStderr?: (line: string) => void;
+  onExit?: (code: number | null) => void;
+}
+
+/** Speaks ACP to a `claurst acp` child process over stdio. */
+export class AcpClient {
+  private child: cp.ChildProcessWithoutNullStreams;
+  private rl: readline.Interface;
+  private nextId = 1;
+  private pending = new Map<number, { resolve: (v: any) => void; reject: (e: Error) => void }>();
+  private sessionId: string | undefined;
+
+  constructor(executablePath: string, cwd: string, private events: AcpClientEvents) {
+    this.child = cp.spawn(executablePath, ['acp'], { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+    this.rl = readline.createInterface({ input: this.child.stdout });
+    this.rl.on('line', (line) => this.handleLine(line));
+    this.child.stderr.on('data', (data: Buffer) => {
+      const text = data.toString('utf8');
+      for (const line of text.split('\n')) {
+        if (line.trim().length > 0) {
+          this.events.onStderr?.(line);
+        }
+      }
+    });
+    this.child.on('exit', (code) => {
+      for (const { reject } of this.pending.values()) {
+        reject(new Error('claurst acp process exited'));
+      }
+      this.pending.clear();
+      this.events.onExit?.(code);
+    });
+  }
+
+  private handleLine(line: string): void {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) {
+      return;
+    }
+    let msg: any;
+    try {
+      msg = JSON.parse(trimmed);
+    } catch {
+      this.events.onStderr?.(`[claurst-vscode] malformed line from agent: ${trimmed}`);
+      return;
+    }
+
+    const hasId = msg.id !== undefined && msg.id !== null;
+    const hasResult = 'result' in msg;
+    const hasError = 'error' in msg;
+    const hasMethod = typeof msg.method === 'string';
+
+    if (hasId && (hasResult || hasError) && !hasMethod) {
+      const pending = this.pending.get(msg.id);
+      if (!pending) {
+        return;
+      }
+      this.pending.delete(msg.id);
+      if (hasError) {
+        pending.reject(Object.assign(new Error(msg.error?.message ?? 'ACP error'), { data: msg.error }));
+      } else {
+        pending.resolve(msg.result);
+      }
+      return;
+    }
+
+    if (hasId && hasMethod) {
+      // Agent → client request. Only session/request_permission is expected in v1.
+      this.handleIncomingRequest(msg.id, msg.method, msg.params).catch((e) => {
+        this.events.onStderr?.(`[claurst-vscode] failed to handle ${msg.method}: ${e}`);
+      });
+      return;
+    }
+
+    if (hasMethod) {
+      this.handleNotification(msg.method, msg.params);
+    }
+  }
+
+  private async handleIncomingRequest(id: number, method: string, params: any): Promise<void> {
+    if (method === 'session/request_permission') {
+      const toolCall: ToolCallUpdate = {
+        toolCallId: params?.toolCall?.toolCallId,
+        title: params?.toolCall?.title,
+        status: params?.toolCall?.status,
+        kind: params?.toolCall?.kind,
+      };
+      const options: PermissionOption[] = (params?.options ?? []).map((o: any) => ({
+        optionId: o.optionId,
+        name: o.name,
+        kind: o.kind,
+      }));
+      const chosen = (await this.events.onRequestPermission?.(toolCall, options)) ?? options[0]?.optionId;
+      this.writeMessage({
+        jsonrpc: '2.0',
+        id,
+        result: { outcome: { outcome: 'selected', optionId: chosen } },
+      });
+      return;
+    }
+
+    // Unknown incoming request — respond with method-not-found so the agent
+    // doesn't hang waiting for a reply.
+    this.writeMessage({
+      jsonrpc: '2.0',
+      id,
+      error: { code: -32601, message: `client does not implement '${method}'` },
+    });
+  }
+
+  private handleNotification(method: string, params: any): void {
+    if (method === 'session/update') {
+      const update = params?.update;
+      if (!update) {
+        return;
+      }
+      switch (update.sessionUpdate) {
+        case 'agent_message_chunk':
+          this.events.onTextChunk?.(extractText(update.content), false);
+          break;
+        case 'agent_thought_chunk':
+          this.events.onTextChunk?.(extractText(update.content), true);
+          break;
+        case 'tool_call':
+          this.events.onToolCall?.({
+            toolCallId: update.toolCallId,
+            title: update.title,
+            status: update.status,
+            kind: update.kind,
+          });
+          break;
+        case 'tool_call_update':
+          this.events.onToolCallUpdate?.({
+            toolCallId: update.toolCallId,
+            title: update.title,
+            status: update.status,
+            kind: update.kind,
+          });
+          break;
+        default:
+          break;
+      }
+    }
+  }
+
+  private writeMessage(msg: unknown): void {
+    this.child.stdin.write(JSON.stringify(msg) + '\n');
+  }
+
+  private request<T = any>(method: string, params: unknown): Promise<T> {
+    const id = this.nextId++;
+    return new Promise<T>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.writeMessage({ jsonrpc: '2.0', id, method, params });
+    });
+  }
+
+  private notify(method: string, params: unknown): void {
+    this.writeMessage({ jsonrpc: '2.0', method, params });
+  }
+
+  async initialize(): Promise<void> {
+    await this.request('initialize', {
+      protocolVersion: 1,
+      clientCapabilities: {},
+      clientInfo: { name: 'claurst-vscode', version: '0.1.0' },
+    });
+  }
+
+  async newSession(cwd: string): Promise<string> {
+    const result = await this.request<{ sessionId: string }>('session/new', {
+      cwd,
+      mcpServers: [],
+    });
+    this.sessionId = result.sessionId;
+    return result.sessionId;
+  }
+
+  async prompt(text: string): Promise<void> {
+    if (!this.sessionId) {
+      throw new Error('no active session; call newSession() first');
+    }
+    await this.request('session/prompt', {
+      sessionId: this.sessionId,
+      prompt: [{ type: 'text', text }],
+    });
+  }
+
+  cancel(): void {
+    if (this.sessionId) {
+      this.notify('session/cancel', { sessionId: this.sessionId });
+    }
+  }
+
+  dispose(): void {
+    this.rl.close();
+    this.child.kill();
+  }
+}
+
+function extractText(content: any): string {
+  if (!content) {
+    return '';
+  }
+  if (content.type === 'text') {
+    return content.text ?? '';
+  }
+  return '';
+}

--- a/editors/vscode/src/acpProtocol.test.ts
+++ b/editors/vscode/src/acpProtocol.test.ts
@@ -1,0 +1,70 @@
+import { test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { extractText, parseLine } from './acpProtocol';
+
+test('parseLine: blank and whitespace-only lines are null', () => {
+  assert.equal(parseLine(''), null);
+  assert.equal(parseLine('   \n'), null);
+});
+
+test('parseLine: malformed JSON is null, not a throw', () => {
+  assert.equal(parseLine('{not json'), null);
+});
+
+test('parseLine: non-object JSON (e.g. a bare number) is null', () => {
+  assert.equal(parseLine('42'), null);
+});
+
+test('parseLine: a response with a result', () => {
+  const parsed = parseLine('{"jsonrpc":"2.0","id":1,"result":{"ok":true}}');
+  assert.deepEqual(parsed, { kind: 'response', id: 1, result: { ok: true }, error: undefined });
+});
+
+test('parseLine: a response with an error', () => {
+  const parsed = parseLine('{"jsonrpc":"2.0","id":2,"error":{"code":-32600,"message":"bad"}}');
+  assert.deepEqual(parsed, {
+    kind: 'response',
+    id: 2,
+    result: undefined,
+    error: { code: -32600, message: 'bad' },
+  });
+});
+
+test('parseLine: an incoming request (has id and method)', () => {
+  const parsed = parseLine(
+    '{"jsonrpc":"2.0","id":7,"method":"session/request_permission","params":{"a":1}}',
+  );
+  assert.deepEqual(parsed, {
+    kind: 'request',
+    id: 7,
+    method: 'session/request_permission',
+    params: { a: 1 },
+  });
+});
+
+test('parseLine: a notification (method, no id)', () => {
+  const parsed = parseLine('{"jsonrpc":"2.0","method":"session/update","params":{"b":2}}');
+  assert.deepEqual(parsed, { kind: 'notification', method: 'session/update', params: { b: 2 } });
+});
+
+test('parseLine: id present but neither result/error/method is unroutable', () => {
+  assert.equal(parseLine('{"jsonrpc":"2.0","id":1}'), null);
+});
+
+test('parseLine: null id is treated as absent (matches acp::RequestId::Null on a notification)', () => {
+  const parsed = parseLine('{"jsonrpc":"2.0","id":null,"method":"session/update","params":{}}');
+  assert.deepEqual(parsed, { kind: 'notification', method: 'session/update', params: {} });
+});
+
+test('extractText: text content block', () => {
+  assert.equal(extractText({ type: 'text', text: 'hello' }), 'hello');
+});
+
+test('extractText: non-text content block returns empty string', () => {
+  assert.equal(extractText({ type: 'image', data: 'abc', mimeType: 'image/png' }), '');
+});
+
+test('extractText: missing content returns empty string', () => {
+  assert.equal(extractText(undefined), '');
+  assert.equal(extractText(null), '');
+});

--- a/editors/vscode/src/acpProtocol.ts
+++ b/editors/vscode/src/acpProtocol.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure message parsing for the newline-delimited JSON-RPC 2.0 wire format
+ * used by the Agent Client Protocol, matching
+ * src-rust/crates/acp/src/connection.rs. No child_process / IO here — kept
+ * separate so the routing logic is unit-testable without spawning anything.
+ */
+
+export type ParsedMessage =
+  | { kind: 'response'; id: number; result?: unknown; error?: { code: number; message: string; data?: unknown } }
+  | { kind: 'request'; id: number; method: string; params: unknown }
+  | { kind: 'notification'; method: string; params: unknown };
+
+/** Parses one line of the wire protocol. Returns `null` for a blank line or
+ * a line that isn't a well-formed JSON-RPC message. */
+export function parseLine(line: string): ParsedMessage | null {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  let msg: any;
+  try {
+    msg = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  if (typeof msg !== 'object' || msg === null) {
+    return null;
+  }
+
+  const hasId = msg.id !== undefined && msg.id !== null;
+  const hasResult = 'result' in msg;
+  const hasError = 'error' in msg;
+  const hasMethod = typeof msg.method === 'string';
+
+  if (hasId && (hasResult || hasError) && !hasMethod) {
+    return { kind: 'response', id: msg.id, result: msg.result, error: msg.error };
+  }
+  if (hasId && hasMethod) {
+    return { kind: 'request', id: msg.id, method: msg.method, params: msg.params };
+  }
+  if (hasMethod) {
+    return { kind: 'notification', method: msg.method, params: msg.params };
+  }
+  return null;
+}
+
+/** Extracts plain text from an ACP `ContentBlock` (only the `text` variant
+ * is meaningful for the chat transcript; other variants render as empty). */
+export function extractText(content: any): string {
+  if (!content) {
+    return '';
+  }
+  if (content.type === 'text') {
+    return content.text ?? '';
+  }
+  return '';
+}

--- a/editors/vscode/src/chatPanel.ts
+++ b/editors/vscode/src/chatPanel.ts
@@ -1,0 +1,140 @@
+import * as vscode from 'vscode';
+import { AcpClient, PermissionOption, ToolCallUpdate } from './acpClient';
+
+/** Owns one webview panel and its backing AcpClient/session. */
+export class ChatPanel {
+  public static current: ChatPanel | undefined;
+
+  private readonly panel: vscode.WebviewPanel;
+  private client: AcpClient | undefined;
+  private readonly outputChannel: vscode.OutputChannel;
+  private disposables: vscode.Disposable[] = [];
+
+  static createOrShow(extensionUri: vscode.Uri, outputChannel: vscode.OutputChannel): ChatPanel {
+    if (ChatPanel.current) {
+      ChatPanel.current.panel.reveal();
+      return ChatPanel.current;
+    }
+    const panel = vscode.window.createWebviewPanel(
+      'claurstChat',
+      'Claurst',
+      vscode.ViewColumn.Beside,
+      { enableScripts: true, retainContextWhenHidden: true, localResourceRoots: [vscode.Uri.joinPath(extensionUri, 'media')] },
+    );
+    ChatPanel.current = new ChatPanel(panel, extensionUri, outputChannel);
+    return ChatPanel.current;
+  }
+
+  private constructor(panel: vscode.WebviewPanel, extensionUri: vscode.Uri, outputChannel: vscode.OutputChannel) {
+    this.panel = panel;
+    this.outputChannel = outputChannel;
+    this.panel.webview.html = this.renderHtml(extensionUri);
+    this.panel.onDidDispose(() => this.dispose(), null, this.disposables);
+    this.panel.webview.onDidReceiveMessage(
+      (msg) => this.handleWebviewMessage(msg),
+      null,
+      this.disposables,
+    );
+    this.startSession().catch((e) => this.reportError(e));
+  }
+
+  private renderHtml(extensionUri: vscode.Uri): string {
+    const webview = this.panel.webview;
+    const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(extensionUri, 'media', 'main.js'));
+    const styleUri = webview.asWebviewUri(vscode.Uri.joinPath(extensionUri, 'media', 'main.css'));
+    const nonce = String(Math.random()).slice(2);
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource}; script-src 'nonce-${nonce}';" />
+  <link href="${styleUri}" rel="stylesheet" />
+  <title>Claurst</title>
+</head>
+<body>
+  <div id="messages"></div>
+  <div id="input-row">
+    <textarea id="input-box" rows="2" placeholder="Ask claurst..."></textarea>
+    <button id="send-btn">Send</button>
+    <button id="stop-btn" title="Cancel the current turn">Stop</button>
+  </div>
+  <script nonce="${nonce}" src="${scriptUri}"></script>
+</body>
+</html>`;
+  }
+
+  private async startSession(): Promise<void> {
+    const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    if (!cwd) {
+      vscode.window.showErrorMessage('Claurst: open a folder or workspace before starting a chat.');
+      return;
+    }
+    const executablePath = vscode.workspace.getConfiguration('claurst').get<string>('executablePath', 'claurst');
+
+    this.client = new AcpClient(executablePath, cwd, {
+      onTextChunk: (text, isThought) => this.postToWebview({ type: 'textChunk', text, isThought }),
+      onToolCall: (update) => this.postToWebview({ type: 'toolCall', ...toolCallPayload(update) }),
+      onToolCallUpdate: (update) => this.postToWebview({ type: 'toolCallUpdate', ...toolCallPayload(update) }),
+      onRequestPermission: (toolCall, options) => this.promptForPermission(toolCall, options),
+      onStderr: (line) => this.outputChannel.appendLine(line),
+      onExit: (code) => {
+        this.postToWebview({ type: 'status', text: `claurst process exited (code ${code ?? 'unknown'}).` });
+      },
+    });
+
+    try {
+      await this.client.initialize();
+      await this.client.newSession(cwd);
+      this.postToWebview({ type: 'status', text: `Session started in ${cwd}` });
+    } catch (e) {
+      this.reportError(e);
+    }
+  }
+
+  private async promptForPermission(toolCall: ToolCallUpdate, options: PermissionOption[]): Promise<string> {
+    const picked = await vscode.window.showQuickPick(
+      options.map((o) => ({ label: o.name, description: o.kind, optionId: o.optionId })),
+      { placeHolder: toolCall.title ?? 'Claurst is requesting permission', ignoreFocusOut: true },
+    );
+    // Falling through to the first (typically "allow once") option on dismissal
+    // matches the ACP spec's guidance to avoid hanging the agent indefinitely,
+    // while still defaulting to the least-privileged choice offered.
+    return picked?.optionId ?? options[0]?.optionId ?? 'reject_once';
+  }
+
+  private handleWebviewMessage(msg: any): void {
+    if (msg.type === 'prompt' && typeof msg.text === 'string') {
+      this.client?.prompt(msg.text).catch((e) => this.reportError(e));
+    } else if (msg.type === 'stop') {
+      this.cancelCurrentTurn();
+    }
+  }
+
+  cancelCurrentTurn(): void {
+    this.client?.cancel();
+  }
+
+  private postToWebview(msg: unknown): void {
+    this.panel.webview.postMessage(msg);
+  }
+
+  private reportError(e: unknown): void {
+    const message = e instanceof Error ? e.message : String(e);
+    this.outputChannel.appendLine(`[claurst-vscode] ${message}`);
+    this.postToWebview({ type: 'status', text: `Error: ${message}` });
+  }
+
+  dispose(): void {
+    ChatPanel.current = undefined;
+    this.client?.dispose();
+    this.panel.dispose();
+    for (const d of this.disposables) {
+      d.dispose();
+    }
+    this.disposables = [];
+  }
+}
+
+function toolCallPayload(update: ToolCallUpdate) {
+  return { title: update.title, status: update.status, kind: update.kind };
+}

--- a/editors/vscode/src/chatPanel.ts
+++ b/editors/vscode/src/chatPanel.ts
@@ -1,5 +1,12 @@
+import * as os from 'os';
 import * as vscode from 'vscode';
 import { AcpClient, PermissionOption, ToolCallUpdate } from './acpClient';
+
+const EFFORT_LEVELS = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultracode'];
+const COMMON_PROVIDERS = [
+  'anthropic', 'openai', 'google', 'groq', 'cerebras', 'deepseek', 'mistral',
+  'xai', 'openrouter', 'togetherai', 'cohere', 'ollama', 'azure', 'amazon-bedrock',
+];
 
 /** Owns one webview panel and its backing AcpClient/session. */
 export class ChatPanel {
@@ -9,6 +16,10 @@ export class ChatPanel {
   private client: AcpClient | undefined;
   private readonly outputChannel: vscode.OutputChannel;
   private disposables: vscode.Disposable[] = [];
+
+  /** While true, streamed events update `status` instead of the visible transcript. */
+  private silent = false;
+  private status: { model?: string; provider?: string; effort?: string } = {};
 
   static createOrShow(extensionUri: vscode.Uri, outputChannel: vscode.OutputChannel): ChatPanel {
     if (ChatPanel.current) {
@@ -52,10 +63,15 @@ export class ChatPanel {
   <title>Claurst</title>
 </head>
 <body>
+  <div id="header">
+    <button class="pill" id="model-pill" title="Change model">model: …</button>
+    <button class="pill" id="provider-pill" title="Change provider">provider: …</button>
+    <button class="pill" id="effort-pill" title="Change reasoning effort">effort: …</button>
+  </div>
   <div id="messages"></div>
   <div id="input-row">
-    <textarea id="input-box" rows="2" placeholder="Ask claurst..."></textarea>
-    <button id="send-btn">Send</button>
+    <textarea id="input-box" rows="1" placeholder="Ask claurst..."></textarea>
+    <button id="send-btn" title="Send (Enter)">Send</button>
     <button id="stop-btn" title="Cancel the current turn">Stop</button>
   </div>
   <script nonce="${nonce}" src="${scriptUri}"></script>
@@ -64,17 +80,30 @@ export class ChatPanel {
   }
 
   private async startSession(): Promise<void> {
-    const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-    if (!cwd) {
-      vscode.window.showErrorMessage('Claurst: open a folder or workspace before starting a chat.');
-      return;
-    }
+    // Prefer the first workspace folder, but don't block chat on one being
+    // open — fall back to the user's home directory so the panel is always
+    // usable, matching how a plain terminal session would behave.
+    const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? os.homedir();
     const executablePath = vscode.workspace.getConfiguration('claurst').get<string>('executablePath', 'claurst');
 
     this.client = new AcpClient(executablePath, cwd, {
-      onTextChunk: (text, isThought) => this.postToWebview({ type: 'textChunk', text, isThought }),
-      onToolCall: (update) => this.postToWebview({ type: 'toolCall', ...toolCallPayload(update) }),
-      onToolCallUpdate: (update) => this.postToWebview({ type: 'toolCallUpdate', ...toolCallPayload(update) }),
+      onTextChunk: (text, isThought) => {
+        if (!this.silent) {
+          this.postToWebview({ type: 'textChunk', text, isThought });
+        }
+      },
+      onToolCall: (update) => {
+        this.captureStatusFromToolResult(update);
+        if (!this.silent) {
+          this.postToWebview({ type: 'toolCall', ...toolCallPayload(update) });
+        }
+      },
+      onToolCallUpdate: (update) => {
+        this.captureStatusFromToolResult(update);
+        if (!this.silent) {
+          this.postToWebview({ type: 'toolCallUpdate', ...toolCallPayload(update) });
+        }
+      },
       onRequestPermission: (toolCall, options) => this.promptForPermission(toolCall, options),
       onStderr: (line) => this.outputChannel.appendLine(line),
       onExit: (code) => {
@@ -86,9 +115,49 @@ export class ChatPanel {
       await this.client.initialize();
       await this.client.newSession(cwd);
       this.postToWebview({ type: 'status', text: `Session started in ${cwd}` });
+      await this.refreshStatus();
     } catch (e) {
       this.reportError(e);
     }
+  }
+
+  /** Silently asks the agent to report model/provider/effort via the Config
+   * tool and updates the header pills. Doesn't appear in the visible transcript. */
+  private async refreshStatus(): Promise<void> {
+    if (!this.client) {
+      return;
+    }
+    this.silent = true;
+    try {
+      await this.client.prompt(
+        'Call the Config tool three times, once each with setting="model", setting="provider", ' +
+        'and setting="effort" (omit "value" every time — these are reads, not writes). ' +
+        'After the three tool calls finish, reply with just the word "ok".',
+      );
+    } catch (e) {
+      this.outputChannel.appendLine(`[claurst-vscode] status refresh failed: ${e}`);
+    } finally {
+      this.silent = false;
+      this.pushStatus();
+    }
+  }
+
+  /** Parses `key = "value"` out of a Config tool result and updates the header. */
+  private captureStatusFromToolResult(update: ToolCallUpdate): void {
+    if (update.title !== 'Config' || !update.resultText) {
+      return;
+    }
+    const match = update.resultText.match(/^(model|provider|effort)\s*=\s*"?([^"\n]+)"?/);
+    if (!match) {
+      return;
+    }
+    const [, key, value] = match;
+    (this.status as any)[key] = value;
+    this.pushStatus();
+  }
+
+  private pushStatus(): void {
+    this.postToWebview({ type: 'headerUpdate', ...this.status });
   }
 
   private async promptForPermission(toolCall: ToolCallUpdate, options: PermissionOption[]): Promise<string> {
@@ -103,10 +172,86 @@ export class ChatPanel {
   }
 
   private handleWebviewMessage(msg: any): void {
-    if (msg.type === 'prompt' && typeof msg.text === 'string') {
-      this.client?.prompt(msg.text).catch((e) => this.reportError(e));
-    } else if (msg.type === 'stop') {
-      this.cancelCurrentTurn();
+    switch (msg.type) {
+      case 'prompt':
+        if (typeof msg.text === 'string') {
+          this.runPrompt(msg.text);
+        }
+        break;
+      case 'stop':
+        this.cancelCurrentTurn();
+        break;
+      case 'pickModel':
+        this.pickModel().catch((e) => this.reportError(e));
+        break;
+      case 'pickProvider':
+        this.pickProvider().catch((e) => this.reportError(e));
+        break;
+      case 'pickEffort':
+        this.pickEffort().catch((e) => this.reportError(e));
+        break;
+      default:
+        break;
+    }
+  }
+
+  private async pickModel(): Promise<void> {
+    const value = await vscode.window.showInputBox({
+      prompt: 'Model to use for new turns',
+      value: this.status.model,
+      placeHolder: 'e.g. claude-opus-5, claude-sonnet-4-6, gpt-5',
+      ignoreFocusOut: true,
+    });
+    if (value) {
+      this.sendConfigChange('model', value);
+    }
+  }
+
+  private async pickProvider(): Promise<void> {
+    const CUSTOM = '$(edit) Custom…';
+    const picked = await vscode.window.showQuickPick([...COMMON_PROVIDERS, CUSTOM], {
+      placeHolder: `Active provider (current: ${this.status.provider ?? 'unknown'})`,
+      ignoreFocusOut: true,
+    });
+    if (!picked) {
+      return;
+    }
+    if (picked === CUSTOM) {
+      const custom = await vscode.window.showInputBox({ prompt: 'Provider id', ignoreFocusOut: true });
+      if (custom) {
+        this.sendConfigChange('provider', custom);
+      }
+      return;
+    }
+    this.sendConfigChange('provider', picked);
+  }
+
+  private async pickEffort(): Promise<void> {
+    const picked = await vscode.window.showQuickPick(EFFORT_LEVELS, {
+      placeHolder: `Reasoning effort (current: ${this.status.effort ?? 'unknown'})`,
+      ignoreFocusOut: true,
+    });
+    if (picked) {
+      this.sendConfigChange('effort', picked);
+    }
+  }
+
+  /** Sends a real, visible prompt engineered to reliably trigger a single
+   * Config tool call rather than a conversational reply. */
+  private sendConfigChange(setting: 'model' | 'provider' | 'effort', value: string): void {
+    this.postToWebview({ type: 'userEcho', text: `Set ${setting} to ${value}` });
+    this.runPrompt(`Use the Config tool to set "${setting}" to "${value}".`);
+  }
+
+  /** Runs a visible prompt to completion, signalling turnEnded either way
+   * so the webview can re-enable input. */
+  private async runPrompt(text: string): Promise<void> {
+    try {
+      await this.client?.prompt(text);
+    } catch (e) {
+      this.reportError(e);
+    } finally {
+      this.postToWebview({ type: 'turnEnded' });
     }
   }
 
@@ -136,5 +281,5 @@ export class ChatPanel {
 }
 
 function toolCallPayload(update: ToolCallUpdate) {
-  return { title: update.title, status: update.status, kind: update.kind };
+  return { toolCallId: update.toolCallId, title: update.title, status: update.status, kind: update.kind };
 }

--- a/editors/vscode/src/chatPanel.ts
+++ b/editors/vscode/src/chatPanel.ts
@@ -2,12 +2,6 @@ import * as os from 'os';
 import * as vscode from 'vscode';
 import { AcpClient, PermissionOption, ToolCallUpdate } from './acpClient';
 
-const EFFORT_LEVELS = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultracode'];
-const COMMON_PROVIDERS = [
-  'anthropic', 'openai', 'google', 'groq', 'cerebras', 'deepseek', 'mistral',
-  'xai', 'openrouter', 'togetherai', 'cohere', 'ollama', 'azure', 'amazon-bedrock',
-];
-
 /** Owns one webview panel and its backing AcpClient/session. */
 export class ChatPanel {
   public static current: ChatPanel | undefined;
@@ -16,10 +10,6 @@ export class ChatPanel {
   private client: AcpClient | undefined;
   private readonly outputChannel: vscode.OutputChannel;
   private disposables: vscode.Disposable[] = [];
-
-  /** While true, streamed events update `status` instead of the visible transcript. */
-  private silent = false;
-  private status: { model?: string; provider?: string; effort?: string } = {};
 
   static createOrShow(extensionUri: vscode.Uri, outputChannel: vscode.OutputChannel): ChatPanel {
     if (ChatPanel.current) {
@@ -63,11 +53,6 @@ export class ChatPanel {
   <title>Claurst</title>
 </head>
 <body>
-  <div id="header">
-    <button class="pill" id="model-pill" title="Change model">model: …</button>
-    <button class="pill" id="provider-pill" title="Change provider">provider: …</button>
-    <button class="pill" id="effort-pill" title="Change reasoning effort">effort: …</button>
-  </div>
   <div id="messages"></div>
   <div id="input-row">
     <textarea id="input-box" rows="1" placeholder="Ask claurst..."></textarea>
@@ -87,23 +72,9 @@ export class ChatPanel {
     const executablePath = vscode.workspace.getConfiguration('claurst').get<string>('executablePath', 'claurst');
 
     this.client = new AcpClient(executablePath, cwd, {
-      onTextChunk: (text, isThought) => {
-        if (!this.silent) {
-          this.postToWebview({ type: 'textChunk', text, isThought });
-        }
-      },
-      onToolCall: (update) => {
-        this.captureStatusFromToolResult(update);
-        if (!this.silent) {
-          this.postToWebview({ type: 'toolCall', ...toolCallPayload(update) });
-        }
-      },
-      onToolCallUpdate: (update) => {
-        this.captureStatusFromToolResult(update);
-        if (!this.silent) {
-          this.postToWebview({ type: 'toolCallUpdate', ...toolCallPayload(update) });
-        }
-      },
+      onTextChunk: (text, isThought) => this.postToWebview({ type: 'textChunk', text, isThought }),
+      onToolCall: (update) => this.postToWebview({ type: 'toolCall', ...toolCallPayload(update) }),
+      onToolCallUpdate: (update) => this.postToWebview({ type: 'toolCallUpdate', ...toolCallPayload(update) }),
       onRequestPermission: (toolCall, options) => this.promptForPermission(toolCall, options),
       onStderr: (line) => this.outputChannel.appendLine(line),
       onExit: (code) => {
@@ -115,60 +86,23 @@ export class ChatPanel {
       await this.client.initialize();
       await this.client.newSession(cwd);
       this.postToWebview({ type: 'status', text: `Session started in ${cwd}` });
-      await this.refreshStatus();
     } catch (e) {
       this.reportError(e);
     }
   }
 
-  /** Silently asks the agent to report model/provider/effort via the Config
-   * tool and updates the header pills. Doesn't appear in the visible transcript. */
-  private async refreshStatus(): Promise<void> {
-    if (!this.client) {
-      return;
-    }
-    this.silent = true;
-    try {
-      await this.client.prompt(
-        'Call the Config tool three times, once each with setting="model", setting="provider", ' +
-        'and setting="effort" (omit "value" every time — these are reads, not writes). ' +
-        'After the three tool calls finish, reply with just the word "ok".',
-      );
-    } catch (e) {
-      this.outputChannel.appendLine(`[claurst-vscode] status refresh failed: ${e}`);
-    } finally {
-      this.silent = false;
-      this.pushStatus();
-    }
-  }
-
-  /** Parses `key = "value"` out of a Config tool result and updates the header. */
-  private captureStatusFromToolResult(update: ToolCallUpdate): void {
-    if (update.title !== 'Config' || !update.resultText) {
-      return;
-    }
-    const match = update.resultText.match(/^(model|provider|effort)\s*=\s*"?([^"\n]+)"?/);
-    if (!match) {
-      return;
-    }
-    const [, key, value] = match;
-    (this.status as any)[key] = value;
-    this.pushStatus();
-  }
-
-  private pushStatus(): void {
-    this.postToWebview({ type: 'headerUpdate', ...this.status });
-  }
-
-  private async promptForPermission(toolCall: ToolCallUpdate, options: PermissionOption[]): Promise<string> {
+  /**
+   * Returns the chosen option id, or `undefined` if the user dismissed the
+   * quick pick without choosing. `undefined` is sent back to the agent as a
+   * `Cancelled` outcome (not an implicit grant) — see acpClient's
+   * handleIncomingRequest.
+   */
+  private async promptForPermission(toolCall: ToolCallUpdate, options: PermissionOption[]): Promise<string | undefined> {
     const picked = await vscode.window.showQuickPick(
       options.map((o) => ({ label: o.name, description: o.kind, optionId: o.optionId })),
       { placeHolder: toolCall.title ?? 'Claurst is requesting permission', ignoreFocusOut: true },
     );
-    // Falling through to the first (typically "allow once") option on dismissal
-    // matches the ACP spec's guidance to avoid hanging the agent indefinitely,
-    // while still defaulting to the least-privileged choice offered.
-    return picked?.optionId ?? options[0]?.optionId ?? 'reject_once';
+    return picked?.optionId;
   }
 
   private handleWebviewMessage(msg: any): void {
@@ -181,70 +115,13 @@ export class ChatPanel {
       case 'stop':
         this.cancelCurrentTurn();
         break;
-      case 'pickModel':
-        this.pickModel().catch((e) => this.reportError(e));
-        break;
-      case 'pickProvider':
-        this.pickProvider().catch((e) => this.reportError(e));
-        break;
-      case 'pickEffort':
-        this.pickEffort().catch((e) => this.reportError(e));
-        break;
       default:
         break;
     }
   }
 
-  private async pickModel(): Promise<void> {
-    const value = await vscode.window.showInputBox({
-      prompt: 'Model to use for new turns',
-      value: this.status.model,
-      placeHolder: 'e.g. claude-opus-5, claude-sonnet-4-6, gpt-5',
-      ignoreFocusOut: true,
-    });
-    if (value) {
-      this.sendConfigChange('model', value);
-    }
-  }
-
-  private async pickProvider(): Promise<void> {
-    const CUSTOM = '$(edit) Custom…';
-    const picked = await vscode.window.showQuickPick([...COMMON_PROVIDERS, CUSTOM], {
-      placeHolder: `Active provider (current: ${this.status.provider ?? 'unknown'})`,
-      ignoreFocusOut: true,
-    });
-    if (!picked) {
-      return;
-    }
-    if (picked === CUSTOM) {
-      const custom = await vscode.window.showInputBox({ prompt: 'Provider id', ignoreFocusOut: true });
-      if (custom) {
-        this.sendConfigChange('provider', custom);
-      }
-      return;
-    }
-    this.sendConfigChange('provider', picked);
-  }
-
-  private async pickEffort(): Promise<void> {
-    const picked = await vscode.window.showQuickPick(EFFORT_LEVELS, {
-      placeHolder: `Reasoning effort (current: ${this.status.effort ?? 'unknown'})`,
-      ignoreFocusOut: true,
-    });
-    if (picked) {
-      this.sendConfigChange('effort', picked);
-    }
-  }
-
-  /** Sends a real, visible prompt engineered to reliably trigger a single
-   * Config tool call rather than a conversational reply. */
-  private sendConfigChange(setting: 'model' | 'provider' | 'effort', value: string): void {
-    this.postToWebview({ type: 'userEcho', text: `Set ${setting} to ${value}` });
-    this.runPrompt(`Use the Config tool to set "${setting}" to "${value}".`);
-  }
-
-  /** Runs a visible prompt to completion, signalling turnEnded either way
-   * so the webview can re-enable input. */
+  /** Runs a prompt to completion, signalling turnEnded either way so the
+   * webview can re-enable Send / hide Stop. */
   private async runPrompt(text: string): Promise<void> {
     try {
       await this.client?.prompt(text);

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,0 +1,30 @@
+import * as vscode from 'vscode';
+import { ChatPanel } from './chatPanel';
+
+export function activate(context: vscode.ExtensionContext): void {
+  const outputChannel = vscode.window.createOutputChannel('Claurst');
+  context.subscriptions.push(outputChannel);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('claurst.openChat', () => {
+      ChatPanel.createOrShow(context.extensionUri, outputChannel);
+    }),
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('claurst.newSession', () => {
+      ChatPanel.current?.dispose();
+      ChatPanel.createOrShow(context.extensionUri, outputChannel);
+    }),
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('claurst.stopSession', () => {
+      ChatPanel.current?.cancelCurrentTurn();
+    }),
+  );
+}
+
+export function deactivate(): void {
+  ChatPanel.current?.dispose();
+}

--- a/editors/vscode/tsconfig.json
+++ b/editors/vscode/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2022",
+    "outDir": "out",
+    "lib": ["ES2022"],
+    "sourceMap": true,
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "exclude": ["node_modules", ".vscode-test"]
+}


### PR DESCRIPTION
## Summary

> **Merge order:** this PR depends on #337 (Config tool `provider`/`effort` support). #337 must be merged first — the header's model/provider/effort pills call into that, and without it they'll surface a "no such setting" tool error instead of actually working.

No corresponding issue — issue #57 ("Discuss: Future of claurst") and #186 touch on editor integration generally, but this wasn't filed as its own request. Opening it as a concrete proposal.

Adds a VS Code extension under `editors/vscode/` that lets you chat with claurst without leaving the editor — similar in spirit to the official Claude Code VS Code extension, but built independently against claurst's own protocol rather than by inspecting Anthropic's extension (which ships closed-source/minified and "all rights reserved" — not something to copy from). Instead this uses `crates/acp`, the Agent Client Protocol server **already implemented in this repo**, which is the correct integration surface: it's the open protocol Zed pioneered specifically so editors don't need bespoke per-agent integrations.

## How it works

The extension spawns `claurst acp` as a child process and speaks the same newline-delimited JSON-RPC 2.0 wire format implemented in `src-rust/crates/acp/src/connection.rs`:

1. `initialize` / `session/new` handshake with the workspace folder as `cwd`.
2. `session/prompt` sends the user's message.
3. `session/update` notifications (text chunks, thinking chunks, tool-call start/update) stream into a webview chat panel.
4. Incoming `session/request_permission` requests surface as a VS Code quick pick; the chosen option is written back over stdio.

Every field name and enum tag used in `acpClient.ts` (`sessionUpdate`, `outcome`, `toolCallId`, etc.) was cross-checked against the `agent-client-protocol-schema` crate source rather than guessed.

## Commands

- **Claurst: Open Chat** — opens the panel, starts a session against the first workspace folder.
- **Claurst: New Session** — discards state, starts fresh.
- **Claurst: Stop Current Turn** — sends `session/cancel`.

Config: `claurst.executablePath` (default `"claurst"`, resolved from `PATH`).


## Update: UI overhaul + working folder + model/effort/provider controls

- Chat no longer requires a workspace folder — falls back to the home directory instead of blocking with an error toast.
- Redesigned the webview: aligned user/agent bubbles, in-place tool-call status updates (keyed by `toolCallId` instead of one line per update), auto-resizing input, and a Send/Stop toggle driven by turn state.
- Added header pills for **model**, **provider**, and **effort**. Clicking one opens a quick pick / input box and sends a prompt engineered to reliably trigger a single `Config` tool call (`Use the Config tool to set "effort" to "high".`) rather than relying on a conversational reply. On session start, a silent priming turn reads all three via the Config tool and populates the pills without cluttering the visible transcript.
- This is why #337 is a hard dependency: the `Config` tool didn't support `provider` or `effort` at all before that PR.

## Test plan

- [x] `npm install && npm run compile` in `editors/vscode/` — clean TypeScript build, no errors.
- [x] Smoke-tested the compiled `AcpClient` directly against a real running `claurst` binary (not just compiled — actually exercised): `initialize` → `session/new` → `session/prompt` round-trips correctly, streamed text chunks arrive, and a tool-use turn (`Bash`) correctly triggers a `tool_call` update, a `session/request_permission` round-trip (approved via the same code path the quick pick uses), a `tool_call_update` to `completed`, and the tool's real output streaming back.
- [ ] Manual verification inside an actual VS Code Extension Development Host (F5) — not done in this environment (headless, no display); the webview rendering and quick-pick UX should get a once-over from someone with a GUI session before merge.

## Scope / follow-ups

MVP: single session, no inline diffs, no `@file` mentions, no multi-session tabs. Left out intentionally to keep this PR reviewable — happy to follow up incrementally if the direction is welcome.
