### PR TITLE
fix: show custom provider name in picker group header

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Preserve CRLF line endings in files that use them on main,
+# so diffs don't churn from line-ending normalization.
+src-rust/crates/api/src/registry.rs -text
+src-rust/crates/commands/src/providers.rs -text

--- a/FEATURE_DESIGN_batch_commands_no_model.md
+++ b/FEATURE_DESIGN_batch_commands_no_model.md
@@ -1,0 +1,216 @@
+# Feature: Bang (`!`) Batch Commands Independent of Model
+
+## Problem
+
+Claurst currently has NO `!` batch command feature. Users cannot run shell
+commands directly from the input prompt without going through the model (which
+consumes tokens, takes time, and adds the command to the conversation context).
+
+The user wants: typing `! <command>` in the prompt should execute the command
+directly via the `Bash` tool, WITHOUT sending anything to the model. The output
+should be displayed inline. Zero token consumption.
+
+## Current State
+
+- `src-rust/crates/tui/src/app.rs` (~line 6730): `take_input()` returns the raw
+  input string. If it's a slash command (`is_slash_command()`), it's intercepted.
+  Otherwise, the input goes to `claurst_query` → model turn.
+- `src-rust/crates/tui/src/input.rs` (`is_slash_command`): returns true for
+  `/`-prefixed input. There's no `!`-prefix handling.
+- `src-rust/crates/tui/src/app.rs` (~line 5396): `bash_command_allowed_by_prefix()`
+  handles the bash prefix allowlist for the `Bash` tool permission system —
+  this is about tool permission, not direct execution.
+- `src-rust/crates/tools/src/` has `Bash` tool, but it's invoked by the model
+  during a turn, not directly by user input.
+
+## Design
+
+### 1. Intercept `!` prefix in input handler
+
+In `src-rust/crates/tui/src/app.rs` (~line 6720, the Enter/submit handler):
+
+```rust
+let input = self.take_input();
+if input.starts_with('!') {
+    let command = input[1..].trim();
+    if !command.is_empty() {
+        return Ok(Some(format!("__BANG__{}", command)));
+    }
+    continue;
+}
+```
+
+Or better: intercept before `take_input()` returns to the query path, similar
+to how slash commands are intercepted:
+
+```rust
+// Check for bang command BEFORE sending to model
+if self.prompt_input.text.starts_with('!') {
+    let command = self.prompt_input.text[1..].trim().to_string();
+    if !command.is_empty() {
+        self.clear_prompt();
+        self.execute_bang_command(command).await;
+        continue;
+    }
+}
+```
+
+### 2. `execute_bang_command()` method
+
+The bash tool in claurst is `PtyBashTool` (`tools/src/lib.rs:569`), a stateful
+PTY-based tool. Using it for `!` commands would bypass the PTY state machine and
+is unnecessarily complex for a one-shot command. Instead, use
+`std::process::Command` (or `tokio::process::Command` for async) directly:
+
+```rust
+async fn execute_bang_command(&mut self, command: String) {
+    // Display the command as a user-style message in the transcript
+    // (display_messages only — NOT self.messages, so model never sees it)
+    let display_msg = DisplayMessage::bang_command(format!("$ {}", command));
+    self.display_messages.push(display_msg);
+
+    // Execute via tokio::process::Command — NO model round-trip, NO PTY
+    let result = tokio::process::Command::new("bash")
+        .arg("-c")
+        .arg(&command)
+        .current_dir(&self.working_dir)
+        .output()
+        .await;
+
+    match result {
+        Ok(output) => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let display = if stderr.is_empty() {
+                stdout.to_string()
+            } else {
+                format!("{}\n--- stderr ---\n{}", stdout, stderr)
+            };
+            let exit_code = output.status.code().unwrap_or(-1);
+            let full = if exit_code != 0 {
+                format!("{}\n[exit: {}]", display, exit_code)
+            } else {
+                display.to_string()
+            };
+            self.display_messages.push(DisplayMessage::bang_output(full));
+        }
+        Err(e) => {
+            self.display_messages.push(DisplayMessage::bang_error(
+                format!("Error: {}", e),
+            ));
+        }
+    }
+
+    // NO token consumption — no query, no model call
+    // NO context pollution — command + output in display_messages only
+}
+```
+
+New `DisplayMessage` variants: `bang_command`, `bang_output`, `bang_error` —
+rendered via the existing `render_bash_input_line()` pattern. These are
+display-only and never enter the conversation sent to the model.
+
+### 3. Permission handling
+
+The `!` command still goes through the normal `Bash` permission system:
+- In `default` mode: prompt the user before execution (existing permission dialog)
+- In `acceptEdits` / `bypassPermissions` mode: auto-approve
+- The `bash_prefix_allowlist` applies — previously-allowed prefixes skip the prompt
+- **In `plan` mode: `!` commands are BLOCKED**. Plan mode restricts to read-only
+  operations (verified: `PermissionMode::Plan` in `lib.rs`). Shell execution is
+  not read-only. The `!` prefix should show: "Bang commands disabled in plan mode."
+  and not execute. This prevents accidental writes during analysis sessions.
+
+### 4. Multi-line / batch support
+
+Claurst's input is single-line: Enter submits, Shift+Enter inserts a newline
+(verified at `app.rs:7246` `shift_enter_inserts_newline_not_submit`). The `!!`
+multi-line design must work within this model:
+
+- `!` followed by a single command → execute directly (one line, Enter submits)
+- `!!` (double bang) → enters **multi-line bang mode**: the prompt shows
+  `!!>` prefix. Each Enter inserts a newline (does NOT submit). User presses
+  `Ctrl+D` or types a blank line then Enter to execute the full multi-line
+  script as `bash -c "<script>"`.
+- Multi-line mode is exited after execution, back to normal prompt.
+- Output of `!` / `!!` commands is NOT sent to the model (truly independent)
+
+### 5. Settings
+
+```jsonc
+{
+  "bangCommands": {
+    "enabled": false,
+    "addToHistory": false,
+    "showInTranscript": true
+  }
+}
+```
+
+- `enabled`: toggle the feature (default `false` — `!` is a surprising prefix
+  for users who don't expect it; opt-in is safer)
+- `addToHistory`: add `!` commands to a **separate** shell-command history (not
+  the prompt history), recalled via `Alt+Up` / `Alt+Down` (avoids accidentally
+  re-submitting a shell command as a prompt)
+- `showInTranscript`: display command + output in chat transcript (vs. just
+  showing a brief confirmation)
+
+### 6. Rendering
+
+Use `render_bash_input_line()` from `src-rust/crates/tui/src/messages/mod.rs:1280`
+(which already exists!) to render the command. Output rendered as a code block
+system message.
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `src-rust/crates/tui/src/app.rs` | `!` prefix interception in submit handler, `execute_bang_command()` |
+| `src-rust/crates/tui/src/input.rs` | `is_bang_command()` helper (parallel to `is_slash_command()`) |
+| `src-rust/crates/tui/src/messages/mod.rs` | New `DisplayMessage` variants for bang output |
+| `src-rust/crates/core/src/lib.rs` | `Settings.bang_commands` config field |
+| `src-rust/docs/commands.md` | Document `!` command syntax |
+
+## Key insight
+
+The critical design point: `!` commands must NOT enter the `claurst_query`
+pipeline at all. They execute locally and display output, but the model never
+sees them. This means:
+- No `ProviderRequest` is built
+- No `provider.create_message_stream()` call
+- No tokens consumed
+- Command + output not added to `self.messages` (the conversation sent to model)
+- Only added to `display_messages` (what the user sees)
+
+## Compatibility
+
+- Existing slash commands (`/...`) unaffected — `!` checked separately
+- `PtyBashTool` (model-invoked Bash tool) still works normally during a turn
+- `bash_prefix_allowlist` applies to `!` commands too
+- `plan` mode blocks `!` commands entirely
+
+## Testing strategy
+
+- **Unit test**: `is_bang_command()` true for `!ls`, `!! script`; false for
+  `ls`, `/help`, `!` alone (empty)
+- **Unit test**: `execute_bang_command()` runs `echo hello` → stdout "hello\n"
+  displayed, exit code 0
+- **Unit test**: `execute_bang_command()` runs `false` → stderr shown, exit
+  code 1 displayed
+- **Unit test**: command not found → error message displayed, no panic
+- **Integration test**: `!` command output appears in `display_messages`, NOT
+  in `self.messages` (verify model never sees it)
+- **Integration test**: `plan` mode → `!` command blocked, message shown
+- **Integration test**: `bypassPermissions` mode → `!` auto-executes, no dialog
+- **Error paths**: command spawn fails (e.g. `bash` not on PATH) → error
+  displayed; command takes >30s → timeout, kill process, show partial output
+
+## Error handling
+
+- Command spawn fails (`bash` not found) → `DisplayMessage::bang_error("Error:
+  command not found: bash")` in display_messages
+- Command timeout (default 30s, configurable) → kill child process, display
+  partial output + "[timeout after 30s]"
+- Non-zero exit code → output shown with `[exit: N]` marker, no error dialog
+  (it's not a claurst error, just a command result)
+- Stderr present → shown after stdout with `--- stderr ---` separator

--- a/FEATURE_DESIGN_cursor_cli_acp_support.md
+++ b/FEATURE_DESIGN_cursor_cli_acp_support.md
@@ -1,0 +1,271 @@
+# Feature: Cursor CLI ACP Support
+
+## Problem
+
+Claurst has an ACP **server** (`src-rust/crates/acp/`) — editors like Zed connect
+to claurst as a subprocess. But claurst has no ACP **client** mode — it cannot
+connect to another ACP agent (like Cursor's `agent acp` CLI) as a provider.
+
+The user's opencode config had a `cursor-acp` provider pointing at
+`http://127.0.0.1:32124/v1`. Claurst cannot use Cursor's models because:
+1. Cursor CLI uses ACP (JSON-RPC 2.0 over stdio), not a REST `/v1/chat/completions`
+   endpoint
+2. Claurst only has OpenAI-compatible REST providers + native providers (Anthropic,
+   Google, etc.) — no ACP-client provider
+
+## Jcode Reference (the working implementation)
+
+Jcode has a full Cursor ACP runtime: `crates/jcode-provider-cursor-acp-runtime/src/lib.rs`
+(1940 lines). Key patterns:
+
+### 1. Subprocess management
+- Spawns `agent --force --trust acp` as a subprocess (Cursor CLI)
+- `DEFAULT_COMMAND = "agent"`, `DEFAULT_ACP_ARG = "acp"`
+- `DEFAULT_PERMISSION_ARGS = ["--force", "--trust"]` (before `acp` subcommand)
+- Env overrides: `JCODE_CURSOR_ACP_PATH`, `JCODE_CURSOR_ACP_ARGS`,
+  `JCODE_CURSOR_ACP_EXTRA_ARGS`
+- `ACP_HANDSHAKE_TIMEOUT = 30s`, `ACP_READ_TIMEOUT = 120s` per line
+
+### 2. Protocol implementation
+- Newline-delimited JSON-RPC 2.0 over stdin/stdout
+- `IncomingMessage` struct: parse `{id, method, params, result, error}`
+- `AcpProcess` struct: owns `Child`, `ChildStdin`, `BufReader<ChildStdout>`
+- Stderr captured to bounded tail (`STDERR_TAIL_BYTES = 8192`) for debugging
+
+### 3. Model catalog discovery
+- `ModelCatalog` struct: `models: Vec<String>`, `current: Option<String>`
+- Parses `availableModels`, `currentModelId`, `configOptions` from initialize response
+- `resolve_model()`: exact ID match, or bare ID when exactly one bracketed variant
+  exists
+- Process-wide `SHARED_DISCOVERED_MODELS: OnceLock<Arc<RwLock<Vec<String>>>>` —
+  one prefetch populates all instances
+
+### 4. Streaming
+- `session/prompt` → streams `session/update` notifications
+- Maps ACP events to jcode's `StreamEvent` enum
+- `ACP_READ_TIMEOUT = 120s` per line (long-running tools OK, hung process detected)
+
+## Design
+
+### 1. New module in `claurst_api`
+
+New file: `src-rust/crates/api/src/providers/cursor_acp.rs`
+
+```rust
+pub struct CursorAcpProvider {
+    // tokio::sync::Mutex — NOT std::sync::Mutex — because create_message_stream()
+    // is async and holds the lock across .await points. A std::sync::Mutex would
+    // block the async runtime. LlmProvider requires Send + Sync; tokio::sync::Mutex
+    // satisfies both for async contexts.
+    process: tokio::sync::Mutex<Option<AcpProcess>>,
+    model: tokio::sync::RwLock<String>,
+    command: CursorAcpCommand,
+}
+
+struct AcpProcess {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    stderr_tail: Arc<RwLock<String>>,
+    next_id: u64,
+    session_id: String,
+    catalog: ModelCatalog,
+    supports_images: bool,
+}
+
+impl Drop for AcpProcess {
+    fn drop(&mut self) {
+        // Kill the Cursor subprocess to prevent orphaned processes.
+        // Jcode's AcpProcess does the same (verified in jcode source).
+        let _ = self.child.start_kill();
+    }
+}
+```
+
+Implements `LlmProvider` trait (verified at `provider.rs:75`) — `create_message_stream()`
+is the streaming entry point. The `process` field uses `Option<AcpProcess>` so the
+mutex can be held with `None` during reconnection (see reconnection strategy below).
+
+### 2. Provider registration
+
+In `src-rust/crates/api/src/providers/openai_compat_providers.rs` or a new
+`providers/mod.rs` entry:
+
+```rust
+// In provider_from_key() in registry.rs:
+"cursor-acp" => Some(Arc::new(CursorAcpProvider::new(key))),
+```
+
+In `src-rust/crates/api/src/registry.rs` `runtime_provider_for()`:
+```rust
+"cursor-acp" => return Some(Arc::new(CursorAcpProvider::from_env())),
+```
+
+### 3. Settings
+
+```jsonc
+{
+  "provider": "cursor-acp",
+  "providers": {
+    "cursor-acp": {
+      "api_base": null,
+      "api_key": null,
+      "enabled": true,
+      "options": {
+        "command": "agent",
+        "args": ["--force", "--trust", "acp"],
+        "models": []
+      }
+    }
+  }
+}
+```
+
+Env vars (parallel to jcode):
+- `CLAURST_CURSOR_ACP_PATH` — executable (default: `agent`)
+- `CLAURST_CURSOR_ACP_ARGS` — full arg list (default: `--force --trust acp`)
+- `CLAURST_CURSOR_ACP_EXTRA_ARGS` — permission args before `acp` (default:
+  `--force --trust`)
+
+### 4. ACP client protocol flow
+
+```
+1. Spawn: agent --force --trust acp (subprocess)
+2. initialize → get capabilities + model catalog
+3. session/new (cwd = current working dir)
+4. session/prompt → stream session/update events
+   - Map text deltas → claurst StreamEvent::Text
+   - Map tool calls → claurst StreamEvent::ToolCall
+   - Map tool results → claurst StreamEvent::ToolResult
+   - Map thinking → claurst StreamEvent::Thinking
+5. session/cancel on user interrupt
+```
+
+**Connection reuse**: claurst's `Connection` struct (`acp/src/connection.rs:47`) is
+already bidirectional — it has `send_request()` (outbound request + pending response
+routing via `DashMap<String, oneshot::Sender<...>>`) and `run_reader()` (inbound
+parsing → `Inbound::Request` / `Inbound::Notification`). As a **client**, claurst
+sends `initialize`/`session/new`/`session/prompt` requests (outbound), and receives
+responses (routed internally to pending futures) + `session/update` notifications
+(inbound). The `Connection` handles both paths correctly.
+
+**Lifecycle caveat**: `Connection::new(writer)` creates the writer side. `run_reader()`
+must be spawned as a separate tokio task to pump inbound messages. The reader task
+writes parsed inbound to an `mpsc` channel. The client must consume this channel
+concurrently with `send_request()` calls. The `AcpProcess` owns both the writer
+(via `Connection`) and the reader task handle. On drop, both are cleaned up:
+subprocess killed, reader task aborted.
+
+### 5. Model catalog
+
+On `initialize`, parse the Cursor response to extract available models. Register
+them in `ModelRegistry` as `cursor-acp/<model_id>`. Use jcode's `ModelCatalog`
+parsing logic as reference:
+- `availableModels` array
+- `currentModelId` string
+- `configOptions` with `category: "model"`
+
+Claurst's `ModelRegistry` is already a singleton — custom provider models are
+registered directly into it (no need for jcode's process-wide `OnceLock` cache).
+
+### 6. Permission flow
+
+Cursor ACP sends `session/request_permission` for tool calls. Claurst's existing
+permission system (`src-rust/crates/tui/src/dialogs.rs` `PermissionRequest`) handles
+this:
+- `default` mode: show permission dialog
+- `acceptEdits`/`bypassPermissions`: auto-approve
+- Map ACP permission request → claurst `PermissionRequest`
+
+### 7. Reconnection strategy
+
+When the Cursor subprocess crashes mid-session (exit code non-zero, stdin EOF,
+or `ACP_READ_TIMEOUT` exceeded):
+
+1. **Detect**: `run_reader()` returns EOF or error. The current `create_message_stream()`
+   call returns `ProviderError` to the caller.
+2. **Propagate error**: user sees "Cursor ACP subprocess exited (code N)" with
+   the stderr tail (last 8KB) for debugging.
+3. **Lazy reconnection**: the next `create_message_stream()` call checks if
+   `process` is `None` (dropped after crash). If so, it re-spawns the subprocess,
+   runs `initialize` + `session/new`, and retries. This is lazy — no background
+   reconnection loop, just re-on-demand.
+4. **Session loss**: a new `session/new` means the conversation context is lost
+   (Cursor's session is per-subprocess). The provider logs a warning: "Cursor ACP
+   session lost — starting fresh session." The claurst conversation history is
+   re-sent on the next `session/prompt` (claurst already sends full context).
+
+This mirrors jcode's behavior: error → propagate → re-on-demand, not auto-restart.
+
+## Files to modify/create
+
+| File | Change |
+|------|--------|
+| `src-rust/crates/api/src/providers/cursor_acp.rs` | **NEW** — `CursorAcpProvider`, `AcpProcess`, `ModelCatalog` |
+| `src-rust/crates/api/src/providers/mod.rs` | Add `cursor_acp` module |
+| `src-rust/crates/api/src/registry.rs` | Register `cursor-acp` provider id |
+| `src-rust/crates/core/src/lib.rs` | Cursor ACP env var resolution |
+| `src-rust/crates/acp/src/connection.rs` | Reuse as client (already bidirectional) |
+| `src-rust/crates/api/src/model_registry.rs` | Register cursor ACP models |
+| `src-rust/docs/providers.md` | Document `cursor-acp` provider |
+
+## Jcode files referenced
+
+| File | Purpose |
+|------|---------|
+| `crates/jcode-provider-cursor-acp-runtime/src/lib.rs` | Full ACP client implementation (1940 lines) |
+| `crates/jcode-provider-cursor-runtime/src/agent_transport.rs` | Alternative Cursor transport (572 lines) |
+
+## Key insights from jcode
+
+1. **`--force --trust` are top-level flags**, not `acp` subcommand flags — they
+   must come before `acp` on the command line
+2. **Model IDs are opaque** — don't try to parse them, just pass through
+3. **Process-wide model cache** — `OnceLock<Arc<RwLock<Vec<String>>>>` so one
+   prefetch populates all provider instances
+4. **Per-line read timeout** (120s) not per-response — long-running tools don't
+   trip it, only hung processes do
+5. **stderr tail** — bounded 8KB ring buffer for debugging spawn failures
+
+## Compatibility
+
+- Existing ACP server (`claurst acp`) unaffected — this is a client, not server
+- Cursor CLI must be installed (`agent` on PATH) — `CursorAcpCommand::configured()`
+  gates availability
+- Works alongside other providers — `cursor-acp` is just another provider id
+
+## Testing strategy
+
+- **Unit test**: `CursorAcpCommand::from_env()` parses env vars correctly, falls
+  back to defaults
+- **Unit test**: `CursorAcpCommand::configured()` returns false when `agent` not
+  on PATH, true when it is
+- **Unit test**: `resolve_model()` — exact ID match wins, bare ID resolves when
+  one bracketed variant exists, ambiguous → error
+- **Unit test**: `ModelCatalog::merge()` parses `availableModels` +
+  `currentModelId` + `configOptions`
+- **Integration test** (requires mock ACP server): spawn mock → initialize →
+  session/new → session/prompt → verify `StreamEvent::Text` deltas received
+- **Integration test**: mock server sends `session/request_permission` →
+  permission dialog shown in `default` mode
+- **Integration test**: mock server crashes mid-stream → error propagated,
+  next call re-spawns and reconnects
+- **Integration test**: Drop of `CursorAcpProvider` → subprocess killed
+  (verify no orphaned `agent` process)
+- **Error paths**: `agent` not found → `ProviderStatus::Unavailable`;
+  `initialize` timeout (30s) → error with stderr tail; `session/prompt` read
+  timeout (120s) → error, subprocess not killed (tool may be running)
+
+## Error handling
+
+- Subprocess spawn fails → `ProviderError::Connection("failed to spawn agent:
+  {error}")` with stderr tail if available
+- `initialize` handshake timeout (30s) → `ProviderError::Connection("handshake
+  timeout — Cursor CLI may be unresponsive")`
+- `session/prompt` read timeout (120s per line) → `ProviderError::Connection
+  ("read timeout — Cursor CLI stopped responding")`, subprocess kept alive
+  (a tool may still be running; killing mid-tool is worse than waiting)
+- Subprocess exits non-zero → `ProviderError::Connection("Cursor CLI exited
+  (code N): {stderr_tail}")`, process set to `None` for lazy reconnection
+- Invalid JSON-RPC line from subprocess → logged, skipped (robustness — one
+  bad line shouldn't kill the session)

--- a/FEATURE_DESIGN_model_favorite_selector.md
+++ b/FEATURE_DESIGN_model_favorite_selector.md
@@ -1,0 +1,148 @@
+# Feature: Model Favorite Selector
+
+## Problem
+
+Claurst's `/model` picker shows all models from all providers in a flat list. Users
+with many providers (especially after the multiple-custom-providers feature) end up
+scrolling through a long list to find their preferred models. There's no way to
+pin/favorite models for quick access.
+
+## Current State
+
+- `src-rust/crates/api/src/model_registry.rs`: `ModelRegistry` stores models keyed
+  by `"provider/model"`. `list_visible_by_provider()` returns models for one
+  provider. `best_model_for_provider()` picks a default by priority patterns.
+- `src-rust/crates/commands/src/providers.rs` (or `display.rs`): the `/model`
+  command opens a picker dialog that lists available models.
+- `src-rust/crates/tui/src/dialog_select.rs`: generic selection dialog used by
+  model picker.
+- `src-rust/crates/core/src/lib.rs`: `Config::model` field persists the selected
+  model. No "favorites" or "recent models" concept exists.
+- `src-rust/crates/core/src/output_styles.rs`: `/output-style` picker is a
+  reference pattern for a similar UI picker.
+
+## Design
+
+### 1. Settings: `favoriteModels` array
+
+```jsonc
+{
+  "favoriteModels": [
+    "custom-openai/together_ai/revolut-ca/glm-5-2",
+    "nvidia/z-ai/glm-5.2",
+    "openai/gpt-5.5"
+  ]
+}
+```
+
+Persisted in `~/.claurst/settings.json`. Simple array of `"provider/model"` keys.
+
+### 2. TUI: favorites toggle in a dedicated model picker widget
+
+The generic `dialog_select.rs` is used by many pickers (slash commands, output
+styles, etc.). Adding favorites-specific key handling and grouped sections to it
+would violate SRP — the generic dialog becomes model-picker-specific.
+
+**Solution**: create a new `src-rust/crates/tui/src/model_picker.rs` widget that
+owns the model picker rendering and key handling. It wraps the existing
+selection logic but adds:
+- A "★ Favorites" section at the top of the list
+- `f` or `*` key to toggle favorite state on the highlighted model
+- Favorite indicator: `★` prefix for favorited, `☆` for non-favorited
+- Two grouped sections:
+  1. **★ Favorites** — favorited models that exist in the current registry
+  2. **All Models** — full list (existing behavior, minus favorited duplicates)
+
+This keeps `dialog_select.rs` unchanged and isolates model-specific logic.
+
+### 3. Toggle mechanism
+
+- Key `f` or `*` in the model picker → calls `toggle_favorite(model_key)`
+- Updates `Settings.favoriteModels` array and saves to disk
+- Picker re-renders immediately to reflect the change
+
+### 4. Persistence
+
+`favoriteModels: Vec<String>` lives on **`Settings`** (top-level, not nested in
+`Config`). This matches `providers` and `modelOverrides` which are also
+top-level on `Settings` — they are user preferences, not runtime behavior.
+Verified: `theme` and `output_style` are on `Config` (`lib.rs:1021,1023`) because
+they are runtime behavior; `favoriteModels` is a preference → `Settings`.
+
+In `src-rust/crates/core/src/lib.rs` `Settings` struct (around line 1208):
+```rust
+#[serde(default)]
+pub favorite_models: Vec<String>,
+```
+
+`effective_config()` merge: `Settings.favorite_models` is available directly on
+the `Settings` struct — no merge needed since it's not on `Config` (unlike
+`model_overrides` which gets merged into `config.model_overrides`). The TUI reads
+it via `Settings::load_sync().favorite_models`.
+
+### 5. Model picker rendering
+
+The new `model_picker.rs` widget renders grouped sections. Validation function:
+
+```rust
+/// Filter favorites to only those present in the current model registry.
+/// Stale favorites (model removed from catalog, provider uninstalled) are
+/// silently excluded from the picker display but NOT removed from settings
+/// (user may re-install the provider later).
+fn valid_favorites(
+    favorites: &[String],
+    registry: &ModelRegistry,
+) -> Vec<String> {
+    favorites
+        .iter()
+        .filter(|key| {
+            if let Some((provider, model)) = key.split_once('/') {
+                registry.get(provider, model).is_some()
+            } else {
+                false
+            }
+        })
+        .cloned()
+        .collect()
+}
+```
+
+Reference: `output_styles.rs` `all_styles()` grouping pattern, and jcode's
+model picker preview (`state_model_poke_03.rs` shows `inline_interactive_state`
+with `selected` index and `preview` mode).
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `src-rust/crates/core/src/lib.rs` | `Settings.favorite_models: Vec<String>` field |
+| `src-rust/crates/tui/src/model_picker.rs` | **NEW** — dedicated model picker widget with grouped rendering + `f`/`*` key handler |
+| `src-rust/crates/commands/src/providers.rs` | `/model` command wires favorites into picker |
+| `src-rust/crates/tui/src/app.rs` | Route model picker key events to new widget |
+| `src-rust/docs/configuration.md` | Document `favoriteModels` |
+
+## Reference: jcode pattern
+
+Jcode's model picker (`state_model_poke_03.rs`) uses an `inline_interactive_state`
+with `selected` index and `preview` mode. Arrow keys navigate. This is a good
+reference for the interactive navigation pattern.
+
+## Compatibility
+
+- Empty `favoriteModels` → picker works exactly as today (no favorites section)
+- Favorites referencing non-existent models → silently filtered out at render
+  time via `valid_favorites()` (NOT removed from settings — user may re-install
+  the provider later)
+- Favorites work across all providers, including custom providers
+
+## Testing strategy
+
+- **Unit test**: `valid_favorites()` filters stale entries, keeps valid ones
+- **Unit test**: `favorite_models` deserialization (empty array default)
+- **Unit test**: `toggle_favorite()` adds/removes from array, saves to disk
+- **Integration test**: open model picker with 3 favorites → "★ Favorites"
+  section shows 3 items, "All Models" section shows remaining (no duplicates)
+- **Integration test**: favorite a model, remove provider, reopen picker →
+  stale favorite hidden, no crash
+- **Error paths**: settings write fails (read-only filesystem) → error logged,
+  in-memory state still toggles correctly

--- a/FEATURE_DESIGN_multiple_openai_compatible_providers.md
+++ b/FEATURE_DESIGN_multiple_openai_compatible_providers.md
@@ -1,0 +1,254 @@
+# Feature: Multiple OpenAI-Compatible Providers
+
+## Problem
+
+Claurst has exactly ONE generic OpenAI-compatible provider slot (`custom-openai`).
+Users with multiple custom OpenAI-compatible endpoints (e.g. two Revolut gateways,
+a local vLLM + a cloud gateway, a coding endpoint + a non-coding endpoint) cannot
+register them simultaneously. The `providers` map only accepts known fixed provider
+ids — `custom-openai` is the single catch-all.
+
+## Root Cause
+
+`src-rust/crates/api/src/providers/openai_compat_providers.rs`:
+`provider_for_id()` is a hardcoded `match` on provider id strings. Each OpenAI-compat
+backend is a distinct fixed id with its own factory fn. Only `"custom-openai"` routes
+to the generic adapter, and `custom_openai()` reads `providers["custom-openai"]`
+exclusively.
+
+`src-rust/crates/core/src/lib.rs`:
+`ProviderConfig` struct has no `models` sub-map (unlike opencode). Model catalog
+comes from bundled snapshot + models.dev, not settings.
+
+`src-rust/crates/query/src/lib.rs` (~line 798):
+`effective_model.split_once('/')` parses provider prefix. `selected_provider_id()`
+derives provider from model string's first `/`.
+
+## Design
+
+### 1. Settings schema: `customProviders` map
+
+Add a new top-level settings key. Uses a **map** (not array) for O(1) lookup
+by id and to prevent duplicate ids:
+
+```jsonc
+{
+  "customProviders": {
+    "llmg-coding": {
+      "name": "LLMG Coding Gateway",
+      "apiBase": "https://llm-gateway-coding.revolut.com/proxy/openai/opencode",
+      "apiKey": "{env:LLMG_CODING_API_KEY}",
+      "headers": { "x-coding-tool": "opencode" },
+      "models": {
+        "together_ai/revolut-ca/glm-5-2": {
+          "name": "T.AI GLM5.2",
+          "contextWindow": 230000,
+          "maxOutputTokens": 32072,
+          "reasoningEffort": "high",
+          "variants": {
+            "max": { "reasoningEffort": "max" },
+            "high": { "reasoningEffort": "high" },
+            "none": { "reasoningEffort": "none" }
+          }
+        }
+      },
+      "requestTimeoutSecs": 300
+    },
+    "llmg-non-coding": {
+      "name": "LLMG Non-Coding Gateway",
+      "apiBase": "https://llm-gateway-coding.revolut.com/proxy/openai/opencode",
+      "apiKey": null,
+      "models": {
+        "fireworks_revolut-non-coding/accounts/revolut-non-coding/deployments/hxjsp23w": {
+          "name": "FW GLM 5.2",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 131072
+        }
+      }
+    }
+  }
+}
+```
+
+#### Rust structs
+
+`CustomProviderDef` is a **new** struct — NOT `ProviderConfig`. It lives on
+`Settings` directly and carries fields that `ProviderConfig` does not have
+(`headers`, `models`). The existing `ProviderConfig` struct (`lib.rs:907`) is
+unchanged — it only has `api_key`, `api_base`, `enabled`, `models_whitelist`,
+`models_blacklist`, `options`, `request_timeout_secs`. The `headers` field is
+**not** added to `ProviderConfig` (it's only relevant for custom OpenAI-compat
+providers, not for native providers like Anthropic/Google).
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CustomProviderDef {
+    pub name: String,
+    #[serde(rename = "apiBase", alias = "api_base")]
+    pub api_base: String,
+    #[serde(rename = "apiKey", alias = "api_key", default)]
+    pub api_key: Option<String>,
+    /// Custom HTTP headers sent on every request. Only on CustomProviderDef,
+    /// NOT on ProviderConfig (native providers don't need this).
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
+    /// Model catalog local to this provider.
+    #[serde(default)]
+    pub models: HashMap<String, CustomModelDef>,
+    #[serde(rename = "requestTimeoutSecs", alias = "request_timeout_secs", default)]
+    pub request_timeout_secs: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CustomModelDef {
+    #[serde(rename = "contextWindow", alias = "context_window", default)]
+    pub context_window: Option<u32>,
+    #[serde(rename = "maxOutputTokens", alias = "max_output_tokens", default)]
+    pub max_output_tokens: Option<u32>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(rename = "reasoningEffort", alias = "reasoning_effort", default)]
+    pub reasoning_effort: Option<String>,
+    #[serde(default)]
+    pub variants: HashMap<String, ModelVariant>,
+}
+```
+
+Field naming follows claurst's existing serde convention: snake_case Rust
+fields with `#[serde(rename = "camelCase")]` + `#[serde(alias = "snake_case")]`
+for JSON compatibility. This matches `ProviderConfig::request_timeout_secs`
+(`rename = "requestTimeoutSecs"`), `ModelOverride::context_window`
+(`rename = "contextWindow"`), etc.
+
+Each entry is a self-contained provider definition with:
+- **Map key**: unique id, becomes the provider id in `provider/model` routing
+- `name`: display name in picker
+- `apiBase`: OpenAI-compatible base URL (claurst appends `/chat/completions`)
+- `apiKey`: API key (`{env:VAR}` substitution supported)
+- `headers`: custom HTTP headers (sent on every request) — **only on
+  `CustomProviderDef`, not `ProviderConfig`**
+- `models`: model catalog local to this provider (primary catalog source)
+- `requestTimeoutSecs`: per-provider timeout override
+
+### 2. Provider routing changes
+
+**`openai_compat_providers.rs`**: add `provider_for_custom_id(id: &str) -> Option<OpenAiCompatProvider>`
+that looks up `Settings.customProviders` by id (map lookup, O(1)). Called BEFORE
+the fixed `match` in `provider_for_id()` so custom ids take priority. Custom
+providers use `OpenAiCompatProvider::new(id, name, api_base)` +
+`.with_api_key(key)` + `.with_header(name, value)` (builder API already exists
+in `openai_compat.rs:173-179`).
+
+**`registry.rs`**: `provider_from_key()` and `runtime_provider_for()` must check
+custom providers first, then fall through to the existing fixed-id dispatch.
+
+**`query/src/lib.rs`** (~line 798): the `known_providers` array is a hardcoded
+list. Instead of adding custom ids to this array (which is compiled in and
+can't know custom ids at compile time), add a **runtime check**:
+```rust
+if known_providers.contains(&p) || settings.custom_providers.contains_key(p) {
+    (p.to_string(), m.to_string())
+}
+```
+This requires `Settings` to be accessible at that call site (it already is via
+`tool_ctx.config`).
+
+### 3. Model registry integration
+
+Custom provider models registered into `ModelRegistry` at load time, keyed as
+`<custom_provider_id>/<model_id>`. The `modelOverrides` map remains for metadata
+correction; `customProviders[].models` is the primary catalog source for these
+providers.
+
+### 4. `/add` command
+
+New slash command to add a custom provider interactively:
+
+```
+/add <name> <apiBase> [apiKey]
+```
+
+Writes to `customProviders` map in `settings.json`.
+
+**Concurrent write safety**: claurst rewrites `settings.json` on startup and
+during `/connect`. To prevent races:
+1. Load current settings from disk (fresh read, not in-memory cache)
+2. Insert the new entry into `customProviders` map
+3. Write atomically: serialize to `settings.json.tmp`, then `fs::rename()` to
+   `settings.json` (atomic on Unix). This matches `Settings::save_sync()` if it
+   already uses atomic writes — check and reuse; if not, add it there.
+4. A `parking_lot::Mutex` or file-lock guards concurrent saves across the
+   process. A single `save_settings()` entry point serializes all writes.
+
+The TUI custom provider dialog (`custom_provider_dialog.rs`) is extended to
+support naming the provider and editing its model list.
+
+### 5. Effort / variants per model
+
+Each model entry in `customProviders[].models` can carry `reasoningEffort` and
+`variants` (like opencode). These map to `reasoning_effort` in the request body
+via the existing `merge_openai_compatible_options` path in `request_options.rs:34`.
+
+**Blocking fix**: `is_openaiish_provider()` in `query/src/runner/provider_options.rs:62`
+is a hardcoded `matches!()` list that does NOT include custom provider ids. The
+effort mapping is skipped for unknown providers. Solution: change the check to
+also accept custom provider ids:
+```rust
+pub(crate) fn is_openaiish_provider(provider_id: &str) -> bool {
+    // ... existing fixed list ...
+    || settings.custom_providers.contains_key(provider_id)
+}
+```
+Alternatively, since all custom providers are OpenAI-compatible by definition,
+the simplest fix is to return `true` for any id present in `customProviders`.
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `src-rust/crates/core/src/lib.rs` | Add `CustomProviderDef`, `CustomModelDef` structs; `Settings.customProviders` field |
+| `src-rust/crates/api/src/providers/openai_compat_providers.rs` | `provider_for_custom_id()`, headers support |
+| `src-rust/crates/api/src/providers/openai_compat.rs` | `with_headers()` from settings (already has builder API) |
+| `src-rust/crates/api/src/registry.rs` | Custom provider dispatch in `provider_from_key` + `runtime_provider_for` |
+| `src-rust/crates/api/src/model_registry.rs` | Register custom provider models |
+| `src-rust/crates/query/src/lib.rs` | Include custom ids in `known_providers` list (~line 798) |
+| `src-rust/crates/commands/src/providers.rs` | `/add` command |
+| `src-rust/crates/tui/src/custom_provider_dialog.rs` | Extended dialog with name field |
+| `src-rust/docs/configuration.md` | Document `customProviders` |
+
+## Compatibility
+
+- Existing `custom-openai` single-slot config continues to work (legacy fallback)
+- Existing fixed provider ids (together-ai, nvidia, etc.) unaffected
+- `modelOverrides` still works for any provider
+
+## Testing strategy
+
+- **Unit tests**: `CustomProviderDef` deserialization (camelCase + snake_case
+  aliases), `{env:VAR}` substitution in `apiKey`, header map serialization
+- **Unit tests**: `provider_for_custom_id()` returns `Some` for registered ids,
+  `None` for unknown ids
+- **Unit tests**: `is_openaiish_provider()` returns `true` for custom ids
+- **Integration test**: load settings with 2 custom providers → `ModelRegistry`
+  contains entries for both under `<id>/<model>` keys
+- **Integration test**: `model = "llmg-coding/together_ai/revolut-ca/glm-5-2"`
+  → provider dispatched as `llmg-coding`, model sent as `together_ai/revolut-ca/glm-5-2`
+- **Integration test**: `/add` command writes to settings.json atomically —
+  verify file not corrupted if process killed mid-write
+- **Error paths**: invalid `apiBase` (not a URL) → user-facing error message;
+  duplicate `id` in map → serde rejects (map key uniqueness guaranteed);
+  missing `apiBase` → validation error on provider construction
+
+## Error handling
+
+- Invalid custom provider config (missing `apiBase`, unparseable URL) → logged
+  to stderr, provider skipped (not registered), user warned via status notice
+- API key env var not set → provider registered but `health_check()` returns
+  `ProviderStatus::Unavailable` (existing pattern from `openai_compat_providers.rs`)
+- Custom headers with invalid header names → rejected at provider construction
+  time with a descriptive error
+
+## Merge order
+
+This feature should land **first** — `model-favorite-selector` and
+`cursor-cli-acp-support` both benefit from custom provider ids existing.

--- a/FEATURE_DESIGN_todo_management_status_indicator.md
+++ b/FEATURE_DESIGN_todo_management_status_indicator.md
@@ -1,0 +1,273 @@
+# Feature: Todo Management + Status Indicator with Poke Verification
+
+## Problem
+
+Claurst has a `TodoWrite` tool (`src-rust/crates/tools/src/todo_write.rs`) that
+persists todos to `~/.claurst/todos/<session_id>.json`, and a `GoalCompleteTool`
+for goal completion audits. However:
+
+1. No **live status indicator** in the TUI showing todo progress (pending /
+   in-progress / completed counts)
+2. No **auto-poke mechanism** to evaluate whether work is done — the model just
+   stops and the user has to manually continue
+3. No **inline todo card** in the chat transcript
+
+Jcode solves this comprehensively. This feature ports jcode's approach to claurst.
+
+## Jcode Reference (researched from `~/Documents/projects/jcode`)
+
+### Todo data structure (`crates/jcode-task-types/src/lib.rs:198`)
+```rust
+pub struct TodoItem {
+    pub content: String,
+    pub status: String,       // "pending" | "in_progress" | "completed"
+    pub priority: String,     // "high" | "medium" | "low"
+    pub id: String,
+    pub group: Option<String>,
+    pub confidence: Option<u8>,           // 0-100 forward-looking confidence
+    pub completion_confidence: Option<u8>, // confidence when marked done
+    pub confidence_history: Vec<u8>,     // every distinct confidence value
+    pub blocked_by: Vec<String>,
+    pub assigned_to: Option<String>,
+}
+```
+
+### Auto-poke mechanism (`crates/jcode-base/src/todo.rs:297`)
+```rust
+pub fn build_auto_poke_message(incomplete_count: usize) -> String {
+    format!(
+        "You have {} incomplete todo{}. Continue working, or update the todo tool.",
+        incomplete_count,
+        if incomplete_count == 1 { "" } else { "s" },
+    )
+}
+```
+
+`is_auto_poke_message()` identifies synthetic continuation prompts. When the model
+stops with incomplete todos, a synthetic user message is queued. The model treats
+it as a normal continuation turn. The live UI hides it (shows "Auto-poking..."
+notice instead).
+
+### Overnight auto-poke (`crates/jcode-tui/src/tui/app/commands_overnight.rs`)
+- `OVERNIGHT_MAX_POKES: u16 = 48` — safety budget
+- `schedule_overnight_poke_followup_if_needed()` — checks poke budget, schedules
+  next continuation
+- Stops after: cancellation, budget exhaustion, no-progress turns, or non-retryable
+  errors
+- `stop_overnight_auto_poke_for_non_retryable_error()` — halts on fatal errors
+
+### Todo card UI (`crates/jcode-tui/src/tui/app/todos_view.rs`)
+- `toggle_todo_card()` — shows/hides inline card in chat transcript
+- `show_todo_card()` — pushes a display message with `role: "todos"`
+- `refresh_todo_card_if_needed()` — live-refreshes when todo list changes
+  (hash-based diff to avoid unnecessary re-renders)
+- `todo_card_rendered_hash` — tracks last rendered state
+
+### Status indicator (`crates/jcode-tui/src/tui/info_widget_todos.rs`)
+- Progress pips: `○` pending, `▶` in-progress (amber), `✓` completed, `✗` cancelled
+- `EXACT_PIP_FLOOR: usize = 12` — below this count, render 1:1 pip per todo
+- Confidence weighting: `todo_confidence_weight(priority)` — high=3, medium=2, low=1
+- `todo_display_confidence()` — shows confidence score
+
+## Design
+
+### 1. Enhanced TodoItem struct
+
+Extend claurst's existing `TodoWrite` tool input schema. **Current claurst
+`TodoItem`** (verified at `todo_write.rs:134-139`):
+```rust
+struct TodoItem {
+    id: String,
+    content: String,
+    status: TodoStatus,
+    #[serde(default)]
+    priority: Option<String>,  // already exists!
+}
+```
+
+Current claurst already has `id`, `content`, `status`, `priority`. It does NOT
+have `activeForm`. New fields to add: `group`, `confidence`,
+`completion_confidence`, `confidence_history`, `blocked_by`, `assigned_to`.
+
+```jsonc
+{
+  "todos": [
+    {
+      "id": "unique-id",
+      "content": "Implement feature X",
+      "status": "in_progress",
+      "priority": "high",
+      "group": "Phase 1",
+      "confidence": 75,
+      "blocked_by": ["other-todo-id"]
+    }
+  ]
+}
+```
+
+```rust
+#[derive(Debug, Clone, Deserialize)]
+struct TodoItem {
+    id: String,                              // existing
+    content: String,                         // existing
+    status: TodoStatus,                       // existing
+    #[serde(default)]
+    priority: Option<String>,                // existing
+    #[serde(default)]
+    group: Option<String>,                  // NEW
+    #[serde(default)]
+    confidence: Option<u8>,                  // NEW (0-100)
+    #[serde(default)]
+    completion_confidence: Option<u8>,       // NEW
+    #[serde(default)]
+    confidence_history: Vec<u8>,            // NEW, capped at 20 entries
+    #[serde(default)]
+    blocked_by: Vec<String>,                // NEW
+    #[serde(default)]
+    assigned_to: Option<String>,             // NEW
+}
+```
+
+`confidence_history` is capped at **20 entries** (jcode doesn't cap, but long
+sessions could grow it unboundedly). When the cap is reached, the oldest entry
+is evicted (ring buffer semantics).
+
+### 2. Auto-poke mechanism (port from jcode)
+
+**`src-rust/crates/tools/src/todo_write.rs`** or new `src-rust/crates/core/src/todo.rs`:
+```rust
+pub fn build_auto_poke_message(incomplete_count: usize) -> String {
+    format!(
+        "You have {} incomplete todo{}. Continue working, or update the todo tool.",
+        incomplete_count,
+        if incomplete_count == 1 { "" } else { "s" },
+    )
+}
+
+pub fn is_auto_poke_message(message: &str) -> bool { /* ... */ }
+```
+
+**`src-rust/crates/tui/src/app.rs`**: After model stops, check if todos have
+incomplete items. If so, queue `build_auto_poke_message(count)` as a synthetic
+user message and re-submit. Show "Auto-poking..." status notice instead of the
+raw message.
+
+**Auto-poke is ON by default.** This is the core value proposition of the
+feature — users who don't want it can disable via `/todos auto-poke off` or
+settings `"autoPokeEnabled": false`. When `/goal` is active, auto-poke is
+always ON (cannot be disabled — it's how the goal system continues work).
+
+Safety: max pokes per session (configurable, default 48 like jcode). Stop on:
+- Cancellation
+- Budget exhaustion (48 pokes)
+- **3 consecutive no-progress turns** (todo hash unchanged across 3 turns —
+  model is stuck repeating itself without advancing any todo)
+- Non-retryable errors (auth failures, context overflow, rate limit)
+
+No-progress detection: compute a hash of `[(id, status)]` sorted by id after
+each model turn. If the hash is unchanged for 3 consecutive turns, stop
+auto-poking and notify the user: "Auto-poke stopped: no progress for 3 turns."
+
+### 3. Inline todo card (port from jcode)
+
+**`src-rust/crates/tui/src/app.rs`**:
+- `toggle_todo_card()` — `/todos` command toggles card visibility
+- Card renders as a `DisplayMessage` with `SystemMessageStyle::TodoCard` (new
+  variant — claurst's `Message` enum at `app.rs:793` has no `"todos"` role, so
+  a new `SystemMessageStyle` variant is the least-invasive approach)
+- Shows: status pips (○▶✓✗), confidence, group headers, blocked_by markers
+- `refresh_todo_card_if_needed()` — hash-based live update
+
+### 4. Status indicator in status bar
+
+**`src-rust/crates/tui/src/render.rs`**: Add todo progress indicator to the
+status bar:
+```
+Todos: ▶ 2 ○ 3 ✓ 5  (67%)
+```
+- `▶` in-progress count (amber)
+- `○` pending count
+- `✓` completed count
+- Percentage = completed / total
+
+### 5. Poke verification (jcode pattern)
+
+When model calls `GoalCompleteTool` or stops with all todos completed:
+- **Verify**: check that all todos are actually `completed` (not just claimed)
+- **Poke**: if any todo is incomplete, inject auto-poke message and continue
+- **Audit**: `GoalCompleteTool` already requires `audit_summary` + `evidence`
+  — extend it to also verify todo state
+
+**Transition relaxation for verification**: claurst's `validate_transition()`
+(`todo_write.rs:191`) currently forbids `completed → pending` and
+`in_progress → pending`. This is correct for normal model-driven updates.
+However, poke verification may need to **reopen** a falsely-completed todo if
+the model claims done but evidence doesn't match. Solution: add a new
+`TodoWrite` input field `force_reopen: bool` (default `false`). When `true`,
+the transition check is skipped. The model is instructed to use this only when
+poke verification finds a false completion. The `force_reopen` field is NOT
+exposed in the normal tool description — it's mentioned only in the
+auto-poke prompt to prevent casual use.
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `src-rust/crates/tools/src/todo_write.rs` | Enhanced `TodoItem` schema, persistence |
+| `src-rust/crates/core/src/lib.rs` or new `todo.rs` | `build_auto_poke_message`, `is_auto_poke_message` |
+| `src-rust/crates/tui/src/app.rs` | Auto-poke scheduling, todo card, status bar hook |
+| `src-rust/crates/tui/src/render.rs` | Todo progress indicator in status bar |
+| `src-rust/crates/tui/src/messages/mod.rs` | Todo card rendering (`render_bash_input_line` pattern) |
+| `src-rust/crates/commands/src/lib.rs` | `/todos` command (toggle card) |
+| `src-rust/crates/tools/src/goal_complete.rs` | Todo verification before accepting completion |
+| `src-rust/docs/advanced.md` | Document auto-poke + todo status |
+
+## Jcode files referenced
+
+| File | Purpose |
+|------|---------|
+| `crates/jcode-base/src/todo.rs` | `build_auto_poke_message`, `is_auto_poke_message`, todo logic |
+| `crates/jcode-task-types/src/lib.rs` | `TodoItem` struct, `TodoPlan` |
+| `crates/jcode-tui/src/tui/app/todos_view.rs` | Todo card rendering, `toggle_todo_card` |
+| `crates/jcode-tui/src/tui/info_widget_todos.rs` | Progress pips, confidence weighting |
+| `crates/jcode-tui/src/tui/app/commands_overnight.rs` | Overnight auto-poke state machine |
+| `crates/jcode-tui/src/tui/app/commands.rs` | `is_poke_message`, `queued_messages_are_only_pokes` |
+| `crates/jcode-tui/src/tui/app/remote.rs` | `schedule_auto_poke_followup_if_needed` |
+
+## Compatibility
+
+- Existing `TodoWrite` calls with old schema (id/content/status/priority only) →
+  still work, new fields default to `None`/empty
+- Auto-poke **ON by default**; disable via `/todos auto-poke off` or settings
+  `"autoPokeEnabled": false`. During `/goal` sessions, auto-poke is always ON.
+- No breaking changes to session transcript format
+
+## Testing strategy
+
+- **Unit test**: `build_auto_poke_message()` produces correct text for 0, 1, N
+  todos
+- **Unit test**: `is_auto_poke_message()` true for poke messages, false for
+  real user input
+- **Unit test**: `TodoItem` deserialization with old schema (no new fields) →
+  new fields are `None`/empty
+- **Unit test**: `TodoItem` with `force_reopen: true` allows `completed → pending`
+- **Unit test**: `confidence_history` cap at 20 entries — 21st insert evicts oldest
+- **Unit test**: no-progress hash — 3 identical hashes → stop signal
+- **Integration test**: model stops with 2 incomplete todos → auto-poke message
+  queued, "Auto-poking..." status shown, not raw message
+- **Integration test**: model completes all todos → `GoalCompleteTool` verifies
+  todo state, accepts completion
+- **Integration test**: model marks todo completed but evidence empty → poke
+  reopens todo via `force_reopen`, continues
+- **Integration test**: 3 no-progress turns → auto-poke stops, user notified
+- **Error paths**: todos file read fails (corrupt JSON) → empty list, no crash;
+  auto-poke budget exhausted → "Auto-poke stopped: budget of 48 reached"
+
+## Error handling
+
+- Todo file read error (corrupt JSON, permissions) → empty list returned, error
+  logged to `~/.claurst/logs/`, auto-poke continues with 0 todos (no-op)
+- Auto-poke scheduling fails (query engine error) → user notified, auto-poke
+  disabled for rest of session
+- `force_reopen` on a non-completed todo → no-op (transition check skipped but
+  status already not `completed`, so no state change)

--- a/WORKFLOW_STATE.md
+++ b/WORKFLOW_STATE.md
@@ -2,65 +2,47 @@
 
 ## Objective
 Clone claurst repo, create separate feature branches for 5 features, research
-codebase + jcode reference, write design docs per branch.
+codebase + jcode reference, write design docs per branch, review design docs,
+apply review fixes.
 
 ## Current status
-Complete. Repo cloned, 5 branches created, design docs committed per branch.
+Complete. Repo cloned, 5 branches created, design docs committed + reviewed +
+review fixes applied. All blocking and important review items resolved.
 
 ## Last completed step
-All 5 feature branches created with committed design docs. Research of claurst
-codebase + jcode reference complete.
+Applied review fixes to all 5 design docs. Each branch now has 2 commits:
+1. Initial design doc
+2. Review fixes applied
 
 ## Blockers
-None. Design phase complete. Implementation not started (user only requested
-branches + design).
+None. Design + review phase complete. Implementation not started.
 
-## Branches created
+## Branches
 
-| Branch | Design doc | Status |
-|--------|-----------|--------|
-| `feature/multiple-openai-compatible-providers` | `FEATURE_DESIGN_multiple_openai_compatible_providers.md` | Design committed |
-| `feature/model-favorite-selector` | `FEATURE_DESIGN_model_favorite_selector.md` | Design committed |
-| `feature/todo-management-status-indicator` | `FEATURE_DESIGN_todo_management_status_indicator.md` | Design committed |
-| `feature/batch-commands-no-model` | `FEATURE_DESIGN_batch_commands_no_model.md` | Design committed |
-| `feature/cursor-cli-acp-support` | `FEATURE_DESIGN_cursor_cli_acp_support.md` | Design committed |
+| Branch | Commits | Review fixes applied |
+|--------|---------|---------------------|
+| `feature/multiple-openai-compatible-providers` | 2 | headers on CustomProviderDef (not ProviderConfig), atomic writes for /add, is_openaiish_provider runtime check, HashMap not array, testing + error handling |
+| `feature/model-favorite-selector` | 2 | dedicated model_picker.rs widget (not dialog_select), valid_favorites() validation, Settings not Config placement, testing |
+| `feature/todo-management-status-indicator` | 2 | corrected schema (has id/content/status/priority, NOT activeForm), auto-poke ON by default, force_reopen for completed→pending, no-progress 3-turn threshold, confidence_history cap at 20, SystemMessageStyle::TodoCard, testing |
+| `feature/batch-commands-no-model` | 2 | std::process::Command (not PtyBashTool), !! multi-line via Shift+Enter, plan mode blocks !, separate shell history, default off, testing |
+| `feature/cursor-cli-acp-support` | 2 | tokio::sync::Mutex, Drop with start_kill, Connection client-mode lifecycle, lazy reconnection, ModelRegistry singleton (no OnceLock), testing + error handling |
 
-## Key research findings
+## Review verdicts (post-fix)
 
-### 1. Multiple OpenAI-compatible providers
-- Root cause: `provider_for_id()` is hardcoded `match` in
-  `openai_compat_providers.rs`; only `"custom-openai"` is generic
-- Fix: `customProviders` array in settings + dynamic dispatch before fixed match
-- No upstream PR implements this (confirmed via GitHub search)
+All 5 design docs pass review. Blocking items resolved:
+- multiple-providers: headers field clarified, atomic writes specified
+- model-favorite: separate widget, stale validation specified
+- todo-management: factual schema corrected, auto-poke default ON
+- batch-commands: std::process::Command, !! multi-line model specified
+- cursor-acp: tokio::sync::Mutex, Drop lifecycle, reconnection strategy
 
-### 2. Model favorite selector
-- No existing favorites concept in claurst
-- `ModelRegistry` keyed by `"provider/model"` — favorites = simple array of keys
-- Reference: jcode's model picker has `inline_interactive_state` with
-  `selected` + `preview` mode
-
-### 3. Todo management + poke verification
-- Claurst has `TodoWrite` tool (basic: content/status/activeForm) + `GoalCompleteTool`
-- Missing: live status indicator, auto-poke, inline todo card
-- Jcode pattern: `build_auto_poke_message()` in `jcode-base/src/todo.rs`,
-  `OvernightAutoPokeState` in `commands_overnight.rs`, todo card in
-  `todos_view.rs`, progress pips in `info_widget_todos.rs`
-- Jcode `TodoItem` has: confidence, completion_confidence, confidence_history,
-  blocked_by, group, assigned_to
-
-### 4. Bang (`!`) batch commands
-- Claurst has NO `!` feature currently — this is new, not a fix
-- Design: intercept `!` prefix before model query, execute via Bash directly,
-  zero token consumption, output in display_messages only (not conversation)
-- Existing `render_bash_input_line()` in messages/mod.rs can be reused
-
-### 5. Cursor CLI ACP support
-- Claurst has ACP **server** only (`crates/acp/`) — no client
-- Jcode has full implementation: `jcode-provider-cursor-acp-runtime` (1940 lines)
-- Key: spawn `agent --force --trust acp` subprocess, JSON-RPC 2.0 over stdio,
-  reuse claurst's `Connection` struct as client
-- Cursor models are opaque IDs, catalog discovered from `initialize` response
+## Recommended merge order
+1. `feature/multiple-openai-compatible-providers` — other features depend on custom provider ids
+2. `feature/model-favorite-selector` — benefits from custom provider models
+3. `feature/cursor-cli-acp-support` — independent but benefits from custom provider infrastructure
+4. `feature/todo-management-status-indicator` — independent, most complex
+5. `feature/batch-commands-no-model` — fully independent, simplest
 
 ## Next action
-Switch to `main` branch. Implementation of any feature can begin by checking out
-the corresponding branch and following the design doc.
+Switch to a feature branch and begin implementation following the design doc.
+Recommended start: `feature/multiple-openai-compatible-providers` (foundational).

--- a/WORKFLOW_STATE.md
+++ b/WORKFLOW_STATE.md
@@ -1,0 +1,66 @@
+# Workflow State
+
+## Objective
+Clone claurst repo, create separate feature branches for 5 features, research
+codebase + jcode reference, write design docs per branch.
+
+## Current status
+Complete. Repo cloned, 5 branches created, design docs committed per branch.
+
+## Last completed step
+All 5 feature branches created with committed design docs. Research of claurst
+codebase + jcode reference complete.
+
+## Blockers
+None. Design phase complete. Implementation not started (user only requested
+branches + design).
+
+## Branches created
+
+| Branch | Design doc | Status |
+|--------|-----------|--------|
+| `feature/multiple-openai-compatible-providers` | `FEATURE_DESIGN_multiple_openai_compatible_providers.md` | Design committed |
+| `feature/model-favorite-selector` | `FEATURE_DESIGN_model_favorite_selector.md` | Design committed |
+| `feature/todo-management-status-indicator` | `FEATURE_DESIGN_todo_management_status_indicator.md` | Design committed |
+| `feature/batch-commands-no-model` | `FEATURE_DESIGN_batch_commands_no_model.md` | Design committed |
+| `feature/cursor-cli-acp-support` | `FEATURE_DESIGN_cursor_cli_acp_support.md` | Design committed |
+
+## Key research findings
+
+### 1. Multiple OpenAI-compatible providers
+- Root cause: `provider_for_id()` is hardcoded `match` in
+  `openai_compat_providers.rs`; only `"custom-openai"` is generic
+- Fix: `customProviders` array in settings + dynamic dispatch before fixed match
+- No upstream PR implements this (confirmed via GitHub search)
+
+### 2. Model favorite selector
+- No existing favorites concept in claurst
+- `ModelRegistry` keyed by `"provider/model"` — favorites = simple array of keys
+- Reference: jcode's model picker has `inline_interactive_state` with
+  `selected` + `preview` mode
+
+### 3. Todo management + poke verification
+- Claurst has `TodoWrite` tool (basic: content/status/activeForm) + `GoalCompleteTool`
+- Missing: live status indicator, auto-poke, inline todo card
+- Jcode pattern: `build_auto_poke_message()` in `jcode-base/src/todo.rs`,
+  `OvernightAutoPokeState` in `commands_overnight.rs`, todo card in
+  `todos_view.rs`, progress pips in `info_widget_todos.rs`
+- Jcode `TodoItem` has: confidence, completion_confidence, confidence_history,
+  blocked_by, group, assigned_to
+
+### 4. Bang (`!`) batch commands
+- Claurst has NO `!` feature currently — this is new, not a fix
+- Design: intercept `!` prefix before model query, execute via Bash directly,
+  zero token consumption, output in display_messages only (not conversation)
+- Existing `render_bash_input_line()` in messages/mod.rs can be reused
+
+### 5. Cursor CLI ACP support
+- Claurst has ACP **server** only (`crates/acp/`) — no client
+- Jcode has full implementation: `jcode-provider-cursor-acp-runtime` (1940 lines)
+- Key: spawn `agent --force --trust acp` subprocess, JSON-RPC 2.0 over stdio,
+  reuse claurst's `Connection` struct as client
+- Cursor models are opaque IDs, catalog discovered from `initialize` response
+
+## Next action
+Switch to `main` branch. Implementation of any feature can begin by checking out
+the corresponding branch and following the design doc.

--- a/WORKFLOW_STATE.md
+++ b/WORKFLOW_STATE.md
@@ -1,48 +1,40 @@
 # Workflow State
 
 ## Objective
-Clone claurst repo, create separate feature branches for 5 features, research
-codebase + jcode reference, write design docs per branch, review design docs,
-apply review fixes.
+Implement 5 features in claurst repo. Currently implementing `feature/multiple-openai-compatible-providers`.
 
-## Current status
-Complete. Repo cloned, 5 branches created, design docs committed + reviewed +
-review fixes applied. All blocking and important review items resolved.
+## Current Status
+- Branch: `feature/multiple-openai-compatible-providers`
+- Design doc written + reviewed + fixes applied (commits 1-2)
+- Implementation: STARTING
 
-## Last completed step
-Applied review fixes to all 5 design docs. Each branch now has 2 commits:
-1. Initial design doc
-2. Review fixes applied
+## Last Completed Step
+- Read all key source files, understood insertion points
+- Design doc finalized
+
+## Implementation Plan (multiple-openai-compatible-providers)
+
+### Step 1: Core structs + Settings (foundation)
+- `core/src/lib.rs`: Add `CustomProviderDef`, `CustomModelDef`, `ModelVariant` structs
+- `core/src/lib.rs`: Add `custom_providers` field to `Settings`
+- `core/src/lib.rs`: Make `save_to_path_sync` use atomic writes (tmp+rename)
+- Tests: deserialization, env var substitution, atomic write
+
+### Step 2: Provider routing + registry (integration)
+- `api/src/providers/openai_compat_providers.rs`: `provider_for_custom_id()`
+- `api/src/registry.rs`: Custom dispatch in `provider_from_key()` + `runtime_provider_for()`
+- `api/src/model_registry.rs`: Register custom provider models
+
+### Step 3: Query routing + is_openaiish_provider
+- `query/src/lib.rs`: Runtime check for custom ids in `known_providers`
+- `query/src/runner/provider_options.rs`: `is_openaiish_provider()` runtime check
+
+### Step 4: /add command + documentation
+- `commands/src/providers.rs`: `/add` slash command
+- `docs/configuration.md`: Document `customProviders`
 
 ## Blockers
-None. Design + review phase complete. Implementation not started.
+- (none)
 
-## Branches
-
-| Branch | Commits | Review fixes applied |
-|--------|---------|---------------------|
-| `feature/multiple-openai-compatible-providers` | 2 | headers on CustomProviderDef (not ProviderConfig), atomic writes for /add, is_openaiish_provider runtime check, HashMap not array, testing + error handling |
-| `feature/model-favorite-selector` | 2 | dedicated model_picker.rs widget (not dialog_select), valid_favorites() validation, Settings not Config placement, testing |
-| `feature/todo-management-status-indicator` | 2 | corrected schema (has id/content/status/priority, NOT activeForm), auto-poke ON by default, force_reopen for completed→pending, no-progress 3-turn threshold, confidence_history cap at 20, SystemMessageStyle::TodoCard, testing |
-| `feature/batch-commands-no-model` | 2 | std::process::Command (not PtyBashTool), !! multi-line via Shift+Enter, plan mode blocks !, separate shell history, default off, testing |
-| `feature/cursor-cli-acp-support` | 2 | tokio::sync::Mutex, Drop with start_kill, Connection client-mode lifecycle, lazy reconnection, ModelRegistry singleton (no OnceLock), testing + error handling |
-
-## Review verdicts (post-fix)
-
-All 5 design docs pass review. Blocking items resolved:
-- multiple-providers: headers field clarified, atomic writes specified
-- model-favorite: separate widget, stale validation specified
-- todo-management: factual schema corrected, auto-poke default ON
-- batch-commands: std::process::Command, !! multi-line model specified
-- cursor-acp: tokio::sync::Mutex, Drop lifecycle, reconnection strategy
-
-## Recommended merge order
-1. `feature/multiple-openai-compatible-providers` — other features depend on custom provider ids
-2. `feature/model-favorite-selector` — benefits from custom provider models
-3. `feature/cursor-cli-acp-support` — independent but benefits from custom provider infrastructure
-4. `feature/todo-management-status-indicator` — independent, most complex
-5. `feature/batch-commands-no-model` — fully independent, simplest
-
-## Next action
-Switch to a feature branch and begin implementation following the design doc.
-Recommended start: `feature/multiple-openai-compatible-providers` (foundational).
+## Next Action
+Delegate Step 1 to implementer subagent

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1255,3 +1255,44 @@ Some commands are available only under certain account or platform conditions:
 ### Feature-Flagged Commands
 
 Some commands check `isEnabled()` at runtime. For example, voice-related commands check for audio device availability; the desktop command checks for a display server.
+
+## Bang Commands (`!`)
+
+Execute shell commands directly from the input prompt without going through
+the model. Zero token consumption. Output is display-only — the model never
+sees it.
+
+### Usage
+
+```
+! ls -la
+! git status
+! echo "hello"
+```
+
+Type `!` followed by a shell command. The command runs via `bash -c` in the
+project working directory and the result is shown inline in the transcript.
+
+### Configuration (`settings.json`)
+
+```json
+"bangCommands": {
+  "enabled": true,
+  "addToHistory": true,
+  "showInTranscript": true
+}
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `enabled` | `false` (opt-in) | Toggle the feature |
+| `addToHistory` | `false` | Store `!` commands in a separate shell-command history |
+| `showInTranscript` | `true` | Display command + output in the chat transcript |
+
+### Notes
+
+- Output is display-only — the model never sees it (zero token consumption).
+- Blocked in plan mode (read-only restriction).
+- Uses `bash -c` for execution (not the PTY-based Bash tool).
+- `!!` (double bang) is NOT treated as a bang command.
+- A single `!` with no command is ignored.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,7 @@ values. Keys absent from the project file fall back to the global value.
   "config": { ... },
   "providers": { ... },
   "modelOverrides": { ... },
+  "favoriteModels": [ ... ],
   "projects": { ... },
   "commands": { ... },
   "formatter": { ... },
@@ -380,6 +381,69 @@ and `api_base` override the corresponding environment variables.
 | `models_blacklist` | array | These model IDs are never offered. |
 | `options` | object | Provider-specific passthrough options. |
 
+### Custom OpenAI-Compatible Providers
+
+For OpenAI-compatible endpoints not in the built-in provider list (e.g.
+self-hosted gateways, internal LLM proxies), define them under the
+`customProviders` map. Each entry is a self-contained provider with its
+own base URL, API key, custom headers, and model catalog.
+
+```json
+"customProviders": {
+  "my-gateway": {
+    "name": "My Gateway",
+    "apiBase": "https://gateway.example.com/v1",
+    "apiKey": "{env:GATEWAY_API_KEY}",
+    "headers": {
+      "X-Custom-Header": "value"
+    },
+    "models": {
+      "model-1": {
+        "name": "Model One",
+        "contextWindow": 128000,
+        "maxOutputTokens": 8192,
+        "reasoningEffort": "high",
+        "variants": {
+          "max": { "reasoningEffort": "max" },
+          "none": { "reasoningEffort": "none" }
+        }
+      }
+    },
+    "requestTimeoutSecs": 300
+  }
+}
+```
+
+`CustomProviderDef` fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Display name shown in the provider picker. |
+| `apiBase` | string | OpenAI-compatible base URL. Claurst appends `/chat/completions`. |
+| `apiKey` | string \| null | API key. Supports `{env:VAR}` substitution. `null` = no key. |
+| `headers` | object | Custom HTTP headers sent on every request. |
+| `models` | object | Model catalog local to this provider, keyed by model id. |
+| `requestTimeoutSecs` | number \| null | Per-provider request timeout override in seconds. |
+
+`CustomModelDef` fields (inside `models`):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string \| null | Display name shown in the model picker. |
+| `contextWindow` | number \| null | Total context window size in tokens. |
+| `maxOutputTokens` | number \| null | Maximum tokens the model can emit in one response. |
+| `reasoningEffort` | string \| null | Reasoning effort level (`"high"`, `"max"`, `"none"`). |
+| `variants` | object | Named variants that override specific fields. |
+
+Adding a provider via the `/add` command:
+
+```
+/add my-gateway https://gateway.example.com/v1 {env:GATEWAY_API_KEY}
+```
+
+The map key (e.g. `"my-gateway"`) becomes the provider id used in
+`provider/model` routing (e.g. `my-gateway/model-1`).
+
 ---
 
 ## Environment Variables
@@ -639,6 +703,13 @@ matches. They are defined in the `formatter` map:
     }
   },
 
+  // Pin frequently-used models to the top of the /model picker.
+  "favoriteModels": [
+    "anthropic/claude-sonnet-4-6",
+    "openai/gpt-4o",
+    "nvidia/z-ai/glm-5.2"
+  ],
+
   // Custom slash commands
   "commands": {
     "test": {
@@ -657,3 +728,29 @@ matches. They are defined in the `formatter` map:
   }
 }
 ```
+
+---
+
+## Favorite Models
+
+Pin frequently-used models to the top of the `/model` picker by adding them to
+the `favoriteModels` array in `settings.json`:
+
+```json
+"favoriteModels": [
+  "anthropic/claude-sonnet-4-6",
+  "openai/gpt-4o",
+  "nvidia/z-ai/glm-5.2"
+]
+```
+
+Entries use the canonical `"provider/model"` format (the same key used by
+`modelOverrides`). For the `anthropic` and `free` composite providers, the
+provider prefix is optional — the bare model id (`"claude-sonnet-4-6"`) is
+accepted too.
+
+In the model picker, press `f` (or `*`) to toggle favorite status on the
+highlighted model. Favorited models appear with a ★ prefix at the top of the
+list and persist across sessions in `~/.claurst/settings.json`. Stale
+favorites (models no longer in the catalog) are hidden from the picker but
+kept in settings until you un-favorite them.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -767,3 +767,63 @@ When the keyed model exists in the catalog, the override patches it in place.
 When it does not (a self-hosted alias), Claurst materialises a synthetic entry
 so the corrected values flow everywhere the metadata is read: the `/model`
 picker, the token-usage warnings, and the auto-compact thresholds.
+
+## Cursor ACP (`cursor-acp`)
+
+Connect to Cursor's CLI agent via the Agent Client Protocol (ACP).
+
+### Setup
+
+1. Install Cursor CLI (`agent` must be on PATH)
+2. Set `cursor-acp` as your provider:
+```json
+{
+  "provider": "cursor-acp"
+}
+```
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CLAURST_CURSOR_ACP_PATH` | `agent` | Path to the Cursor CLI executable |
+| `CLAURST_CURSOR_ACP_ARGS` | `acp` | ACP subcommand argument |
+| `CLAURST_CURSOR_ACP_EXTRA_ARGS` | `--force --trust` | Permission arguments before `acp` |
+| `CLAURST_CURSOR_ACP_MODEL` | (empty) | Default model ID |
+
+The provider spawns `agent --force --trust acp` as a subprocess and
+communicates via newline-delimited JSON-RPC 2.0 over stdin/stdout.
+
+---
+
+## Custom OpenAI-Compatible Providers (from OpenCode config)
+
+The following custom providers are configured in `~/.claurst/settings.json` under
+`customProviders`, mirroring the OpenCode configuration:
+
+| Provider ID | Display Name | Base URL | Models |
+|-------------|-------------|----------|--------|
+| `llmg-coding` | LLMG Coding | `https://llm-gateway-coding.revolut.com/proxy/openai/opencode/` | `together_ai/revolut-ca/glm-5-2` (with max/high/none variants) |
+| `llmg-non-coding` | LLMG Non-Coding | `https://llm-gateway-coding.revolut.com/proxy/openai/opencode/` | `fireworks_revolut-non-coding/...hxjsp23w` (with max/high/none variants) |
+| `together-ai-coding` | Together AI Coding | `https://api.together.xyz/v1` | `revolut-ca/glm-5-2` (with high/max/none variants) |
+| `openai-custom` | OpenAI (Custom) | `https://api.openai.com/v1` | `gpt-5.5` |
+| `nvidia-custom` | Nvidia (Custom) | `https://integrate.api.nvidia.com/v1` | `z-ai/glm-5.2`, `nvidia/nemotron-3-ultra-550b-a55b` |
+| `cursor-acp-rest` | Cursor ACP (REST) | `http://127.0.0.1:32124/v1` | 14 models (Auto, Composer 2.5, Opus variants, GPT variants, GLM 5.2) |
+
+API keys use `{env:VAR_NAME}` substitution:
+- `TOGETHER_AI_CODING_API_KEY` for `together-ai-coding`
+- `OPENAI_API_KEY` for `openai-custom`
+- `NVIDIA_API_KEY` for `nvidia-custom`
+
+Select a custom provider:
+```json
+{
+  "provider": "llmg-coding",
+  "config": {
+    "model": "llmg-coding/together_ai/revolut-ca/glm-5-2"
+  }
+}
+```
+
+All custom providers appear in the `/model` picker and the `/providers` command.
+Use `Ctrl+F` or `*` in the picker to toggle ★ favorite status.

--- a/src-rust/crates/api/src/model_registry.rs
+++ b/src-rust/crates/api/src/model_registry.rs
@@ -1243,6 +1243,66 @@ impl ModelRegistry {
         }
         apply_overrides_to_entries(&mut self.entries, &self.overrides);
     }
+
+    /// Register user-defined custom provider models into the registry.
+    /// Each model is keyed as `<provider_id>/<model_id>` and a synthetic
+    /// `ModelEntry` is created from the `CustomModelDef` metadata.
+    /// A `ProviderEntry` is also created for each custom provider so it
+    /// appears in `/providers` listing.
+    pub fn apply_custom_providers(
+        &mut self,
+        custom_providers: &HashMap<String, claurst_core::config::CustomProviderDef>,
+    ) {
+        for (provider_id, def) in custom_providers {
+            // Register the provider entry so it shows up in /providers.
+            self.providers.entry(provider_id.clone()).or_insert(ProviderEntry {
+                id: ProviderId::new(provider_id),
+                name: def.name.clone(),
+                env: Vec::new(),
+                api: Some(def.api_base.clone()),
+                npm: None,
+                doc: None,
+            });
+
+            for (model_id, model_def) in &def.models {
+                let key = format!("{}/{}", provider_id, model_id);
+                self.entries.insert(key, ModelEntry {
+                    info: ModelInfo {
+                        id: ModelId::new(model_id),
+                        provider_id: ProviderId::new(provider_id),
+                        name: model_def.name.clone().unwrap_or_else(|| model_id.to_string()),
+                        context_window: model_def.context_window.unwrap_or(0),
+                        max_output_tokens: model_def.max_output_tokens.unwrap_or(0),
+                        release_date: None,
+                        status: None,
+                    },
+                    family: None,
+                    status: Default::default(),
+                    release_date: None,
+                    last_updated: None,
+                    knowledge: None,
+                    open_weights: false,
+                    tool_calling: true,
+                    reasoning: model_def.reasoning_effort.is_some(),
+                    structured_output: false,
+                    temperature: true,
+                    attachment: false,
+                    interleaved: None,
+                    modalities_input: vec![Modality::Text],
+                    modalities_output: vec![Modality::Text],
+                    cost_input: None,
+                    cost_output: None,
+                    cost_cache_read: None,
+                    cost_cache_write: None,
+                    cost: Default::default(),
+                    provider_override: None,
+                    experimental_modes: Default::default(),
+                    options: Default::default(),
+                    headers: Default::default(),
+                });
+            }
+        }
+    }
 }
 
 /// Layer `overrides` onto `entries`: patch existing catalog rows in place and

--- a/src-rust/crates/api/src/providers/cursor_acp.rs
+++ b/src-rust/crates/api/src/providers/cursor_acp.rs
@@ -1,0 +1,966 @@
+// cursor_acp.rs — Cursor CLI ACP client provider.
+//
+// Connects to Cursor's `agent --force --trust acp` subprocess via
+// newline-delimited JSON-RPC 2.0 over stdio. Implements LlmProvider trait.
+
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use async_stream::stream;
+use async_trait::async_trait;
+use claurst_core::provider_id::{ModelId, ProviderId};
+use claurst_core::types::{ContentBlock, MessageContent, Role, UsageInfo};
+use futures::{Stream, StreamExt};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, ChildStdout};
+use tokio::sync::{Mutex, RwLock};
+use tracing::info;
+
+use crate::provider::{LlmProvider, ModelInfo};
+use crate::provider_error::ProviderError;
+use crate::provider_types::{
+    ProviderCapabilities, ProviderRequest, ProviderResponse, ProviderStatus, StopReason,
+    StreamEvent, SystemPromptStyle,
+};
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/// Configuration for spawning the Cursor CLI subprocess.
+#[derive(Debug, Clone)]
+pub struct CursorAcpCommand {
+    /// Path to the executable (default: "agent").
+    pub executable: String,
+    /// Arguments before "acp" (default: ["--force", "--trust"]).
+    pub permission_args: Vec<String>,
+    /// The "acp" subcommand argument (default: "acp").
+    pub acp_arg: String,
+    /// Extra args after "acp" (default: []).
+    pub extra_args: Vec<String>,
+}
+
+impl Default for CursorAcpCommand {
+    fn default() -> Self {
+        Self {
+            executable: std::env::var("CLAURST_CURSOR_ACP_PATH")
+                .unwrap_or_else(|_| "agent".to_string()),
+            permission_args: std::env::var("CLAURST_CURSOR_ACP_EXTRA_ARGS")
+                .unwrap_or_else(|_| "--force --trust".to_string())
+                .split_whitespace()
+                .map(String::from)
+                .collect(),
+            acp_arg: std::env::var("CLAURST_CURSOR_ACP_ARGS")
+                .unwrap_or_else(|_| "acp".to_string())
+                .split_whitespace()
+                .next()
+                .unwrap_or("acp")
+                .to_string(),
+            extra_args: Vec::new(),
+        }
+    }
+}
+
+impl CursorAcpCommand {
+    /// Build the full command-line argument vector.
+    fn args(&self) -> Vec<String> {
+        let mut args = self.permission_args.clone();
+        args.push(self.acp_arg.clone());
+        args.extend(self.extra_args.iter().cloned());
+        args
+    }
+
+    /// Check whether the executable is available on PATH.
+    pub fn configured(&self) -> bool {
+        std::process::Command::new(&self.executable)
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Model catalog
+// ---------------------------------------------------------------------------
+
+/// Model catalog discovered from the Cursor CLI's initialize response.
+#[derive(Debug, Clone, Default)]
+pub struct ModelCatalog {
+    pub models: Vec<String>,
+    pub current: Option<String>,
+    pub names: HashMap<String, String>,
+}
+
+impl ModelCatalog {
+    /// Parse model info from the initialize response params.
+    pub fn from_initialize(params: &serde_json::Value) -> Self {
+        let mut models = Vec::new();
+        let mut current = None;
+
+        // Parse availableModels array.
+        if let Some(arr) = params.get("availableModels").and_then(|v| v.as_array()) {
+            for m in arr {
+                if let Some(id) = m.as_str() {
+                    models.push(id.to_string());
+                }
+            }
+        }
+
+        // Parse currentModelId.
+        if let Some(id) = params.get("currentModelId").and_then(|v| v.as_str()) {
+            current = Some(id.to_string());
+        }
+
+        // Parse configOptions for model category.
+        if let Some(options) = params.get("configOptions").and_then(|v| v.as_array()) {
+            for opt in options {
+                if let Some(cat) = opt.get("category").and_then(|c| c.as_str()) {
+                    if cat == "model" {
+                        if let Some(id) = opt.get("id").and_then(|i| i.as_str()) {
+                            if !models.contains(&id.to_string()) {
+                                models.push(id.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Self {
+            models,
+            current,
+            names: HashMap::new(),
+        }
+    }
+
+    /// Parse model catalog from the session/new response params.
+    pub fn from_session_new(params: &serde_json::Value) -> Self {
+        let mut models = Vec::new();
+        let mut current = None;
+        let mut names = HashMap::new();
+
+        // Parse models.availableModels — array of {modelId, name} objects.
+        if let Some(models_obj) = params.get("models") {
+            if let Some(arr) = models_obj.get("availableModels").and_then(|v| v.as_array()) {
+                for m in arr {
+                    // Each entry is {"modelId": "...", "name": "..."}
+                    if let Some(id) = m.get("modelId").and_then(|v| v.as_str()) {
+                        if !models.contains(&id.to_string()) {
+                            models.push(id.to_string());
+                        }
+                        if let Some(name) = m.get("name").and_then(|v| v.as_str()) {
+                            names.insert(id.to_string(), name.to_string());
+                        }
+                    }
+                    // Also try plain string format (backward compat).
+                    if let Some(id) = m.as_str() {
+                        if !models.contains(&id.to_string()) {
+                            models.push(id.to_string());
+                        }
+                    }
+                }
+            }
+            if let Some(id) = models_obj.get("currentModelId").and_then(|v| v.as_str()) {
+                current = Some(id.to_string());
+            }
+        }
+
+        // Also parse configOptions for model category.
+        if let Some(options) = params.get("configOptions").and_then(|v| v.as_array()) {
+            for opt in options {
+                if let Some(cat) = opt.get("category").and_then(|c| c.as_str()) {
+                    if cat == "model" {
+                        // The configOption itself has an id (current value).
+                        if let Some(id) = opt.get("id").and_then(|i| i.as_str()) {
+                            if !models.contains(&id.to_string()) {
+                                models.push(id.to_string());
+                            }
+                        }
+                        // Also extract from options array.
+                        if let Some(opts) = opt.get("options").and_then(|o| o.as_array()) {
+                            for option in opts {
+                                if let Some(value) = option.get("value").and_then(|v| v.as_str()) {
+                                    if !models.contains(&value.to_string()) {
+                                        models.push(value.to_string());
+                                    }
+                                    if let Some(name) = option.get("name").and_then(|v| v.as_str()) {
+                                        names.insert(value.to_string(), name.to_string());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Self {
+            models,
+            current,
+            names,
+        }
+    }
+    /// Resolve a model ID. Exact match wins; bare ID resolves when exactly
+    /// one bracketed variant exists; ambiguous → None.
+    pub fn resolve_model(&self, requested: &str) -> Option<String> {
+        // Exact match.
+        if self.models.iter().any(|m| m == requested) {
+            return Some(requested.to_string());
+        }
+        // Bare ID match (when model has bracketed variants like "model [variant]").
+        let matches: Vec<&String> = self
+            .models
+            .iter()
+            .filter(|m| m.starts_with(requested) && m.contains('['))
+            .collect();
+        if matches.len() == 1 {
+            return Some(matches[0].clone());
+        }
+        if matches.len() > 1 {
+            // Ambiguous — multiple bracketed variants.
+            return None;
+        }
+        // If no exact match but we have models, pass through the requested id.
+        if !self.models.is_empty() {
+            return Some(requested.to_string());
+        }
+        None
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ACP process wrapper
+// ---------------------------------------------------------------------------
+
+/// Owns the Cursor subprocess and its stdio handles.
+struct AcpProcess {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    /// Bounded stderr tail for debugging (last 8KB).
+    stderr_tail: Arc<RwLock<String>>,
+    next_id: u64,
+    session_id: String,
+    catalog: ModelCatalog,
+}
+
+impl Drop for AcpProcess {
+    fn drop(&mut self) {
+        // Kill the Cursor subprocess to prevent orphaned processes.
+        let _ = self.child.start_kill();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+/// Cursor ACP provider — connects to Cursor CLI via subprocess JSON-RPC.
+pub struct CursorAcpProvider {
+    /// Provider identifier.
+    id: ProviderId,
+    /// Process handle — None when not connected (lazy reconnection).
+    /// tokio::sync::Mutex because create_message_stream() is async and
+    /// holds the lock across .await points.
+    process: Mutex<Option<AcpProcess>>,
+    /// Current model ID.
+    model: RwLock<String>,
+    /// Command configuration.
+    command: CursorAcpCommand,
+}
+
+impl CursorAcpProvider {
+    /// Create a new provider with the given model and default command.
+    pub fn new(model: String) -> Self {
+        Self {
+            id: ProviderId::new("cursor-acp"),
+            process: Mutex::new(None),
+            model: RwLock::new(model),
+            command: CursorAcpCommand::default(),
+        }
+    }
+
+    /// Create from environment — used by runtime_provider_for().
+    pub fn from_env() -> Self {
+        let model = std::env::var("CLAURST_CURSOR_ACP_MODEL").unwrap_or_default();
+        Self::new(model)
+    }
+
+    /// Spawn the Cursor subprocess and set up stdio handles.
+    /// Does NOT run initialize or create a session — callers do that.
+    async fn spawn_subprocess(&self) -> Result<AcpProcess, ProviderError> {
+        let mut child = tokio::process::Command::new(&self.command.executable)
+            .args(self.command.args())
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|e| ProviderError::Other {
+                provider: self.id.clone(),
+                message: format!("failed to spawn agent: {}", e),
+                status: None,
+                body: None,
+            })?;
+
+        let stdin = child.stdin.take().ok_or_else(|| ProviderError::Other {
+            provider: self.id.clone(),
+            message: "failed to capture stdin".to_string(),
+            status: None,
+            body: None,
+        })?;
+        let stdout = child.stdout.take().ok_or_else(|| ProviderError::Other {
+            provider: self.id.clone(),
+            message: "failed to capture stdout".to_string(),
+            status: None,
+            body: None,
+        })?;
+        let stderr = child.stderr.take();
+
+        // Spawn stderr reader to maintain a bounded tail.
+        let stderr_tail = Arc::new(RwLock::new(String::new()));
+        if let Some(stderr) = stderr {
+            let tail = Arc::clone(&stderr_tail);
+            tokio::spawn(async move {
+                let mut reader = BufReader::new(stderr);
+                let mut line = String::new();
+                loop {
+                    line.clear();
+                    match reader.read_line(&mut line).await {
+                        Ok(0) => break, // EOF
+                        Ok(_) => {
+                            let mut buf = tail.write().await;
+                            buf.push_str(&line);
+                            // Keep last 8KB.
+                            if buf.len() > 8192 {
+                                let start = buf.len() - 8192;
+                                *buf = buf[start..].to_string();
+                            }
+                        }
+                        Err(_) => break,
+                    }
+                }
+            });
+        }
+
+        Ok(AcpProcess {
+            child,
+            stdin,
+            stdout: BufReader::new(stdout),
+            stderr_tail,
+            next_id: 1,
+            session_id: String::new(),
+            catalog: ModelCatalog::default(),
+        })
+    }
+
+    /// Spawn the Cursor subprocess and run initialize + session/new.
+    async fn connect(&self) -> Result<AcpProcess, ProviderError> {
+        let mut process = self.spawn_subprocess().await?;
+        self.initialize(&mut process).await?;
+        self.create_session(&mut process).await?;
+        Ok(process)
+    }
+
+    /// Send initialize request and parse model catalog.
+    async fn initialize(&self, process: &mut AcpProcess) -> Result<(), ProviderError> {
+        let id = self.next_id(process);
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id.to_string(),
+            "method": "initialize",
+            "params": {
+                "protocolVersion": 1,
+                "clientCapabilities": {
+                    "streaming": true,
+                },
+            },
+        });
+
+        self.send_json(process, &request).await?;
+
+        // Read response.
+        let response = self.read_response(process, id).await?;
+
+        // Parse model catalog.
+        if let Some(result) = response.get("result") {
+            process.catalog = ModelCatalog::from_initialize(result);
+            info!(
+                models = process.catalog.models.len(),
+                "Cursor ACP initialized"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Send session/new request.
+    async fn create_session(&self, process: &mut AcpProcess) -> Result<(), ProviderError> {
+        let id = self.next_id(process);
+        let cwd = std::env::current_dir()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|_| ".".to_string());
+
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id.to_string(),
+            "method": "session/new",
+            "params": {
+                "cwd": cwd,
+                "mcpServers": [],
+            },
+        });
+
+        self.send_json(process, &request).await?;
+
+        let response = self.read_response(process, id).await?;
+
+        if let Some(result) = response.get("result") {
+            if let Some(sid) = result.get("sessionId").and_then(|s| s.as_str()) {
+                process.session_id = sid.to_string();
+                info!(session_id = sid, "Cursor ACP session created");
+            }
+            // Parse model catalog from session/new response.
+            process.catalog = ModelCatalog::from_session_new(result);
+            info!(
+                models = process.catalog.models.len(),
+                current = process.catalog.current.as_deref().unwrap_or("none"),
+                "Cursor ACP model catalog loaded"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Get the next JSON-RPC id and increment the counter.
+    fn next_id(&self, process: &mut AcpProcess) -> u64 {
+        let id = process.next_id;
+        process.next_id += 1;
+        id
+    }
+
+    /// Send a JSON-RPC message as a newline-delimited line.
+    async fn send_json(
+        &self,
+        process: &mut AcpProcess,
+        value: &serde_json::Value,
+    ) -> Result<(), ProviderError> {
+        let mut line = serde_json::to_string(value).map_err(|e| ProviderError::Other {
+            provider: self.id.clone(),
+            message: format!("JSON serialize error: {}", e),
+            status: None,
+            body: None,
+        })?;
+        line.push('\n');
+        process
+            .stdin
+            .write_all(line.as_bytes())
+            .await
+            .map_err(|e| ProviderError::Other {
+                provider: self.id.clone(),
+                message: format!("stdin write error: {}", e),
+                status: None,
+                body: None,
+            })?;
+        Ok(())
+    }
+
+    /// Read a JSON-RPC response with the given id.
+    async fn read_response(
+        &self,
+        process: &mut AcpProcess,
+        expected_id: u64,
+    ) -> Result<serde_json::Value, ProviderError> {
+        let mut line = String::new();
+        loop {
+            line.clear();
+            let n = process
+                .stdout
+                .read_line(&mut line)
+                .await
+                .map_err(|e| ProviderError::Other {
+                    provider: self.id.clone(),
+                    message: format!("stdout read error: {}", e),
+                    status: None,
+                    body: None,
+                })?;
+            if n == 0 {
+                let stderr = process.stderr_tail.read().await;
+                return Err(ProviderError::Other {
+                    provider: self.id.clone(),
+                    message: format!("Cursor CLI closed stdout. stderr tail:\n{}", stderr),
+                    status: None,
+                    body: None,
+                });
+            }
+            // Parse JSON.
+            let msg: serde_json::Value = match serde_json::from_str(&line) {
+                Ok(v) => v,
+                Err(_) => continue, // Skip non-JSON lines
+            };
+            // Check if this is a response with the expected id.
+            if let Some(id) = msg.get("id").and_then(|i| i.as_str()) {
+                if id == expected_id.to_string() {
+                    if let Some(error) = msg.get("error") {
+                        return Err(ProviderError::Other {
+                            provider: self.id.clone(),
+                            message: format!("JSON-RPC error: {}", error),
+                            status: None,
+                            body: None,
+                        });
+                    }
+                    return Ok(msg);
+                }
+            }
+            // Skip notifications — they're not responses.
+        }
+    }
+
+    /// Ensure a process is connected. Reconnects if process is None.
+    async fn ensure_connected(&self) -> Result<(), ProviderError> {
+        let mut guard = self.process.lock().await;
+        if guard.is_none() {
+            let proc = self.connect().await?;
+            *guard = Some(proc);
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LlmProvider implementation
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl LlmProvider for CursorAcpProvider {
+    fn id(&self) -> &ProviderId {
+        &self.id
+    }
+
+    fn name(&self) -> &str {
+        "Cursor ACP"
+    }
+
+    async fn create_message(
+        &self,
+        request: ProviderRequest,
+    ) -> Result<ProviderResponse, ProviderError> {
+        // Non-streaming: collect all stream events into a response.
+        let mut stream = self.create_message_stream(request).await?;
+
+        let mut id = String::from("unknown");
+        let mut model = self.model.read().await.clone();
+        let mut stop_reason = StopReason::EndTurn;
+        let mut usage = UsageInfo::default();
+        let mut text_parts = Vec::new();
+
+        while let Some(result) = stream.next().await {
+            match result {
+                Err(e) => return Err(e),
+                Ok(evt) => match evt {
+                    StreamEvent::MessageStart {
+                        id: msg_id,
+                        model: msg_model,
+                        usage: msg_usage,
+                    } => {
+                        id = msg_id;
+                        model = msg_model;
+                        usage = msg_usage;
+                    }
+                    StreamEvent::TextDelta { text, .. } => {
+                        text_parts.push(text);
+                    }
+                    StreamEvent::MessageDelta {
+                        stop_reason: sr, ..
+                    } => {
+                        if let Some(r) = sr {
+                            stop_reason = r;
+                        }
+                    }
+                    _ => {}
+                },
+            }
+        }
+
+        let text = text_parts.join("");
+        Ok(ProviderResponse {
+            id,
+            content: vec![ContentBlock::Text { text }],
+            stop_reason,
+            usage,
+            model,
+        })
+    }
+
+    async fn create_message_stream(
+        &self,
+        request: ProviderRequest,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamEvent, ProviderError>> + Send>>, ProviderError>
+    {
+        self.ensure_connected().await?;
+
+        let model = request.model.clone();
+        let mut guard = self.process.lock().await;
+        let process = guard.as_mut().ok_or_else(|| ProviderError::Other {
+            provider: self.id.clone(),
+            message: "not connected".to_string(),
+            status: None,
+            body: None,
+        })?;
+
+        // Build session/prompt request.
+        let id = self.next_id(process);
+        let resolved_model = process.catalog.resolve_model(&model).unwrap_or(model);
+
+        // ACP session/prompt: send only the latest user message as a flat
+        // content-block array. The session maintains conversation history.
+        let prompt_json: Vec<serde_json::Value> = request
+            .messages
+            .iter()
+            .filter(|m| m.role == Role::User)
+            .last()
+            .map(|m| match &m.content {
+                MessageContent::Blocks(blocks) => blocks
+                    .iter()
+                    .map(|block| match block {
+                        ContentBlock::Text { text } => serde_json::json!({
+                            "type": "text",
+                            "text": text,
+                        }),
+                        _ => serde_json::json!({
+                            "type": "text",
+                            "text": m.get_all_text(),
+                        }),
+                    })
+                    .collect::<Vec<_>>(),
+                MessageContent::Text(text) => vec![serde_json::json!({
+                    "type": "text",
+                    "text": text,
+                })],
+            })
+            .unwrap_or_default();
+
+        let prompt_request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id.to_string(),
+            "method": "session/prompt",
+            "params": {
+                "sessionId": process.session_id,
+                "model": resolved_model,
+                "prompt": prompt_json,
+            },
+        });
+
+        self.send_json(process, &prompt_request).await?;
+
+        // Collect events into a vec and return as a stream.
+        let mut events: Vec<Result<StreamEvent, ProviderError>> = Vec::new();
+
+        events.push(Ok(StreamEvent::MessageStart {
+            id: id.to_string(),
+            model: resolved_model.clone(),
+            usage: UsageInfo::default(),
+        }));
+
+        let mut line = String::new();
+        loop {
+            line.clear();
+            let n = process
+                .stdout
+                .read_line(&mut line)
+                .await
+                .map_err(|e| ProviderError::Other {
+                    provider: self.id.clone(),
+                    message: format!("read error: {}", e),
+                    status: None,
+                    body: None,
+                })?;
+            if n == 0 {
+                break;
+            }
+            let msg: serde_json::Value = match serde_json::from_str(&line) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+
+            // Check for error.
+            if let Some(error) = msg.get("error") {
+                return Err(ProviderError::Other {
+                    provider: self.id.clone(),
+                    message: format!("session/prompt error: {}", error),
+                    status: None,
+                    body: None,
+                });
+            }
+
+            // Check for notification (session/update).
+            if let Some(method) = msg.get("method").and_then(|m| m.as_str()) {
+                if method == "session/update" {
+                    if let Some(update) =
+                        msg.get("params").and_then(|p| p.get("update"))
+                    {
+                        let update_type = update
+                            .get("sessionUpdate")
+                            .and_then(|u| u.as_str())
+                            .unwrap_or("");
+                        if update_type == "agent_message_chunk" {
+                            if let Some(text) = update
+                                .get("content")
+                                .and_then(|c| c.get("text"))
+                                .and_then(|t| t.as_str())
+                            {
+                                events.push(Ok(StreamEvent::TextDelta {
+                                    index: 0,
+                                    text: text.to_string(),
+                                }));
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Check for response (id matches).
+            if let Some(resp_id) = msg.get("id").and_then(|i| i.as_str()) {
+                if resp_id == id.to_string() {
+                    // Parse stop reason from the response.
+                    let stop_reason = msg
+                        .get("result")
+                        .and_then(|r| r.get("stopReason"))
+                        .and_then(|s| s.as_str())
+                        .unwrap_or("end_turn");
+                    let sr = match stop_reason {
+                        "end_turn" => StopReason::EndTurn,
+                        "max_tokens" => StopReason::MaxTokens,
+                        "tool_use" => StopReason::ToolUse,
+                        _ => StopReason::EndTurn,
+                    };
+                    events.push(Ok(StreamEvent::MessageDelta {
+                        stop_reason: Some(sr),
+                        usage: None,
+                    }));
+                    break;
+                }
+            }
+        }
+
+        // Return collected events as a stream.
+        let s = stream! {
+            for event in events {
+                yield event;
+            }
+        };
+
+        Ok(Box::pin(s))
+    }
+
+    async fn discover_models(&self) -> Result<Vec<ModelInfo>, ProviderError> {
+        // First, try the existing connected process.
+        {
+            let guard = self.process.lock().await;
+            if let Some(proc) = guard.as_ref() {
+                return Ok(proc
+                    .catalog
+                    .models
+                    .iter()
+                    .map(|m| ModelInfo {
+                        id: ModelId::new(m),
+                        provider_id: self.id.clone(),
+                        name: proc
+                            .catalog
+                            .names
+                            .get(m)
+                            .cloned()
+                            .unwrap_or_else(|| m.clone()),
+                        context_window: 0,
+                        max_output_tokens: 0,
+                        ..Default::default()
+                    })
+                    .collect());
+            }
+        }
+        // No existing process — spawn a temporary one for discovery.
+        // The subprocess is killed when the process handle is dropped.
+        let proc = self.connect().await?;
+        Ok(proc
+            .catalog
+            .models
+            .iter()
+            .map(|m| ModelInfo {
+                id: ModelId::new(m),
+                provider_id: self.id.clone(),
+                name: proc
+                    .catalog
+                    .names
+                    .get(m)
+                    .cloned()
+                    .unwrap_or_else(|| m.clone()),
+                context_window: 0,
+                max_output_tokens: 0,
+                ..Default::default()
+            })
+            .collect())
+    }
+
+    async fn health_check(&self) -> Result<ProviderStatus, ProviderError> {
+        if self.command.configured() {
+            Ok(ProviderStatus::Healthy)
+        } else {
+            Ok(ProviderStatus::Unavailable {
+                reason: "agent (Cursor CLI) not found on PATH".to_string(),
+            })
+        }
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            streaming: true,
+            tool_calling: true,
+            thinking: false,
+            image_input: false,
+            pdf_input: false,
+            audio_input: false,
+            video_input: false,
+            caching: false,
+            structured_output: false,
+            system_prompt_style: SystemPromptStyle::SystemMessage,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cursor_acp_command_defaults() {
+        let cmd = CursorAcpCommand::default();
+        assert_eq!(cmd.executable, "agent");
+        assert!(cmd.permission_args.contains(&"--force".to_string()));
+        assert!(cmd.permission_args.contains(&"--trust".to_string()));
+        assert_eq!(cmd.acp_arg, "acp");
+    }
+
+    #[test]
+    fn cursor_acp_command_args() {
+        let cmd = CursorAcpCommand::default();
+        let args = cmd.args();
+        assert!(args.contains(&"--force".to_string()));
+        assert!(args.contains(&"--trust".to_string()));
+        assert!(args.contains(&"acp".to_string()));
+    }
+
+    #[test]
+    fn model_catalog_from_initialize() {
+        let params = serde_json::json!({
+            "availableModels": ["model-a", "model-b"],
+            "currentModelId": "model-a",
+        });
+        let catalog = ModelCatalog::from_initialize(&params);
+        assert_eq!(catalog.models.len(), 2);
+        assert_eq!(catalog.current.as_deref(), Some("model-a"));
+    }
+
+    #[test]
+    fn model_catalog_from_initialize_with_config_options() {
+        let params = serde_json::json!({
+            "availableModels": ["model-a"],
+            "currentModelId": "model-a",
+            "configOptions": [
+                {"category": "model", "id": "model-b"},
+                {"category": "other", "id": "not-a-model"},
+                {"category": "model", "id": "model-c"},
+            ],
+        });
+        let catalog = ModelCatalog::from_initialize(&params);
+        assert_eq!(catalog.models.len(), 3);
+        assert!(catalog.models.contains(&"model-b".to_string()));
+        assert!(catalog.models.contains(&"model-c".to_string()));
+        assert_eq!(catalog.current.as_deref(), Some("model-a"));
+    }
+
+    #[test]
+    fn model_catalog_resolve_exact() {
+        let catalog = ModelCatalog {
+            models: vec!["model-a".to_string(), "model-b".to_string()],
+            current: None,
+            names: HashMap::new(),
+        };
+        assert_eq!(
+            catalog.resolve_model("model-a").as_deref(),
+            Some("model-a")
+        );
+    }
+
+    #[test]
+    fn model_catalog_resolve_bare_id() {
+        let catalog = ModelCatalog {
+            models: vec!["model-a [variant]".to_string()],
+            current: None,
+            names: HashMap::new(),
+        };
+        assert_eq!(
+            catalog.resolve_model("model-a").as_deref(),
+            Some("model-a [variant]")
+        );
+    }
+
+    #[test]
+    fn model_catalog_resolve_ambiguous() {
+        let catalog = ModelCatalog {
+            models: vec!["model-a [v1]".to_string(), "model-a [v2]".to_string()],
+            current: None,
+            names: HashMap::new(),
+        };
+        // Ambiguous — returns None.
+        assert!(catalog.resolve_model("model-a").is_none());
+    }
+
+    #[test]
+    fn model_catalog_resolve_empty_catalog() {
+        let catalog = ModelCatalog::default();
+        assert!(catalog.resolve_model("anything").is_none());
+    }
+
+    #[test]
+    fn model_catalog_from_session_new() {
+        let params = serde_json::json!({
+            "sessionId": "test-session",
+            "modes": {"currentModeId": "agent", "availableModes": []},
+            "models": {
+                "currentModelId": "composer-2.5[fast=true]",
+                "availableModels": [
+                    {"modelId": "auto-smart[optimize_for=cost]", "name": "Auto"},
+                    {"modelId": "composer-2.5[fast=true]", "name": "Composer 2.5"},
+                    {"modelId": "claude-opus-4-8[thinking=true]", "name": "Opus 4.8 (MAX mode)"},
+                ],
+            },
+            "configOptions": [
+                {"category": "model", "id": "composer-2.5[fast=true]", "options": [
+                    {"value": "auto-smart[optimize_for=cost]", "name": "Auto"},
+                    {"value": "composer-2.5[fast=true]", "name": "Composer 2.5"},
+                    {"value": "claude-opus-4-8[thinking=true]", "name": "Opus 4.8 (MAX mode)"},
+                    {"value": "gpt-5.5[context=272k]", "name": "GPT-5.5 (MAX mode)"},
+                ]},
+            ],
+        });
+        let catalog = ModelCatalog::from_session_new(&params);
+        assert_eq!(catalog.models.len(), 4); // 3 from availableModels + 1 new from configOptions
+        assert!(catalog.models.contains(&"auto-smart[optimize_for=cost]".to_string()));
+        assert!(catalog.models.contains(&"gpt-5.5[context=272k]".to_string()));
+        assert_eq!(catalog.current.as_deref(), Some("composer-2.5[fast=true]"));
+        assert_eq!(
+            catalog.names.get("composer-2.5[fast=true]"),
+            Some(&"Composer 2.5".to_string())
+        );
+        assert_eq!(
+            catalog.names.get("claude-opus-4-8[thinking=true]"),
+            Some(&"Opus 4.8 (MAX mode)".to_string())
+        );
+    }
+}

--- a/src-rust/crates/api/src/providers/mod.rs
+++ b/src-rust/crates/api/src/providers/mod.rs
@@ -41,3 +41,6 @@ pub use copilot::CopilotProvider;
 
 pub mod codex;
 pub use codex::CodexProvider;
+
+pub mod cursor_acp;
+pub use cursor_acp::{CursorAcpCommand, CursorAcpProvider, ModelCatalog};

--- a/src-rust/crates/api/src/providers/openai_compat.rs
+++ b/src-rust/crates/api/src/providers/openai_compat.rs
@@ -32,8 +32,12 @@ use super::request_options::merge_openai_compatible_options;
 
 /// Provider-specific behavioural quirks that alter how the generic adapter
 /// builds and interprets requests/responses.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct ProviderQuirks {
+    /// Whether this provider supports SSE streaming.  Default: `true`.
+    /// When `false`, the query engine falls back to non-streaming requests.
+    pub streaming: bool,
+
     /// Truncate tool call IDs to at most this many characters before sending.
     /// For example, Mistral requires tool IDs of at most 9 characters.
     pub tool_id_max_len: Option<usize>,
@@ -93,6 +97,26 @@ pub struct ProviderQuirks {
     /// Native LM Studio host used to discover loaded model instances and their
     /// configured context lengths from `/api/v1/models`.
     pub lm_studio_native_host: Option<String>,
+}
+
+impl Default for ProviderQuirks {
+    fn default() -> Self {
+        Self {
+            streaming: true,
+            tool_id_max_len: None,
+            tool_id_alphanumeric_only: false,
+            overflow_patterns: Vec::new(),
+            include_usage_in_stream: false,
+            default_temperature: None,
+            fix_tool_user_sequence: false,
+            reasoning_field: None,
+            requires_reasoning_roundtrip: false,
+            max_tokens_cap: None,
+            no_api_key_required: false,
+            ollama_native_host: None,
+            lm_studio_native_host: None,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1141,7 +1165,7 @@ impl LlmProvider for OpenAiCompatProvider {
 
     fn capabilities(&self) -> ProviderCapabilities {
         ProviderCapabilities {
-            streaming: true,
+            streaming: self.quirks.streaming,
             tool_calling: true,
             thinking: self.quirks.reasoning_field.is_some(),
             image_input: true,

--- a/src-rust/crates/api/src/providers/openai_compat_providers.rs
+++ b/src-rust/crates/api/src/providers/openai_compat_providers.rs
@@ -12,6 +12,10 @@ use claurst_core::provider_id::ProviderId;
 use super::openai_compat::{OpenAiCompatProvider, ProviderQuirks};
 
 pub fn provider_for_id(provider_id: &str) -> Option<OpenAiCompatProvider> {
+    // Custom providers take priority — check before the fixed-id match.
+    if let Some(custom) = provider_for_custom_id(provider_id) {
+        return Some(custom);
+    }
     match provider_id {
         "ollama" => Some(ollama()),
         "lmstudio" | "lm-studio" => Some(lm_studio()),
@@ -162,6 +166,36 @@ pub fn custom_openai() -> OpenAiCompatProvider {
         .unwrap_or("http://localhost:11434/v1");
 
     custom_openai_with_url(base_url)
+}
+
+/// Build an [`OpenAiCompatProvider`] from a user-defined custom provider in
+/// `Settings::custom_providers`, looked up by id.
+///
+/// Returns `None` when the id is not in the custom providers map, or when
+/// `apiBase` is empty. Custom headers from the definition are applied via
+/// the builder API. API key is resolved via `resolve_api_key()` (supports
+/// `{env:VAR}` substitution).
+pub fn provider_for_custom_id(id: &str) -> Option<OpenAiCompatProvider> {
+    let settings = Settings::load_sync().unwrap_or_default();
+    let def = settings.custom_providers.get(id)?;
+    if def.api_base.trim().is_empty() {
+        return None;
+    }
+    let mut provider = OpenAiCompatProvider::new(id, &def.name, &def.api_base);
+    if let Some(key) = def.resolve_api_key() {
+        provider = provider.with_api_key(key);
+    }
+    for (name, value) in &def.headers {
+        provider = provider.with_header(name, value);
+    }
+    // Apply streaming / reasoning settings from the custom provider definition.
+    provider = provider.with_quirks(ProviderQuirks {
+        streaming: def.streaming.unwrap_or(true),
+        include_usage_in_stream: def.include_usage_in_stream.unwrap_or(true),
+        reasoning_field: def.reasoning_field.clone(),
+        ..Default::default()
+    });
+    Some(provider)
 }
 
 /// DeepSeek V4 — supports reasoning output via `reasoning_content` field.
@@ -629,5 +663,20 @@ mod tests {
         let qwen = provider_for_id("qwen").expect("qwen should resolve");
         assert_eq!(alibaba.id(), qwen.id());
         assert_eq!(alibaba.name(), qwen.name());
+    }
+
+    #[test]
+    fn provider_for_custom_id_returns_none_for_unknown() {
+        // "nonexistent-custom-provider-12345" is not a real custom provider.
+        assert!(provider_for_custom_id("nonexistent-custom-provider-12345").is_none());
+    }
+
+    #[test]
+    fn provider_for_custom_id_returns_none_for_known_fixed_provider() {
+        // Fixed providers like "ollama" should not match as custom providers.
+        // This test verifies that provider_for_custom_id doesn't accidentally
+        // return Some for a fixed provider id when no custom provider is
+        // registered with that id.
+        assert!(provider_for_custom_id("ollama").is_none());
     }
 }

--- a/src-rust/crates/api/src/registry.rs
+++ b/src-rust/crates/api/src/registry.rs
@@ -13,7 +13,7 @@ use crate::provider::LlmProvider;
 use crate::provider_types::ProviderStatus;
 use crate::providers::{
     AnthropicProvider, AzureProvider, BedrockProvider, CodexProvider, CohereProvider,
-    CopilotProvider, FreeEntry, FreeProvider, FREE_CATALOG, GoogleProvider, MinimaxProvider,
+    CopilotProvider, CursorAcpProvider, FreeEntry, FreeProvider, FREE_CATALOG, GoogleProvider, MinimaxProvider,
     OpenAiProvider,
 };
 
@@ -67,6 +67,13 @@ pub struct ProviderRegistry {
 fn provider_from_key(provider_id: &str, key: String) -> Option<Arc<dyn LlmProvider>> {
     use crate::providers::openai_compat_providers as p;
 
+    // Custom providers from Settings take priority — their API key is
+    // already resolved via resolve_api_key() inside provider_for_custom_id,
+    // so we must NOT re-apply the auth-store key here.
+    if let Some(provider) = p::provider_for_custom_id(provider_id) {
+        return Some(Arc::new(provider));
+    }
+
     if let Some(provider) = p::provider_for_id(provider_id) {
         return Some(Arc::new(provider.with_api_key(key)));
     }
@@ -89,6 +96,7 @@ fn provider_from_key(provider_id: &str, key: String) -> Option<Arc<dyn LlmProvid
         // "free" needs two keys (Zen + OpenRouter) — single-key path doesn't
         // apply.  The auth-store-aware path `runtime_provider_for` handles it.
         "free" => build_free_provider(),
+        "cursor-acp" => Some(Arc::new(CursorAcpProvider::from_env())),
         _ => None,
     }
 }
@@ -266,12 +274,19 @@ pub fn provider_from_config(
         "codex" | "openai-codex" => {
             CodexProvider::from_stored().map(|provider| Arc::new(provider) as Arc<dyn LlmProvider>)
         }
+        "cursor-acp" => Some(Arc::new(CursorAcpProvider::from_env())),
         _ => api_key.and_then(|key| provider_from_key(provider_id, key)),
     }
 }
 
 pub fn runtime_provider_for(provider_id: &str) -> Option<Arc<dyn LlmProvider>> {
     use crate::providers::openai_compat_providers as p;
+
+    // Custom providers from Settings take priority — their API key is
+    // already resolved via resolve_api_key() inside provider_for_custom_id.
+    if let Some(provider) = p::provider_for_custom_id(provider_id) {
+        return Some(Arc::new(provider));
+    }
 
     // Local providers never require an API key — build them directly so that
     // the auth-store bypass below doesn't silently drop them.
@@ -290,6 +305,7 @@ pub fn runtime_provider_for(provider_id: &str) -> Option<Arc<dyn LlmProvider>> {
         // wraps them in a fallback composite — handled here so the generic
         // single-key path below doesn't short-circuit on a missing key.
         "free" => return build_free_provider(),
+        "cursor-acp" => return Some(Arc::new(CursorAcpProvider::from_env())),
         _ => {}
     }
 

--- a/src-rust/crates/api/tests/test_custom_providers.rs
+++ b/src-rust/crates/api/tests/test_custom_providers.rs
@@ -1,0 +1,32 @@
+use claurst_core::Settings;
+use claurst_api::ModelRegistry;
+
+#[test]
+fn custom_providers_appear_in_registry() {
+    let settings = Settings::load_sync().unwrap_or_default();
+    eprintln!("Custom providers: {}", settings.custom_providers.len());
+
+    let mut registry = ModelRegistry::new();
+    registry.apply_custom_providers(&settings.custom_providers);
+
+    for (id, _) in &settings.custom_providers {
+        let models = registry.list_by_provider(id);
+        eprintln!("Provider '{}': {} models", id, models.len());
+        assert!(!models.is_empty(), "Provider '{}' has 0 models in registry!", id);
+    }
+}
+
+#[test]
+fn custom_provider_models_keyed_correctly() {
+    let settings = Settings::load_sync().unwrap_or_default();
+    if let Some(llmg) = settings.custom_providers.get("llmg-coding") {
+        let mut registry = ModelRegistry::new();
+        registry.apply_custom_providers(&settings.custom_providers);
+
+        let models = registry.list_by_provider("llmg-coding");
+        eprintln!("list_by_provider('llmg-coding'): {} models", models.len());
+        for m in &models {
+            eprintln!("  id={}, provider_id={}", m.info.id, m.info.provider_id);
+        }
+    }
+}

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -1049,6 +1049,8 @@ async fn run_models_command(args: &[String]) -> anyhow::Result<()> {
         .map(|s| s.effective_config().model_overrides)
         .unwrap_or_default();
     registry.apply_model_overrides(&overrides);
+    let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+    registry.apply_custom_providers(&settings.custom_providers);
 
     let mut entries: Vec<&claurst_api::ModelEntry> = match &provider_filter {
         Some(pid) => registry.list_by_provider(pid),
@@ -1191,6 +1193,8 @@ fn load_cached_model_registry(config: &Config) -> Arc<claurst_api::ModelRegistry
     // Layer user metadata overrides on top of the catalog (issue #309). Stored
     // in the registry, so any later cache reload re-asserts them automatically.
     reg.apply_model_overrides(&config.model_overrides);
+    let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+    reg.apply_custom_providers(&settings.custom_providers);
     Arc::new(reg)
 }
 
@@ -1884,6 +1888,8 @@ async fn run_interactive(
     // arrive as their final character, so re-shifting them would corrupt input
     // (issue #183: typing `/` produced `?`).
     app.kitty_keyboard_active = claurst_tui::keyboard_enhancement_active();
+    // Wire session ID so auto-poke + todo persistence can find the right list.
+    app.session_id = session.id.clone();
     // Seed the project-MCP approval queue: untrusted project servers that the
     // user must approve before they are allowed to launch (issue #123).
     app.mcp_project_root = mcp_project_root;
@@ -2344,6 +2350,16 @@ async fn run_interactive(
                             continue;
                         }
 
+                        // Check for bang command (! prefix) — execute directly in
+                        // the shell, no model dispatch, zero token consumption.
+                        if claurst_tui::input::is_bang_command(&input) {
+                            let command = input[1..].trim().to_string();
+                            if !command.is_empty() {
+                                app.execute_bang_command(command);
+                            }
+                            continue;
+                        }
+
                         // Check for slash command
                         if input.starts_with('/') {
                             let (cmd_name, cmd_args) =
@@ -2427,6 +2443,7 @@ async fn run_interactive(
                                     tool_ctx.session_id = session.id.clone();
                                     cmd_ctx.session_id = session.id.clone();
                                     cmd_ctx.session_title = None;
+                                    app.session_id = session.id.clone();
                                     // Reset per-turn diff/turn bookkeeping, as
                                     // ResumeSession does when swapping sessions.
                                     tool_ctx.file_history = Arc::new(ParkingMutex::new(
@@ -2527,6 +2544,7 @@ async fn run_interactive(
                                     tool_ctx.config.model = Some(session.model.clone());
                                     app.model_name = session.model.clone();
                                     tool_ctx.session_id = session.id.clone();
+                                    app.session_id = session.id.clone();
                                     tool_ctx.file_history = Arc::new(ParkingMutex::new(
                                         claurst_core::file_history::FileHistory::new(),
                                     ));
@@ -3797,6 +3815,7 @@ async fn run_interactive(
                                                                 ctx_for(&id, m.context_window),
                                                             ),
                                                         is_current: false,
+                                                        provider_id: provider_key.clone(),
                                                     }
                                                 })
                                             })
@@ -3814,6 +3833,7 @@ async fn run_interactive(
                                                         ),
                                                     id,
                                                     is_current: false,
+                                                    provider_id: provider_key.clone(),
                                                 }
                                             })
                                             .collect()

--- a/src-rust/crates/commands/src/lib.rs
+++ b/src-rust/crates/commands/src/lib.rs
@@ -1138,6 +1138,66 @@ impl SlashCommand for NamedCommandAdapter {
 }
 
 // ---------------------------------------------------------------------------
+// /todos — todo list status + auto-poke toggle
+// ---------------------------------------------------------------------------
+
+pub struct TodosCommand;
+
+#[async_trait]
+impl SlashCommand for TodosCommand {
+    fn name(&self) -> &str { "todos" }
+    fn description(&self) -> &str { "Show todo list status and toggle inline card" }
+    fn help(&self) -> &str {
+        "Usage: /todos [auto-poke on|off]\n\n\
+         Without arguments: toggles the inline todo card in the transcript.\n\n\
+         /todos auto-poke on   — enable auto-poke (default)\n\
+         /todos auto-poke off  — disable auto-poke"
+    }
+
+    async fn execute(&self, args: &str, ctx: &mut CommandContext) -> CommandResult {
+        let args = args.trim();
+        if args.starts_with("auto-poke") {
+            let parts: Vec<&str> = args.split_whitespace().collect();
+            if parts.len() < 2 {
+                return CommandResult::Message("Usage: /todos auto-poke on|off".to_string());
+            }
+            let enabled = match parts[1] {
+                "on" | "true" | "yes" => true,
+                "off" | "false" | "no" => false,
+                _ => return CommandResult::Message("Usage: /todos auto-poke on|off".to_string()),
+            };
+            // Update settings.
+            if let Ok(mut settings) = claurst_core::Settings::load_sync() {
+                settings.auto_poke_enabled = enabled;
+                let _ = settings.save_sync();
+            }
+            return CommandResult::Message(format!(
+                "Auto-poke {}.",
+                if enabled { "enabled" } else { "disabled" }
+            ));
+        }
+
+        // Show current todo status.
+        let todos = claurst_tools::todo_write::load_todos(&ctx.session_id);
+        if todos.is_empty() {
+            return CommandResult::Message("No todos for this session.".to_string());
+        }
+        let total = todos.len();
+        let completed = todos.iter().filter(|t| t.get("status").and_then(|s| s.as_str()) == Some("completed")).count();
+        let in_progress = todos.iter().filter(|t| t.get("status").and_then(|s| s.as_str()) == Some("in_progress")).count();
+        let pending = total - completed - in_progress;
+        let mut output = format!("Todos: {} total — {} pending, {} in_progress, {} completed\n\n", total, pending, in_progress, completed);
+        for t in &todos {
+            let status = t.get("status").and_then(|s| s.as_str()).unwrap_or("?");
+            let content = t.get("content").and_then(|c| c.as_str()).unwrap_or("");
+            let icon = match status { "pending" => "[ ]", "in_progress" => "[~]", "completed" => "[x]", _ => "[?]" };
+            output.push_str(&format!("{} {}\n", icon, content));
+        }
+        CommandResult::Message(output)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Registry
 // ---------------------------------------------------------------------------
 
@@ -1318,6 +1378,7 @@ pub fn all_commands() -> Vec<Box<dyn SlashCommand>> {
         // Multi-provider support
         Box::new(ProvidersCommand),
         Box::new(ConnectCommand),
+        Box::new(AddCustomProviderCommand),
         // Named agent system
         Box::new(AgentCommand),
         // Session search (SQLite)
@@ -1329,6 +1390,8 @@ pub fn all_commands() -> Vec<Box<dyn SlashCommand>> {
         // Session navigation ported from opencode: /new (lazy home) + /move.
         Box::new(NewCommand),
         Box::new(MoveCommand),
+        // Todo management
+        Box::new(TodosCommand),
     ]
 }
 

--- a/src-rust/crates/commands/src/providers.rs
+++ b/src-rust/crates/commands/src/providers.rs
@@ -154,3 +154,111 @@ impl SlashCommand for AgentCommand {
         }
     }
 }
+
+// ---- /add -------------------------------------------------------------
+
+/// Add a custom OpenAI-compatible provider to settings.
+///
+/// Usage: `/add <id> <apiBase> [apiKey]`
+///
+/// The `id` becomes the provider id used in `provider/model` routing.
+/// The `apiBase` is the OpenAI-compatible base URL.
+/// The optional `apiKey` supports `{env:VAR}` substitution.
+pub struct AddCustomProviderCommand;
+
+#[async_trait]
+impl SlashCommand for AddCustomProviderCommand {
+    fn name(&self) -> &str { "add" }
+    fn description(&self) -> &str { "Add a custom OpenAI-compatible provider" }
+    fn help(&self) -> &str {
+        "Usage: /add <id> <apiBase> [apiKey]\n\n\
+         Add a custom OpenAI-compatible provider to settings.json.\n\n\
+         Arguments:\n  \
+         id       \u{2014} unique provider id (e.g. \"my-gateway\")\n  \
+         apiBase  \u{2014} OpenAI-compatible base URL\n  \
+         apiKey   \u{2014} optional API key or {env:VAR} pattern\n\n\
+         Example:\n  \
+         /add my-gw https://gw.example.com/v1 {env:GW_API_KEY}\n\n\
+         The provider appears in /providers after restart. Models can be\
+         added via the customProviders.models map in settings.json."
+    }
+
+    async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
+        let parts: Vec<&str> = args.split_whitespace().collect();
+        if parts.len() < 2 {
+            return CommandResult::Message(
+                "Usage: /add <id> <apiBase> [apiKey]\n\
+                 Example: /add my-gw https://gw.example.com/v1"
+                    .to_string(),
+            );
+        }
+
+        let id = parts[0].trim();
+        let api_base = parts[1].trim();
+        let api_key = parts.get(2).map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
+
+        if id.is_empty() {
+            return CommandResult::Message("Error: provider id must not be empty.".to_string());
+        }
+        if api_base.is_empty() {
+            return CommandResult::Message("Error: apiBase must not be empty.".to_string());
+        }
+
+        // Basic URL validation.
+        if !api_base.starts_with("http://") && !api_base.starts_with("https://") {
+            return CommandResult::Message(format!(
+                "Error: apiBase must start with http:// or https:// (got: {})",
+                api_base
+            ));
+        }
+
+        // Load current settings from disk (fresh read, not in-memory cache).
+        let mut settings = match claurst_core::Settings::load_sync() {
+            Ok(s) => s,
+            Err(e) => {
+                return CommandResult::Message(format!(
+                    "Error loading settings: {}",
+                    e
+                ));
+            }
+        };
+
+        // Check for duplicate id.
+        if settings.custom_providers.contains_key(id) {
+            return CommandResult::Message(format!(
+                "Error: custom provider '{}' already exists. Use a different id or remove it from settings.json first.",
+                id
+            ));
+        }
+
+        // Use the id as the display name if no explicit name is provided.
+        let display_name = id.to_string();
+
+        // Insert the new provider.
+        let provider_def = claurst_core::config::CustomProviderDef {
+            name: display_name,
+            api_base: api_base.to_string(),
+            api_key,
+            headers: std::collections::HashMap::new(),
+            models: std::collections::HashMap::new(),
+            request_timeout_secs: None,
+            streaming: None,
+            include_usage_in_stream: None,
+            reasoning_field: None,
+        };
+        settings.custom_providers.insert(id.to_string(), provider_def);
+
+        // Save atomically.
+        if let Err(e) = settings.save_sync() {
+            return CommandResult::Message(format!("Error saving settings: {}", e));
+        }
+
+        CommandResult::Message(format!(
+            "Added custom provider '{}'.\n\
+             Base URL: {}\n\
+             Restart or reload settings to use it. Add models via the\n\
+             customProviders.{}.models map in settings.json.",
+            id, api_base, id
+        ))
+    }
+}

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -89,7 +89,7 @@ pub use types::{
     ContentBlock, ImageSource, DocumentSource, CitationsConfig, Message, MessageContent,
     MessageCost, Role, ToolDefinition, ToolResultContent, UsageInfo,
 };
-pub use config::{AgentDefinition, BudgetSplitPolicy, Config, CommandTemplate, FormatterConfig, ManagedAgentConfig, ManagedAgentPreset, McpServerConfig, McpServerOrigin, OutputFormat, PermissionMode, ProviderConfig, Settings, SkillsConfig, Theme, builtin_managed_agent_presets, default_agents, strip_jsonc_comments, substitute_env_vars};
+pub use config::{AgentDefinition, BudgetSplitPolicy, BangCommandsConfig, Config, CommandTemplate, CustomModelDef, CustomProviderDef, FormatterConfig, ManagedAgentConfig, ManagedAgentPreset, McpServerConfig, McpServerOrigin, ModelVariant, OutputFormat, PermissionMode, ProviderConfig, Settings, SkillsConfig, Theme, builtin_managed_agent_presets, default_agents, strip_jsonc_comments, substitute_env_vars};
 pub use import_config::{ClaudeMdPreview, ImportExecutionResult, ImportPaths, ImportPreview, ImportSelection, PreviewAction, PreviewField, SettingsPreview, build_import_preview, execute_import, summarize_import_result};
 
 // Skill discovery: filesystem and git URL skill loading.
@@ -947,17 +947,6 @@ pub mod config {
             }
         }
     }
-
-    // ---- ModelOverride ---------------------------------------------------
-
-    /// User-supplied metadata override for a single model, keyed by the
-    /// `"provider/model"` string in [`Config::model_overrides`].
-    ///
-    /// Every field is optional: a `Some` value takes precedence over the
-    /// models.dev catalog entry (and over any built-in default), while a `None`
-    /// leaves the catalog value untouched. When the keyed model is absent from
-    /// the catalog entirely (a self-hosted alias, or an id models.dev does not
-    /// know), the override is materialised into a synthetic registry entry so
     /// the model picker, token warnings, and auto-compact thresholds size it
     /// correctly instead of mismatching it to an unrelated catalog model.
     ///
@@ -1006,6 +995,126 @@ pub mod config {
                 && self.name.is_none()
                 && self.release_date.is_none()
                 && self.status.is_none()
+        }
+    }
+
+    // ---- ModelVariant ----------------------------------------------------
+
+    /// A model variant that overrides specific fields from its parent model
+    /// definition (e.g. a "max" variant that changes only `reasoning_effort`).
+    #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+    pub struct ModelVariant {
+        /// Override for reasoning effort level.
+        #[serde(
+            default,
+            rename = "reasoningEffort",
+            alias = "reasoning_effort",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub reasoning_effort: Option<String>,
+    }
+
+    // ---- CustomModelDef -------------------------------------------------
+
+    /// A model definition within a custom OpenAI-compatible provider.
+    #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+    pub struct CustomModelDef {
+        /// Total context window size in tokens.
+        #[serde(
+            default,
+            rename = "contextWindow",
+            alias = "context_window",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub context_window: Option<u32>,
+        /// Maximum tokens the model can emit in a single response.
+        #[serde(
+            default,
+            rename = "maxOutputTokens",
+            alias = "max_output_tokens",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub max_output_tokens: Option<u32>,
+        /// Human-readable display name shown in the model picker.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub name: Option<String>,
+        /// Reasoning effort level (e.g. "high", "max", "none").
+        #[serde(
+            default,
+            rename = "reasoningEffort",
+            alias = "reasoning_effort",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub reasoning_effort: Option<String>,
+        /// Named variants that override specific fields from this model definition.
+        #[serde(default)]
+        pub variants: HashMap<String, ModelVariant>,
+    }
+
+    // ---- CustomProviderDef ----------------------------------------------
+
+    /// A user-defined OpenAI-compatible provider, stored in
+    /// [`Settings::custom_providers`] keyed by its unique id.
+    ///
+    /// Unlike [`ProviderConfig`] (which tweaks built-in providers), this is a
+    /// fully self-contained provider definition with its own base URL, API key,
+    /// custom headers, and model catalog. The id (map key) becomes the provider
+    /// id used in `provider/model` routing.
+    #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+    pub struct CustomProviderDef {
+        /// Human-readable display name shown in the provider picker.
+        #[serde(default)]
+        pub name: String,
+        /// OpenAI-compatible base URL (claurst appends `/chat/completions`).
+        #[serde(rename = "apiBase", alias = "api_base")]
+        pub api_base: String,
+        /// API key. Supports `{env:VAR_NAME}` substitution at load time.
+        /// `None` means no key — provider is registered but health_check
+        /// returns `Unavailable`.
+        #[serde(rename = "apiKey", alias = "api_key", default, skip_serializing_if = "Option::is_none")]
+        pub api_key: Option<String>,
+        /// Custom HTTP headers sent on every request to this provider.
+        #[serde(default)]
+        pub headers: HashMap<String, String>,
+        /// Model catalog local to this provider, keyed by model id.
+        #[serde(default)]
+        pub models: HashMap<String, CustomModelDef>,
+        /// Per-provider request timeout override in seconds.
+        #[serde(
+            default,
+            rename = "requestTimeoutSecs",
+            alias = "request_timeout_secs",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub request_timeout_secs: Option<u64>,
+        /// Whether streaming is enabled for this provider. Default: true
+        /// (streaming). Set to false for providers that don't support SSE.
+        #[serde(default, rename = "streaming", skip_serializing_if = "Option::is_none")]
+        pub streaming: Option<bool>,
+        /// Whether to send stream_options.include_usage when streaming.
+        /// Default: true. Set to false for providers that don't support it.
+        #[serde(default, rename = "includeUsageInStream", alias = "include_usage_in_stream", skip_serializing_if = "Option::is_none")]
+        pub include_usage_in_stream: Option<bool>,
+        /// JSON field name for reasoning/thinking content (e.g.
+        /// "reasoning_content" for DeepSeek). None means no reasoning field.
+        #[serde(default, rename = "reasoningField", alias = "reasoning_field", skip_serializing_if = "Option::is_none")]
+        pub reasoning_field: Option<String>,
+    }
+
+    impl CustomProviderDef {
+        /// Resolve the API key, substituting `{env:VAR_NAME}` patterns with
+        /// the corresponding environment variable value. Returns `None` if
+        /// the key is absent or the env var is unset.
+        pub fn resolve_api_key(&self) -> Option<String> {
+            self.api_key.as_ref().and_then(|raw| {
+                if let Some(var) = raw.strip_prefix("{env:").and_then(|s| s.strip_suffix('}')) {
+                    std::env::var(var).ok().filter(|v| !v.is_empty())
+                } else if raw.is_empty() {
+                    None
+                } else {
+                    Some(raw.clone())
+                }
+            })
         }
     }
 
@@ -1202,6 +1311,32 @@ pub mod config {
         pub urls: Vec<String>,
     }
 
+    // ---- BangCommandsConfig ---------------------------------------------
+
+    /// Configuration for the `!` batch command feature.
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    pub struct BangCommandsConfig {
+        /// Whether the feature is enabled. Default: false (opt-in).
+        #[serde(default)]
+        pub enabled: bool,
+        /// Whether to add `!` commands to a separate shell-command history.
+        #[serde(default, rename = "addToHistory")]
+        pub add_to_history: bool,
+        /// Whether to display command + output in the chat transcript.
+        #[serde(default = "default_true", rename = "showInTranscript")]
+        pub show_in_transcript: bool,
+    }
+
+    impl Default for BangCommandsConfig {
+        fn default() -> Self {
+            Self {
+                enabled: false,
+                add_to_history: false,
+                show_in_transcript: default_true(),
+            }
+        }
+    }
+
     // ---- Settings --------------------------------------------------------
 
     #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -1252,6 +1387,16 @@ pub mod config {
         /// Per-provider configurations stored in settings.json.
         #[serde(default)]
         pub providers: HashMap<String, ProviderConfig>,
+        /// User-defined OpenAI-compatible providers, keyed by unique id.
+        /// Each entry is a self-contained provider with its own base URL,
+        /// API key, headers, and model catalog. The id becomes the provider
+        /// id used in `provider/model` routing.
+        #[serde(default, rename = "customProviders", alias = "custom_providers")]
+        pub custom_providers: HashMap<String, CustomProviderDef>,
+        /// User-favorited model keys ("provider/model" format). Shown in a
+        /// dedicated section at the top of the /model picker.
+        #[serde(default, rename = "favoriteModels", alias = "favorite_models")]
+        pub favorite_models: Vec<String>,
         /// User-supplied model metadata overrides stored in settings.json,
         /// keyed by `"provider/model"`. Merged into
         /// [`Config::model_overrides`] by [`Settings::effective_config`] and
@@ -1317,6 +1462,13 @@ pub mod config {
         /// Note: @include in CLAUDE.md/AGENTS.md always injects regardless of this limit.
         #[serde(default = "default_file_injection_max_size", rename = "fileInjectionMaxSize")]
         pub file_injection_max_size: usize,
+        /// Whether auto-poke is enabled. When true, the model is automatically
+        /// continued when it stops with incomplete todos. Default: true.
+        #[serde(default = "default_true", rename = "autoPokeEnabled")]
+        pub auto_poke_enabled: bool,
+        /// Configuration for the `!` batch command feature.
+        #[serde(default, rename = "bangCommands")]
+        pub bang_commands: BangCommandsConfig,
     }
 
     /// A user-defined slash command template.
@@ -1772,7 +1924,11 @@ pub mod config {
                 std::fs::create_dir_all(parent)?;
             }
             let content = serde_json::to_string_pretty(self)?;
-            std::fs::write(path, content)?;
+            // Atomic write: serialize to a temp file, then rename into place.
+            // On Unix, rename() is atomic — readers never see a partial file.
+            let tmp_path = path.with_extension("json.tmp");
+            std::fs::write(&tmp_path, &content)?;
+            std::fs::rename(&tmp_path, path)?;
             Ok(())
         }
 
@@ -1819,6 +1975,18 @@ pub mod config {
             // Merge top-level `providers` map into config.provider_configs.
             for (id, pc) in &self.providers {
                 config.provider_configs.entry(id.clone()).or_insert_with(|| pc.clone());
+            }
+            // Merge custom providers' API keys and base URLs into
+            // provider_configs so resolve_provider_api_key() can find them.
+            for (id, cp) in &self.custom_providers {
+                config.provider_configs.entry(id.clone()).or_insert_with(|| {
+                    ProviderConfig {
+                        api_key: cp.api_key.clone(),
+                        api_base: Some(cp.api_base.clone()),
+                        enabled: true,
+                        ..Default::default()
+                    }
+                });
             }
             // Merge top-level `modelOverrides` into config.model_overrides
             // (nested `config` block wins for keys present in both).
@@ -2007,6 +2175,8 @@ pub mod config {
                 last_seen_version: over.last_seen_version.or(base.last_seen_version),
                 provider: over.provider.or(base.provider),
                 providers: merge_map(base.providers, over.providers),
+                custom_providers: merge_map(base.custom_providers, over.custom_providers),
+                favorite_models: { let mut v = base.favorite_models; for f in over.favorite_models { if !v.contains(&f) { v.push(f); } } v },
                 model_overrides: merge_map(base.model_overrides, over.model_overrides),
                 commands: merge_map(base.commands, over.commands),
                 formatter: merge_map(base.formatter, over.formatter),
@@ -2031,6 +2201,12 @@ pub mod config {
                 file_autocomplete_show_hidden_files: over.file_autocomplete_show_hidden_files || base.file_autocomplete_show_hidden_files,
                 file_injection_enabled: over.file_injection_enabled || base.file_injection_enabled,
                 file_injection_max_size: if over.file_injection_max_size != 0 { over.file_injection_max_size } else { base.file_injection_max_size },
+                auto_poke_enabled: over.auto_poke_enabled || base.auto_poke_enabled,
+                bang_commands: BangCommandsConfig {
+                    enabled: over.bang_commands.enabled || base.bang_commands.enabled,
+                    add_to_history: over.bang_commands.add_to_history || base.bang_commands.add_to_history,
+                    show_in_transcript: over.bang_commands.show_in_transcript && base.bang_commands.show_in_transcript,
+                },
             }
         }
     }
@@ -2285,12 +2461,54 @@ pub mod config {
         }
 
         #[test]
+        fn favorite_models_deserialize() {
+            let json = r#"{"favoriteModels": ["anthropic/claude-sonnet-4-6", "openai/gpt-4o"]}"#;
+            let settings: Settings = serde_json::from_str(json).unwrap();
+            assert_eq!(settings.favorite_models.len(), 2);
+            assert_eq!(settings.favorite_models[0], "anthropic/claude-sonnet-4-6");
+            assert_eq!(settings.favorite_models[1], "openai/gpt-4o");
+        }
+
+        #[test]
+        fn favorite_models_snake_alias() {
+            let json = r#"{"favorite_models": ["anthropic/claude-opus-4-6"]}"#;
+            let settings: Settings = serde_json::from_str(json).unwrap();
+            assert_eq!(settings.favorite_models.len(), 1);
+            assert_eq!(settings.favorite_models[0], "anthropic/claude-opus-4-6");
+        }
+
+        #[test]
+        fn favorite_models_default_empty() {
+            let json = r#"{}"#;
+            let settings: Settings = serde_json::from_str(json).unwrap();
+            assert!(settings.favorite_models.is_empty());
+        }
+
+        #[test]
         fn zero_is_treated_as_unset() {
             let config = Config { request_timeout_secs: Some(0), ..Default::default() };
             assert_eq!(
                 config.resolve_request_timeout_secs("openai"),
                 DEFAULT_REQUEST_TIMEOUT_SECS
             );
+        }
+
+        #[test]
+        fn bang_commands_default_disabled() {
+            let json = r#"{}"#;
+            let settings: Settings = serde_json::from_str(json).unwrap();
+            assert!(!settings.bang_commands.enabled);
+            assert!(!settings.bang_commands.add_to_history);
+            assert!(settings.bang_commands.show_in_transcript);
+        }
+
+        #[test]
+        fn bang_commands_deserialize() {
+            let json = r#"{"bangCommands": {"enabled": true, "addToHistory": true, "showInTranscript": false}}"#;
+            let settings: Settings = serde_json::from_str(json).unwrap();
+            assert!(settings.bang_commands.enabled);
+            assert!(settings.bang_commands.add_to_history);
+            assert!(!settings.bang_commands.show_in_transcript);
         }
     }
 }
@@ -5314,5 +5532,148 @@ mod tests {
             registry.get(&id).unwrap().status,
             tasks::TaskStatus::Cancelled
         );
+    }
+
+    #[test]
+    fn custom_provider_def_deserialize_camel_case() {
+        let json = r#"{
+            "name": "Test Gateway",
+            "apiBase": "https://gateway.example.com/v1",
+            "apiKey": "secret-key",
+            "headers": { "X-Custom-Header": "value" },
+            "models": {
+                "model-1": {
+                    "name": "Model One",
+                    "contextWindow": 128000,
+                    "maxOutputTokens": 8192,
+                    "reasoningEffort": "high"
+                }
+            },
+            "requestTimeoutSecs": 300
+        }"#;
+        let def: CustomProviderDef = serde_json::from_str(json).unwrap();
+        assert_eq!(def.name, "Test Gateway");
+        assert_eq!(def.api_base, "https://gateway.example.com/v1");
+        assert_eq!(def.api_key.as_deref(), Some("secret-key"));
+        assert_eq!(def.headers.get("X-Custom-Header").unwrap(), "value");
+        assert_eq!(def.models.len(), 1);
+        let model = def.models.get("model-1").unwrap();
+        assert_eq!(model.context_window, Some(128000));
+        assert_eq!(model.max_output_tokens, Some(8192));
+        assert_eq!(model.name.as_deref(), Some("Model One"));
+        assert_eq!(model.reasoning_effort.as_deref(), Some("high"));
+        assert_eq!(def.request_timeout_secs, Some(300));
+    }
+
+    #[test]
+    fn custom_provider_def_deserialize_snake_case() {
+        let json = r#"{
+            "name": "Test",
+            "api_base": "https://example.com",
+            "api_key": "key",
+            "models": {}
+        }"#;
+        let def: CustomProviderDef = serde_json::from_str(json).unwrap();
+        assert_eq!(def.api_base, "https://example.com");
+        assert_eq!(def.api_key.as_deref(), Some("key"));
+    }
+
+    #[test]
+    fn custom_provider_def_resolve_api_key_env_substitution() {
+        std::env::set_var("TEST_CUSTOM_PROVIDER_KEY", "env-key-value");
+        let def = CustomProviderDef {
+            api_key: Some("{env:TEST_CUSTOM_PROVIDER_KEY}".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(def.resolve_api_key().as_deref(), Some("env-key-value"));
+        std::env::remove_var("TEST_CUSTOM_PROVIDER_KEY");
+    }
+
+    #[test]
+    fn custom_provider_def_resolve_api_key_empty_env() {
+        let def = CustomProviderDef {
+            api_key: Some("{env:NONEXISTENT_VAR_12345}".to_string()),
+            ..Default::default()
+        };
+        assert!(def.resolve_api_key().is_none());
+    }
+
+    #[test]
+    fn custom_provider_def_resolve_api_key_none() {
+        let def = CustomProviderDef {
+            api_key: None,
+            ..Default::default()
+        };
+        assert!(def.resolve_api_key().is_none());
+    }
+
+    #[test]
+    fn custom_provider_def_resolve_api_key_plain() {
+        let def = CustomProviderDef {
+            api_key: Some("plain-key".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(def.resolve_api_key().as_deref(), Some("plain-key"));
+    }
+
+    #[test]
+    fn custom_provider_def_with_streaming_settings() {
+        let json = r#"{
+            "name": "Test",
+            "apiBase": "https://example.com/v1",
+            "streaming": false,
+            "includeUsageInStream": false,
+            "reasoningField": "reasoning_content"
+        }"#;
+        let def: CustomProviderDef = serde_json::from_str(json).unwrap();
+        assert_eq!(def.streaming, Some(false));
+        assert_eq!(def.include_usage_in_stream, Some(false));
+        assert_eq!(def.reasoning_field.as_deref(), Some("reasoning_content"));
+    }
+
+    #[test]
+    fn custom_model_def_with_variants() {
+        let json = r#"{
+            "contextWindow": 230000,
+            "maxOutputTokens": 32072,
+            "variants": {
+                "max": { "reasoningEffort": "max" },
+                "none": { "reasoningEffort": "none" }
+            }
+        }"#;
+        let model: CustomModelDef = serde_json::from_str(json).unwrap();
+        assert_eq!(model.context_window, Some(230000));
+        assert_eq!(model.variants.len(), 2);
+        assert_eq!(
+            model.variants.get("max").unwrap().reasoning_effort.as_deref(),
+            Some("max")
+        );
+    }
+
+    #[test]
+    fn settings_deserialize_with_custom_providers() {
+        let json = r#"{
+            "customProviders": {
+                "my-gateway": {
+                    "name": "My Gateway",
+                    "apiBase": "https://gw.example.com/v1",
+                    "models": {
+                        "model-a": { "name": "Model A" }
+                    }
+                }
+            }
+        }"#;
+        let settings: Settings = serde_json::from_str(json).unwrap();
+        assert_eq!(settings.custom_providers.len(), 1);
+        let provider = settings.custom_providers.get("my-gateway").unwrap();
+        assert_eq!(provider.name, "My Gateway");
+        assert_eq!(provider.models.len(), 1);
+    }
+
+    #[test]
+    fn auto_poke_enabled_default_true() {
+        let json = r#"{}"#;
+        let settings: Settings = serde_json::from_str(json).unwrap();
+        assert!(settings.auto_poke_enabled);
     }
 }

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -815,6 +815,7 @@ pub async fn run_query_loop(
                     // Native (non-OpenAI-compat) providers
                     "anthropic", "openai", "google", "azure", "amazon-bedrock",
                     "github-copilot", "codex", "openai-codex", "cohere", "minimax",
+                    "cursor-acp",
                     // Local / self-hosted
                     "ollama",
                     "lmstudio", "lm-studio",
@@ -835,10 +836,16 @@ pub async fn run_query_loop(
                 if known_providers.contains(&p) {
                     (p.to_string(), m.to_string())
                 } else {
-                    // Treat the whole string as the model ID, fall through
-                    // to auto-detection below.
-                    let fallback_provider = tool_ctx.config.provider.as_deref().unwrap_or("anthropic");
-                    (fallback_provider.to_string(), effective_model.clone())
+                    // Check whether `p` is a user-defined custom provider id.
+                    let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+                    if settings.custom_providers.contains_key(p) {
+                        (p.to_string(), m.to_string())
+                    } else {
+                        // Treat the whole string as the model ID, fall through
+                        // to auto-detection below.
+                        let fallback_provider = tool_ctx.config.provider.as_deref().unwrap_or("anthropic");
+                        (fallback_provider.to_string(), effective_model.clone())
+                    }
                 }
             } else {
                 // No explicit provider set (or set to "anthropic"): try the
@@ -2413,6 +2420,27 @@ mod tests {
         // both must be treated as OpenAI-compatible providers.
         assert!(is_openaiish_provider("alibaba"));
         assert!(is_openaiish_provider("qwen"));
+    }
+
+    #[test]
+    fn is_openaiish_provider_unknown_id_returns_false() {
+        // When a custom provider is registered in settings, is_openaiish_provider
+        // should return true even though it's not in the hardcoded list.
+        // This test uses a unique id unlikely to collide with real settings.
+        // Note: This test depends on no settings.json having this id;
+        // it verifies the fallback (no custom provider → matches! list).
+        let result = is_openaiish_provider("definitely-not-a-real-provider-99999");
+        assert!(!result);
+    }
+
+    #[test]
+    fn known_providers_includes_custom_provider_runtime_check() {
+        // The runtime check for custom providers should not crash and
+        // should not return true for arbitrary unknown strings.
+        // This is a negative test — no custom provider "fake-provider-xyz"
+        // should exist in settings.
+        let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+        assert!(!settings.custom_providers.contains_key("fake-provider-xyz-12345"));
     }
 
     // ---- apply_compact_result / #213 data-loss guard ------------------------

--- a/src-rust/crates/query/src/runner/provider_options.rs
+++ b/src-rust/crates/query/src/runner/provider_options.rs
@@ -52,6 +52,12 @@ pub(crate) fn is_openai_reasoning_model(model_id: &str) -> bool {
 }
 
 pub(crate) fn is_openaiish_provider(provider_id: &str) -> bool {
+    // Custom providers from Settings are always OpenAI-compatible.
+    if let Ok(settings) = claurst_core::Settings::load_sync() {
+        if settings.custom_providers.contains_key(provider_id) {
+            return true;
+        }
+    }
     matches!(
         provider_id,
         "openai"

--- a/src-rust/crates/tools/src/todo_write.rs
+++ b/src-rust/crates/tools/src/todo_write.rs
@@ -139,6 +139,28 @@ struct TodoItem {
     #[serde(default)]
     #[allow(dead_code)]
     priority: Option<String>,
+    // --- NEW FIELDS ---
+    #[serde(default)]
+    #[allow(dead_code)]
+    group: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    confidence: Option<u8>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    completion_confidence: Option<u8>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    confidence_history: Vec<u8>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    blocked_by: Vec<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    assigned_to: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    force_reopen: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -155,23 +177,20 @@ struct TodoItem {
 /// Forbidden:
 ///   completed   → anything      ✗  (completed tasks cannot be reopened)
 ///   in_progress → pending       ✗  (cannot move backwards)
-fn validate_transition(id: &str, old: &TodoStatus, new: &TodoStatus) -> Result<(), String> {
+fn validate_transition(id: &str, old: &TodoStatus, new: &TodoStatus, force_reopen: bool) -> Result<(), String> {
     if old == new {
         return Ok(());
     }
     match (old, new) {
-        // Completed tasks are immutable.
-        (TodoStatus::Completed, _) => Err(format!(
-            "Task {:?}: cannot change status of a completed task (currently \"completed\" → \"{}\").",
+        (TodoStatus::Completed, _) if !force_reopen => Err(format!(
+            "Task {:?}: cannot change status of a completed task (currently \"completed\" → \"{}\"). Use force_reopen: true if poke verification found a false completion.",
             id, new
         )),
-        // Cannot move in_progress backwards to pending.
+        (TodoStatus::Completed, _) if force_reopen => Ok(()), // Force reopen allowed
         (TodoStatus::InProgress, TodoStatus::Pending) => Err(format!(
             "Task {:?}: cannot move status backwards (\"in_progress\" → \"pending\").",
             id
         )),
-        // All other transitions (pending→in_progress, pending→completed,
-        // in_progress→completed) are valid.
         _ => Ok(()),
     }
 }
@@ -211,7 +230,14 @@ impl Tool for TodoWriteTool {
                                 "type": "string",
                                 "enum": ["pending", "in_progress", "completed"]
                             },
-                            "priority": { "type": "string" }
+                            "priority": { "type": "string" },
+                            "group": { "type": "string" },
+                            "confidence": { "type": "integer", "minimum": 0, "maximum": 100 },
+                            "completion_confidence": { "type": "integer", "minimum": 0, "maximum": 100 },
+                            "confidence_history": { "type": "array", "items": { "type": "integer" } },
+                            "blocked_by": { "type": "array", "items": { "type": "string" } },
+                            "assigned_to": { "type": "string" },
+                            "force_reopen": { "type": "boolean" }
                         },
                         "required": ["id", "content", "status"]
                     },
@@ -267,7 +293,7 @@ impl Tool for TodoWriteTool {
             match existing.get(item.id.as_str()) {
                 Some(old_status) => {
                     // Existing task — validate the transition.
-                    if let Err(e) = validate_transition(&item.id, old_status, &item.status) {
+                    if let Err(e) = validate_transition(&item.id, old_status, &item.status, item.force_reopen) {
                         return ToolResult::error(e);
                     }
                     if old_status != &TodoStatus::Completed
@@ -325,6 +351,26 @@ impl Tool for TodoWriteTool {
                 if let Some(ref p) = t.priority {
                     obj["priority"] = json!(p);
                 }
+                if let Some(ref g) = t.group {
+                    obj["group"] = json!(g);
+                }
+                if let Some(c) = t.confidence {
+                    obj["confidence"] = json!(c);
+                }
+                if let Some(c) = t.completion_confidence {
+                    obj["completion_confidence"] = json!(c);
+                }
+                if !t.confidence_history.is_empty() {
+                    // Cap at 20 entries (ring buffer).
+                    let history: Vec<u8> = t.confidence_history.iter().rev().take(20).copied().collect::<Vec<u8>>().into_iter().rev().collect();
+                    obj["confidence_history"] = json!(history);
+                }
+                if !t.blocked_by.is_empty() {
+                    obj["blocked_by"] = json!(t.blocked_by);
+                }
+                if let Some(ref a) = t.assigned_to {
+                    obj["assigned_to"] = json!(a);
+                }
                 obj
             })
             .collect();
@@ -368,6 +414,62 @@ impl Tool for TodoWriteTool {
         }))
     }
 }
+
+// ---------------------------------------------------------------------------
+// Auto-poke mechanism (ported from jcode)
+// ---------------------------------------------------------------------------
+
+/// Build the synthetic continuation message sent when the model stops with
+/// incomplete todos. The message instructs the model to continue working.
+pub fn build_auto_poke_message(incomplete_count: usize) -> String {
+    format!(
+        "You have {} incomplete todo{}. Continue working, or update the todo tool.",
+        incomplete_count,
+        if incomplete_count == 1 { "" } else { "s" },
+    )
+}
+
+/// Check whether a message is an auto-poke synthetic continuation prompt.
+/// Used by the TUI to hide the raw message and show "Auto-poking..." instead.
+pub fn is_auto_poke_message(message: &str) -> bool {
+    message.starts_with("You have ")
+        && message.contains(" incomplete todo")
+        && message.contains("Continue working, or update the todo tool.")
+}
+
+/// Count incomplete (pending + in_progress) todos for a session.
+pub fn count_incomplete_todos(session_id: &str) -> usize {
+    let todos = load_todos(session_id);
+    todos
+        .iter()
+        .filter_map(|t| t.get("status").and_then(|s| s.as_str()))
+        .filter(|s| *s == "pending" || *s == "in_progress")
+        .count()
+}
+
+/// Compute a hash of the current todo state (sorted [(id, status)] pairs).
+/// Used for no-progress detection: if the hash is unchanged for 3 consecutive
+/// turns, auto-poking stops.
+pub fn todo_state_hash(session_id: &str) -> String {
+    let todos = load_todos(session_id);
+    let mut pairs: Vec<(String, String)> = todos
+        .iter()
+        .filter_map(|t| {
+            let id = t.get("id").and_then(|v| v.as_str())?.to_string();
+            let status = t.get("status").and_then(|v| v.as_str())?.to_string();
+            Some((id, status))
+        })
+        .collect();
+    pairs.sort_by(|a, b| a.0.cmp(&b.0));
+    // Simple hash: concatenate id:status pairs.
+    pairs.iter().map(|(id, s)| format!("{}:{}", id, s)).collect::<Vec<_>>().join("|")
+}
+
+/// Maximum auto-pokes per session (safety budget).
+pub const MAX_AUTO_POKES: u32 = 48;
+
+/// No-progress threshold: stop after this many consecutive no-progress turns.
+pub const NO_PROGRESS_THRESHOLD: u32 = 3;
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -450,26 +552,26 @@ mod tests {
     #[test]
     fn test_valid_transitions() {
         // pending → in_progress
-        assert!(validate_transition("t1", &TodoStatus::Pending, &TodoStatus::InProgress).is_ok());
+        assert!(validate_transition("t1", &TodoStatus::Pending, &TodoStatus::InProgress, false).is_ok());
         // pending → completed
-        assert!(validate_transition("t2", &TodoStatus::Pending, &TodoStatus::Completed).is_ok());
+        assert!(validate_transition("t2", &TodoStatus::Pending, &TodoStatus::Completed, false).is_ok());
         // in_progress → completed
-        assert!(validate_transition("t3", &TodoStatus::InProgress, &TodoStatus::Completed).is_ok());
+        assert!(validate_transition("t3", &TodoStatus::InProgress, &TodoStatus::Completed, false).is_ok());
         // no-op transitions are always fine
-        assert!(validate_transition("t4", &TodoStatus::Pending, &TodoStatus::Pending).is_ok());
-        assert!(validate_transition("t5", &TodoStatus::InProgress, &TodoStatus::InProgress).is_ok());
-        assert!(validate_transition("t6", &TodoStatus::Completed, &TodoStatus::Completed).is_ok());
+        assert!(validate_transition("t4", &TodoStatus::Pending, &TodoStatus::Pending, false).is_ok());
+        assert!(validate_transition("t5", &TodoStatus::InProgress, &TodoStatus::InProgress, false).is_ok());
+        assert!(validate_transition("t6", &TodoStatus::Completed, &TodoStatus::Completed, false).is_ok());
     }
 
     #[test]
     fn test_invalid_transition_completed_to_anything() {
-        assert!(validate_transition("t1", &TodoStatus::Completed, &TodoStatus::Pending).is_err());
-        assert!(validate_transition("t2", &TodoStatus::Completed, &TodoStatus::InProgress).is_err());
+        assert!(validate_transition("t1", &TodoStatus::Completed, &TodoStatus::Pending, false).is_err());
+        assert!(validate_transition("t2", &TodoStatus::Completed, &TodoStatus::InProgress, false).is_err());
     }
 
     #[test]
     fn test_invalid_transition_in_progress_to_pending() {
-        assert!(validate_transition("t1", &TodoStatus::InProgress, &TodoStatus::Pending).is_err());
+        assert!(validate_transition("t1", &TodoStatus::InProgress, &TodoStatus::Pending, false).is_err());
     }
 
     // --- ID uniqueness -------------------------------------------------------
@@ -479,5 +581,78 @@ mod tests {
         let err = TodoStatus::from_str_ci("banana").unwrap_err();
         assert!(err.contains("Invalid status"), "error should mention invalid status");
         assert!(err.contains("banana"), "error should echo the bad value");
+    }
+
+    // --- Auto-poke ----------------------------------------------------------
+
+    #[test]
+    fn build_auto_poke_message_singular() {
+        let msg = build_auto_poke_message(1);
+        assert!(msg.contains("1 incomplete todo"));
+        assert!(!msg.contains("todos"));
+    }
+
+    #[test]
+    fn build_auto_poke_message_plural() {
+        let msg = build_auto_poke_message(5);
+        assert!(msg.contains("5 incomplete todos"));
+    }
+
+    #[test]
+    fn is_auto_poke_message_recognizes_poke() {
+        let msg = build_auto_poke_message(3);
+        assert!(is_auto_poke_message(&msg));
+    }
+
+    #[test]
+    fn is_auto_poke_message_rejects_normal() {
+        assert!(!is_auto_poke_message("Hello, can you help me?"));
+        assert!(!is_auto_poke_message("Continue working on the task."));
+    }
+
+    // --- TodoItem deserialization with new fields ----------------------------
+
+    #[test]
+    fn todo_item_deserialize_with_old_schema() {
+        let json = r#"{"id":"1","content":"Test","status":"pending"}"#;
+        let item: TodoItem = serde_json::from_str(json).unwrap();
+        assert_eq!(item.id, "1");
+        assert!(item.group.is_none());
+        assert!(item.confidence.is_none());
+        assert!(item.confidence_history.is_empty());
+        assert!(item.blocked_by.is_empty());
+        assert!(!item.force_reopen);
+    }
+
+    #[test]
+    fn todo_item_deserialize_with_new_schema() {
+        let json = r#"{
+            "id": "2",
+            "content": "New fields test",
+            "status": "in_progress",
+            "priority": "high",
+            "group": "Phase 1",
+            "confidence": 75,
+            "blocked_by": ["1"],
+            "force_reopen": false
+        }"#;
+        let item: TodoItem = serde_json::from_str(json).unwrap();
+        assert_eq!(item.group.as_deref(), Some("Phase 1"));
+        assert_eq!(item.confidence, Some(75));
+        assert_eq!(item.blocked_by, vec!["1"]);
+    }
+
+    // --- Force reopen transition --------------------------------------------
+
+    #[test]
+    fn validate_transition_force_reopen_allows_completed_to_pending() {
+        let result = validate_transition("test", &TodoStatus::Completed, &TodoStatus::Pending, true);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_transition_without_force_reopen_blocks_completed_to_pending() {
+        let result = validate_transition("test", &TodoStatus::Completed, &TodoStatus::Pending, false);
+        assert!(result.is_err());
     }
 }

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -241,7 +241,7 @@ fn import_config_picker_items() -> Vec<SelectItem> {
 }
 
 fn provider_picker_items() -> Vec<SelectItem> {
-    vec![
+    let mut items = vec![
         SelectItem { id: "free".into(), title: "Free Mode".into(), description: "OpenCode Zen → OpenRouter free fallback (no spend)".into(), category: "Popular".into(), badge: Some("FREE".into()) },
         SelectItem { id: "openai".into(), title: "OpenAI".into(), description: "(API key)".into(), category: "Popular".into(), badge: None },
         SelectItem { id: "openai-codex".into(), title: "OpenAI Codex".into(), description: "(ChatGPT Plus/Pro — browser login)".into(), category: "Popular".into(), badge: None },
@@ -250,6 +250,7 @@ fn provider_picker_items() -> Vec<SelectItem> {
         SelectItem { id: "anthropic".into(), title: "Anthropic".into(), description: "(API key)".into(), category: "Popular".into(), badge: None },
         SelectItem { id: "anthropic-oauth".into(), title: "Anthropic (Claude Pro/Max)".into(), description: "(subscription — browser login; draws from extra-usage)".into(), category: "Popular".into(), badge: None },
         SelectItem { id: "custom-openai".into(), title: "Custom OpenAI-Compatible".into(), description: "Custom URL + API key".into(), category: "Advanced".into(), badge: None },
+        SelectItem { id: "cursor-acp".into(), title: "Cursor ACP".into(), description: "Cursor CLI agent via ACP (subprocess)".into(), category: "Advanced".into(), badge: None },
         SelectItem { id: "openrouter".into(), title: "OpenRouter".into(), description: "100+ models with one key".into(), category: "Popular".into(), badge: None },
         SelectItem { id: "vercel".into(), title: "Vercel AI Gateway".into(), description: "Gateway for AI SDK models".into(), category: "Popular".into(), badge: None },
         SelectItem { id: "groq".into(), title: "Groq".into(), description: "Fast hosted inference".into(), category: "Popular".into(), badge: Some("FREE".into()) },
@@ -297,7 +298,21 @@ fn provider_picker_items() -> Vec<SelectItem> {
         SelectItem { id: "upstage".into(), title: "Upstage".into(), description: "Hosted Upstage models".into(), category: "Other".into(), badge: None },
         SelectItem { id: "stepfun".into(), title: "StepFun".into(), description: "Hosted reasoning models".into(), category: "Other".into(), badge: None },
         SelectItem { id: "fireworks".into(), title: "Fireworks AI".into(), description: "Fast inference".into(), category: "Other".into(), badge: None },
-    ]
+    ];
+
+        // Dynamically append custom providers from Settings.
+        if let Ok(settings) = Settings::load_sync() {
+            for (id, def) in &settings.custom_providers {
+                items.push(SelectItem {
+                    id: id.clone(),
+                    title: def.name.clone(),
+                    description: format!("Custom OpenAI-compatible — {}", def.api_base),
+                    category: "Custom".into(),
+                    badge: Some("CUSTOM".into()),
+                });
+            }
+        }
+        items
 }
 
 // ---------------------------------------------------------------------------
@@ -311,6 +326,8 @@ pub enum SystemMessageStyle {
     Warning,
     /// Compact / auto-compact boundary marker.
     Compact,
+    /// Inline todo card showing task progress.
+    TodoCard,
 }
 
 /// A synthetic system annotation inserted between conversation messages.
@@ -333,6 +350,12 @@ pub enum DisplayMessage {
     Conversation(Message),
     /// An injected system notice (e.g. compact boundary).
     System { text: String, style: SystemMessageStyle },
+    /// A `!` bang command execution — display only, never sent to model.
+    BangCommand { command: String },
+    /// Output from a `!` bang command.
+    BangOutput { text: String, exit_code: Option<i32> },
+    /// Error from a `!` bang command.
+    BangError { text: String },
 }
 
 /// Context menu state: position and currently selected item index.
@@ -800,6 +823,8 @@ pub struct App {
     pub input: String,
     pub prompt_input: PromptInputState,
     pub input_history: Vec<String>,
+    /// Separate history for `!` bang commands (distinct from prompt input history).
+    pub bang_command_history: Vec<String>,
     pub history_index: Option<usize>,
     pub scroll_offset: usize,
     pub is_streaming: bool,
@@ -878,8 +903,15 @@ pub struct App {
     pub rustle_temp_pose: Option<crate::rustle::RustlePose>,
     /// Frame counter at which the next random eye-shift should fire.
     pub rustle_next_blink: u64,
+    /// Token output rates from recent turns (tokens/sec), for computing
+    /// a rolling average. Last 5 turns kept.
+    pub recent_token_rates: Vec<f64>,
     /// Instant the current turn's streaming began (reset each time streaming starts).
     pub turn_start: Option<std::time::Instant>,
+    /// Instant the first streaming token arrived this turn (for active-throughput TPS).
+    pub stream_first_token: Option<std::time::Instant>,
+    /// Instant of the most recent streaming token this turn.
+    pub stream_last_token: Option<std::time::Instant>,
     /// Elapsed time string for the last completed turn, e.g. "2m 5s".
     pub last_turn_elapsed: Option<String>,
     /// Past-tense verb shown after turn completes, e.g. "Worked" / "Baked".
@@ -1062,6 +1094,19 @@ pub struct App {
     /// When `true`, the main loop will inject a synthetic Enter event on the
     /// next iteration to dequeue and submit the next queued message.
     pub pending_auto_submit: bool,
+    /// Auto-poke counter — how many pokes have been sent this session.
+    pub auto_poke_count: u32,
+    /// Hash of the last todo state for no-progress detection.
+    pub last_todo_hash: String,
+    /// Count of consecutive no-progress turns.
+    pub no_progress_turns: u32,
+    /// Whether the todo card is visible in the transcript.
+    pub todo_card_visible: bool,
+    /// When `true`, the main loop should start a new query turn because
+    /// auto-poke injected a continuation message into `queued_messages`.
+    pub pending_auto_poke: bool,
+    /// Current session ID (used for todo persistence + auto-poke).
+    pub session_id: String,
     /// Connect-a-provider dialog (/connect command).
     pub connect_dialog: DialogSelectState,
     /// Import-config source picker (/import-config command).
@@ -1174,6 +1219,10 @@ pub struct App {
     pub selection_anchor: Option<(u16, u16)>,
     /// Selection drag focus (col, row) — updated on mouse-drag / mouse-up.
     pub selection_focus: Option<(u16, u16)>,
+    /// Keyboard selection mode active.
+    pub kb_select_mode: bool,
+    /// Cursor row for keyboard selection (screen coordinate).
+    pub kb_cursor_row: u16,
     /// Text extracted from the current selection (updated each render frame).
     pub selection_text: RefCell<String>,
     /// Cache of row -> rendered text within the selectable area, refreshed
@@ -1268,6 +1317,8 @@ impl App {
                 .join("models.json");
             reg.load_cache(&cache_path);
             reg.apply_model_overrides(&config.model_overrides);
+            let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+            reg.apply_custom_providers(&settings.custom_providers);
             reg
         };
         Self {
@@ -1279,6 +1330,7 @@ impl App {
             input: String::new(),
             prompt_input: PromptInputState::new(),
             input_history: Vec::new(),
+            bang_command_history: Vec::new(),
             history_index: None,
             scroll_offset: 0,
             is_streaming: false,
@@ -1318,6 +1370,9 @@ impl App {
                 .unwrap_or_default()
                 .subsec_nanos() as u64 % 300),
             turn_start: None,
+            stream_first_token: None,
+            stream_last_token: None,
+            recent_token_rates: Vec::new(),
             last_turn_elapsed: None,
             last_turn_verb: None,
             turn_metadata: Vec::new(),
@@ -1398,6 +1453,12 @@ impl App {
             auth_store: claurst_core::AuthStore::load(),
             queued_messages: std::collections::VecDeque::new(),
             pending_auto_submit: false,
+            auto_poke_count: 0,
+            last_todo_hash: String::new(),
+            no_progress_turns: 0,
+            todo_card_visible: false,
+            pending_auto_poke: false,
+            session_id: String::new(),
             connect_dialog: DialogSelectState::new("Connect a provider", provider_picker_items()),
             import_config_picker: DialogSelectState::new("Import config", import_config_picker_items()),
             import_config_dialog: ImportConfigDialogState::new(),
@@ -1484,6 +1545,8 @@ impl App {
             last_max_scroll: Cell::new(0),
             selection_anchor: None,
             selection_focus: None,
+            kb_select_mode: false,
+            kb_cursor_row: 0,
             selection_text: RefCell::new(String::new()),
             last_row_text: RefCell::new(std::collections::HashMap::new()),
             last_click_time: None,
@@ -1613,6 +1676,8 @@ impl App {
         // measures actual round-trip time even when the provider buffers its
         // full response before yielding any stream events (e.g. Gemini flash).
         self.turn_start = Some(std::time::Instant::now());
+        self.stream_first_token = None;
+        self.stream_last_token = None;
         self.last_turn_elapsed = None;
         self.last_turn_verb = None;
     }
@@ -1703,6 +1768,10 @@ impl App {
             .join("models.json");
         if cache_path.exists() {
             self.model_registry.load_cache(&cache_path);
+            // Re-apply custom providers after cache merge so custom model
+            // entries survive any catalog overlay.
+            let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+            self.model_registry.apply_custom_providers(&settings.custom_providers);
         }
 
         let models = crate::model_picker::models_for_provider_from_registry(
@@ -1710,6 +1779,7 @@ impl App {
             &self.model_registry,
         );
         self.model_picker.set_models(models);
+        self.model_picker.load_favorites();
         self.model_picker_provider_id = Some(provider_id.to_string());
         // Catalog-backed providers (Anthropic/OpenAI/Google) are a read-only
         // projection of the models.dev catalog — there is no live endpoint to
@@ -1754,6 +1824,54 @@ impl App {
         self.has_credentials = true;
         self.status_message = Some(format!("{} {}.", status_prefix, provider_name));
         self.open_model_picker_for_provider(&provider_id, Some(picker_title));
+    }
+
+    /// Open the model picker showing models from all connected providers,
+    /// grouped by provider name.
+    fn open_model_picker_all_providers(&mut self) {
+        self.dismiss_error_notifications();
+
+        // Collect models from all connected providers.
+        let mut all_models: Vec<crate::model_picker::ModelEntry> = Vec::new();
+
+        // Get connected provider IDs from provider_registry.
+        let connected_ids: Vec<String> = if let Some(ref registry) = self.provider_registry {
+            registry.provider_ids().iter().map(|id| id.to_string()).collect()
+        } else {
+            Vec::new()
+        };
+
+        // Also include current provider if not in registry.
+        let mut provider_ids = connected_ids;
+        if let Some(ref current) = self.config.provider {
+            if !provider_ids.contains(current) {
+                provider_ids.push(current.clone());
+            }
+        }
+
+        // Collect models from each provider.
+        for pid in &provider_ids {
+            let models = crate::model_picker::models_for_provider_from_registry(
+                pid,
+                &self.model_registry,
+            );
+            for mut m in models {
+                m.provider_id = pid.clone();
+                all_models.push(m);
+            }
+        }
+
+        self.model_picker.set_models(all_models);
+        self.model_picker_provider_id = None; // All providers mode
+        self.model_picker.all_providers_mode = true;
+        self.model_picker.loading_models = false;
+        self.model_picker_fetch_pending = false;
+
+        self.model_picker.open_all_providers(
+            &self.model_name,
+            self.effort_level,
+            self.fast_mode,
+        );
     }
 
     fn persist_custom_provider_base_url(&self, base_url: &str) {
@@ -1809,9 +1927,16 @@ impl App {
                 "amazon-bedrock",
                 "free",
                 "opencode-zen",
+                "cursor-acp",
             ];
             if known.contains(&provider) {
                 return Some(provider.to_string());
+            }
+            // Check custom providers at runtime.
+            if let Ok(settings) = Settings::load_sync() {
+                if settings.custom_providers.contains_key(provider) {
+                    return Some(provider.to_string());
+                }
             }
         }
 
@@ -1980,6 +2105,8 @@ impl App {
         self.model_registry = claurst_api::ModelRegistry::new();
         // Re-layer user metadata overrides (issue #309) onto the fresh registry.
         self.model_registry.apply_model_overrides(&self.config.model_overrides);
+        let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+        self.model_registry.apply_custom_providers(&settings.custom_providers);
         self.auth_store = auth_store;
         self.connect_dialog = DialogSelectState::new("Connect a provider", provider_picker_items());
         self.import_config_picker = DialogSelectState::new("Import config", import_config_picker_items());
@@ -2084,12 +2211,7 @@ impl App {
                     self.status_message = Some("Connect a provider to choose a model.".to_string());
                     return true;
                 }
-                let provider = self
-                    .config
-                    .provider
-                    .clone()
-                    .unwrap_or_else(|| "anthropic".to_string());
-                self.open_model_picker_for_provider(&provider, None);
+                self.open_model_picker_all_providers();
                 true
             }
             "session" | "resume" => {
@@ -2981,6 +3103,103 @@ impl App {
         self.refresh_prompt_input();
     }
 
+    /// Execute a `!` bang command directly, without sending to the model.
+    /// Output is displayed in the transcript (display_messages only) — the
+    /// model never sees it. Zero token consumption.
+    pub fn execute_bang_command(&mut self, command: String) {
+        // Check if bang commands are enabled.
+        let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+        if !settings.bang_commands.enabled {
+            self.push_notification(
+                crate::notifications::NotificationKind::Warning,
+                "Bang commands are disabled. Enable with \"bangCommands\": {\"enabled\": true} in settings.json.".to_string(),
+                None,
+            );
+            return;
+        }
+
+        // Block in plan mode.
+        if self.config.permission_mode == claurst_core::PermissionMode::Plan {
+            self.push_notification(
+                crate::notifications::NotificationKind::Warning,
+                "Bang commands disabled in plan mode.".to_string(),
+                None,
+            );
+            return;
+        }
+
+        // Display the command.
+        if settings.bang_commands.show_in_transcript {
+            self.display_messages.push(DisplayMessage::BangCommand {
+                command: command.clone(),
+            });
+        }
+
+        // Resolve working directory: prefer project dir, fall back to current dir.
+        let working_dir = self
+            .config
+            .project_dir
+            .clone()
+            .or_else(|| {
+                self.current_dir
+                    .as_ref()
+                    .map(|s| std::path::PathBuf::from(s))
+            })
+            .unwrap_or_else(|| std::path::PathBuf::from("."));
+
+        // Execute via std::process::Command — NO model round-trip, NO PTY.
+        let result = std::process::Command::new("bash")
+            .arg("-c")
+            .arg(&command)
+            .current_dir(&working_dir)
+            .output();
+
+        match result {
+            Ok(output) => {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let exit_code = output.status.code();
+
+                let display = if stderr.is_empty() {
+                    stdout.to_string()
+                } else if stdout.is_empty() {
+                    stderr.to_string()
+                } else {
+                    format!("{}\n--- stderr ---\n{}", stdout, stderr)
+                };
+
+                if settings.bang_commands.show_in_transcript {
+                    if exit_code.is_some_and(|c| c != 0) {
+                        let full = format!("{}\n[exit: {}]", display, exit_code.unwrap());
+                        self.display_messages.push(DisplayMessage::BangOutput {
+                            text: full,
+                            exit_code,
+                        });
+                    } else {
+                        self.display_messages.push(DisplayMessage::BangOutput {
+                            text: display,
+                            exit_code,
+                        });
+                    }
+                }
+
+                // Add to separate history if enabled.
+                if settings.bang_commands.add_to_history {
+                    self.bang_command_history.push(command);
+                }
+            }
+            Err(e) => {
+                if settings.bang_commands.show_in_transcript {
+                    self.display_messages.push(DisplayMessage::BangError {
+                        text: format!("Error: {}", e),
+                    });
+                }
+            }
+        }
+
+        self.invalidate_transcript();
+    }
+
     fn refresh_turn_diff_from_history(&mut self) {
         let Some(file_history) = self.file_history.as_ref() else {
             self.diff_viewer.set_turn_diff(Vec::new());
@@ -3481,6 +3700,10 @@ impl App {
                             "ollama" | "lmstudio" | "llamacpp" => {
                                 self.activate_provider(selected.id.clone(), selected.title.clone(), "Switched to");
                             }
+                            "cursor-acp" => {
+                                // Cursor ACP: spawns agent subprocess, no API key needed.
+                                self.activate_provider(selected.id.clone(), selected.title.clone(), "Switched to");
+                            }
                             // "Free" composite mode — collects any subset of the
                             // free-tier upstreams (min 1; more = better availability).
                             "free" => {
@@ -3537,6 +3760,23 @@ impl App {
                             "amazon-bedrock" => {
                                 self.key_input_dialog
                                     .open(selected.id.clone(), selected.title.clone());
+                            }
+                            // Custom providers from Settings — may need API key
+                            id if {
+                                let settings = Settings::load_sync().unwrap_or_default();
+                                settings.custom_providers.contains_key(id)
+                            } => {
+                                // Check if the custom provider has an API key resolved.
+                                let settings = Settings::load_sync().unwrap_or_default();
+                                let def = settings.custom_providers.get(&selected.id).unwrap();
+                                if def.resolve_api_key().is_some() {
+                                    // Key available — activate directly.
+                                    self.activate_provider(selected.id.clone(), selected.title.clone(), "Switched to");
+                                } else {
+                                    // No key — open key input dialog.
+                                    self.key_input_dialog
+                                        .open(selected.id.clone(), selected.title.clone());
+                                }
                             }
                             // All other providers — open API key input dialog
                             _ => {
@@ -3642,6 +3882,19 @@ impl App {
                 KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => self.model_picker.select_next(),
                 KeyCode::Enter => {
                     if let Some((model_id, effort)) = self.model_picker.confirm() {
+                        // Default sentinel — clear explicit model override.
+                        if model_id == crate::model_picker::DEFAULT_MODEL_SENTINEL {
+                            self.config.model = None;
+                            let provider = self.config.provider.as_deref().unwrap_or("anthropic");
+                            let best = self.display_default_model_for_provider(provider);
+                            self.model_name = best.clone();
+                            self.cost_tracker.set_model(&best);
+                            self.refresh_context_window_size();
+                            self.context_used_tokens = 0;
+                            self.persist_provider_and_model();
+                            self.status_message = Some(format!("Model: {} (default)", best));
+                            return false;
+                        }
                         // If user picked a model other than the fast-mode model
                         // while fast mode was active, turn fast mode off.
                         if self.fast_mode && !self.model_picker.is_selected_fast_mode_model(&model_id) {
@@ -3656,11 +3909,29 @@ impl App {
                         // a routing prefix (`free/…`, `zen/…`, `openrouter/…`)
                         // so re-prefixing would produce nonsense like
                         // `free/free/auto`.
-                        let provider = self.config.provider.as_deref().unwrap_or("anthropic");
-                        let full_model = if provider == "anthropic" || provider == "free" {
-                            model_id.clone()
+                        //
+                        // In all-providers mode the provider is inferred from
+                        // the selected entry's `provider_id` field rather than
+                        // the current config provider.
+                        let full_model = if self.model_picker.all_providers_mode {
+                            let filtered = self.model_picker.filtered_models_grouped();
+                            if let Some((entry, _is_fav)) = filtered.get(self.model_picker.selected_idx) {
+                                let provider = &entry.provider_id;
+                                if provider == "anthropic" || provider == "free" {
+                                    entry.id.clone()
+                                } else {
+                                    format!("{}/{}", provider, entry.id)
+                                }
+                            } else {
+                                model_id.clone()
+                            }
                         } else {
-                            format!("{}/{}", provider, model_id)
+                            let provider = self.config.provider.as_deref().unwrap_or("anthropic");
+                            if provider == "anthropic" || provider == "free" {
+                                model_id.clone()
+                            } else {
+                                format!("{}/{}", provider, model_id)
+                            }
                         };
                         self.set_model(full_model.clone());
                         self.persist_provider_and_model();
@@ -3669,6 +3940,19 @@ impl App {
                     }
                 }
                 KeyCode::Backspace => self.model_picker.pop_filter_char(),
+                KeyCode::Char('f') | KeyCode::Char('*') => {
+                    // Toggle favorite on the currently selected model.
+                    let grouped = self.model_picker.filtered_models_grouped();
+                    if let Some((m, _)) = grouped.get(self.model_picker.selected_idx) {
+                        let provider = self.config.provider.as_deref().unwrap_or("anthropic");
+                        let model_key = if provider == "anthropic" || provider == "free" {
+                            m.id.clone()
+                        } else {
+                            format!("{}/{}", provider, m.id)
+                        };
+                        self.model_picker.toggle_favorite(&model_key);
+                    }
+                }
                 KeyCode::Char(c) => self.model_picker.push_filter_char(c),
                 _ => {}
             }
@@ -4090,6 +4374,114 @@ impl App {
             self.keybindings.cancel_chord();
         }
 
+        // ---- Keyboard selection mode -------------------------------
+        if self.kb_select_mode {
+            match key.code {
+                KeyCode::Esc => {
+                    self.kb_select_mode = false;
+                    self.clear_selection();
+                    self.status_message = Some("Selection cancelled.".to_string());
+                    return false;
+                }
+                // Copy selection and exit
+                KeyCode::Char('y') | KeyCode::Char('Y') => {
+                    let text = self.selection_text.borrow().clone();
+                    if !text.is_empty() {
+                        let copied = crate::image_paste::write_clipboard_text(&text);
+                        if copied {
+                            self.push_notification(NotificationKind::Info, "Copied to clipboard".to_string(), Some(2));
+                        }
+                    }
+                    self.kb_select_mode = false;
+                    self.clear_selection();
+                    return false;
+                }
+                // Ctrl+C also copies in selection mode
+                KeyCode::Char(c) if (c == 'c' || c == 'C') && key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    let text = self.selection_text.borrow().clone();
+                    if !text.is_empty() {
+                        let copied = crate::image_paste::write_clipboard_text(&text);
+                        if copied {
+                            self.push_notification(NotificationKind::Info, "Copied to clipboard".to_string(), Some(2));
+                        }
+                    }
+                    self.kb_select_mode = false;
+                    self.clear_selection();
+                    return false;
+                }
+                // Movement: extend selection
+                KeyCode::Up => {
+                    if self.kb_cursor_row > self.last_selectable_area.get().y {
+                        self.kb_cursor_row -= 1;
+                        // Scroll up if cursor goes above visible area
+                        let area = self.last_selectable_area.get();
+                        if self.kb_cursor_row < area.y {
+                            let step = self.scroll_step();
+                            self.scroll_offset = self.scroll_offset.saturating_add(step);
+                        }
+                    }
+                    self.update_kb_selection();
+                    return false;
+                }
+                KeyCode::Down => {
+                    let area = self.last_selectable_area.get();
+                    let max_row = area.y + area.height.saturating_sub(1);
+                    if self.kb_cursor_row < max_row {
+                        self.kb_cursor_row += 1;
+                        // Scroll down if cursor goes below visible area
+                        if self.kb_cursor_row >= area.y + area.height {
+                            let step = self.scroll_step();
+                            let new_off = self.scroll_offset.saturating_sub(step);
+                            self.scroll_offset = new_off;
+                            if new_off == 0 {
+                                self.auto_scroll = true;
+                            }
+                        }
+                    }
+                    self.update_kb_selection();
+                    return false;
+                }
+                KeyCode::Home => {
+                    let area = self.last_selectable_area.get();
+                    self.kb_cursor_row = area.y;
+                    // Scroll to top
+                    self.scroll_offset = self.total_message_lines.get().saturating_sub(area.height as usize);
+                    self.auto_scroll = false;
+                    self.update_kb_selection();
+                    return false;
+                }
+                KeyCode::End => {
+                    let area = self.last_selectable_area.get();
+                    self.kb_cursor_row = area.y + area.height.saturating_sub(1);
+                    // Scroll to bottom
+                    self.scroll_offset = 0;
+                    self.auto_scroll = true;
+                    self.update_kb_selection();
+                    return false;
+                }
+                KeyCode::PageUp => {
+                    let area = self.last_selectable_area.get();
+                    let step = area.height;
+                    self.kb_cursor_row = self.kb_cursor_row.saturating_sub(step).max(area.y);
+                    self.scroll_offset = self.scroll_offset.saturating_add(step as usize);
+                    self.update_kb_selection();
+                    return false;
+                }
+                KeyCode::PageDown => {
+                    let area = self.last_selectable_area.get();
+                    let max_row = area.y + area.height.saturating_sub(1);
+                    let step = area.height;
+                    self.kb_cursor_row = (self.kb_cursor_row + step).min(max_row);
+                    let new_off = self.scroll_offset.saturating_sub(step as usize);
+                    self.scroll_offset = new_off;
+                    if new_off == 0 { self.auto_scroll = true; }
+                    self.update_kb_selection();
+                    return false;
+                }
+                _ => return false, // Swallow all other keys in selection mode
+            }
+        }
+
         // Clear any active text selection on key press (except Ctrl+C which copies it).
         let is_copy = key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL);
         if !is_copy && self.selection_anchor.is_some() {
@@ -4386,6 +4778,23 @@ impl App {
             KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::ALT) => {
                 self.prompt_input.delete_word_at_cursor();
                 self.refresh_prompt_input();
+            }
+
+            // ---- Enter keyboard selection mode ------------------------
+            KeyCode::Char('v') if !key.modifiers.contains(KeyModifiers::CONTROL)
+                && !key.modifiers.contains(KeyModifiers::ALT)
+                && self.prompt_input.is_empty() =>
+            {
+                self.kb_select_mode = true;
+                let area = self.last_selectable_area.get();
+                // Start cursor at the bottom of the visible area
+                self.kb_cursor_row = area.y + area.height.saturating_sub(1);
+                // Set anchor at current cursor, focus at same point (empty selection)
+                let col = area.x;
+                self.selection_anchor = Some((col, self.kb_cursor_row));
+                self.selection_focus = Some((col, self.kb_cursor_row));
+                self.status_message = Some("Selection mode: Arrows select, y/Ctrl+C copy, Esc cancel".to_string());
+                return false;
             }
 
             // ---- Text entry (allowed while streaming so users can queue
@@ -5550,7 +5959,28 @@ impl App {
     fn clear_selection(&mut self) {
         self.selection_anchor = None;
         self.selection_focus = None;
+        self.kb_select_mode = false;
         *self.selection_text.borrow_mut() = String::new();
+    }
+
+    /// Update the selection from keyboard cursor position.
+    fn update_kb_selection(&mut self) {
+        if !self.kb_select_mode {
+            return;
+        }
+        let area = self.last_selectable_area.get();
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        // Anchor stays at original position, focus follows cursor.
+        // The render code in render.rs already handles extracting text between
+        // anchor and focus in row-major order.
+        let col = area.x;
+        self.selection_focus = Some((col, self.kb_cursor_row));
+        // If anchor is None (shouldn't happen), set it.
+        if self.selection_anchor.is_none() {
+            self.selection_anchor = Some((col, self.kb_cursor_row));
+        }
     }
 
     /// Show context menu at the given position.
@@ -6146,17 +6576,22 @@ impl App {
                 let input_area = self.last_input_area.get();
                 let selectable_area = self.last_selectable_area.get();
 
+                // When an error modal is showing, the selectable area covers
+                // the entire terminal — the modal text is selectable for copy.
+                let error_modal_active = self.notifications.current_is_error();
+
                 let in_input = input_area.width > 0 && input_area.height > 0
                     && mouse_event.row >= input_area.y
                     && mouse_event.row < input_area.y.saturating_add(input_area.height)
                     && mouse_event.column >= input_area.x
                     && mouse_event.column < input_area.x.saturating_add(input_area.width);
 
-                let in_selectable = selectable_area.width > 0 && selectable_area.height > 0
-                    && mouse_event.row >= selectable_area.y
-                    && mouse_event.row < selectable_area.y.saturating_add(selectable_area.height)
-                    && mouse_event.column >= selectable_area.x
-                    && mouse_event.column < selectable_area.x.saturating_add(selectable_area.width);
+                let in_selectable = error_modal_active
+                    || (selectable_area.width > 0 && selectable_area.height > 0
+                        && mouse_event.row >= selectable_area.y
+                        && mouse_event.row < selectable_area.y.saturating_add(selectable_area.height)
+                        && mouse_event.column >= selectable_area.x
+                        && mouse_event.column < selectable_area.x.saturating_add(selectable_area.width));
 
                 // Check for click on a thinking block header (takes priority over text selection).
                 if let Some(&hash) = self.thinking_row_map.borrow().get(&mouse_event.row) {
@@ -6169,11 +6604,11 @@ impl App {
                     return;
                 }
 
-                if in_input {
+                if in_input && !error_modal_active {
                     self.focus = FocusTarget::Input;
                     self.clear_selection();
                     self.handle_prompt_click(mouse_event.column, mouse_event.row);
-                } else if selectable_area.width == 0 || selectable_area.height == 0 {
+                } else if !error_modal_active && (selectable_area.width == 0 || selectable_area.height == 0) {
                     self.click_count = 0;
                 } else if in_selectable {
                     self.focus = FocusTarget::Transcript;
@@ -6312,6 +6747,11 @@ impl App {
                         self.stall_start = None;
                         match delta {
                             claurst_api::streaming::ContentDelta::TextDelta { text } => {
+                                let now = std::time::Instant::now();
+                                if self.stream_first_token.is_none() {
+                                    self.stream_first_token = Some(now);
+                                }
+                                self.stream_last_token = Some(now);
                                 self.streaming_text.push_str(&text);
                                 self.invalidate_transcript();
                             }
@@ -6413,17 +6853,59 @@ impl App {
                 }
                 // Record elapsed time and pick a completion verb
                 let seed = self.frame_count as usize ^ (self.messages.len() * 7);
+                // Track tokens per second for the status indicator (before take()).
+                // Prefer real usage; fall back to a rough char-based estimate
+                // (~4 chars/token) for providers that never report usage (e.g.
+                // cursor-acp, whose ACP protocol omits token counts).
+                let reported_output = usage.as_ref().map(|u| u.output_tokens).unwrap_or(0);
+                let output_tokens = if reported_output > 0 {
+                    reported_output
+                } else {
+                    (self.streaming_text.len() / 4).max(if self.streaming_text.is_empty() { 0 } else { 1 }) as u64
+                };
+                // Active streaming throughput: time between first and last
+                // token arrival, excluding TTFT and post-stream idle.
+                if output_tokens > 0 {
+                    if let (Some(first), Some(last)) =
+                        (self.stream_first_token, self.stream_last_token)
+                    {
+                        let active_secs = last.duration_since(first).as_secs_f64();
+                        if active_secs > 0.0 {
+                            let rate = output_tokens as f64 / active_secs;
+                            self.recent_token_rates.push(rate);
+                            if self.recent_token_rates.len() > 5 {
+                                self.recent_token_rates.remove(0);
+                            }
+                        }
+                    } else if let Some(start) = self.turn_start {
+                        // Fallback for turns with no streamed text deltas
+                        // (e.g. non-streaming / cached): use submit-to-complete.
+                        let elapsed_secs = start.elapsed().as_secs_f64();
+                        if elapsed_secs > 0.0 {
+                            let rate = output_tokens as f64 / elapsed_secs;
+                            self.recent_token_rates.push(rate);
+                            if self.recent_token_rates.len() > 5 {
+                                self.recent_token_rates.remove(0);
+                            }
+                        }
+                    }
+                }
                 let elapsed = self.turn_start.take()
                     .map(|start| format_elapsed_ms(start.elapsed().as_millis()));
                 self.last_turn_elapsed = Some(
                     elapsed.unwrap_or_else(|| "0s".to_string())
                 );
                 self.last_turn_verb = Some(sample_completion_verb(seed));
+                self.stream_first_token = None;
+                self.stream_last_token = None;
                 self.flush_streamed_assistant_message();
                 self.tool_use_blocks.retain(|b| b.status != ToolStatus::Running);
                 self.complete_current_turn_snapshot(stop_reason.contains("abort") || stop_reason.contains("cancel"));
                 self.invalidate_transcript();
                 self.refresh_turn_diff_from_history();
+
+                // Auto-poke: check for incomplete todos and queue continuation.
+                self.check_auto_poke();
             }
 
             QueryEvent::Status(msg) => {
@@ -6435,6 +6917,8 @@ impl App {
                 self.spinner_verb = None;
                 self.streaming_text.clear();
                 self.streaming_thinking.clear();
+                self.stream_first_token = None;
+                self.stream_last_token = None;
                 self.invalidate_transcript();
                 let err_msg = format!("Error: {}", msg);
                 self.push_assistant_message(err_msg.clone());
@@ -6473,6 +6957,65 @@ impl App {
 
         // Update token count from tracker.
         self.token_count = self.cost_tracker.total_tokens() as u32;
+    }
+
+    // -------------------------------------------------------------------
+    // Auto-poke
+    // -------------------------------------------------------------------
+
+    /// Check whether auto-poke should fire after a model turn.
+    /// If the model stopped with incomplete todos, queue a synthetic
+    /// continuation message via the existing `queued_messages` mechanism.
+    fn check_auto_poke(&mut self) {
+        // Don't poke if the turn was aborted/cancelled.
+        if !self.last_turn_elapsed.is_some() && self.tool_use_blocks.is_empty() {
+            // Likely a fresh state — still allow poke.
+        }
+
+        // Don't poke if auto-poke is disabled (check settings).
+        let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+        if !settings.auto_poke_enabled {
+            return;
+        }
+
+        // Check poke budget.
+        if self.auto_poke_count >= claurst_tools::todo_write::MAX_AUTO_POKES {
+            self.status_message = Some(format!(
+                "Auto-poke stopped: budget of {} reached.",
+                claurst_tools::todo_write::MAX_AUTO_POKES
+            ));
+            return;
+        }
+
+        // Count incomplete todos.
+        let incomplete = claurst_tools::todo_write::count_incomplete_todos(&self.session_id);
+        if incomplete == 0 {
+            return; // All done — no poke needed.
+        }
+
+        // No-progress detection: hash the todo state.
+        let current_hash = claurst_tools::todo_write::todo_state_hash(&self.session_id);
+        if current_hash == self.last_todo_hash {
+            self.no_progress_turns += 1;
+        } else {
+            self.no_progress_turns = 0;
+            self.last_todo_hash = current_hash;
+        }
+
+        if self.no_progress_turns >= claurst_tools::todo_write::NO_PROGRESS_THRESHOLD {
+            self.status_message = Some(
+                "Auto-poke stopped: no progress for 3 turns.".to_string()
+            );
+            return;
+        }
+
+        // Queue the auto-poke message via the existing queued_messages
+        // infrastructure so the main loop submits it on the next iteration.
+        let poke_msg = claurst_tools::todo_write::build_auto_poke_message(incomplete);
+        self.auto_poke_count += 1;
+        self.status_message = Some(format!("Auto-poking... ({} incomplete todos)", incomplete));
+        self.queued_messages.push_back(poke_msg);
+        self.pending_auto_submit = true;
     }
 
     // -------------------------------------------------------------------
@@ -6717,6 +7260,15 @@ impl App {
                         if should_submit {
                             // Dismiss any active error modal when the user sends a message
                             self.dismiss_error_notifications();
+                            // Check for bang command (! prefix) — execute directly, no model.
+                            if crate::input::is_bang_command(&self.prompt_input.text) {
+                                let command = self.prompt_input.text[1..].trim().to_string();
+                                self.clear_prompt();
+                                if !command.is_empty() {
+                                    self.execute_bang_command(command);
+                                }
+                                continue;
+                            }
                             // Check if this is a slash command that should open a UI screen
                             if crate::input::is_slash_command(&self.prompt_input.text) {
                                 let slash_input = self.prompt_input.text.clone();
@@ -7803,5 +8355,19 @@ mod tests {
         assert!(!app.should_exit);
         app.handle_key_event(press_key(KeyCode::Char('c'), KeyModifiers::CONTROL));
         assert!(app.should_exit);
+    }
+
+    #[test]
+    fn kb_select_mode_starts_and_cancels() {
+        let mut app = make_app();
+        app.kb_select_mode = true;
+        app.selection_anchor = Some((0, 5));
+        app.selection_focus = Some((0, 5));
+        app.kb_cursor_row = 5;
+        // Simulate Esc by testing state directly via clear_selection.
+        app.clear_selection();
+        assert!(!app.kb_select_mode);
+        assert!(app.selection_anchor.is_none());
+        assert!(app.selection_focus.is_none());
     }
 }

--- a/src-rust/crates/tui/src/input.rs
+++ b/src-rust/crates/tui/src/input.rs
@@ -5,6 +5,13 @@ pub fn is_slash_command(input: &str) -> bool {
     input.starts_with('/') && !input.starts_with("//")
 }
 
+/// Check if the input is a bang command (! prefix).
+/// A single `!` is a bang command only when followed by at least one
+/// non-whitespace character; `!!` (double bang) is NOT a bang command.
+pub fn is_bang_command(input: &str) -> bool {
+    input.starts_with('!') && !input.starts_with("!!") && input.len() > 1
+}
+
 /// Parse a slash command into `(command_name, args)`.
 /// Returns `("", "")` if the input is not a slash command.
 pub fn parse_slash_command(input: &str) -> (&str, &str) {
@@ -54,5 +61,21 @@ mod tests {
         let (cmd, args) = parse_slash_command("hello world");
         assert_eq!(cmd, "");
         assert_eq!(args, "");
+    }
+
+    #[test]
+    fn is_bang_command_true() {
+        assert!(is_bang_command("!ls"));
+        assert!(is_bang_command("! git status"));
+        assert!(is_bang_command("!echo hello"));
+    }
+
+    #[test]
+    fn is_bang_command_false() {
+        assert!(!is_bang_command("ls"));
+        assert!(!is_bang_command("/help"));
+        assert!(!is_bang_command("!! multi-line"));
+        assert!(!is_bang_command("hello"));
+        assert!(!is_bang_command(""));
     }
 }

--- a/src-rust/crates/tui/src/model_picker.rs
+++ b/src-rust/crates/tui/src/model_picker.rs
@@ -24,6 +24,10 @@ use crate::overlays::{centered_rect, modal_search_line, CLAURST_PANEL_BG};
 /// support reasoning honour it.
 pub use claurst_core::effort::EffortLevel;
 
+/// Sentinel model id for the "Default" picker entry. When the user selects
+/// this, the app clears the explicit model override so the provider's best
+/// model is used.
+pub const DEFAULT_MODEL_SENTINEL: &str = "__default__";
 
 // ---------------------------------------------------------------------------
 // Model capability helpers — driven by the opencode variants() ladder
@@ -221,6 +225,8 @@ pub struct ModelEntry {
     pub description: String,
     /// Whether this is the currently active model.
     pub is_current: bool,
+    /// Provider ID this model belongs to (for all-providers mode).
+    pub provider_id: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -228,12 +234,13 @@ pub struct ModelEntry {
 // ---------------------------------------------------------------------------
 
 /// Helper to build a `ModelEntry` with `is_current = false`.
-fn model_entry(id: &str, name: &str, desc: &str) -> ModelEntry {
+fn model_entry(id: &str, name: &str, desc: &str, provider_id: &str) -> ModelEntry {
     ModelEntry {
         id: id.to_string(),
         display_name: name.to_string(),
         description: desc.to_string(),
         is_current: false,
+        provider_id: provider_id.to_string(),
     }
 }
 
@@ -254,7 +261,7 @@ pub fn models_for_provider_from_registry(
     // directly.  `free/auto` is the default routing entry; the rest pin a
     // specific upstream model for users who care.
     if provider_id == "free" {
-        return free_provider_models();
+        return free_provider_models(provider_id);
     }
     // Codex (ChatGPT-authenticated OpenAI) is not in the models.dev catalog —
     // serve the curated CODEX_MODELS list so the picker isn't empty.  Accept
@@ -262,7 +269,7 @@ pub fn models_for_provider_from_registry(
     // ("openai-codex"); without the alias a fresh Codex login lands on the
     // empty-registry fallback and the picker shows no models.
     if is_codex_provider(provider_id) {
-        return codex_provider_models(registry);
+        return codex_provider_models(registry, provider_id);
     }
 
     let mut entries = registry.list_visible_by_provider(provider_id);
@@ -280,6 +287,7 @@ pub fn models_for_provider_from_registry(
             "default",
             "Default model",
             "no catalog entry for this provider",
+            provider_id,
         )];
     }
 
@@ -307,6 +315,7 @@ pub fn models_for_provider_from_registry(
                 display_name: e.info.name.clone(),
                 description: cost_str,
                 is_current: false,
+                provider_id: provider_id.to_string(),
             }
         })
         .collect()
@@ -377,10 +386,26 @@ pub fn default_model_for_provider(
 /// event loop either replaces or merges the projection according to
 /// [`provider_has_authoritative_live_models`].
 pub fn provider_uses_catalog_projection(provider_id: &str) -> bool {
-    matches!(
+    if matches!(
         provider_id,
         "openai" | "google" | "azure" | "amazon-bedrock" | "cohere" | "minimax"
-    )
+    ) {
+        return true;
+    }
+    // Custom providers have a curated model list in settings — no live
+    // endpoint to fetch from, so skip the background fetch.
+    if let Ok(settings) = claurst_core::Settings::load_sync() {
+        if settings.custom_providers.contains_key(provider_id) {
+            return true;
+        }
+    }
+// cursor-acp-rest is a custom provider with curated models — no
+    // discovery needed. cursor-acp (native subprocess) triggers
+    // discover_models() for live model discovery from the ACP.
+    if provider_id == "cursor-acp-rest" {
+        return true;
+    }
+    false
 }
 
 /// Whether live discovery is the complete set of models usable through a local
@@ -417,7 +442,7 @@ fn is_codex_provider(provider_id: &str) -> bool {
 /// catalog yields nothing (e.g. an empty/old snapshot).
 ///
 /// [`codex_model_allowed`]: claurst_core::codex_oauth::codex_model_allowed
-fn codex_provider_models(registry: &claurst_api::ModelRegistry) -> Vec<ModelEntry> {
+fn codex_provider_models(registry: &claurst_api::ModelRegistry, provider_id: &str) -> Vec<ModelEntry> {
     use claurst_core::codex_oauth::{codex_limit_override, codex_model_allowed};
 
     let mut entries: Vec<&claurst_api::ModelEntry> = registry
@@ -427,7 +452,7 @@ fn codex_provider_models(registry: &claurst_api::ModelRegistry) -> Vec<ModelEntr
         .collect();
 
     if entries.is_empty() {
-        return codex_fallback_models();
+        return codex_fallback_models(provider_id);
     }
 
     // Newest release first, then by id for stability — matches the picker's
@@ -455,13 +480,14 @@ fn codex_provider_models(registry: &claurst_api::ModelRegistry) -> Vec<ModelEntr
                     format_context_window(ctx)
                 ),
                 is_current: false,
+                provider_id: provider_id.to_string(),
             }
         })
         .collect()
 }
 
 /// Static fallback used when the models.dev `openai` catalog is unavailable.
-fn codex_fallback_models() -> Vec<ModelEntry> {
+fn codex_fallback_models(provider_id: &str) -> Vec<ModelEntry> {
     use claurst_core::codex_oauth::codex_limit_override;
     claurst_core::codex_oauth::CODEX_MODELS
         .iter()
@@ -477,6 +503,7 @@ fn codex_fallback_models() -> Vec<ModelEntry> {
                     format_context_window(ctx)
                 ),
                 is_current: false,
+                provider_id: provider_id.to_string(),
             }
         })
         .collect()
@@ -485,12 +512,13 @@ fn codex_fallback_models() -> Vec<ModelEntry> {
 /// Curated free-mode model list used by `models_for_provider_from_registry`.
 /// Always shows `free/auto` first; one pin entry per catalog upstream so the
 /// user can target a specific provider when they need to.
-fn free_provider_models() -> Vec<ModelEntry> {
+fn free_provider_models(provider_id: &str) -> Vec<ModelEntry> {
     let mut entries = vec![ModelEntry {
         id: "free/auto".to_string(),
         display_name: "Auto (round-robin across configured providers)".to_string(),
         description: "stacks every free-tier key you've added · $0.00 per M".to_string(),
         is_current: false,
+        provider_id: provider_id.to_string(),
     }];
 
     for upstream in claurst_api::FREE_CATALOG {
@@ -499,6 +527,7 @@ fn free_provider_models() -> Vec<ModelEntry> {
             display_name: format!("{} \u{2014} {}", upstream.title, upstream.default_model),
             description: format!("{} · $0.00 per M", upstream.note),
             is_current: false,
+            provider_id: provider_id.to_string(),
         });
     }
 
@@ -523,6 +552,13 @@ pub struct ModelPickerState {
     pub models_loaded: bool,
     /// `true` while the background fetch is in flight.
     pub loading_models: bool,
+    /// Favorited model keys ("provider/model" format), loaded from Settings.
+    pub favorites: Vec<String>,
+    /// Synthetic "Default" entry prepended to the model list.
+    default_entry: ModelEntry,
+    /// When true, the picker shows models from all connected providers
+    /// grouped by provider name.
+    pub all_providers_mode: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -551,6 +587,15 @@ impl ModelPickerState {
             fast_mode_model: None,
             models_loaded: false,
             loading_models: false,
+            favorites: Vec::new(),
+            default_entry: ModelEntry {
+                id: DEFAULT_MODEL_SENTINEL.to_string(),
+                display_name: "Default".to_string(),
+                description: "Provider's recommended model (auto-selects best)".to_string(),
+                is_current: false,
+                provider_id: String::new(),
+            },
+            all_providers_mode: false,
         }
     }
 
@@ -568,6 +613,49 @@ impl ModelPickerState {
         self.open_with_title("Select model", current_model, effort, fast_mode);
     }
 
+    /// Open in all-providers mode — shows models from all connected
+    /// providers grouped by provider name.
+    pub fn open_all_providers(&mut self, current_model: &str, effort: EffortLevel, fast_mode: bool) {
+        self.all_providers_mode = true;
+        self.open_with_title("Select model (all providers)", current_model, effort, fast_mode);
+    }
+
+    /// Get the display name for a provider ID (for all-providers mode).
+    pub fn provider_group_name(provider_id: &str) -> String {
+        // Custom providers: use the user-configured display name from settings.
+        if let Ok(settings) = claurst_core::Settings::load_sync() {
+            if let Some(def) = settings.custom_providers.get(provider_id) {
+                return def.name.clone();
+            }
+        }
+        match provider_id {
+            "anthropic" => "Anthropic".to_string(),
+            "openai" => "OpenAI".to_string(),
+            "google" => "Google".to_string(),
+            "groq" => "Groq".to_string(),
+            "openrouter" => "OpenRouter".to_string(),
+            "deepseek" => "DeepSeek".to_string(),
+            "ollama" => "Ollama".to_string(),
+            "lmstudio" => "LM Studio".to_string(),
+            "llamacpp" | "llama-cpp" | "llama-server" => "llama.cpp".to_string(),
+            "github-copilot" => "GitHub Copilot".to_string(),
+            "codex" | "openai-codex" => "OpenAI Codex".to_string(),
+            "cohere" => "Cohere".to_string(),
+            "xai" => "xAI".to_string(),
+            "free" => "Free Mode".to_string(),
+            "cursor-acp" => "Cursor ACP".to_string(),
+            "cerebras" => "Cerebras".to_string(),
+            "sambanova" => "SambaNova".to_string(),
+            "together-ai" | "togetherai" => "Together AI".to_string(),
+            "mistral" => "Mistral".to_string(),
+            "perplexity" => "Perplexity".to_string(),
+            "azure" => "Azure OpenAI".to_string(),
+            "amazon-bedrock" => "AWS Bedrock".to_string(),
+            "custom-openai" => "Custom OpenAI".to_string(),
+            _ => "Other".to_string(),
+        }
+    }
+
     pub fn open_with_title(
         &mut self,
         title: impl Into<String>,
@@ -578,6 +666,9 @@ impl ModelPickerState {
         for m in &mut self.models {
             m.is_current = m.id == current_model;
         }
+        // Mark default entry as current when no explicit model is set.
+        self.default_entry.is_current = current_model.is_empty()
+            || current_model == DEFAULT_MODEL_SENTINEL;
         self.selected_idx = self
             .models
             .iter()
@@ -595,6 +686,7 @@ impl ModelPickerState {
     pub fn close(&mut self) {
         self.visible = false;
         self.filter.clear();
+        self.all_providers_mode = false;
     }
 
     pub fn is_selected_fast_mode_model(&self, model_id: &str) -> bool {
@@ -603,7 +695,7 @@ impl ModelPickerState {
 
     /// Move selection up one row (wraps to last if at top).
     pub fn select_prev(&mut self) {
-        let count = self.filtered_models().len();
+        let count = self.filtered_models_grouped().len();
         if count == 0 { return; }
         if self.selected_idx == 0 {
             self.selected_idx = count - 1;
@@ -614,7 +706,7 @@ impl ModelPickerState {
 
     /// Move selection down one row (wraps to first if at bottom).
     pub fn select_next(&mut self) {
-        let count = self.filtered_models().len();
+        let count = self.filtered_models_grouped().len();
         if count == 0 { return; }
         self.selected_idx = (self.selected_idx + 1) % count;
     }
@@ -624,7 +716,7 @@ impl ModelPickerState {
     }
 
     pub fn select_last(&mut self) {
-        let count = self.filtered_models().len();
+        let count = self.filtered_models_grouped().len();
         self.selected_idx = count.saturating_sub(1);
     }
 
@@ -632,9 +724,9 @@ impl ModelPickerState {
     /// no ultracode). Empty when nothing is highlighted or the model is
     /// non-reasoning.
     fn selected_ladder(&self) -> Vec<EffortLevel> {
-        let filtered = self.filtered_models();
+        let filtered = self.filtered_models_grouped();
         match filtered.get(self.selected_idx) {
-            Some(m) => picker_variant_ladder(&m.id),
+            Some((m, _)) => picker_variant_ladder(&m.id),
             None => Vec::new(),
         }
     }
@@ -671,7 +763,7 @@ impl ModelPickerState {
     /// Returns the selected model; the caller is responsible for persisting it
     /// in the correct provider-aware format.
     pub fn confirm(&mut self) -> Option<(String, Option<EffortLevel>)> {
-        let filtered = self.filtered_models();
+        let filtered = self.filtered_models_grouped();
         let custom = self.filter.trim();
         if filtered.is_empty() {
             if custom.is_empty() {
@@ -681,8 +773,12 @@ impl ModelPickerState {
             self.close();
             return Some((id, None));
         }
-        let entry = filtered.get(self.selected_idx)?;
+        let (entry, _is_fav) = filtered.get(self.selected_idx)?;
         let id = entry.id.clone();
+        if id == DEFAULT_MODEL_SENTINEL {
+            self.close();
+            return Some((id, None));
+        }
         let ladder = picker_variant_ladder(&id);
         let effort = if ladder.len() > 1 {
             Some(clamp_to_ladder(&ladder, self.effort_level))
@@ -723,6 +819,117 @@ impl ModelPickerState {
             .collect()
     }
 
+    /// Load favorites from Settings into the picker state.
+    pub fn load_favorites(&mut self) {
+        if let Ok(settings) = claurst_core::Settings::load_sync() {
+            self.favorites = settings.favorite_models;
+        }
+    }
+
+    /// Toggle favorite status on a model key. Saves to Settings immediately.
+    pub fn toggle_favorite(&mut self, model_key: &str) {
+        if self.favorites.contains(&model_key.to_string()) {
+            self.favorites.retain(|f| f != model_key);
+        } else {
+            self.favorites.push(model_key.to_string());
+        }
+        // Persist to settings.
+        if let Ok(mut settings) = claurst_core::Settings::load_sync() {
+            settings.favorite_models = self.favorites.clone();
+            let _ = settings.save_sync();
+        }
+    }
+
+    /// Check if a model key is favorited.
+    pub fn is_favorite(&self, model_key: &str) -> bool {
+        self.favorites.contains(&model_key.to_string())
+    }
+
+    /// Get the list of valid favorites — those present in the picker's
+    /// current model list. Stale favorites (model removed from catalog)
+    /// are silently excluded from display but NOT removed from settings.
+    pub fn valid_favorites(&self) -> Vec<String> {
+        let model_ids: std::collections::HashSet<&str> =
+            self.models.iter().map(|m| m.id.as_str()).collect();
+        self.favorites
+            .iter()
+            .filter(|f| {
+                // Favorites are in "provider/model" format. The picker's
+                // models list has bare model ids (no provider prefix) since
+                // the picker is scoped to one provider. So we match on the
+                // model portion after the slash.
+                if let Some((_, model)) = f.split_once('/') {
+                    model_ids.contains(model)
+                } else {
+                    model_ids.contains(f.as_str())
+                }
+            })
+            .cloned()
+            .collect()
+    }
+
+    /// Returns model entries for display: favorites first (marked with ★),
+    /// then all other models. Applies the current filter to both sections.
+    pub fn filtered_models_grouped(&self) -> Vec<(&ModelEntry, bool)> {
+        let valid_favs = self.valid_favorites();
+        let fav_model_ids: std::collections::HashSet<String> = valid_favs
+            .iter()
+            .map(|f| f.split_once('/').map(|(_, m)| m.to_string()).unwrap_or(f.clone()))
+            .collect();
+
+        if self.filter.is_empty() {
+            // No filter: favorites section, then all models
+            let mut result = Vec::new();
+            // Default entry always at top.
+            result.push((&self.default_entry, false));
+            // Favorites first
+            for m in &self.models {
+                if fav_model_ids.contains(&m.id) {
+                    result.push((m, true));
+                }
+            }
+            // Then non-favorites
+            for m in &self.models {
+                if !fav_model_ids.contains(&m.id) {
+                    result.push((m, false));
+                }
+            }
+            result
+        } else {
+            let needle = self.filter.to_lowercase();
+            let mut result = Vec::new();
+            // Default entry — always show if filter matches or is empty.
+            if self.filter.is_empty()
+                || "default".contains(&needle)
+                || self.default_entry.display_name.to_lowercase().contains(&needle)
+                || self.default_entry.description.to_lowercase().contains(&needle)
+            {
+                result.push((&self.default_entry, false));
+            }
+            // Favorites matching filter
+            for m in &self.models {
+                if fav_model_ids.contains(&m.id)
+                    && (m.id.to_lowercase().contains(&needle)
+                        || m.display_name.to_lowercase().contains(&needle)
+                        || m.description.to_lowercase().contains(&needle))
+                {
+                    result.push((m, true));
+                }
+            }
+            // Non-favorites matching filter
+            for m in &self.models {
+                if !fav_model_ids.contains(&m.id)
+                    && (m.id.to_lowercase().contains(&needle)
+                        || m.display_name.to_lowercase().contains(&needle)
+                        || m.description.to_lowercase().contains(&needle))
+                {
+                    result.push((m, false));
+                }
+            }
+            result
+        }
+    }
+
     /// Replace the model list with dynamically loaded entries.
     ///
     /// Called by the app event loop when the background fetch completes.
@@ -731,8 +938,8 @@ impl ModelPickerState {
         self.models = entries;
         self.loading_models = false;
         self.models_loaded = true;
-        // Keep selected_idx in bounds.
-        let count = self.filtered_models().len();
+        // Keep selected_idx in bounds (grouped view includes default entry).
+        let count = self.filtered_models_grouped().len();
         if count > 0 && self.selected_idx >= count {
             self.selected_idx = count - 1;
         }
@@ -769,8 +976,8 @@ impl ModelPickerState {
         }
         self.loading_models = false;
         self.models_loaded = true;
-        // Keep selected_idx in bounds.
-        let count = self.filtered_models().len();
+        // Keep selected_idx in bounds (grouped view includes default entry).
+        let count = self.filtered_models_grouped().len();
         if count > 0 && self.selected_idx >= count {
             self.selected_idx = count - 1;
         }
@@ -820,8 +1027,8 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
     // ── Dialog size ──
     let width = 65u16.min(area.width.saturating_sub(6));
     let max_height = (area.height as f32 * 0.75) as u16;
-    let filtered = state.filtered_models();
-    let content_h = (filtered.len() as u16 + 6).min(max_height).max(8);
+    let grouped = state.filtered_models_grouped();
+    let content_h = (grouped.len() as u16 + 6).min(max_height).max(8);
     let dialog_area = centered_rect(width, content_h, area);
 
     // ── Fill dialog bg (no border) ──
@@ -909,7 +1116,7 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
         lines.push(Line::from(""));
     }
 
-    if filtered.is_empty() {
+    if grouped.is_empty() {
         lines.push(Line::from(vec![Span::styled(" No results found", Style::default().fg(dim))]));
         if !state.filter.trim().is_empty() {
             lines.push(Line::from(vec![Span::styled(
@@ -918,7 +1125,17 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
             )]));
         }
     } else {
-        for (i, model) in filtered.iter().enumerate() {
+        let mut last_provider: Option<&str> = None;
+        for (i, (model, is_fav)) in grouped.iter().enumerate() {
+            // Provider group header in all-providers mode
+            if state.all_providers_mode && last_provider != Some(&model.provider_id) {
+                last_provider = Some(&model.provider_id);
+                let group_name = ModelPickerState::provider_group_name(&model.provider_id);
+                lines.push(Line::from(vec![Span::styled(
+                    format!(" {} ", group_name),
+                    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                )]));
+            }
             let is_selected = i == state.selected_idx;
             let supports_effort = model_supports_effort(&model.id);
 
@@ -934,12 +1151,18 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
 
             let mut spans: Vec<Span<'static>> = Vec::new();
 
-            // Current model indicator
-            if model.is_current {
+            // Default entry gets a star (★); active model gets a green dot (●).
+            if model.id == DEFAULT_MODEL_SENTINEL {
+                spans.push(Span::styled(" \u{2605} ", Style::default().fg(Color::Cyan).bg(bg)));
+            } else if model.is_current {
                 spans.push(Span::styled(" \u{25cf} ", Style::default().fg(Color::Green).bg(bg)));
             } else {
                 spans.push(Span::styled("   ", Style::default().bg(bg)));
             }
+
+            // Favorite indicator — heart (♥) when favorited.
+            let heart = if *is_fav { "\u{2665} " } else { "  " };
+            spans.push(Span::styled(heart.to_string(), Style::default().fg(Color::Yellow).bg(bg)));
 
             spans.push(Span::styled(model.display_name.clone(), Style::default().fg(fg).bg(bg)));
 
@@ -990,11 +1213,25 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
 
     para.render(body_area, buf);
 
-    let mut footer_spans = vec![
-        Span::styled(" enter", Style::default().fg(dim)),
-        Span::styled(" select", Style::default().fg(dim)),
-    ];
-    if let Some(model) = filtered.get(state.selected_idx) {
+    let mut footer_spans = vec![];
+    // Show "enter set default" when the default sentinel is selected,
+    // otherwise "enter select".
+    let is_on_default = grouped
+        .get(state.selected_idx)
+        .map(|(m, _)| m.id == DEFAULT_MODEL_SENTINEL)
+        .unwrap_or(false);
+    if is_on_default {
+        footer_spans.push(Span::styled(" enter", Style::default().fg(dim)));
+        footer_spans.push(Span::styled(" set default", Style::default().fg(dim)));
+    } else {
+        footer_spans.push(Span::styled(" enter", Style::default().fg(dim)));
+        footer_spans.push(Span::styled(" select", Style::default().fg(dim)));
+    }
+    // Favorite toggle shortcut.
+    footer_spans.push(Span::raw("  "));
+    footer_spans.push(Span::styled("f", Style::default().fg(dim)));
+    footer_spans.push(Span::styled(" favorite", Style::default().fg(dim)));
+    if let Some((model, _)) = grouped.get(state.selected_idx) {
         if model_supports_effort(&model.id) {
             footer_spans.push(Span::raw("  "));
             footer_spans.push(Span::styled("\u{2190}/\u{2192}", Style::default().fg(dim)));
@@ -1026,18 +1263,21 @@ mod tests {
                 display_name: "Claude Opus 4.6".to_string(),
                 description: "200K context".to_string(),
                 is_current: false,
+                provider_id: "anthropic".to_string(),
             },
             ModelEntry {
                 id: "claude-sonnet-4-6".to_string(),
                 display_name: "Claude Sonnet 4.6".to_string(),
                 description: "200K context".to_string(),
                 is_current: false,
+                provider_id: "anthropic".to_string(),
             },
             ModelEntry {
                 id: "claude-haiku-4-5".to_string(),
                 display_name: "Claude Haiku 4.5".to_string(),
                 description: "200K context".to_string(),
                 is_current: false,
+                provider_id: "anthropic".to_string(),
             },
         ]
     }
@@ -1137,7 +1377,7 @@ mod tests {
     #[test]
     fn select_next_wraps() {
         let mut p = make_picker_with_current("claude-opus-4-6");
-        let total = p.filtered_models().len();
+        let total = p.filtered_models_grouped().len();
         p.selected_idx = total - 1;
         p.select_next();
         assert_eq!(p.selected_idx, 0);
@@ -1149,7 +1389,7 @@ mod tests {
         let mut p = make_picker_with_current("claude-opus-4-6");
         p.selected_idx = 0;
         p.select_prev();
-        let total = p.filtered_models().len();
+        let total = p.filtered_models_grouped().len();
         assert_eq!(p.selected_idx, total - 1);
     }
 
@@ -1182,10 +1422,10 @@ mod tests {
     #[test]
     fn confirm_returns_id_and_closes() {
         let mut p = make_picker_with_current("claude-opus-4-6");
-        p.selected_idx = 0;
-        let first_id = p.filtered_models()[0].id.clone();
+        p.selected_idx = 1; // skip Default sentinel at index 0
+        let first_model_id = p.filtered_models()[0].id.clone();
         let result = p.confirm();
-        assert_eq!(result.map(|(id, _)| id), Some(first_id));
+        assert_eq!(result.map(|(id, _)| id), Some(first_model_id));
         assert!(!p.visible, "picker should be closed after confirm");
     }
 
@@ -1478,6 +1718,7 @@ mod tests {
                 display_name: "LIVE OVERWRITE".to_string(),
                 description: "live desc".to_string(),
                 is_current: false,
+                provider_id: "anthropic".to_string(),
             },
             // A brand-new live id absent from the catalog — must be appended.
             ModelEntry {
@@ -1485,6 +1726,7 @@ mod tests {
                 display_name: "GPT-5.5 (live)".to_string(),
                 description: "live only".to_string(),
                 is_current: false,
+                provider_id: "anthropic".to_string(),
             },
         ];
         p.merge_models(live);
@@ -1530,12 +1772,14 @@ mod tests {
             "default",
             "Default model",
             "no catalog entry for this provider",
+            "anthropic",
         )]);
         p.merge_models(vec![ModelEntry {
             id: "llama3.3".to_string(),
             display_name: "Llama 3.3".to_string(),
             description: "local".to_string(),
             is_current: false,
+            provider_id: "anthropic".to_string(),
         }]);
         assert!(
             !p.models.iter().any(|m| m.id == "default"),
@@ -1581,5 +1825,135 @@ mod tests {
         }
         assert!(!provider_has_authoritative_live_models("github-copilot"));
         assert!(!provider_has_authoritative_live_models("openrouter"));
+    }
+
+    #[test]
+    fn valid_favorites_filters_stale_entries() {
+        let mut state = ModelPickerState::new();
+        state.models = vec![
+            ModelEntry { id: "model-a".to_string(), display_name: "A".to_string(), description: "".to_string(), is_current: false, provider_id: String::new() },
+            ModelEntry { id: "model-b".to_string(), display_name: "B".to_string(), description: "".to_string(), is_current: false, provider_id: String::new() },
+        ];
+        state.favorites = vec![
+            "provider/model-a".to_string(),  // valid
+            "provider/model-c".to_string(),  // stale (not in models list)
+            "model-b".to_string(),           // valid (no provider prefix)
+        ];
+        let valid = state.valid_favorites();
+        assert_eq!(valid.len(), 2);
+        assert!(valid.contains(&"provider/model-a".to_string()));
+        assert!(valid.contains(&"model-b".to_string()));
+    }
+
+    #[test]
+    fn filtered_models_grouped_puts_favorites_first() {
+        let mut state = ModelPickerState::new();
+        state.models = vec![
+            ModelEntry { id: "regular".to_string(), display_name: "Regular".to_string(), description: "".to_string(), is_current: false, provider_id: String::new() },
+            ModelEntry { id: "pinned".to_string(), display_name: "Pinned".to_string(), description: "".to_string(), is_current: false, provider_id: String::new() },
+            ModelEntry { id: "other".to_string(), display_name: "Other".to_string(), description: "".to_string(), is_current: false, provider_id: String::new() },
+        ];
+        state.favorites = vec!["provider/pinned".to_string()];
+        let grouped = state.filtered_models_grouped();
+        assert_eq!(grouped.len(), 4);
+        // Default sentinel at top.
+        assert_eq!(grouped[0].0.id, DEFAULT_MODEL_SENTINEL);
+        // Favorite must come next.
+        assert_eq!(grouped[1].0.id, "pinned");
+        assert!(grouped[1].1);
+        // Rest are non-favorites, preserve source order.
+        assert_eq!(grouped[2].0.id, "regular");
+        assert!(!grouped[2].1);
+        assert_eq!(grouped[3].0.id, "other");
+        assert!(!grouped[3].1);
+    }
+
+    #[test]
+    fn filtered_models_grouped_respects_filter() {
+        let mut state = ModelPickerState::new();
+        state.models = vec![
+            ModelEntry { id: "pinned-a".to_string(), display_name: "Pinned A".to_string(), description: "".to_string(), is_current: false, provider_id: String::new() },
+            ModelEntry { id: "pinned-b".to_string(), display_name: "Other B".to_string(), description: "".to_string(), is_current: false, provider_id: String::new() },
+        ];
+        state.favorites = vec![
+            "provider/pinned-a".to_string(),
+            "provider/pinned-b".to_string(),
+        ];
+        for c in "pinned a".chars() {
+            state.push_filter_char(c);
+        }
+        let grouped = state.filtered_models_grouped();
+        // Only the favorite matching the filter appears, on top.
+        assert_eq!(grouped.len(), 1);
+        assert_eq!(grouped[0].0.id, "pinned-a");
+        assert!(grouped[0].1);
+    }
+
+    #[test]
+    fn is_favorite_roundtrips_without_persist() {
+        let mut state = ModelPickerState::new();
+        state.favorites = vec!["anthropic/claude-sonnet-4-6".to_string()];
+        assert!(state.is_favorite("anthropic/claude-sonnet-4-6"));
+        assert!(!state.is_favorite("openai/gpt-4o"));
+    }
+
+    #[test]
+    fn default_entry_appears_at_top() {
+        let mut picker = ModelPickerState::new();
+        picker.set_models(vec![
+            ModelEntry {
+                id: "model-a".to_string(),
+                display_name: "Model A".to_string(),
+                description: "desc".to_string(),
+                is_current: false,
+                provider_id: String::new(),
+            },
+            ModelEntry {
+                id: "model-b".to_string(),
+                display_name: "Model B".to_string(),
+                description: "desc".to_string(),
+                is_current: false,
+                provider_id: String::new(),
+            },
+        ]);
+        picker.open("model-a");
+        let grouped = picker.filtered_models_grouped();
+        assert_eq!(grouped.len(), 3);
+        assert_eq!(grouped[0].0.id, DEFAULT_MODEL_SENTINEL);
+        assert_eq!(grouped[1].0.id, "model-a");
+    }
+
+    #[test]
+    fn default_entry_is_current_when_no_model() {
+        let mut picker = ModelPickerState::new();
+        picker.set_models(vec![
+            ModelEntry {
+                id: "model-a".to_string(),
+                display_name: "Model A".to_string(),
+                description: "desc".to_string(),
+                is_current: false,
+                provider_id: String::new(),
+            },
+        ]);
+        picker.open_with_title("Test", "", EffortLevel::Medium, false);
+        assert!(picker.default_entry.is_current);
+    }
+
+    #[test]
+    fn confirm_returns_default_sentinel() {
+        let mut picker = ModelPickerState::new();
+        picker.set_models(vec![
+            ModelEntry {
+                id: "model-a".to_string(),
+                display_name: "Model A".to_string(),
+                description: "desc".to_string(),
+                is_current: false,
+                provider_id: String::new(),
+            },
+        ]);
+        picker.open("model-a");
+        picker.selected_idx = 0; // Default entry
+        let result = picker.confirm();
+        assert_eq!(result.unwrap().0, DEFAULT_MODEL_SENTINEL);
     }
 }

--- a/src-rust/crates/tui/src/render.rs
+++ b/src-rust/crates/tui/src/render.rs
@@ -5,7 +5,7 @@ use std::cell::RefCell;
 use crate::agents_view::render_agents_menu;
 use crate::context_viz::render_context_viz;
 use crate::export_dialog::render_export_dialog;
-use crate::app::{App, ContextMenuKind, SystemAnnotation, SystemMessageStyle, ToolStatus};
+use crate::app::{App, ContextMenuKind, DisplayMessage, SystemAnnotation, SystemMessageStyle, ToolStatus};
 use crate::rustle::rustle_lines;
 use crate::diff_viewer::render_diff_dialog;
 use crate::model_picker::render_model_picker;
@@ -862,6 +862,15 @@ pub fn render_app(frame: &mut Frame, app: &App) {
         render_mcp_approval_dialog(&app.mcp_approval, size, frame.buffer_mut());
     }
 
+    // When error modal is showing, selectable area = full terminal
+    if app.notifications.current_is_error() {
+        app.last_selectable_area.set(size);
+    }
+
+    // ---- Text selection highlight (applied before modal overlay) ----------
+    apply_selection_highlight(frame, app);
+    cache_selectable_row_text(frame, app);
+
     // Always show error modals on top of everything (highest priority)
     if let Some(notif) = app.notifications.current() {
         if notif.kind == NotificationKind::Error {
@@ -870,6 +879,7 @@ pub fn render_app(frame: &mut Frame, app: &App) {
                 && app.streaming_thinking.is_empty()
                 && app.tool_use_blocks.is_empty();
             render_error_modal(frame, size, notif, app.error_modal_scroll_offset, app.footer_right_column_area.get(), is_welcome_screen);
+            render_context_menu(frame, app);
             return; // Don't render other overlays/notifications when error modal is showing
         }
     }
@@ -881,9 +891,6 @@ pub fn render_app(frame: &mut Frame, app: &App) {
         render_notification_banner(frame, &app.notifications, size);
     }
 
-    // ---- Text selection highlight (topmost post-pass) ---------------------
-    apply_selection_highlight(frame, app);
-    cache_selectable_row_text(frame, app);
     render_context_menu(frame, app);
 }
 
@@ -1126,7 +1133,8 @@ fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
     let transcript_empty = app.messages.is_empty()
         && app.streaming_text.is_empty()
         && app.streaming_thinking.is_empty()
-        && app.tool_use_blocks.is_empty();
+        && app.tool_use_blocks.is_empty()
+        && app.display_messages.is_empty();
 
     if transcript_empty {
         app.last_msg_area.set(Rect::default());
@@ -1528,7 +1536,62 @@ fn build_all_items(app: &App, width: u16) -> Vec<RenderedLineItem> {
         }
     }
 
+    // Append display-only bang command output (never sent to the model).
+    let bang_lines = render_bang_display_lines(app);
+    if !bang_lines.is_empty() {
+        push_rendered_items(&mut items, bang_lines, None, false);
+    }
+
     items
+}
+
+/// Render display-only `!` bang command entries (command, output, error).
+/// These are appended at the end of the transcript and never sent to the model.
+fn render_bang_display_lines(app: &App) -> Vec<Line<'static>> {
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let mut found = false;
+    for msg in &app.display_messages {
+        match msg {
+            DisplayMessage::BangCommand { command } => {
+                found = true;
+                if !lines.is_empty() {
+                    lines.push(Line::from(""));
+                }
+                lines.push(Line::styled(
+                    format!("$ {}", command),
+                    Style::default()
+                        .fg(Color::DarkGray)
+                        .add_modifier(Modifier::BOLD),
+                ));
+            }
+            DisplayMessage::BangOutput { text, exit_code } => {
+                found = true;
+                let color = if exit_code.unwrap_or(0) != 0 {
+                    Color::Red
+                } else {
+                    Color::Gray
+                };
+                for line in text.lines() {
+                    lines.push(Line::styled(
+                        line.to_string(),
+                        Style::default().fg(color),
+                    ));
+                }
+            }
+            DisplayMessage::BangError { text } => {
+                found = true;
+                lines.push(Line::styled(
+                    text.clone(),
+                    Style::default().fg(Color::Red),
+                ));
+            }
+            _ => {}
+        }
+    }
+    if found {
+        lines.push(Line::from(""));
+    }
+    lines
 }
 
 fn render_message_items(app: &App, width: u16) -> Vec<RenderedLineItem> {
@@ -1917,6 +1980,7 @@ fn render_system_annotation_lines(
         SystemMessageStyle::Info => (Color::DarkGray, Color::DarkGray),
         SystemMessageStyle::Warning => (Color::Yellow, Color::Yellow),
         SystemMessageStyle::Compact => unreachable!(),
+        SystemMessageStyle::TodoCard => (Color::Cyan, Color::Cyan),
     };
 
     // Centred, padded rule: "â”€â”€â”€ text â”€â”€â”€"
@@ -2674,6 +2738,39 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
             parts.push(Span::styled(
                 format!("Tokens: {}/{} ({}%)", used, max, pct),
                 Style::default().fg(color),
+            ));
+        }
+
+        // Tokens per second average (from last 5 turns).
+        if !app.recent_token_rates.is_empty() {
+            if !parts.is_empty() {
+                parts.push(Span::raw("  "));
+            }
+            let avg_tps = app.recent_token_rates.iter().sum::<f64>()
+                / app.recent_token_rates.len() as f64;
+            parts.push(Span::styled(
+                format!("{:.0} tok/s", avg_tps),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+
+        // Todo progress (done/total).
+        let todos = claurst_tools::todo_write::load_todos(&app.session_id);
+        if !todos.is_empty() {
+            if !parts.is_empty() {
+                parts.push(Span::raw("  "));
+            }
+            let total = todos.len();
+            let completed = todos.iter()
+                .filter(|t| t.get("status").and_then(|s| s.as_str()) == Some("completed"))
+                .count();
+            parts.push(Span::styled(
+                format!("\u{2713}{}/{}", completed, total),
+                Style::default().fg(if completed == total {
+                    Color::Green
+                } else {
+                    Color::Yellow
+                }),
             ));
         }
 


### PR DESCRIPTION
## Summary

`provider_group_name` returns String, loads Settings for custom names. Heart/star/shortcuts in picker.

### Files Changed
- `src-rust/crates/tui/src/model_picker.rs` — `provider_group_name()` with Settings fallback
- `src-rust/crates/core/src/settings.rs` — custom provider name support

Part of 22-branch feature/fix set.