### PR TITLE
feat: model picker shows all connected providers

### DIFF
--- a/WORKFLOW_STATE.md
+++ b/WORKFLOW_STATE.md
@@ -2,65 +2,47 @@
 
 ## Objective
 Clone claurst repo, create separate feature branches for 5 features, research
-codebase + jcode reference, write design docs per branch.
+codebase + jcode reference, write design docs per branch, review design docs,
+apply review fixes.
 
 ## Current status
-Complete. Repo cloned, 5 branches created, design docs committed per branch.
+Complete. Repo cloned, 5 branches created, design docs committed + reviewed +
+review fixes applied. All blocking and important review items resolved.
 
 ## Last completed step
-All 5 feature branches created with committed design docs. Research of claurst
-codebase + jcode reference complete.
+Applied review fixes to all 5 design docs. Each branch now has 2 commits:
+1. Initial design doc
+2. Review fixes applied
 
 ## Blockers
-None. Design phase complete. Implementation not started (user only requested
-branches + design).
+None. Design + review phase complete. Implementation not started.
 
-## Branches created
+## Branches
 
-| Branch | Design doc | Status |
-|--------|-----------|--------|
-| `feature/multiple-openai-compatible-providers` | `FEATURE_DESIGN_multiple_openai_compatible_providers.md` | Design committed |
-| `feature/model-favorite-selector` | `FEATURE_DESIGN_model_favorite_selector.md` | Design committed |
-| `feature/todo-management-status-indicator` | `FEATURE_DESIGN_todo_management_status_indicator.md` | Design committed |
-| `feature/batch-commands-no-model` | `FEATURE_DESIGN_batch_commands_no_model.md` | Design committed |
-| `feature/cursor-cli-acp-support` | `FEATURE_DESIGN_cursor_cli_acp_support.md` | Design committed |
+| Branch | Commits | Review fixes applied |
+|--------|---------|---------------------|
+| `feature/multiple-openai-compatible-providers` | 2 | headers on CustomProviderDef (not ProviderConfig), atomic writes for /add, is_openaiish_provider runtime check, HashMap not array, testing + error handling |
+| `feature/model-favorite-selector` | 2 | dedicated model_picker.rs widget (not dialog_select), valid_favorites() validation, Settings not Config placement, testing |
+| `feature/todo-management-status-indicator` | 2 | corrected schema (has id/content/status/priority, NOT activeForm), auto-poke ON by default, force_reopen for completed→pending, no-progress 3-turn threshold, confidence_history cap at 20, SystemMessageStyle::TodoCard, testing |
+| `feature/batch-commands-no-model` | 2 | std::process::Command (not PtyBashTool), !! multi-line via Shift+Enter, plan mode blocks !, separate shell history, default off, testing |
+| `feature/cursor-cli-acp-support` | 2 | tokio::sync::Mutex, Drop with start_kill, Connection client-mode lifecycle, lazy reconnection, ModelRegistry singleton (no OnceLock), testing + error handling |
 
-## Key research findings
+## Review verdicts (post-fix)
 
-### 1. Multiple OpenAI-compatible providers
-- Root cause: `provider_for_id()` is hardcoded `match` in
-  `openai_compat_providers.rs`; only `"custom-openai"` is generic
-- Fix: `customProviders` array in settings + dynamic dispatch before fixed match
-- No upstream PR implements this (confirmed via GitHub search)
+All 5 design docs pass review. Blocking items resolved:
+- multiple-providers: headers field clarified, atomic writes specified
+- model-favorite: separate widget, stale validation specified
+- todo-management: factual schema corrected, auto-poke default ON
+- batch-commands: std::process::Command, !! multi-line model specified
+- cursor-acp: tokio::sync::Mutex, Drop lifecycle, reconnection strategy
 
-### 2. Model favorite selector
-- No existing favorites concept in claurst
-- `ModelRegistry` keyed by `"provider/model"` — favorites = simple array of keys
-- Reference: jcode's model picker has `inline_interactive_state` with
-  `selected` + `preview` mode
-
-### 3. Todo management + poke verification
-- Claurst has `TodoWrite` tool (basic: content/status/activeForm) + `GoalCompleteTool`
-- Missing: live status indicator, auto-poke, inline todo card
-- Jcode pattern: `build_auto_poke_message()` in `jcode-base/src/todo.rs`,
-  `OvernightAutoPokeState` in `commands_overnight.rs`, todo card in
-  `todos_view.rs`, progress pips in `info_widget_todos.rs`
-- Jcode `TodoItem` has: confidence, completion_confidence, confidence_history,
-  blocked_by, group, assigned_to
-
-### 4. Bang (`!`) batch commands
-- Claurst has NO `!` feature currently — this is new, not a fix
-- Design: intercept `!` prefix before model query, execute via Bash directly,
-  zero token consumption, output in display_messages only (not conversation)
-- Existing `render_bash_input_line()` in messages/mod.rs can be reused
-
-### 5. Cursor CLI ACP support
-- Claurst has ACP **server** only (`crates/acp/`) — no client
-- Jcode has full implementation: `jcode-provider-cursor-acp-runtime` (1940 lines)
-- Key: spawn `agent --force --trust acp` subprocess, JSON-RPC 2.0 over stdio,
-  reuse claurst's `Connection` struct as client
-- Cursor models are opaque IDs, catalog discovered from `initialize` response
+## Recommended merge order
+1. `feature/multiple-openai-compatible-providers` — other features depend on custom provider ids
+2. `feature/model-favorite-selector` — benefits from custom provider models
+3. `feature/cursor-cli-acp-support` — independent but benefits from custom provider infrastructure
+4. `feature/todo-management-status-indicator` — independent, most complex
+5. `feature/batch-commands-no-model` — fully independent, simplest
 
 ## Next action
-Switch to `main` branch. Implementation of any feature can begin by checking out
-the corresponding branch and following the design doc.
+Switch to a feature branch and begin implementation following the design doc.
+Recommended start: `feature/multiple-openai-compatible-providers` (foundational).

--- a/WORKFLOW_STATE.md
+++ b/WORKFLOW_STATE.md
@@ -1,0 +1,66 @@
+# Workflow State
+
+## Objective
+Clone claurst repo, create separate feature branches for 5 features, research
+codebase + jcode reference, write design docs per branch.
+
+## Current status
+Complete. Repo cloned, 5 branches created, design docs committed per branch.
+
+## Last completed step
+All 5 feature branches created with committed design docs. Research of claurst
+codebase + jcode reference complete.
+
+## Blockers
+None. Design phase complete. Implementation not started (user only requested
+branches + design).
+
+## Branches created
+
+| Branch | Design doc | Status |
+|--------|-----------|--------|
+| `feature/multiple-openai-compatible-providers` | `FEATURE_DESIGN_multiple_openai_compatible_providers.md` | Design committed |
+| `feature/model-favorite-selector` | `FEATURE_DESIGN_model_favorite_selector.md` | Design committed |
+| `feature/todo-management-status-indicator` | `FEATURE_DESIGN_todo_management_status_indicator.md` | Design committed |
+| `feature/batch-commands-no-model` | `FEATURE_DESIGN_batch_commands_no_model.md` | Design committed |
+| `feature/cursor-cli-acp-support` | `FEATURE_DESIGN_cursor_cli_acp_support.md` | Design committed |
+
+## Key research findings
+
+### 1. Multiple OpenAI-compatible providers
+- Root cause: `provider_for_id()` is hardcoded `match` in
+  `openai_compat_providers.rs`; only `"custom-openai"` is generic
+- Fix: `customProviders` array in settings + dynamic dispatch before fixed match
+- No upstream PR implements this (confirmed via GitHub search)
+
+### 2. Model favorite selector
+- No existing favorites concept in claurst
+- `ModelRegistry` keyed by `"provider/model"` — favorites = simple array of keys
+- Reference: jcode's model picker has `inline_interactive_state` with
+  `selected` + `preview` mode
+
+### 3. Todo management + poke verification
+- Claurst has `TodoWrite` tool (basic: content/status/activeForm) + `GoalCompleteTool`
+- Missing: live status indicator, auto-poke, inline todo card
+- Jcode pattern: `build_auto_poke_message()` in `jcode-base/src/todo.rs`,
+  `OvernightAutoPokeState` in `commands_overnight.rs`, todo card in
+  `todos_view.rs`, progress pips in `info_widget_todos.rs`
+- Jcode `TodoItem` has: confidence, completion_confidence, confidence_history,
+  blocked_by, group, assigned_to
+
+### 4. Bang (`!`) batch commands
+- Claurst has NO `!` feature currently — this is new, not a fix
+- Design: intercept `!` prefix before model query, execute via Bash directly,
+  zero token consumption, output in display_messages only (not conversation)
+- Existing `render_bash_input_line()` in messages/mod.rs can be reused
+
+### 5. Cursor CLI ACP support
+- Claurst has ACP **server** only (`crates/acp/`) — no client
+- Jcode has full implementation: `jcode-provider-cursor-acp-runtime` (1940 lines)
+- Key: spawn `agent --force --trust acp` subprocess, JSON-RPC 2.0 over stdio,
+  reuse claurst's `Connection` struct as client
+- Cursor models are opaque IDs, catalog discovered from `initialize` response
+
+## Next action
+Switch to `main` branch. Implementation of any feature can begin by checking out
+the corresponding branch and following the design doc.

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -3797,6 +3797,7 @@ async fn run_interactive(
                                                                 ctx_for(&id, m.context_window),
                                                             ),
                                                         is_current: false,
+                                                        provider_id: provider_key.clone(),
                                                     }
                                                 })
                                             })
@@ -3814,6 +3815,7 @@ async fn run_interactive(
                                                         ),
                                                     id,
                                                     is_current: false,
+                                                    provider_id: provider_key.clone(),
                                                 }
                                             })
                                             .collect()

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -1756,6 +1756,54 @@ impl App {
         self.open_model_picker_for_provider(&provider_id, Some(picker_title));
     }
 
+    /// Open the model picker showing models from all connected providers,
+    /// grouped by provider name.
+    fn open_model_picker_all_providers(&mut self) {
+        self.dismiss_error_notifications();
+
+        // Collect models from all connected providers.
+        let mut all_models: Vec<crate::model_picker::ModelEntry> = Vec::new();
+
+        // Get connected provider IDs from provider_registry.
+        let connected_ids: Vec<String> = if let Some(ref registry) = self.provider_registry {
+            registry.provider_ids().iter().map(|id| id.to_string()).collect()
+        } else {
+            Vec::new()
+        };
+
+        // Also include current provider if not in registry.
+        let mut provider_ids = connected_ids;
+        if let Some(ref current) = self.config.provider {
+            if !provider_ids.contains(current) {
+                provider_ids.push(current.clone());
+            }
+        }
+
+        // Collect models from each provider.
+        for pid in &provider_ids {
+            let models = crate::model_picker::models_for_provider_from_registry(
+                pid,
+                &self.model_registry,
+            );
+            for mut m in models {
+                m.provider_id = pid.clone();
+                all_models.push(m);
+            }
+        }
+
+        self.model_picker.set_models(all_models);
+        self.model_picker_provider_id = None; // All providers mode
+        self.model_picker.all_providers_mode = true;
+        self.model_picker.loading_models = false;
+        self.model_picker_fetch_pending = false;
+
+        self.model_picker.open_all_providers(
+            &self.model_name,
+            self.effort_level,
+            self.fast_mode,
+        );
+    }
+
     fn persist_custom_provider_base_url(&self, base_url: &str) {
         let mut settings = Settings::load_sync().unwrap_or_default();
         let entry = settings.providers.entry("custom-openai".to_string()).or_default();
@@ -2084,12 +2132,7 @@ impl App {
                     self.status_message = Some("Connect a provider to choose a model.".to_string());
                     return true;
                 }
-                let provider = self
-                    .config
-                    .provider
-                    .clone()
-                    .unwrap_or_else(|| "anthropic".to_string());
-                self.open_model_picker_for_provider(&provider, None);
+                self.open_model_picker_all_providers();
                 true
             }
             "session" | "resume" => {
@@ -3656,11 +3699,29 @@ impl App {
                         // a routing prefix (`free/…`, `zen/…`, `openrouter/…`)
                         // so re-prefixing would produce nonsense like
                         // `free/free/auto`.
-                        let provider = self.config.provider.as_deref().unwrap_or("anthropic");
-                        let full_model = if provider == "anthropic" || provider == "free" {
-                            model_id.clone()
+                        //
+                        // In all-providers mode the provider is inferred from
+                        // the selected entry's `provider_id` field rather than
+                        // the current config provider.
+                        let full_model = if self.model_picker.all_providers_mode {
+                            let filtered = self.model_picker.filtered_models();
+                            if let Some(entry) = filtered.get(self.model_picker.selected_idx) {
+                                let provider = &entry.provider_id;
+                                if provider == "anthropic" || provider == "free" {
+                                    entry.id.clone()
+                                } else {
+                                    format!("{}/{}", provider, entry.id)
+                                }
+                            } else {
+                                model_id.clone()
+                            }
                         } else {
-                            format!("{}/{}", provider, model_id)
+                            let provider = self.config.provider.as_deref().unwrap_or("anthropic");
+                            if provider == "anthropic" || provider == "free" {
+                                model_id.clone()
+                            } else {
+                                format!("{}/{}", provider, model_id)
+                            }
                         };
                         self.set_model(full_model.clone());
                         self.persist_provider_and_model();

--- a/src-rust/crates/tui/src/model_picker.rs
+++ b/src-rust/crates/tui/src/model_picker.rs
@@ -221,6 +221,8 @@ pub struct ModelEntry {
     pub description: String,
     /// Whether this is the currently active model.
     pub is_current: bool,
+    /// Provider ID this model belongs to (for all-providers mode).
+    pub provider_id: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -228,12 +230,13 @@ pub struct ModelEntry {
 // ---------------------------------------------------------------------------
 
 /// Helper to build a `ModelEntry` with `is_current = false`.
-fn model_entry(id: &str, name: &str, desc: &str) -> ModelEntry {
+fn model_entry(id: &str, name: &str, desc: &str, provider_id: &str) -> ModelEntry {
     ModelEntry {
         id: id.to_string(),
         display_name: name.to_string(),
         description: desc.to_string(),
         is_current: false,
+        provider_id: provider_id.to_string(),
     }
 }
 
@@ -254,7 +257,7 @@ pub fn models_for_provider_from_registry(
     // directly.  `free/auto` is the default routing entry; the rest pin a
     // specific upstream model for users who care.
     if provider_id == "free" {
-        return free_provider_models();
+        return free_provider_models(provider_id);
     }
     // Codex (ChatGPT-authenticated OpenAI) is not in the models.dev catalog —
     // serve the curated CODEX_MODELS list so the picker isn't empty.  Accept
@@ -262,7 +265,7 @@ pub fn models_for_provider_from_registry(
     // ("openai-codex"); without the alias a fresh Codex login lands on the
     // empty-registry fallback and the picker shows no models.
     if is_codex_provider(provider_id) {
-        return codex_provider_models(registry);
+        return codex_provider_models(registry, provider_id);
     }
 
     let mut entries = registry.list_visible_by_provider(provider_id);
@@ -280,6 +283,7 @@ pub fn models_for_provider_from_registry(
             "default",
             "Default model",
             "no catalog entry for this provider",
+            provider_id,
         )];
     }
 
@@ -307,6 +311,7 @@ pub fn models_for_provider_from_registry(
                 display_name: e.info.name.clone(),
                 description: cost_str,
                 is_current: false,
+                provider_id: provider_id.to_string(),
             }
         })
         .collect()
@@ -417,7 +422,7 @@ fn is_codex_provider(provider_id: &str) -> bool {
 /// catalog yields nothing (e.g. an empty/old snapshot).
 ///
 /// [`codex_model_allowed`]: claurst_core::codex_oauth::codex_model_allowed
-fn codex_provider_models(registry: &claurst_api::ModelRegistry) -> Vec<ModelEntry> {
+fn codex_provider_models(registry: &claurst_api::ModelRegistry, provider_id: &str) -> Vec<ModelEntry> {
     use claurst_core::codex_oauth::{codex_limit_override, codex_model_allowed};
 
     let mut entries: Vec<&claurst_api::ModelEntry> = registry
@@ -427,7 +432,7 @@ fn codex_provider_models(registry: &claurst_api::ModelRegistry) -> Vec<ModelEntr
         .collect();
 
     if entries.is_empty() {
-        return codex_fallback_models();
+        return codex_fallback_models(provider_id);
     }
 
     // Newest release first, then by id for stability — matches the picker's
@@ -455,13 +460,14 @@ fn codex_provider_models(registry: &claurst_api::ModelRegistry) -> Vec<ModelEntr
                     format_context_window(ctx)
                 ),
                 is_current: false,
+                provider_id: provider_id.to_string(),
             }
         })
         .collect()
 }
 
 /// Static fallback used when the models.dev `openai` catalog is unavailable.
-fn codex_fallback_models() -> Vec<ModelEntry> {
+fn codex_fallback_models(provider_id: &str) -> Vec<ModelEntry> {
     use claurst_core::codex_oauth::codex_limit_override;
     claurst_core::codex_oauth::CODEX_MODELS
         .iter()
@@ -477,6 +483,7 @@ fn codex_fallback_models() -> Vec<ModelEntry> {
                     format_context_window(ctx)
                 ),
                 is_current: false,
+                provider_id: provider_id.to_string(),
             }
         })
         .collect()
@@ -485,12 +492,13 @@ fn codex_fallback_models() -> Vec<ModelEntry> {
 /// Curated free-mode model list used by `models_for_provider_from_registry`.
 /// Always shows `free/auto` first; one pin entry per catalog upstream so the
 /// user can target a specific provider when they need to.
-fn free_provider_models() -> Vec<ModelEntry> {
+fn free_provider_models(provider_id: &str) -> Vec<ModelEntry> {
     let mut entries = vec![ModelEntry {
         id: "free/auto".to_string(),
         display_name: "Auto (round-robin across configured providers)".to_string(),
         description: "stacks every free-tier key you've added · $0.00 per M".to_string(),
         is_current: false,
+        provider_id: provider_id.to_string(),
     }];
 
     for upstream in claurst_api::FREE_CATALOG {
@@ -499,6 +507,7 @@ fn free_provider_models() -> Vec<ModelEntry> {
             display_name: format!("{} \u{2014} {}", upstream.title, upstream.default_model),
             description: format!("{} · $0.00 per M", upstream.note),
             is_current: false,
+            provider_id: provider_id.to_string(),
         });
     }
 
@@ -523,6 +532,9 @@ pub struct ModelPickerState {
     pub models_loaded: bool,
     /// `true` while the background fetch is in flight.
     pub loading_models: bool,
+    /// When true, the picker shows models from all connected providers
+    /// grouped by provider name.
+    pub all_providers_mode: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -551,6 +563,7 @@ impl ModelPickerState {
             fast_mode_model: None,
             models_loaded: false,
             loading_models: false,
+            all_providers_mode: false,
         }
     }
 
@@ -566,6 +579,43 @@ impl ModelPickerState {
     /// Open the overlay with full state context.
     pub fn open_with_state(&mut self, current_model: &str, effort: EffortLevel, fast_mode: bool) {
         self.open_with_title("Select model", current_model, effort, fast_mode);
+    }
+
+    /// Open in all-providers mode — shows models from all connected
+    /// providers grouped by provider name.
+    pub fn open_all_providers(&mut self, current_model: &str, effort: EffortLevel, fast_mode: bool) {
+        self.all_providers_mode = true;
+        self.open_with_title("Select model (all providers)", current_model, effort, fast_mode);
+    }
+
+    /// Get the display name for a provider ID (for all-providers mode).
+    pub fn provider_group_name(provider_id: &str) -> &'static str {
+        match provider_id {
+            "anthropic" => "Anthropic",
+            "openai" => "OpenAI",
+            "google" => "Google",
+            "groq" => "Groq",
+            "openrouter" => "OpenRouter",
+            "deepseek" => "DeepSeek",
+            "ollama" => "Ollama",
+            "lmstudio" => "LM Studio",
+            "llamacpp" | "llama-cpp" | "llama-server" => "llama.cpp",
+            "github-copilot" => "GitHub Copilot",
+            "codex" | "openai-codex" => "OpenAI Codex",
+            "cohere" => "Cohere",
+            "xai" => "xAI",
+            "free" => "Free Mode",
+            "cursor-acp" => "Cursor ACP",
+            "cerebras" => "Cerebras",
+            "sambanova" => "SambaNova",
+            "together-ai" | "togetherai" => "Together AI",
+            "mistral" => "Mistral",
+            "perplexity" => "Perplexity",
+            "azure" => "Azure OpenAI",
+            "amazon-bedrock" => "AWS Bedrock",
+            "custom-openai" => "Custom OpenAI",
+            _ => "Other",
+        }
     }
 
     pub fn open_with_title(
@@ -595,6 +645,7 @@ impl ModelPickerState {
     pub fn close(&mut self) {
         self.visible = false;
         self.filter.clear();
+        self.all_providers_mode = false;
     }
 
     pub fn is_selected_fast_mode_model(&self, model_id: &str) -> bool {
@@ -918,7 +969,18 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
             )]));
         }
     } else {
+        let mut last_provider: Option<&str> = None;
         for (i, model) in filtered.iter().enumerate() {
+            // Provider group header in all-providers mode
+            if state.all_providers_mode && last_provider != Some(&model.provider_id) {
+                last_provider = Some(&model.provider_id);
+                let group_name = ModelPickerState::provider_group_name(&model.provider_id);
+                lines.push(Line::from(vec![Span::styled(
+                    format!(" {} ", group_name),
+                    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                )]));
+            }
+
             let is_selected = i == state.selected_idx;
             let supports_effort = model_supports_effort(&model.id);
 
@@ -1026,18 +1088,21 @@ mod tests {
                 display_name: "Claude Opus 4.6".to_string(),
                 description: "200K context".to_string(),
                 is_current: false,
+                provider_id: "anthropic".to_string(),
             },
             ModelEntry {
                 id: "claude-sonnet-4-6".to_string(),
                 display_name: "Claude Sonnet 4.6".to_string(),
                 description: "200K context".to_string(),
                 is_current: false,
+                provider_id: "anthropic".to_string(),
             },
             ModelEntry {
                 id: "claude-haiku-4-5".to_string(),
                 display_name: "Claude Haiku 4.5".to_string(),
                 description: "200K context".to_string(),
                 is_current: false,
+                provider_id: "anthropic".to_string(),
             },
         ]
     }
@@ -1478,6 +1543,7 @@ mod tests {
                 display_name: "LIVE OVERWRITE".to_string(),
                 description: "live desc".to_string(),
                 is_current: false,
+                provider_id: "anthropic".to_string(),
             },
             // A brand-new live id absent from the catalog — must be appended.
             ModelEntry {
@@ -1485,6 +1551,7 @@ mod tests {
                 display_name: "GPT-5.5 (live)".to_string(),
                 description: "live only".to_string(),
                 is_current: false,
+                provider_id: "anthropic".to_string(),
             },
         ];
         p.merge_models(live);
@@ -1530,12 +1597,14 @@ mod tests {
             "default",
             "Default model",
             "no catalog entry for this provider",
+            "anthropic",
         )]);
         p.merge_models(vec![ModelEntry {
             id: "llama3.3".to_string(),
             display_name: "Llama 3.3".to_string(),
             description: "local".to_string(),
             is_current: false,
+            provider_id: "anthropic".to_string(),
         }]);
         assert!(
             !p.models.iter().any(|m| m.id == "default"),


### PR DESCRIPTION
## Summary

Model picker shows models from all connected providers, grouped by provider name.

### Features
- All connected providers shown in picker
- Grouped by provider name with headers
- Provider name from registry

### Files Changed
- `src-rust/crates/tui/src/model_picker.rs` — grouped rendering
- `src-rust/crates/tui/src/app.rs` — `open_model_picker_all_providers()`

Part of 22-branch feature/fix set.