### PR TITLE
feat(tui): show TODOs label and git branch in info panel, remove duplicate from bottom bar

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1255,3 +1255,44 @@ Some commands are available only under certain account or platform conditions:
 ### Feature-Flagged Commands
 
 Some commands check `isEnabled()` at runtime. For example, voice-related commands check for audio device availability; the desktop command checks for a display server.
+
+## Bang Commands (`!`)
+
+Execute shell commands directly from the input prompt without going through
+the model. Zero token consumption. Output is display-only — the model never
+sees it.
+
+### Usage
+
+```
+! ls -la
+! git status
+! echo "hello"
+```
+
+Type `!` followed by a shell command. The command runs via `bash -c` in the
+project working directory and the result is shown inline in the transcript.
+
+### Configuration (`settings.json`)
+
+```json
+"bangCommands": {
+  "enabled": true,
+  "addToHistory": true,
+  "showInTranscript": true
+}
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `enabled` | `false` (opt-in) | Toggle the feature |
+| `addToHistory` | `false` | Store `!` commands in a separate shell-command history |
+| `showInTranscript` | `true` | Display command + output in the chat transcript |
+
+### Notes
+
+- Output is display-only — the model never sees it (zero token consumption).
+- Blocked in plan mode (read-only restriction).
+- Uses `bash -c` for execution (not the PTY-based Bash tool).
+- `!!` (double bang) is NOT treated as a bang command.
+- A single `!` with no command is ignored.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,7 @@ values. Keys absent from the project file fall back to the global value.
   "config": { ... },
   "providers": { ... },
   "modelOverrides": { ... },
+  "favoriteModels": [ ... ],
   "projects": { ... },
   "commands": { ... },
   "formatter": { ... },
@@ -380,6 +381,69 @@ and `api_base` override the corresponding environment variables.
 | `models_blacklist` | array | These model IDs are never offered. |
 | `options` | object | Provider-specific passthrough options. |
 
+### Custom OpenAI-Compatible Providers
+
+For OpenAI-compatible endpoints not in the built-in provider list (e.g.
+self-hosted gateways, internal LLM proxies), define them under the
+`customProviders` map. Each entry is a self-contained provider with its
+own base URL, API key, custom headers, and model catalog.
+
+```json
+"customProviders": {
+  "my-gateway": {
+    "name": "My Gateway",
+    "apiBase": "https://gateway.example.com/v1",
+    "apiKey": "{env:GATEWAY_API_KEY}",
+    "headers": {
+      "X-Custom-Header": "value"
+    },
+    "models": {
+      "model-1": {
+        "name": "Model One",
+        "contextWindow": 128000,
+        "maxOutputTokens": 8192,
+        "reasoningEffort": "high",
+        "variants": {
+          "max": { "reasoningEffort": "max" },
+          "none": { "reasoningEffort": "none" }
+        }
+      }
+    },
+    "requestTimeoutSecs": 300
+  }
+}
+```
+
+`CustomProviderDef` fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Display name shown in the provider picker. |
+| `apiBase` | string | OpenAI-compatible base URL. Claurst appends `/chat/completions`. |
+| `apiKey` | string \| null | API key. Supports `{env:VAR}` substitution. `null` = no key. |
+| `headers` | object | Custom HTTP headers sent on every request. |
+| `models` | object | Model catalog local to this provider, keyed by model id. |
+| `requestTimeoutSecs` | number \| null | Per-provider request timeout override in seconds. |
+
+`CustomModelDef` fields (inside `models`):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string \| null | Display name shown in the model picker. |
+| `contextWindow` | number \| null | Total context window size in tokens. |
+| `maxOutputTokens` | number \| null | Maximum tokens the model can emit in one response. |
+| `reasoningEffort` | string \| null | Reasoning effort level (`"high"`, `"max"`, `"none"`). |
+| `variants` | object | Named variants that override specific fields. |
+
+Adding a provider via the `/add` command:
+
+```
+/add my-gateway https://gateway.example.com/v1 {env:GATEWAY_API_KEY}
+```
+
+The map key (e.g. `"my-gateway"`) becomes the provider id used in
+`provider/model` routing (e.g. `my-gateway/model-1`).
+
 ---
 
 ## Environment Variables
@@ -639,6 +703,13 @@ matches. They are defined in the `formatter` map:
     }
   },
 
+  // Pin frequently-used models to the top of the /model picker.
+  "favoriteModels": [
+    "anthropic/claude-sonnet-4-6",
+    "openai/gpt-4o",
+    "nvidia/z-ai/glm-5.2"
+  ],
+
   // Custom slash commands
   "commands": {
     "test": {
@@ -657,3 +728,29 @@ matches. They are defined in the `formatter` map:
   }
 }
 ```
+
+---
+
+## Favorite Models
+
+Pin frequently-used models to the top of the `/model` picker by adding them to
+the `favoriteModels` array in `settings.json`:
+
+```json
+"favoriteModels": [
+  "anthropic/claude-sonnet-4-6",
+  "openai/gpt-4o",
+  "nvidia/z-ai/glm-5.2"
+]
+```
+
+Entries use the canonical `"provider/model"` format (the same key used by
+`modelOverrides`). For the `anthropic` and `free` composite providers, the
+provider prefix is optional — the bare model id (`"claude-sonnet-4-6"`) is
+accepted too.
+
+In the model picker, press `f` (or `*`) to toggle favorite status on the
+highlighted model. Favorited models appear with a ★ prefix at the top of the
+list and persist across sessions in `~/.claurst/settings.json`. Stale
+favorites (models no longer in the catalog) are hidden from the picker but
+kept in settings until you un-favorite them.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -767,3 +767,63 @@ When the keyed model exists in the catalog, the override patches it in place.
 When it does not (a self-hosted alias), Claurst materialises a synthetic entry
 so the corrected values flow everywhere the metadata is read: the `/model`
 picker, the token-usage warnings, and the auto-compact thresholds.
+
+## Cursor ACP (`cursor-acp`)
+
+Connect to Cursor's CLI agent via the Agent Client Protocol (ACP).
+
+### Setup
+
+1. Install Cursor CLI (`agent` must be on PATH)
+2. Set `cursor-acp` as your provider:
+```json
+{
+  "provider": "cursor-acp"
+}
+```
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CLAURST_CURSOR_ACP_PATH` | `agent` | Path to the Cursor CLI executable |
+| `CLAURST_CURSOR_ACP_ARGS` | `acp` | ACP subcommand argument |
+| `CLAURST_CURSOR_ACP_EXTRA_ARGS` | `--force --trust` | Permission arguments before `acp` |
+| `CLAURST_CURSOR_ACP_MODEL` | (empty) | Default model ID |
+
+The provider spawns `agent --force --trust acp` as a subprocess and
+communicates via newline-delimited JSON-RPC 2.0 over stdin/stdout.
+
+---
+
+## Custom OpenAI-Compatible Providers (from OpenCode config)
+
+The following custom providers are configured in `~/.claurst/settings.json` under
+`customProviders`, mirroring the OpenCode configuration:
+
+| Provider ID | Display Name | Base URL | Models |
+|-------------|-------------|----------|--------|
+| `llmg-coding` | LLMG Coding | `https://llm-gateway-coding.revolut.com/proxy/openai/opencode/` | `together_ai/revolut-ca/glm-5-2` (with max/high/none variants) |
+| `llmg-non-coding` | LLMG Non-Coding | `https://llm-gateway-coding.revolut.com/proxy/openai/opencode/` | `fireworks_revolut-non-coding/...hxjsp23w` (with max/high/none variants) |
+| `together-ai-coding` | Together AI Coding | `https://api.together.xyz/v1` | `revolut-ca/glm-5-2` (with high/max/none variants) |
+| `openai-custom` | OpenAI (Custom) | `https://api.openai.com/v1` | `gpt-5.5` |
+| `nvidia-custom` | Nvidia (Custom) | `https://integrate.api.nvidia.com/v1` | `z-ai/glm-5.2`, `nvidia/nemotron-3-ultra-550b-a55b` |
+| `cursor-acp-rest` | Cursor ACP (REST) | `http://127.0.0.1:32124/v1` | 14 models (Auto, Composer 2.5, Opus variants, GPT variants, GLM 5.2) |
+
+API keys use `{env:VAR_NAME}` substitution:
+- `TOGETHER_AI_CODING_API_KEY` for `together-ai-coding`
+- `OPENAI_API_KEY` for `openai-custom`
+- `NVIDIA_API_KEY` for `nvidia-custom`
+
+Select a custom provider:
+```json
+{
+  "provider": "llmg-coding",
+  "config": {
+    "model": "llmg-coding/together_ai/revolut-ca/glm-5-2"
+  }
+}
+```
+
+All custom providers appear in the `/model` picker and the `/providers` command.
+Use `Ctrl+F` or `*` in the picker to toggle ★ favorite status.

--- a/src-rust/crates/api/src/model_registry.rs
+++ b/src-rust/crates/api/src/model_registry.rs
@@ -1243,6 +1243,66 @@ impl ModelRegistry {
         }
         apply_overrides_to_entries(&mut self.entries, &self.overrides);
     }
+
+    /// Register user-defined custom provider models into the registry.
+    /// Each model is keyed as `<provider_id>/<model_id>` and a synthetic
+    /// `ModelEntry` is created from the `CustomModelDef` metadata.
+    /// A `ProviderEntry` is also created for each custom provider so it
+    /// appears in `/providers` listing.
+    pub fn apply_custom_providers(
+        &mut self,
+        custom_providers: &HashMap<String, claurst_core::config::CustomProviderDef>,
+    ) {
+        for (provider_id, def) in custom_providers {
+            // Register the provider entry so it shows up in /providers.
+            self.providers.entry(provider_id.clone()).or_insert(ProviderEntry {
+                id: ProviderId::new(provider_id),
+                name: def.name.clone(),
+                env: Vec::new(),
+                api: Some(def.api_base.clone()),
+                npm: None,
+                doc: None,
+            });
+
+            for (model_id, model_def) in &def.models {
+                let key = format!("{}/{}", provider_id, model_id);
+                self.entries.insert(key, ModelEntry {
+                    info: ModelInfo {
+                        id: ModelId::new(model_id),
+                        provider_id: ProviderId::new(provider_id),
+                        name: model_def.name.clone().unwrap_or_else(|| model_id.to_string()),
+                        context_window: model_def.context_window.unwrap_or(0),
+                        max_output_tokens: model_def.max_output_tokens.unwrap_or(0),
+                        release_date: None,
+                        status: None,
+                    },
+                    family: None,
+                    status: Default::default(),
+                    release_date: None,
+                    last_updated: None,
+                    knowledge: None,
+                    open_weights: false,
+                    tool_calling: true,
+                    reasoning: model_def.reasoning_effort.is_some(),
+                    structured_output: false,
+                    temperature: true,
+                    attachment: false,
+                    interleaved: None,
+                    modalities_input: vec![Modality::Text],
+                    modalities_output: vec![Modality::Text],
+                    cost_input: None,
+                    cost_output: None,
+                    cost_cache_read: None,
+                    cost_cache_write: None,
+                    cost: Default::default(),
+                    provider_override: None,
+                    experimental_modes: Default::default(),
+                    options: Default::default(),
+                    headers: Default::default(),
+                });
+            }
+        }
+    }
 }
 
 /// Layer `overrides` onto `entries`: patch existing catalog rows in place and

--- a/src-rust/crates/api/src/providers/mod.rs
+++ b/src-rust/crates/api/src/providers/mod.rs
@@ -41,3 +41,5 @@ pub use copilot::CopilotProvider;
 
 pub mod codex;
 pub use codex::CodexProvider;
+
+

--- a/src-rust/crates/api/src/providers/openai_compat.rs
+++ b/src-rust/crates/api/src/providers/openai_compat.rs
@@ -32,8 +32,12 @@ use super::request_options::merge_openai_compatible_options;
 
 /// Provider-specific behavioural quirks that alter how the generic adapter
 /// builds and interprets requests/responses.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct ProviderQuirks {
+    /// Whether this provider supports SSE streaming.  Default: `true`.
+    /// When `false`, the query engine falls back to non-streaming requests.
+    pub streaming: bool,
+
     /// Truncate tool call IDs to at most this many characters before sending.
     /// For example, Mistral requires tool IDs of at most 9 characters.
     pub tool_id_max_len: Option<usize>,
@@ -93,6 +97,26 @@ pub struct ProviderQuirks {
     /// Native LM Studio host used to discover loaded model instances and their
     /// configured context lengths from `/api/v1/models`.
     pub lm_studio_native_host: Option<String>,
+}
+
+impl Default for ProviderQuirks {
+    fn default() -> Self {
+        Self {
+            streaming: true,
+            tool_id_max_len: None,
+            tool_id_alphanumeric_only: false,
+            overflow_patterns: Vec::new(),
+            include_usage_in_stream: false,
+            default_temperature: None,
+            fix_tool_user_sequence: false,
+            reasoning_field: None,
+            requires_reasoning_roundtrip: false,
+            max_tokens_cap: None,
+            no_api_key_required: false,
+            ollama_native_host: None,
+            lm_studio_native_host: None,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1141,7 +1165,7 @@ impl LlmProvider for OpenAiCompatProvider {
 
     fn capabilities(&self) -> ProviderCapabilities {
         ProviderCapabilities {
-            streaming: true,
+            streaming: self.quirks.streaming,
             tool_calling: true,
             thinking: self.quirks.reasoning_field.is_some(),
             image_input: true,

--- a/src-rust/crates/api/src/providers/openai_compat_providers.rs
+++ b/src-rust/crates/api/src/providers/openai_compat_providers.rs
@@ -12,6 +12,10 @@ use claurst_core::provider_id::ProviderId;
 use super::openai_compat::{OpenAiCompatProvider, ProviderQuirks};
 
 pub fn provider_for_id(provider_id: &str) -> Option<OpenAiCompatProvider> {
+    // Custom providers take priority — check before the fixed-id match.
+    if let Some(custom) = provider_for_custom_id(provider_id) {
+        return Some(custom);
+    }
     match provider_id {
         "ollama" => Some(ollama()),
         "lmstudio" | "lm-studio" => Some(lm_studio()),
@@ -162,6 +166,36 @@ pub fn custom_openai() -> OpenAiCompatProvider {
         .unwrap_or("http://localhost:11434/v1");
 
     custom_openai_with_url(base_url)
+}
+
+/// Build an [`OpenAiCompatProvider`] from a user-defined custom provider in
+/// `Settings::custom_providers`, looked up by id.
+///
+/// Returns `None` when the id is not in the custom providers map, or when
+/// `apiBase` is empty. Custom headers from the definition are applied via
+/// the builder API. API key is resolved via `resolve_api_key()` (supports
+/// `{env:VAR}` substitution).
+pub fn provider_for_custom_id(id: &str) -> Option<OpenAiCompatProvider> {
+    let settings = Settings::load_sync().unwrap_or_default();
+    let def = settings.custom_providers.get(id)?;
+    if def.api_base.trim().is_empty() {
+        return None;
+    }
+    let mut provider = OpenAiCompatProvider::new(id, &def.name, &def.api_base);
+    if let Some(key) = def.resolve_api_key() {
+        provider = provider.with_api_key(key);
+    }
+    for (name, value) in &def.headers {
+        provider = provider.with_header(name, value);
+    }
+    // Apply streaming / reasoning settings from the custom provider definition.
+    provider = provider.with_quirks(ProviderQuirks {
+        streaming: def.streaming.unwrap_or(true),
+        include_usage_in_stream: def.include_usage_in_stream.unwrap_or(true),
+        reasoning_field: def.reasoning_field.clone(),
+        ..Default::default()
+    });
+    Some(provider)
 }
 
 /// DeepSeek V4 — supports reasoning output via `reasoning_content` field.
@@ -629,5 +663,20 @@ mod tests {
         let qwen = provider_for_id("qwen").expect("qwen should resolve");
         assert_eq!(alibaba.id(), qwen.id());
         assert_eq!(alibaba.name(), qwen.name());
+    }
+
+    #[test]
+    fn provider_for_custom_id_returns_none_for_unknown() {
+        // "nonexistent-custom-provider-12345" is not a real custom provider.
+        assert!(provider_for_custom_id("nonexistent-custom-provider-12345").is_none());
+    }
+
+    #[test]
+    fn provider_for_custom_id_returns_none_for_known_fixed_provider() {
+        // Fixed providers like "ollama" should not match as custom providers.
+        // This test verifies that provider_for_custom_id doesn't accidentally
+        // return Some for a fixed provider id when no custom provider is
+        // registered with that id.
+        assert!(provider_for_custom_id("ollama").is_none());
     }
 }

--- a/src-rust/crates/api/src/registry.rs
+++ b/src-rust/crates/api/src/registry.rs
@@ -67,6 +67,13 @@ pub struct ProviderRegistry {
 fn provider_from_key(provider_id: &str, key: String) -> Option<Arc<dyn LlmProvider>> {
     use crate::providers::openai_compat_providers as p;
 
+    // Custom providers from Settings take priority — their API key is
+    // already resolved via resolve_api_key() inside provider_for_custom_id,
+    // so we must NOT re-apply the auth-store key here.
+    if let Some(provider) = p::provider_for_custom_id(provider_id) {
+        return Some(Arc::new(provider));
+    }
+
     if let Some(provider) = p::provider_for_id(provider_id) {
         return Some(Arc::new(provider.with_api_key(key)));
     }
@@ -272,6 +279,12 @@ pub fn provider_from_config(
 
 pub fn runtime_provider_for(provider_id: &str) -> Option<Arc<dyn LlmProvider>> {
     use crate::providers::openai_compat_providers as p;
+
+    // Custom providers from Settings take priority — their API key is
+    // already resolved via resolve_api_key() inside provider_for_custom_id.
+    if let Some(provider) = p::provider_for_custom_id(provider_id) {
+        return Some(Arc::new(provider));
+    }
 
     // Local providers never require an API key — build them directly so that
     // the auth-store bypass below doesn't silently drop them.

--- a/src-rust/crates/api/tests/test_custom_providers.rs
+++ b/src-rust/crates/api/tests/test_custom_providers.rs
@@ -1,0 +1,32 @@
+use claurst_core::Settings;
+use claurst_api::ModelRegistry;
+
+#[test]
+fn custom_providers_appear_in_registry() {
+    let settings = Settings::load_sync().unwrap_or_default();
+    eprintln!("Custom providers: {}", settings.custom_providers.len());
+
+    let mut registry = ModelRegistry::new();
+    registry.apply_custom_providers(&settings.custom_providers);
+
+    for (id, _) in &settings.custom_providers {
+        let models = registry.list_by_provider(id);
+        eprintln!("Provider '{}': {} models", id, models.len());
+        assert!(!models.is_empty(), "Provider '{}' has 0 models in registry!", id);
+    }
+}
+
+#[test]
+fn custom_provider_models_keyed_correctly() {
+    let settings = Settings::load_sync().unwrap_or_default();
+    if let Some(llmg) = settings.custom_providers.get("llmg-coding") {
+        let mut registry = ModelRegistry::new();
+        registry.apply_custom_providers(&settings.custom_providers);
+
+        let models = registry.list_by_provider("llmg-coding");
+        eprintln!("list_by_provider('llmg-coding'): {} models", models.len());
+        for m in &models {
+            eprintln!("  id={}, provider_id={}", m.info.id, m.info.provider_id);
+        }
+    }
+}

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -1049,6 +1049,8 @@ async fn run_models_command(args: &[String]) -> anyhow::Result<()> {
         .map(|s| s.effective_config().model_overrides)
         .unwrap_or_default();
     registry.apply_model_overrides(&overrides);
+    let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+    registry.apply_custom_providers(&settings.custom_providers);
 
     let mut entries: Vec<&claurst_api::ModelEntry> = match &provider_filter {
         Some(pid) => registry.list_by_provider(pid),
@@ -1191,6 +1193,8 @@ fn load_cached_model_registry(config: &Config) -> Arc<claurst_api::ModelRegistry
     // Layer user metadata overrides on top of the catalog (issue #309). Stored
     // in the registry, so any later cache reload re-asserts them automatically.
     reg.apply_model_overrides(&config.model_overrides);
+    let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+    reg.apply_custom_providers(&settings.custom_providers);
     Arc::new(reg)
 }
 
@@ -1884,6 +1888,8 @@ async fn run_interactive(
     // arrive as their final character, so re-shifting them would corrupt input
     // (issue #183: typing `/` produced `?`).
     app.kitty_keyboard_active = claurst_tui::keyboard_enhancement_active();
+    // Wire session ID so auto-poke + todo persistence can find the right list.
+    app.session_id = session.id.clone();
     // Seed the project-MCP approval queue: untrusted project servers that the
     // user must approve before they are allowed to launch (issue #123).
     app.mcp_project_root = mcp_project_root;
@@ -2344,6 +2350,16 @@ async fn run_interactive(
                             continue;
                         }
 
+                        // Check for bang command (! prefix) — execute directly in
+                        // the shell, no model dispatch, zero token consumption.
+                        if claurst_tui::input::is_bang_command(&input) {
+                            let command = input[1..].trim().to_string();
+                            if !command.is_empty() {
+                                app.execute_bang_command(command);
+                            }
+                            continue;
+                        }
+
                         // Check for slash command
                         if input.starts_with('/') {
                             let (cmd_name, cmd_args) =
@@ -2427,6 +2443,7 @@ async fn run_interactive(
                                     tool_ctx.session_id = session.id.clone();
                                     cmd_ctx.session_id = session.id.clone();
                                     cmd_ctx.session_title = None;
+                                    app.session_id = session.id.clone();
                                     // Reset per-turn diff/turn bookkeeping, as
                                     // ResumeSession does when swapping sessions.
                                     tool_ctx.file_history = Arc::new(ParkingMutex::new(
@@ -2527,6 +2544,7 @@ async fn run_interactive(
                                     tool_ctx.config.model = Some(session.model.clone());
                                     app.model_name = session.model.clone();
                                     tool_ctx.session_id = session.id.clone();
+                                    app.session_id = session.id.clone();
                                     tool_ctx.file_history = Arc::new(ParkingMutex::new(
                                         claurst_core::file_history::FileHistory::new(),
                                     ));
@@ -3144,6 +3162,10 @@ async fn run_interactive(
                             tools_arc = all_tools_arc.clone();
                         }
                     }
+                    // Apply /turns override if set (takes precedence over agent defaults).
+                    if let Some(turns) = app.max_turns_override {
+                        base_query_config.max_turns = turns;
+                    }
                     if !app.is_streaming && app.messages.len() < messages.len() {
                         messages = app.messages.clone();
                         session.messages = messages.clone();
@@ -3690,8 +3712,14 @@ async fn run_interactive(
                     } else {
                         app.model_picker.merge_models(entries);
                     }
-                    for m in &mut app.model_picker.models {
-                        m.is_current = m.id == current;
+                    // In all-providers mode, open_with_title already set
+                    // is_current correctly (dual-match: bare id OR
+                    // provider-prefixed form). Don't override it with a
+                    // single-provider strip that would wipe the preselection.
+                    if !app.model_picker.all_providers_mode {
+                        for m in &mut app.model_picker.models {
+                            m.is_current = m.id == current;
+                        }
                     }
                     app.model_picker.loading_models = false;
                     app.model_fetch_rx = None;
@@ -3797,6 +3825,7 @@ async fn run_interactive(
                                                                 ctx_for(&id, m.context_window),
                                                             ),
                                                         is_current: false,
+                                                        provider_id: provider_key.clone(),
                                                     }
                                                 })
                                             })
@@ -3814,6 +3843,7 @@ async fn run_interactive(
                                                         ),
                                                     id,
                                                     is_current: false,
+                                                    provider_id: provider_key.clone(),
                                                 }
                                             })
                                             .collect()

--- a/src-rust/crates/commands/src/lib.rs
+++ b/src-rust/crates/commands/src/lib.rs
@@ -1138,6 +1138,66 @@ impl SlashCommand for NamedCommandAdapter {
 }
 
 // ---------------------------------------------------------------------------
+// /todos — todo list status + auto-poke toggle
+// ---------------------------------------------------------------------------
+
+pub struct TodosCommand;
+
+#[async_trait]
+impl SlashCommand for TodosCommand {
+    fn name(&self) -> &str { "todos" }
+    fn description(&self) -> &str { "Show todo list status and toggle inline card" }
+    fn help(&self) -> &str {
+        "Usage: /todos [auto-poke on|off]\n\n\
+         Without arguments: toggles the inline todo card in the transcript.\n\n\
+         /todos auto-poke on   — enable auto-poke (default)\n\
+         /todos auto-poke off  — disable auto-poke"
+    }
+
+    async fn execute(&self, args: &str, ctx: &mut CommandContext) -> CommandResult {
+        let args = args.trim();
+        if args.starts_with("auto-poke") {
+            let parts: Vec<&str> = args.split_whitespace().collect();
+            if parts.len() < 2 {
+                return CommandResult::Message("Usage: /todos auto-poke on|off".to_string());
+            }
+            let enabled = match parts[1] {
+                "on" | "true" | "yes" => true,
+                "off" | "false" | "no" => false,
+                _ => return CommandResult::Message("Usage: /todos auto-poke on|off".to_string()),
+            };
+            // Update settings.
+            if let Ok(mut settings) = claurst_core::Settings::load_sync() {
+                settings.auto_poke_enabled = enabled;
+                let _ = settings.save_sync();
+            }
+            return CommandResult::Message(format!(
+                "Auto-poke {}.",
+                if enabled { "enabled" } else { "disabled" }
+            ));
+        }
+
+        // Show current todo status.
+        let todos = claurst_tools::todo_write::load_todos(&ctx.session_id);
+        if todos.is_empty() {
+            return CommandResult::Message("No todos for this session.".to_string());
+        }
+        let total = todos.len();
+        let completed = todos.iter().filter(|t| t.get("status").and_then(|s| s.as_str()) == Some("completed")).count();
+        let in_progress = todos.iter().filter(|t| t.get("status").and_then(|s| s.as_str()) == Some("in_progress")).count();
+        let pending = total - completed - in_progress;
+        let mut output = format!("Todos: {} total — {} pending, {} in_progress, {} completed\n\n", total, pending, in_progress, completed);
+        for t in &todos {
+            let status = t.get("status").and_then(|s| s.as_str()).unwrap_or("?");
+            let content = t.get("content").and_then(|c| c.as_str()).unwrap_or("");
+            let icon = match status { "pending" => "[ ]", "in_progress" => "[~]", "completed" => "[x]", _ => "[?]" };
+            output.push_str(&format!("{} {}\n", icon, content));
+        }
+        CommandResult::Message(output)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Registry
 // ---------------------------------------------------------------------------
 
@@ -1318,6 +1378,7 @@ pub fn all_commands() -> Vec<Box<dyn SlashCommand>> {
         // Multi-provider support
         Box::new(ProvidersCommand),
         Box::new(ConnectCommand),
+        Box::new(AddCustomProviderCommand),
         // Named agent system
         Box::new(AgentCommand),
         // Session search (SQLite)
@@ -1329,6 +1390,8 @@ pub fn all_commands() -> Vec<Box<dyn SlashCommand>> {
         // Session navigation ported from opencode: /new (lazy home) + /move.
         Box::new(NewCommand),
         Box::new(MoveCommand),
+        // Todo management
+        Box::new(TodosCommand),
     ]
 }
 

--- a/src-rust/crates/commands/src/providers.rs
+++ b/src-rust/crates/commands/src/providers.rs
@@ -154,3 +154,111 @@ impl SlashCommand for AgentCommand {
         }
     }
 }
+
+// ---- /add -------------------------------------------------------------
+
+/// Add a custom OpenAI-compatible provider to settings.
+///
+/// Usage: `/add <id> <apiBase> [apiKey]`
+///
+/// The `id` becomes the provider id used in `provider/model` routing.
+/// The `apiBase` is the OpenAI-compatible base URL.
+/// The optional `apiKey` supports `{env:VAR}` substitution.
+pub struct AddCustomProviderCommand;
+
+#[async_trait]
+impl SlashCommand for AddCustomProviderCommand {
+    fn name(&self) -> &str { "add" }
+    fn description(&self) -> &str { "Add a custom OpenAI-compatible provider" }
+    fn help(&self) -> &str {
+        "Usage: /add <id> <apiBase> [apiKey]\n\n\
+         Add a custom OpenAI-compatible provider to settings.json.\n\n\
+         Arguments:\n  \
+         id       \u{2014} unique provider id (e.g. \"my-gateway\")\n  \
+         apiBase  \u{2014} OpenAI-compatible base URL\n  \
+         apiKey   \u{2014} optional API key or {env:VAR} pattern\n\n\
+         Example:\n  \
+         /add my-gw https://gw.example.com/v1 {env:GW_API_KEY}\n\n\
+         The provider appears in /providers after restart. Models can be\
+         added via the customProviders.models map in settings.json."
+    }
+
+    async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
+        let parts: Vec<&str> = args.split_whitespace().collect();
+        if parts.len() < 2 {
+            return CommandResult::Message(
+                "Usage: /add <id> <apiBase> [apiKey]\n\
+                 Example: /add my-gw https://gw.example.com/v1"
+                    .to_string(),
+            );
+        }
+
+        let id = parts[0].trim();
+        let api_base = parts[1].trim();
+        let api_key = parts.get(2).map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
+
+        if id.is_empty() {
+            return CommandResult::Message("Error: provider id must not be empty.".to_string());
+        }
+        if api_base.is_empty() {
+            return CommandResult::Message("Error: apiBase must not be empty.".to_string());
+        }
+
+        // Basic URL validation.
+        if !api_base.starts_with("http://") && !api_base.starts_with("https://") {
+            return CommandResult::Message(format!(
+                "Error: apiBase must start with http:// or https:// (got: {})",
+                api_base
+            ));
+        }
+
+        // Load current settings from disk (fresh read, not in-memory cache).
+        let mut settings = match claurst_core::Settings::load_sync() {
+            Ok(s) => s,
+            Err(e) => {
+                return CommandResult::Message(format!(
+                    "Error loading settings: {}",
+                    e
+                ));
+            }
+        };
+
+        // Check for duplicate id.
+        if settings.custom_providers.contains_key(id) {
+            return CommandResult::Message(format!(
+                "Error: custom provider '{}' already exists. Use a different id or remove it from settings.json first.",
+                id
+            ));
+        }
+
+        // Use the id as the display name if no explicit name is provided.
+        let display_name = id.to_string();
+
+        // Insert the new provider.
+        let provider_def = claurst_core::config::CustomProviderDef {
+            name: display_name,
+            api_base: api_base.to_string(),
+            api_key,
+            headers: std::collections::HashMap::new(),
+            models: std::collections::HashMap::new(),
+            request_timeout_secs: None,
+            streaming: None,
+            include_usage_in_stream: None,
+            reasoning_field: None,
+        };
+        settings.custom_providers.insert(id.to_string(), provider_def);
+
+        // Save atomically.
+        if let Err(e) = settings.save_sync() {
+            return CommandResult::Message(format!("Error saving settings: {}", e));
+        }
+
+        CommandResult::Message(format!(
+            "Added custom provider '{}'.\n\
+             Base URL: {}\n\
+             Restart or reload settings to use it. Add models via the\n\
+             customProviders.{}.models map in settings.json.",
+            id, api_base, id
+        ))
+    }
+}

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -89,7 +89,7 @@ pub use types::{
     ContentBlock, ImageSource, DocumentSource, CitationsConfig, Message, MessageContent,
     MessageCost, Role, ToolDefinition, ToolResultContent, UsageInfo,
 };
-pub use config::{AgentDefinition, BudgetSplitPolicy, Config, CommandTemplate, FormatterConfig, ManagedAgentConfig, ManagedAgentPreset, McpServerConfig, McpServerOrigin, OutputFormat, PermissionMode, ProviderConfig, Settings, SkillsConfig, Theme, builtin_managed_agent_presets, default_agents, strip_jsonc_comments, substitute_env_vars};
+pub use config::{AgentDefinition, BudgetSplitPolicy, BangCommandsConfig, Config, CommandTemplate, CustomModelDef, CustomProviderDef, FormatterConfig, ManagedAgentConfig, ManagedAgentPreset, McpServerConfig, McpServerOrigin, ModelVariant, OutputFormat, PermissionMode, ProviderConfig, Settings, SkillsConfig, Theme, builtin_managed_agent_presets, default_agents, strip_jsonc_comments, substitute_env_vars};
 pub use import_config::{ClaudeMdPreview, ImportExecutionResult, ImportPaths, ImportPreview, ImportSelection, PreviewAction, PreviewField, SettingsPreview, build_import_preview, execute_import, summarize_import_result};
 
 // Skill discovery: filesystem and git URL skill loading.
@@ -947,17 +947,6 @@ pub mod config {
             }
         }
     }
-
-    // ---- ModelOverride ---------------------------------------------------
-
-    /// User-supplied metadata override for a single model, keyed by the
-    /// `"provider/model"` string in [`Config::model_overrides`].
-    ///
-    /// Every field is optional: a `Some` value takes precedence over the
-    /// models.dev catalog entry (and over any built-in default), while a `None`
-    /// leaves the catalog value untouched. When the keyed model is absent from
-    /// the catalog entirely (a self-hosted alias, or an id models.dev does not
-    /// know), the override is materialised into a synthetic registry entry so
     /// the model picker, token warnings, and auto-compact thresholds size it
     /// correctly instead of mismatching it to an unrelated catalog model.
     ///
@@ -1006,6 +995,126 @@ pub mod config {
                 && self.name.is_none()
                 && self.release_date.is_none()
                 && self.status.is_none()
+        }
+    }
+
+    // ---- ModelVariant ----------------------------------------------------
+
+    /// A model variant that overrides specific fields from its parent model
+    /// definition (e.g. a "max" variant that changes only `reasoning_effort`).
+    #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+    pub struct ModelVariant {
+        /// Override for reasoning effort level.
+        #[serde(
+            default,
+            rename = "reasoningEffort",
+            alias = "reasoning_effort",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub reasoning_effort: Option<String>,
+    }
+
+    // ---- CustomModelDef -------------------------------------------------
+
+    /// A model definition within a custom OpenAI-compatible provider.
+    #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+    pub struct CustomModelDef {
+        /// Total context window size in tokens.
+        #[serde(
+            default,
+            rename = "contextWindow",
+            alias = "context_window",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub context_window: Option<u32>,
+        /// Maximum tokens the model can emit in a single response.
+        #[serde(
+            default,
+            rename = "maxOutputTokens",
+            alias = "max_output_tokens",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub max_output_tokens: Option<u32>,
+        /// Human-readable display name shown in the model picker.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub name: Option<String>,
+        /// Reasoning effort level (e.g. "high", "max", "none").
+        #[serde(
+            default,
+            rename = "reasoningEffort",
+            alias = "reasoning_effort",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub reasoning_effort: Option<String>,
+        /// Named variants that override specific fields from this model definition.
+        #[serde(default)]
+        pub variants: HashMap<String, ModelVariant>,
+    }
+
+    // ---- CustomProviderDef ----------------------------------------------
+
+    /// A user-defined OpenAI-compatible provider, stored in
+    /// [`Settings::custom_providers`] keyed by its unique id.
+    ///
+    /// Unlike [`ProviderConfig`] (which tweaks built-in providers), this is a
+    /// fully self-contained provider definition with its own base URL, API key,
+    /// custom headers, and model catalog. The id (map key) becomes the provider
+    /// id used in `provider/model` routing.
+    #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+    pub struct CustomProviderDef {
+        /// Human-readable display name shown in the provider picker.
+        #[serde(default)]
+        pub name: String,
+        /// OpenAI-compatible base URL (claurst appends `/chat/completions`).
+        #[serde(rename = "apiBase", alias = "api_base")]
+        pub api_base: String,
+        /// API key. Supports `{env:VAR_NAME}` substitution at load time.
+        /// `None` means no key — provider is registered but health_check
+        /// returns `Unavailable`.
+        #[serde(rename = "apiKey", alias = "api_key", default, skip_serializing_if = "Option::is_none")]
+        pub api_key: Option<String>,
+        /// Custom HTTP headers sent on every request to this provider.
+        #[serde(default)]
+        pub headers: HashMap<String, String>,
+        /// Model catalog local to this provider, keyed by model id.
+        #[serde(default)]
+        pub models: HashMap<String, CustomModelDef>,
+        /// Per-provider request timeout override in seconds.
+        #[serde(
+            default,
+            rename = "requestTimeoutSecs",
+            alias = "request_timeout_secs",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub request_timeout_secs: Option<u64>,
+        /// Whether streaming is enabled for this provider. Default: true
+        /// (streaming). Set to false for providers that don't support SSE.
+        #[serde(default, rename = "streaming", skip_serializing_if = "Option::is_none")]
+        pub streaming: Option<bool>,
+        /// Whether to send stream_options.include_usage when streaming.
+        /// Default: true. Set to false for providers that don't support it.
+        #[serde(default, rename = "includeUsageInStream", alias = "include_usage_in_stream", skip_serializing_if = "Option::is_none")]
+        pub include_usage_in_stream: Option<bool>,
+        /// JSON field name for reasoning/thinking content (e.g.
+        /// "reasoning_content" for DeepSeek). None means no reasoning field.
+        #[serde(default, rename = "reasoningField", alias = "reasoning_field", skip_serializing_if = "Option::is_none")]
+        pub reasoning_field: Option<String>,
+    }
+
+    impl CustomProviderDef {
+        /// Resolve the API key, substituting `{env:VAR_NAME}` patterns with
+        /// the corresponding environment variable value. Returns `None` if
+        /// the key is absent or the env var is unset.
+        pub fn resolve_api_key(&self) -> Option<String> {
+            self.api_key.as_ref().and_then(|raw| {
+                if let Some(var) = raw.strip_prefix("{env:").and_then(|s| s.strip_suffix('}')) {
+                    std::env::var(var).ok().filter(|v| !v.is_empty())
+                } else if raw.is_empty() {
+                    None
+                } else {
+                    Some(raw.clone())
+                }
+            })
         }
     }
 
@@ -1114,6 +1223,12 @@ pub mod config {
         /// Keyboard scrolling (PageUp/PageDown, etc.) is unaffected either way.
         #[serde(default, rename = "mouseCapture", skip_serializing_if = "Option::is_none")]
         pub mouse_capture: Option<bool>,
+        /// Whether the max-steps graceful degradation summary turn is enabled.
+        /// When `true` (default), exceeding `max_turns` runs one final
+        /// tool-less turn asking the model to summarize progress. When `false`,
+        /// the loop returns cold (last assistant message) immediately.
+        #[serde(default = "default_true", rename = "degradationSummaryEnabled")]
+        pub degradation_summary_enabled: bool,
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -1202,6 +1317,32 @@ pub mod config {
         pub urls: Vec<String>,
     }
 
+    // ---- BangCommandsConfig ---------------------------------------------
+
+    /// Configuration for the `!` batch command feature.
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    pub struct BangCommandsConfig {
+        /// Whether the feature is enabled. Default: false (opt-in).
+        #[serde(default)]
+        pub enabled: bool,
+        /// Whether to add `!` commands to a separate shell-command history.
+        #[serde(default, rename = "addToHistory")]
+        pub add_to_history: bool,
+        /// Whether to display command + output in the chat transcript.
+        #[serde(default = "default_true", rename = "showInTranscript")]
+        pub show_in_transcript: bool,
+    }
+
+    impl Default for BangCommandsConfig {
+        fn default() -> Self {
+            Self {
+                enabled: false,
+                add_to_history: false,
+                show_in_transcript: default_true(),
+            }
+        }
+    }
+
     // ---- Settings --------------------------------------------------------
 
     #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -1252,6 +1393,16 @@ pub mod config {
         /// Per-provider configurations stored in settings.json.
         #[serde(default)]
         pub providers: HashMap<String, ProviderConfig>,
+        /// User-defined OpenAI-compatible providers, keyed by unique id.
+        /// Each entry is a self-contained provider with its own base URL,
+        /// API key, headers, and model catalog. The id becomes the provider
+        /// id used in `provider/model` routing.
+        #[serde(default, rename = "customProviders", alias = "custom_providers")]
+        pub custom_providers: HashMap<String, CustomProviderDef>,
+        /// User-favorited model keys ("provider/model" format). Shown in a
+        /// dedicated section at the top of the /model picker.
+        #[serde(default, rename = "favoriteModels", alias = "favorite_models")]
+        pub favorite_models: Vec<String>,
         /// User-supplied model metadata overrides stored in settings.json,
         /// keyed by `"provider/model"`. Merged into
         /// [`Config::model_overrides`] by [`Settings::effective_config`] and
@@ -1317,6 +1468,13 @@ pub mod config {
         /// Note: @include in CLAUDE.md/AGENTS.md always injects regardless of this limit.
         #[serde(default = "default_file_injection_max_size", rename = "fileInjectionMaxSize")]
         pub file_injection_max_size: usize,
+        /// Whether auto-poke is enabled. When true, the model is automatically
+        /// continued when it stops with incomplete todos. Default: true.
+        #[serde(default = "default_true", rename = "autoPokeEnabled")]
+        pub auto_poke_enabled: bool,
+        /// Configuration for the `!` batch command feature.
+        #[serde(default, rename = "bangCommands")]
+        pub bang_commands: BangCommandsConfig,
     }
 
     /// A user-defined slash command template.
@@ -1772,7 +1930,11 @@ pub mod config {
                 std::fs::create_dir_all(parent)?;
             }
             let content = serde_json::to_string_pretty(self)?;
-            std::fs::write(path, content)?;
+            // Atomic write: serialize to a temp file, then rename into place.
+            // On Unix, rename() is atomic — readers never see a partial file.
+            let tmp_path = path.with_extension("json.tmp");
+            std::fs::write(&tmp_path, &content)?;
+            std::fs::rename(&tmp_path, path)?;
             Ok(())
         }
 
@@ -1819,6 +1981,18 @@ pub mod config {
             // Merge top-level `providers` map into config.provider_configs.
             for (id, pc) in &self.providers {
                 config.provider_configs.entry(id.clone()).or_insert_with(|| pc.clone());
+            }
+            // Merge custom providers' API keys and base URLs into
+            // provider_configs so resolve_provider_api_key() can find them.
+            for (id, cp) in &self.custom_providers {
+                config.provider_configs.entry(id.clone()).or_insert_with(|| {
+                    ProviderConfig {
+                        api_key: cp.api_key.clone(),
+                        api_base: Some(cp.api_base.clone()),
+                        enabled: true,
+                        ..Default::default()
+                    }
+                });
             }
             // Merge top-level `modelOverrides` into config.model_overrides
             // (nested `config` block wins for keys present in both).
@@ -1982,6 +2156,7 @@ pub mod config {
                 file_injection_enabled: over.config.file_injection_enabled || base.config.file_injection_enabled,
                 file_injection_max_size: if over.config.file_injection_max_size != 0 { over.config.file_injection_max_size } else { base.config.file_injection_max_size },
                 request_timeout_secs: over.config.request_timeout_secs.or(base.config.request_timeout_secs),
+                degradation_summary_enabled: over.config.degradation_summary_enabled && base.config.degradation_summary_enabled,
             };
             Self {
                 config: merged_config,
@@ -2007,6 +2182,8 @@ pub mod config {
                 last_seen_version: over.last_seen_version.or(base.last_seen_version),
                 provider: over.provider.or(base.provider),
                 providers: merge_map(base.providers, over.providers),
+                custom_providers: merge_map(base.custom_providers, over.custom_providers),
+                favorite_models: { let mut v = base.favorite_models; for f in over.favorite_models { if !v.contains(&f) { v.push(f); } } v },
                 model_overrides: merge_map(base.model_overrides, over.model_overrides),
                 commands: merge_map(base.commands, over.commands),
                 formatter: merge_map(base.formatter, over.formatter),
@@ -2031,6 +2208,12 @@ pub mod config {
                 file_autocomplete_show_hidden_files: over.file_autocomplete_show_hidden_files || base.file_autocomplete_show_hidden_files,
                 file_injection_enabled: over.file_injection_enabled || base.file_injection_enabled,
                 file_injection_max_size: if over.file_injection_max_size != 0 { over.file_injection_max_size } else { base.file_injection_max_size },
+                auto_poke_enabled: over.auto_poke_enabled || base.auto_poke_enabled,
+                bang_commands: BangCommandsConfig {
+                    enabled: over.bang_commands.enabled || base.bang_commands.enabled,
+                    add_to_history: over.bang_commands.add_to_history || base.bang_commands.add_to_history,
+                    show_in_transcript: over.bang_commands.show_in_transcript && base.bang_commands.show_in_transcript,
+                },
             }
         }
     }
@@ -2285,12 +2468,54 @@ pub mod config {
         }
 
         #[test]
+        fn favorite_models_deserialize() {
+            let json = r#"{"favoriteModels": ["anthropic/claude-sonnet-4-6", "openai/gpt-4o"]}"#;
+            let settings: Settings = serde_json::from_str(json).unwrap();
+            assert_eq!(settings.favorite_models.len(), 2);
+            assert_eq!(settings.favorite_models[0], "anthropic/claude-sonnet-4-6");
+            assert_eq!(settings.favorite_models[1], "openai/gpt-4o");
+        }
+
+        #[test]
+        fn favorite_models_snake_alias() {
+            let json = r#"{"favorite_models": ["anthropic/claude-opus-4-6"]}"#;
+            let settings: Settings = serde_json::from_str(json).unwrap();
+            assert_eq!(settings.favorite_models.len(), 1);
+            assert_eq!(settings.favorite_models[0], "anthropic/claude-opus-4-6");
+        }
+
+        #[test]
+        fn favorite_models_default_empty() {
+            let json = r#"{}"#;
+            let settings: Settings = serde_json::from_str(json).unwrap();
+            assert!(settings.favorite_models.is_empty());
+        }
+
+        #[test]
         fn zero_is_treated_as_unset() {
             let config = Config { request_timeout_secs: Some(0), ..Default::default() };
             assert_eq!(
                 config.resolve_request_timeout_secs("openai"),
                 DEFAULT_REQUEST_TIMEOUT_SECS
             );
+        }
+
+        #[test]
+        fn bang_commands_default_disabled() {
+            let json = r#"{}"#;
+            let settings: Settings = serde_json::from_str(json).unwrap();
+            assert!(!settings.bang_commands.enabled);
+            assert!(!settings.bang_commands.add_to_history);
+            assert!(settings.bang_commands.show_in_transcript);
+        }
+
+        #[test]
+        fn bang_commands_deserialize() {
+            let json = r#"{"bangCommands": {"enabled": true, "addToHistory": true, "showInTranscript": false}}"#;
+            let settings: Settings = serde_json::from_str(json).unwrap();
+            assert!(settings.bang_commands.enabled);
+            assert!(settings.bang_commands.add_to_history);
+            assert!(!settings.bang_commands.show_in_transcript);
         }
     }
 }
@@ -5314,5 +5539,148 @@ mod tests {
             registry.get(&id).unwrap().status,
             tasks::TaskStatus::Cancelled
         );
+    }
+
+    #[test]
+    fn custom_provider_def_deserialize_camel_case() {
+        let json = r#"{
+            "name": "Test Gateway",
+            "apiBase": "https://gateway.example.com/v1",
+            "apiKey": "secret-key",
+            "headers": { "X-Custom-Header": "value" },
+            "models": {
+                "model-1": {
+                    "name": "Model One",
+                    "contextWindow": 128000,
+                    "maxOutputTokens": 8192,
+                    "reasoningEffort": "high"
+                }
+            },
+            "requestTimeoutSecs": 300
+        }"#;
+        let def: CustomProviderDef = serde_json::from_str(json).unwrap();
+        assert_eq!(def.name, "Test Gateway");
+        assert_eq!(def.api_base, "https://gateway.example.com/v1");
+        assert_eq!(def.api_key.as_deref(), Some("secret-key"));
+        assert_eq!(def.headers.get("X-Custom-Header").unwrap(), "value");
+        assert_eq!(def.models.len(), 1);
+        let model = def.models.get("model-1").unwrap();
+        assert_eq!(model.context_window, Some(128000));
+        assert_eq!(model.max_output_tokens, Some(8192));
+        assert_eq!(model.name.as_deref(), Some("Model One"));
+        assert_eq!(model.reasoning_effort.as_deref(), Some("high"));
+        assert_eq!(def.request_timeout_secs, Some(300));
+    }
+
+    #[test]
+    fn custom_provider_def_deserialize_snake_case() {
+        let json = r#"{
+            "name": "Test",
+            "api_base": "https://example.com",
+            "api_key": "key",
+            "models": {}
+        }"#;
+        let def: CustomProviderDef = serde_json::from_str(json).unwrap();
+        assert_eq!(def.api_base, "https://example.com");
+        assert_eq!(def.api_key.as_deref(), Some("key"));
+    }
+
+    #[test]
+    fn custom_provider_def_resolve_api_key_env_substitution() {
+        std::env::set_var("TEST_CUSTOM_PROVIDER_KEY", "env-key-value");
+        let def = CustomProviderDef {
+            api_key: Some("{env:TEST_CUSTOM_PROVIDER_KEY}".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(def.resolve_api_key().as_deref(), Some("env-key-value"));
+        std::env::remove_var("TEST_CUSTOM_PROVIDER_KEY");
+    }
+
+    #[test]
+    fn custom_provider_def_resolve_api_key_empty_env() {
+        let def = CustomProviderDef {
+            api_key: Some("{env:NONEXISTENT_VAR_12345}".to_string()),
+            ..Default::default()
+        };
+        assert!(def.resolve_api_key().is_none());
+    }
+
+    #[test]
+    fn custom_provider_def_resolve_api_key_none() {
+        let def = CustomProviderDef {
+            api_key: None,
+            ..Default::default()
+        };
+        assert!(def.resolve_api_key().is_none());
+    }
+
+    #[test]
+    fn custom_provider_def_resolve_api_key_plain() {
+        let def = CustomProviderDef {
+            api_key: Some("plain-key".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(def.resolve_api_key().as_deref(), Some("plain-key"));
+    }
+
+    #[test]
+    fn custom_provider_def_with_streaming_settings() {
+        let json = r#"{
+            "name": "Test",
+            "apiBase": "https://example.com/v1",
+            "streaming": false,
+            "includeUsageInStream": false,
+            "reasoningField": "reasoning_content"
+        }"#;
+        let def: CustomProviderDef = serde_json::from_str(json).unwrap();
+        assert_eq!(def.streaming, Some(false));
+        assert_eq!(def.include_usage_in_stream, Some(false));
+        assert_eq!(def.reasoning_field.as_deref(), Some("reasoning_content"));
+    }
+
+    #[test]
+    fn custom_model_def_with_variants() {
+        let json = r#"{
+            "contextWindow": 230000,
+            "maxOutputTokens": 32072,
+            "variants": {
+                "max": { "reasoningEffort": "max" },
+                "none": { "reasoningEffort": "none" }
+            }
+        }"#;
+        let model: CustomModelDef = serde_json::from_str(json).unwrap();
+        assert_eq!(model.context_window, Some(230000));
+        assert_eq!(model.variants.len(), 2);
+        assert_eq!(
+            model.variants.get("max").unwrap().reasoning_effort.as_deref(),
+            Some("max")
+        );
+    }
+
+    #[test]
+    fn settings_deserialize_with_custom_providers() {
+        let json = r#"{
+            "customProviders": {
+                "my-gateway": {
+                    "name": "My Gateway",
+                    "apiBase": "https://gw.example.com/v1",
+                    "models": {
+                        "model-a": { "name": "Model A" }
+                    }
+                }
+            }
+        }"#;
+        let settings: Settings = serde_json::from_str(json).unwrap();
+        assert_eq!(settings.custom_providers.len(), 1);
+        let provider = settings.custom_providers.get("my-gateway").unwrap();
+        assert_eq!(provider.name, "My Gateway");
+        assert_eq!(provider.models.len(), 1);
+    }
+
+    #[test]
+    fn auto_poke_enabled_default_true() {
+        let json = r#"{}"#;
+        let settings: Settings = serde_json::from_str(json).unwrap();
+        assert!(settings.auto_poke_enabled);
     }
 }

--- a/src-rust/crates/query/src/agent_tool.rs
+++ b/src-rust/crates/query/src/agent_tool.rs
@@ -372,6 +372,7 @@ impl Tool for AgentTool {
             // Sub-agents run to their own completion and never drive goal
             // continuation — stop after one turn like every non-goal run.
             continuation: crate::continuation::ContinuationMode::Default,
+            degradation_enabled: true,
         };
         // -----------------------------------------------------------------------
         // Background mode: spawn and return agent_id immediately.

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -95,6 +95,10 @@ pub struct QueryConfig {
     pub model: String,
     pub max_tokens: u32,
     pub max_turns: u32,
+    /// Whether the max-steps graceful degradation summary turn is enabled.
+    /// When `false`, exceeding `max_turns` returns cold (last assistant
+    /// message) instead of running a final tool-less summary turn.
+    pub degradation_enabled: bool,
     pub system_prompt: Option<String>,
     pub append_system_prompt: Option<String>,
     pub output_style: claurst_core::system_prompt::OutputStyle,
@@ -174,6 +178,7 @@ impl Default for QueryConfig {
             model: claurst_core::constants::DEFAULT_MODEL.to_string(),
             max_tokens: claurst_core::constants::DEFAULT_MAX_TOKENS,
             max_turns: claurst_core::constants::MAX_TURNS_DEFAULT,
+            degradation_enabled: true,
             system_prompt: None,
             append_system_prompt: None,
             output_style: claurst_core::system_prompt::OutputStyle::Default,
@@ -210,6 +215,7 @@ impl QueryConfig {
                 .as_ref()
                 .map(|p| p.display().to_string()),
             managed_agents: cfg.managed_agents.clone(),
+            degradation_enabled: cfg.degradation_summary_enabled,
             ..Default::default()
         }
     }
@@ -231,6 +237,7 @@ impl QueryConfig {
                 .as_ref()
                 .map(|p| p.display().to_string()),
             managed_agents: cfg.managed_agents.clone(),
+            degradation_enabled: cfg.degradation_summary_enabled,
             ..Default::default()
         }
     }
@@ -471,6 +478,21 @@ pub async fn run_query_loop(
         // dispatched exactly once, and re-exceeding the cap afterwards returns
         // cold. Applies to both goal and non-goal runs.
         let degradation_turn = if turn > effective_max_turns {
+            if !config.degradation_enabled {
+                info!(
+                    turns = turn,
+                    max = effective_max_turns,
+                    "Max turns reached — degradation disabled, returning cold"
+                );
+                let last_msg = messages
+                    .last()
+                    .cloned()
+                    .unwrap_or_else(|| Message::assistant("Max turns reached."));
+                return QueryOutcome::EndTurn {
+                    message: last_msg,
+                    usage: UsageInfo::default(),
+                };
+            }
             if degradation_done {
                 info!(
                     turns = turn,
@@ -835,10 +857,16 @@ pub async fn run_query_loop(
                 if known_providers.contains(&p) {
                     (p.to_string(), m.to_string())
                 } else {
-                    // Treat the whole string as the model ID, fall through
-                    // to auto-detection below.
-                    let fallback_provider = tool_ctx.config.provider.as_deref().unwrap_or("anthropic");
-                    (fallback_provider.to_string(), effective_model.clone())
+                    // Check whether `p` is a user-defined custom provider id.
+                    let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+                    if settings.custom_providers.contains_key(p) {
+                        (p.to_string(), m.to_string())
+                    } else {
+                        // Treat the whole string as the model ID, fall through
+                        // to auto-detection below.
+                        let fallback_provider = tool_ctx.config.provider.as_deref().unwrap_or("anthropic");
+                        (fallback_provider.to_string(), effective_model.clone())
+                    }
                 }
             } else {
                 // No explicit provider set (or set to "anthropic"): try the
@@ -971,12 +999,28 @@ pub async fn run_query_loop(
                         })
                         .collect();
 
+                    // Cap max_tokens by the custom model's `maxOutputTokens`
+                    // when the model belongs to a user-defined custom provider.
+                    let effective_max_tokens = {
+                        let mut tok = config.max_tokens;
+                        if let Ok(settings) = claurst_core::Settings::load_sync() {
+                            if let Some(cp) = settings.custom_providers.get(&provider_id_str) {
+                                if let Some(model_def) = cp.models.get(&model_id_str) {
+                                    if let Some(cap) = model_def.max_output_tokens {
+                                        tok = tok.min(cap);
+                                    }
+                                }
+                            }
+                        }
+                        tok
+                    };
+
                     let provider_request = claurst_api::ProviderRequest {
                         model: model_id_str.to_owned(),
                         messages: provider_messages,
                         system_prompt: Some(system_for_provider.clone()),
                         tools: provider_tools,
-                        max_tokens: config.max_tokens,
+                        max_tokens: effective_max_tokens,
                         temperature: effective_temperature.map(|t| t as f64),
                         top_p: None,
                         top_k: None,
@@ -2413,6 +2457,79 @@ mod tests {
         // both must be treated as OpenAI-compatible providers.
         assert!(is_openaiish_provider("alibaba"));
         assert!(is_openaiish_provider("qwen"));
+    }
+
+    #[test]
+    fn is_openaiish_provider_unknown_id_returns_false() {
+        // When a custom provider is registered in settings, is_openaiish_provider
+        // should return true even though it's not in the hardcoded list.
+        // This test uses a unique id unlikely to collide with real settings.
+        // Note: This test depends on no settings.json having this id;
+        // it verifies the fallback (no custom provider → matches! list).
+        let result = is_openaiish_provider("definitely-not-a-real-provider-99999");
+        assert!(!result);
+    }
+
+    #[test]
+    fn known_providers_includes_custom_provider_runtime_check() {
+        // The runtime check for custom providers should not crash and
+        // should not return true for arbitrary unknown strings.
+        // This is a negative test — no custom provider "fake-provider-xyz"
+        // should exist in settings.
+        let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+        assert!(!settings.custom_providers.contains_key("fake-provider-xyz-12345"));
+    }
+
+#[test]
+    fn build_provider_options_custom_provider_reasoning_effort_fallback() {
+        // Bug 2: reasoningEffort from CustomModelDef should be sent for
+        // non-GPT models on custom providers. We set CLAURST_HOME to a
+        // temp dir with a settings.json containing a custom provider whose
+        // model has reasoningEffort: "high", then verify build_provider_options
+        // emits it even though the model is not a GPT reasoning model.
+        use std::sync::Mutex as StdMutex;
+
+        static ENV_LOCK: StdMutex<()> = StdMutex::new(());
+        let _guard = ENV_LOCK.lock().unwrap();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let settings_json = serde_json::json!({
+            "customProviders": {
+                "test-cp-reasoning": {
+                    "name": "Test CP",
+                    "apiBase": "https://example.com/v1",
+                    "models": {
+                        "revolut-ca/glm-5-2": {
+                            "reasoningEffort": "high",
+                            "maxOutputTokens": 32000
+                        }
+                    }
+                }
+            }
+        });
+        std::fs::write(
+            tmp.path().join("settings.json"),
+            serde_json::to_string_pretty(&settings_json).unwrap(),
+        )
+        .unwrap();
+
+        let old = std::env::var_os("CLAURST_HOME");
+        std::env::set_var("CLAURST_HOME", tmp.path());
+
+        let options = build_provider_options(
+            "test-cp-reasoning",
+            "revolut-ca/glm-5-2",
+            None,
+            None,
+        );
+
+        // Restore env immediately.
+        match old {
+            Some(v) => std::env::set_var("CLAURST_HOME", v),
+            None => std::env::remove_var("CLAURST_HOME"),
+        }
+
+        assert_eq!(options["reasoningEffort"], serde_json::json!("high"));
     }
 
     // ---- apply_compact_result / #213 data-loss guard ------------------------

--- a/src-rust/crates/query/src/runner/provider_options.rs
+++ b/src-rust/crates/query/src/runner/provider_options.rs
@@ -52,6 +52,12 @@ pub(crate) fn is_openai_reasoning_model(model_id: &str) -> bool {
 }
 
 pub(crate) fn is_openaiish_provider(provider_id: &str) -> bool {
+    // Custom providers from Settings are always OpenAI-compatible.
+    if let Ok(settings) = claurst_core::Settings::load_sync() {
+        if settings.custom_providers.contains_key(provider_id) {
+            return true;
+        }
+    }
     matches!(
         provider_id,
         "openai"
@@ -262,6 +268,26 @@ pub(crate) fn build_provider_options(
                         options.insert(
                             "thinking".to_string(),
                             serde_json::json!({"type": "disabled"}),
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    // Fallback for custom (user-defined) providers: when the model is not a
+    // GPT reasoning model (so the block above did not insert `reasoningEffort`),
+    // check the model definition in Settings for a `reasoningEffort` override
+    // and apply it. This lets non-GPT models on custom providers (e.g. GLM-5.2)
+    // still send `reasoningEffort` to the API.
+    if !options.contains_key("reasoningEffort") {
+        if let Ok(settings) = claurst_core::Settings::load_sync() {
+            if let Some(cp) = settings.custom_providers.get(provider_id) {
+                if let Some(model_def) = cp.models.get(&model_id) {
+                    if let Some(ref effort) = model_def.reasoning_effort {
+                        options.insert(
+                            "reasoningEffort".to_string(),
+                            serde_json::json!(effort),
                         );
                     }
                 }

--- a/src-rust/crates/tools/src/todo_write.rs
+++ b/src-rust/crates/tools/src/todo_write.rs
@@ -139,6 +139,33 @@ struct TodoItem {
     #[serde(default)]
     #[allow(dead_code)]
     priority: Option<String>,
+    /// Optional 0-100 estimate of the evidence that this task can be
+    /// completed correctly.
+    #[serde(default, deserialize_with = "deserialize_confidence")]
+    confidence: Option<u8>,
+    /// Optional 0-100 estimate recorded when a task is completed.
+    #[serde(default, deserialize_with = "deserialize_confidence")]
+    completion_confidence: Option<u8>,
+}
+
+fn deserialize_confidence<'de, D>(deserializer: D) -> Result<Option<u8>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Value::deserialize(deserializer)?;
+    let score = match value {
+        Value::Null => return Ok(None),
+        Value::Number(number) => number.as_f64(),
+        Value::String(raw) if raw.trim().is_empty() => return Ok(None),
+        Value::String(raw) => raw.trim().parse::<f64>().ok(),
+        _ => None,
+    };
+    let score = score
+        .filter(|score| {
+            score.is_finite() && score.fract() == 0.0 && (0.0..=100.0).contains(score)
+        })
+        .ok_or_else(|| serde::de::Error::custom("confidence must be an integer from 0 to 100"))?;
+    Ok(Some(score as u8))
 }
 
 // ---------------------------------------------------------------------------
@@ -189,7 +216,8 @@ impl Tool for TodoWriteTool {
     fn description(&self) -> &str {
         "Write and manage a todo/task list. Provide the complete list of todos \
          each time (this replaces the entire list). Use this to track progress \
-         on multi-step tasks."
+         on multi-step tasks. Each item may include a confidence percentage from \
+         0 to 100, plus a completion_confidence percentage when completed."
     }
 
     fn permission_level(&self) -> PermissionLevel {
@@ -211,7 +239,19 @@ impl Tool for TodoWriteTool {
                                 "type": "string",
                                 "enum": ["pending", "in_progress", "completed"]
                             },
-                            "priority": { "type": "string" }
+                            "priority": { "type": "string" },
+                            "confidence": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 100,
+                                "description": "Optional confidence percentage that this task can be completed correctly."
+                            },
+                            "completion_confidence": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 100,
+                                "description": "Optional confidence percentage recorded when this task is completed."
+                            }
                         },
                         "required": ["id", "content", "status"]
                     },
@@ -310,6 +350,12 @@ impl Tool for TodoWriteTool {
                 TodoStatus::Completed => "[x]",
             };
             output.push_str(&format!("{} {} ({})\n", icon, item.content, item.id));
+            if let Some(confidence) = item.confidence {
+                output.push_str(&format!("    confidence: {}%\n", confidence));
+            }
+            if let Some(confidence) = item.completion_confidence {
+                output.push_str(&format!("    completion confidence: {}%\n", confidence));
+            }
         }
 
         // --- 6. Persist to disk ----------------------------------------------
@@ -324,6 +370,12 @@ impl Tool for TodoWriteTool {
                 });
                 if let Some(ref p) = t.priority {
                     obj["priority"] = json!(p);
+                }
+                if let Some(confidence) = t.confidence {
+                    obj["confidence"] = json!(confidence);
+                }
+                if let Some(confidence) = t.completion_confidence {
+                    obj["completion_confidence"] = json!(confidence);
                 }
                 obj
             })
@@ -425,6 +477,46 @@ mod tests {
         assert_eq!(loaded[0]["id"].as_str(), Some("1"));
         assert_eq!(loaded[1]["status"].as_str(), Some("completed"));
         // tempdir cleans up automatically.
+    }
+
+    #[test]
+    fn test_confidence_accepts_integer_and_numeric_string() {
+        let input: TodoWriteInput = serde_json::from_value(json!({
+            "todos": [
+                {
+                    "id": "1",
+                    "content": "Task one",
+                    "status": "pending",
+                    "confidence": 80
+                },
+                {
+                    "id": "2",
+                    "content": "Task two",
+                    "status": "completed",
+                    "confidence": "70",
+                    "completion_confidence": 95.0
+                }
+            ]
+        }))
+        .expect("valid confidence values should parse");
+
+        assert_eq!(input.todos[0].confidence, Some(80));
+        assert_eq!(input.todos[1].confidence, Some(70));
+        assert_eq!(input.todos[1].completion_confidence, Some(95));
+    }
+
+    #[test]
+    fn test_confidence_rejects_values_outside_percentage_range() {
+        let result = serde_json::from_value::<TodoWriteInput>(json!({
+            "todos": [{
+                "id": "1",
+                "content": "Task",
+                "status": "pending",
+                "confidence": 101
+            }]
+        }));
+
+        assert!(result.is_err());
     }
 
     // --- Status parsing ------------------------------------------------------

--- a/src-rust/crates/tools/src/todo_write.rs
+++ b/src-rust/crates/tools/src/todo_write.rs
@@ -139,33 +139,28 @@ struct TodoItem {
     #[serde(default)]
     #[allow(dead_code)]
     priority: Option<String>,
-    /// Optional 0-100 estimate of the evidence that this task can be
-    /// completed correctly.
-    #[serde(default, deserialize_with = "deserialize_confidence")]
+    // --- NEW FIELDS ---
+    #[serde(default)]
+    #[allow(dead_code)]
+    group: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
     confidence: Option<u8>,
-    /// Optional 0-100 estimate recorded when a task is completed.
-    #[serde(default, deserialize_with = "deserialize_confidence")]
+    #[serde(default)]
+    #[allow(dead_code)]
     completion_confidence: Option<u8>,
-}
-
-fn deserialize_confidence<'de, D>(deserializer: D) -> Result<Option<u8>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value = Value::deserialize(deserializer)?;
-    let score = match value {
-        Value::Null => return Ok(None),
-        Value::Number(number) => number.as_f64(),
-        Value::String(raw) if raw.trim().is_empty() => return Ok(None),
-        Value::String(raw) => raw.trim().parse::<f64>().ok(),
-        _ => None,
-    };
-    let score = score
-        .filter(|score| {
-            score.is_finite() && score.fract() == 0.0 && (0.0..=100.0).contains(score)
-        })
-        .ok_or_else(|| serde::de::Error::custom("confidence must be an integer from 0 to 100"))?;
-    Ok(Some(score as u8))
+    #[serde(default)]
+    #[allow(dead_code)]
+    confidence_history: Vec<u8>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    blocked_by: Vec<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    assigned_to: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    force_reopen: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -182,23 +177,20 @@ where
 /// Forbidden:
 ///   completed   → anything      ✗  (completed tasks cannot be reopened)
 ///   in_progress → pending       ✗  (cannot move backwards)
-fn validate_transition(id: &str, old: &TodoStatus, new: &TodoStatus) -> Result<(), String> {
+fn validate_transition(id: &str, old: &TodoStatus, new: &TodoStatus, force_reopen: bool) -> Result<(), String> {
     if old == new {
         return Ok(());
     }
     match (old, new) {
-        // Completed tasks are immutable.
-        (TodoStatus::Completed, _) => Err(format!(
-            "Task {:?}: cannot change status of a completed task (currently \"completed\" → \"{}\").",
+        (TodoStatus::Completed, _) if !force_reopen => Err(format!(
+            "Task {:?}: cannot change status of a completed task (currently \"completed\" → \"{}\"). Use force_reopen: true if poke verification found a false completion.",
             id, new
         )),
-        // Cannot move in_progress backwards to pending.
+        (TodoStatus::Completed, _) if force_reopen => Ok(()), // Force reopen allowed
         (TodoStatus::InProgress, TodoStatus::Pending) => Err(format!(
             "Task {:?}: cannot move status backwards (\"in_progress\" → \"pending\").",
             id
         )),
-        // All other transitions (pending→in_progress, pending→completed,
-        // in_progress→completed) are valid.
         _ => Ok(()),
     }
 }
@@ -216,8 +208,7 @@ impl Tool for TodoWriteTool {
     fn description(&self) -> &str {
         "Write and manage a todo/task list. Provide the complete list of todos \
          each time (this replaces the entire list). Use this to track progress \
-         on multi-step tasks. Each item may include a confidence percentage from \
-         0 to 100, plus a completion_confidence percentage when completed."
+         on multi-step tasks."
     }
 
     fn permission_level(&self) -> PermissionLevel {
@@ -240,18 +231,13 @@ impl Tool for TodoWriteTool {
                                 "enum": ["pending", "in_progress", "completed"]
                             },
                             "priority": { "type": "string" },
-                            "confidence": {
-                                "type": "integer",
-                                "minimum": 0,
-                                "maximum": 100,
-                                "description": "Optional confidence percentage that this task can be completed correctly."
-                            },
-                            "completion_confidence": {
-                                "type": "integer",
-                                "minimum": 0,
-                                "maximum": 100,
-                                "description": "Optional confidence percentage recorded when this task is completed."
-                            }
+                            "group": { "type": "string" },
+                            "confidence": { "type": "integer", "minimum": 0, "maximum": 100 },
+                            "completion_confidence": { "type": "integer", "minimum": 0, "maximum": 100 },
+                            "confidence_history": { "type": "array", "items": { "type": "integer" } },
+                            "blocked_by": { "type": "array", "items": { "type": "string" } },
+                            "assigned_to": { "type": "string" },
+                            "force_reopen": { "type": "boolean" }
                         },
                         "required": ["id", "content", "status"]
                     },
@@ -307,7 +293,7 @@ impl Tool for TodoWriteTool {
             match existing.get(item.id.as_str()) {
                 Some(old_status) => {
                     // Existing task — validate the transition.
-                    if let Err(e) = validate_transition(&item.id, old_status, &item.status) {
+                    if let Err(e) = validate_transition(&item.id, old_status, &item.status, item.force_reopen) {
                         return ToolResult::error(e);
                     }
                     if old_status != &TodoStatus::Completed
@@ -350,12 +336,6 @@ impl Tool for TodoWriteTool {
                 TodoStatus::Completed => "[x]",
             };
             output.push_str(&format!("{} {} ({})\n", icon, item.content, item.id));
-            if let Some(confidence) = item.confidence {
-                output.push_str(&format!("    confidence: {}%\n", confidence));
-            }
-            if let Some(confidence) = item.completion_confidence {
-                output.push_str(&format!("    completion confidence: {}%\n", confidence));
-            }
         }
 
         // --- 6. Persist to disk ----------------------------------------------
@@ -371,11 +351,25 @@ impl Tool for TodoWriteTool {
                 if let Some(ref p) = t.priority {
                     obj["priority"] = json!(p);
                 }
-                if let Some(confidence) = t.confidence {
-                    obj["confidence"] = json!(confidence);
+                if let Some(ref g) = t.group {
+                    obj["group"] = json!(g);
                 }
-                if let Some(confidence) = t.completion_confidence {
-                    obj["completion_confidence"] = json!(confidence);
+                if let Some(c) = t.confidence {
+                    obj["confidence"] = json!(c);
+                }
+                if let Some(c) = t.completion_confidence {
+                    obj["completion_confidence"] = json!(c);
+                }
+                if !t.confidence_history.is_empty() {
+                    // Cap at 20 entries (ring buffer).
+                    let history: Vec<u8> = t.confidence_history.iter().rev().take(20).copied().collect::<Vec<u8>>().into_iter().rev().collect();
+                    obj["confidence_history"] = json!(history);
+                }
+                if !t.blocked_by.is_empty() {
+                    obj["blocked_by"] = json!(t.blocked_by);
+                }
+                if let Some(ref a) = t.assigned_to {
+                    obj["assigned_to"] = json!(a);
                 }
                 obj
             })
@@ -420,6 +414,62 @@ impl Tool for TodoWriteTool {
         }))
     }
 }
+
+// ---------------------------------------------------------------------------
+// Auto-poke mechanism (ported from jcode)
+// ---------------------------------------------------------------------------
+
+/// Build the synthetic continuation message sent when the model stops with
+/// incomplete todos. The message instructs the model to continue working.
+pub fn build_auto_poke_message(incomplete_count: usize) -> String {
+    format!(
+        "You have {} incomplete todo{}. Continue working, or update the todo tool.",
+        incomplete_count,
+        if incomplete_count == 1 { "" } else { "s" },
+    )
+}
+
+/// Check whether a message is an auto-poke synthetic continuation prompt.
+/// Used by the TUI to hide the raw message and show "Auto-poking..." instead.
+pub fn is_auto_poke_message(message: &str) -> bool {
+    message.starts_with("You have ")
+        && message.contains(" incomplete todo")
+        && message.contains("Continue working, or update the todo tool.")
+}
+
+/// Count incomplete (pending + in_progress) todos for a session.
+pub fn count_incomplete_todos(session_id: &str) -> usize {
+    let todos = load_todos(session_id);
+    todos
+        .iter()
+        .filter_map(|t| t.get("status").and_then(|s| s.as_str()))
+        .filter(|s| *s == "pending" || *s == "in_progress")
+        .count()
+}
+
+/// Compute a hash of the current todo state (sorted [(id, status)] pairs).
+/// Used for no-progress detection: if the hash is unchanged for 3 consecutive
+/// turns, auto-poking stops.
+pub fn todo_state_hash(session_id: &str) -> String {
+    let todos = load_todos(session_id);
+    let mut pairs: Vec<(String, String)> = todos
+        .iter()
+        .filter_map(|t| {
+            let id = t.get("id").and_then(|v| v.as_str())?.to_string();
+            let status = t.get("status").and_then(|v| v.as_str())?.to_string();
+            Some((id, status))
+        })
+        .collect();
+    pairs.sort_by(|a, b| a.0.cmp(&b.0));
+    // Simple hash: concatenate id:status pairs.
+    pairs.iter().map(|(id, s)| format!("{}:{}", id, s)).collect::<Vec<_>>().join("|")
+}
+
+/// Maximum auto-pokes per session (safety budget).
+pub const MAX_AUTO_POKES: u32 = 48;
+
+/// No-progress threshold: stop after this many consecutive no-progress turns.
+pub const NO_PROGRESS_THRESHOLD: u32 = 3;
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -479,46 +529,6 @@ mod tests {
         // tempdir cleans up automatically.
     }
 
-    #[test]
-    fn test_confidence_accepts_integer_and_numeric_string() {
-        let input: TodoWriteInput = serde_json::from_value(json!({
-            "todos": [
-                {
-                    "id": "1",
-                    "content": "Task one",
-                    "status": "pending",
-                    "confidence": 80
-                },
-                {
-                    "id": "2",
-                    "content": "Task two",
-                    "status": "completed",
-                    "confidence": "70",
-                    "completion_confidence": 95.0
-                }
-            ]
-        }))
-        .expect("valid confidence values should parse");
-
-        assert_eq!(input.todos[0].confidence, Some(80));
-        assert_eq!(input.todos[1].confidence, Some(70));
-        assert_eq!(input.todos[1].completion_confidence, Some(95));
-    }
-
-    #[test]
-    fn test_confidence_rejects_values_outside_percentage_range() {
-        let result = serde_json::from_value::<TodoWriteInput>(json!({
-            "todos": [{
-                "id": "1",
-                "content": "Task",
-                "status": "pending",
-                "confidence": 101
-            }]
-        }));
-
-        assert!(result.is_err());
-    }
-
     // --- Status parsing ------------------------------------------------------
 
     #[test]
@@ -542,26 +552,26 @@ mod tests {
     #[test]
     fn test_valid_transitions() {
         // pending → in_progress
-        assert!(validate_transition("t1", &TodoStatus::Pending, &TodoStatus::InProgress).is_ok());
+        assert!(validate_transition("t1", &TodoStatus::Pending, &TodoStatus::InProgress, false).is_ok());
         // pending → completed
-        assert!(validate_transition("t2", &TodoStatus::Pending, &TodoStatus::Completed).is_ok());
+        assert!(validate_transition("t2", &TodoStatus::Pending, &TodoStatus::Completed, false).is_ok());
         // in_progress → completed
-        assert!(validate_transition("t3", &TodoStatus::InProgress, &TodoStatus::Completed).is_ok());
+        assert!(validate_transition("t3", &TodoStatus::InProgress, &TodoStatus::Completed, false).is_ok());
         // no-op transitions are always fine
-        assert!(validate_transition("t4", &TodoStatus::Pending, &TodoStatus::Pending).is_ok());
-        assert!(validate_transition("t5", &TodoStatus::InProgress, &TodoStatus::InProgress).is_ok());
-        assert!(validate_transition("t6", &TodoStatus::Completed, &TodoStatus::Completed).is_ok());
+        assert!(validate_transition("t4", &TodoStatus::Pending, &TodoStatus::Pending, false).is_ok());
+        assert!(validate_transition("t5", &TodoStatus::InProgress, &TodoStatus::InProgress, false).is_ok());
+        assert!(validate_transition("t6", &TodoStatus::Completed, &TodoStatus::Completed, false).is_ok());
     }
 
     #[test]
     fn test_invalid_transition_completed_to_anything() {
-        assert!(validate_transition("t1", &TodoStatus::Completed, &TodoStatus::Pending).is_err());
-        assert!(validate_transition("t2", &TodoStatus::Completed, &TodoStatus::InProgress).is_err());
+        assert!(validate_transition("t1", &TodoStatus::Completed, &TodoStatus::Pending, false).is_err());
+        assert!(validate_transition("t2", &TodoStatus::Completed, &TodoStatus::InProgress, false).is_err());
     }
 
     #[test]
     fn test_invalid_transition_in_progress_to_pending() {
-        assert!(validate_transition("t1", &TodoStatus::InProgress, &TodoStatus::Pending).is_err());
+        assert!(validate_transition("t1", &TodoStatus::InProgress, &TodoStatus::Pending, false).is_err());
     }
 
     // --- ID uniqueness -------------------------------------------------------
@@ -571,5 +581,78 @@ mod tests {
         let err = TodoStatus::from_str_ci("banana").unwrap_err();
         assert!(err.contains("Invalid status"), "error should mention invalid status");
         assert!(err.contains("banana"), "error should echo the bad value");
+    }
+
+    // --- Auto-poke ----------------------------------------------------------
+
+    #[test]
+    fn build_auto_poke_message_singular() {
+        let msg = build_auto_poke_message(1);
+        assert!(msg.contains("1 incomplete todo"));
+        assert!(!msg.contains("todos"));
+    }
+
+    #[test]
+    fn build_auto_poke_message_plural() {
+        let msg = build_auto_poke_message(5);
+        assert!(msg.contains("5 incomplete todos"));
+    }
+
+    #[test]
+    fn is_auto_poke_message_recognizes_poke() {
+        let msg = build_auto_poke_message(3);
+        assert!(is_auto_poke_message(&msg));
+    }
+
+    #[test]
+    fn is_auto_poke_message_rejects_normal() {
+        assert!(!is_auto_poke_message("Hello, can you help me?"));
+        assert!(!is_auto_poke_message("Continue working on the task."));
+    }
+
+    // --- TodoItem deserialization with new fields ----------------------------
+
+    #[test]
+    fn todo_item_deserialize_with_old_schema() {
+        let json = r#"{"id":"1","content":"Test","status":"pending"}"#;
+        let item: TodoItem = serde_json::from_str(json).unwrap();
+        assert_eq!(item.id, "1");
+        assert!(item.group.is_none());
+        assert!(item.confidence.is_none());
+        assert!(item.confidence_history.is_empty());
+        assert!(item.blocked_by.is_empty());
+        assert!(!item.force_reopen);
+    }
+
+    #[test]
+    fn todo_item_deserialize_with_new_schema() {
+        let json = r#"{
+            "id": "2",
+            "content": "New fields test",
+            "status": "in_progress",
+            "priority": "high",
+            "group": "Phase 1",
+            "confidence": 75,
+            "blocked_by": ["1"],
+            "force_reopen": false
+        }"#;
+        let item: TodoItem = serde_json::from_str(json).unwrap();
+        assert_eq!(item.group.as_deref(), Some("Phase 1"));
+        assert_eq!(item.confidence, Some(75));
+        assert_eq!(item.blocked_by, vec!["1"]);
+    }
+
+    // --- Force reopen transition --------------------------------------------
+
+    #[test]
+    fn validate_transition_force_reopen_allows_completed_to_pending() {
+        let result = validate_transition("test", &TodoStatus::Completed, &TodoStatus::Pending, true);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_transition_without_force_reopen_blocks_completed_to_pending() {
+        let result = validate_transition("test", &TodoStatus::Completed, &TodoStatus::Pending, false);
+        assert!(result.is_err());
     }
 }

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -101,11 +101,12 @@ const PROMPT_SLASH_COMMANDS: &[(&str, &str)] = &[
     ("upgrade", "Check for updates and upgrade to the latest version"),
     ("vim", "Toggle vim keybindings"),
     ("voice", "Toggle voice input mode"),
+    ("turns", "Set or disable the max turn limit (e.g. /turns 25, /turns off)"),
 ];
 
 fn help_command_category(name: &str) -> &'static str {
     match name {
-        "connect" | "model" | "providers" | "refresh" | "fast" | "effort" | "voice" => "Model & Provider",
+        "connect" | "model" | "providers" | "refresh" | "fast" | "effort" | "voice" | "turns" => "Model & Provider",
         "changes" | "diff" | "review" | "rewind" | "export" | "copy" | "share" | "links" => "Review & History",
         "stats" | "cost" | "context" | "insights" | "heapdump" | "doctor" => "Diagnostics",
         "config" | "settings" | "theme" | "keybindings" | "hooks" | "mcp" | "import-config" => {
@@ -241,7 +242,7 @@ fn import_config_picker_items() -> Vec<SelectItem> {
 }
 
 fn provider_picker_items() -> Vec<SelectItem> {
-    vec![
+    let mut items = vec![
         SelectItem { id: "free".into(), title: "Free Mode".into(), description: "OpenCode Zen → OpenRouter free fallback (no spend)".into(), category: "Popular".into(), badge: Some("FREE".into()) },
         SelectItem { id: "openai".into(), title: "OpenAI".into(), description: "(API key)".into(), category: "Popular".into(), badge: None },
         SelectItem { id: "openai-codex".into(), title: "OpenAI Codex".into(), description: "(ChatGPT Plus/Pro — browser login)".into(), category: "Popular".into(), badge: None },
@@ -297,7 +298,21 @@ fn provider_picker_items() -> Vec<SelectItem> {
         SelectItem { id: "upstage".into(), title: "Upstage".into(), description: "Hosted Upstage models".into(), category: "Other".into(), badge: None },
         SelectItem { id: "stepfun".into(), title: "StepFun".into(), description: "Hosted reasoning models".into(), category: "Other".into(), badge: None },
         SelectItem { id: "fireworks".into(), title: "Fireworks AI".into(), description: "Fast inference".into(), category: "Other".into(), badge: None },
-    ]
+    ];
+
+        // Dynamically append custom providers from Settings.
+        if let Ok(settings) = Settings::load_sync() {
+            for (id, def) in &settings.custom_providers {
+                items.push(SelectItem {
+                    id: id.clone(),
+                    title: def.name.clone(),
+                    description: format!("Custom OpenAI-compatible — {}", def.api_base),
+                    category: "Custom".into(),
+                    badge: Some("CUSTOM".into()),
+                });
+            }
+        }
+        items
 }
 
 // ---------------------------------------------------------------------------
@@ -311,6 +326,8 @@ pub enum SystemMessageStyle {
     Warning,
     /// Compact / auto-compact boundary marker.
     Compact,
+    /// Inline todo card showing task progress.
+    TodoCard,
 }
 
 /// A synthetic system annotation inserted between conversation messages.
@@ -333,6 +350,12 @@ pub enum DisplayMessage {
     Conversation(Message),
     /// An injected system notice (e.g. compact boundary).
     System { text: String, style: SystemMessageStyle },
+    /// A `!` bang command execution — display only, never sent to model.
+    BangCommand { command: String },
+    /// Output from a `!` bang command.
+    BangOutput { text: String, exit_code: Option<i32> },
+    /// Error from a `!` bang command.
+    BangError { text: String },
 }
 
 /// Context menu state: position and currently selected item index.
@@ -800,6 +823,8 @@ pub struct App {
     pub input: String,
     pub prompt_input: PromptInputState,
     pub input_history: Vec<String>,
+    /// Separate history for `!` bang commands (distinct from prompt input history).
+    pub bang_command_history: Vec<String>,
     pub history_index: Option<usize>,
     pub scroll_offset: usize,
     pub is_streaming: bool,
@@ -837,6 +862,8 @@ pub struct App {
     pub effort_level: EffortLevel,
     /// Whether fast mode is currently active (model locked to FAST_MODE_MODEL).
     pub fast_mode: bool,
+    /// Override for max turns (set via /turns command). None = use config/agent default.
+    pub max_turns_override: Option<u32>,
     /// Current agent mode name: "build", "plan".
     pub agent_mode: Option<String>,
     /// Accent color derived from the current agent mode.
@@ -878,8 +905,15 @@ pub struct App {
     pub rustle_temp_pose: Option<crate::rustle::RustlePose>,
     /// Frame counter at which the next random eye-shift should fire.
     pub rustle_next_blink: u64,
+    /// Token output rates from recent turns (tokens/sec), for computing
+    /// a rolling average. Last 5 turns kept.
+    pub recent_token_rates: Vec<f64>,
     /// Instant the current turn's streaming began (reset each time streaming starts).
     pub turn_start: Option<std::time::Instant>,
+    /// Instant the first streaming token arrived this turn (for active-throughput TPS).
+    pub stream_first_token: Option<std::time::Instant>,
+    /// Instant of the most recent streaming token this turn.
+    pub stream_last_token: Option<std::time::Instant>,
     /// Elapsed time string for the last completed turn, e.g. "2m 5s".
     pub last_turn_elapsed: Option<String>,
     /// Past-tense verb shown after turn completes, e.g. "Worked" / "Baked".
@@ -1062,6 +1096,19 @@ pub struct App {
     /// When `true`, the main loop will inject a synthetic Enter event on the
     /// next iteration to dequeue and submit the next queued message.
     pub pending_auto_submit: bool,
+    /// Auto-poke counter — how many pokes have been sent this session.
+    pub auto_poke_count: u32,
+    /// Hash of the last todo state for no-progress detection.
+    pub last_todo_hash: String,
+    /// Count of consecutive no-progress turns.
+    pub no_progress_turns: u32,
+    /// Whether the todo card is visible in the transcript.
+    pub todo_card_visible: bool,
+    /// When `true`, the main loop should start a new query turn because
+    /// auto-poke injected a continuation message into `queued_messages`.
+    pub pending_auto_poke: bool,
+    /// Current session ID (used for todo persistence + auto-poke).
+    pub session_id: String,
     /// Connect-a-provider dialog (/connect command).
     pub connect_dialog: DialogSelectState,
     /// Import-config source picker (/import-config command).
@@ -1142,6 +1189,12 @@ pub struct App {
     /// None when no goal is active. Updated by the REPL after each turn.
     pub active_goal_badge: Option<String>,
 
+    /// Number of discovered skills (from `.claurst/skills/` etc.) for the
+    /// status-bar indicator.
+    pub skill_count: usize,
+    /// Number of configured MCP servers for the status-bar indicator.
+    pub mcp_server_count: usize,
+
     // ---- Thinking block expansion state ----------------------------------
     /// Set of thinking block content hashes that are expanded.
     pub thinking_expanded: std::collections::HashSet<u64>,
@@ -1174,6 +1227,10 @@ pub struct App {
     pub selection_anchor: Option<(u16, u16)>,
     /// Selection drag focus (col, row) — updated on mouse-drag / mouse-up.
     pub selection_focus: Option<(u16, u16)>,
+    /// Keyboard selection mode active.
+    pub kb_select_mode: bool,
+    /// Cursor row for keyboard selection (screen coordinate).
+    pub kb_cursor_row: u16,
     /// Text extracted from the current selection (updated each render frame).
     pub selection_text: RefCell<String>,
     /// Cache of row -> rendered text within the selectable area, refreshed
@@ -1268,8 +1325,15 @@ impl App {
                 .join("models.json");
             reg.load_cache(&cache_path);
             reg.apply_model_overrides(&config.model_overrides);
+            let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+            reg.apply_custom_providers(&settings.custom_providers);
             reg
         };
+        let skill_count = {
+            let cwd = std::env::current_dir().unwrap_or_default();
+            claurst_core::discover_skills(&cwd, &config.skills).len()
+        };
+        let mcp_server_count = config.mcp_servers.len();
         Self {
             config,
             cost_tracker,
@@ -1279,6 +1343,7 @@ impl App {
             input: String::new(),
             prompt_input: PromptInputState::new(),
             input_history: Vec::new(),
+            bang_command_history: Vec::new(),
             history_index: None,
             scroll_offset: 0,
             is_streaming: false,
@@ -1299,6 +1364,7 @@ impl App {
             has_credentials: true, // overridden by caller when no key is configured
             effort_level: EffortLevel::Medium,
             fast_mode: false,
+            max_turns_override: None,
             agent_mode: None,
             agent_mode_changed: false,
             accent_color: ACCENT_BUILD,
@@ -1318,6 +1384,9 @@ impl App {
                 .unwrap_or_default()
                 .subsec_nanos() as u64 % 300),
             turn_start: None,
+            stream_first_token: None,
+            stream_last_token: None,
+            recent_token_rates: Vec::new(),
             last_turn_elapsed: None,
             last_turn_verb: None,
             turn_metadata: Vec::new(),
@@ -1398,6 +1467,12 @@ impl App {
             auth_store: claurst_core::AuthStore::load(),
             queued_messages: std::collections::VecDeque::new(),
             pending_auto_submit: false,
+            auto_poke_count: 0,
+            last_todo_hash: String::new(),
+            no_progress_turns: 0,
+            todo_card_visible: false,
+            pending_auto_poke: false,
+            session_id: String::new(),
             connect_dialog: DialogSelectState::new("Connect a provider", provider_picker_items()),
             import_config_picker: DialogSelectState::new("Import config", import_config_picker_items()),
             import_config_dialog: ImportConfigDialogState::new(),
@@ -1471,6 +1546,8 @@ impl App {
             worktree_branch: None,
             agent_type_badge: None,
             active_goal_badge: None,
+            skill_count,
+            mcp_server_count,
             thinking_expanded: std::collections::HashSet::new(),
             last_msg_area: Cell::new(ratatui::layout::Rect::default()),
             last_selectable_area: Cell::new(ratatui::layout::Rect::default()),
@@ -1484,6 +1561,8 @@ impl App {
             last_max_scroll: Cell::new(0),
             selection_anchor: None,
             selection_focus: None,
+            kb_select_mode: false,
+            kb_cursor_row: 0,
             selection_text: RefCell::new(String::new()),
             last_row_text: RefCell::new(std::collections::HashMap::new()),
             last_click_time: None,
@@ -1613,6 +1692,8 @@ impl App {
         // measures actual round-trip time even when the provider buffers its
         // full response before yielding any stream events (e.g. Gemini flash).
         self.turn_start = Some(std::time::Instant::now());
+        self.stream_first_token = None;
+        self.stream_last_token = None;
         self.last_turn_elapsed = None;
         self.last_turn_verb = None;
     }
@@ -1703,6 +1784,10 @@ impl App {
             .join("models.json");
         if cache_path.exists() {
             self.model_registry.load_cache(&cache_path);
+            // Re-apply custom providers after cache merge so custom model
+            // entries survive any catalog overlay.
+            let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+            self.model_registry.apply_custom_providers(&settings.custom_providers);
         }
 
         let models = crate::model_picker::models_for_provider_from_registry(
@@ -1710,6 +1795,7 @@ impl App {
             &self.model_registry,
         );
         self.model_picker.set_models(models);
+        self.model_picker.load_favorites();
         self.model_picker_provider_id = Some(provider_id.to_string());
         // Catalog-backed providers (Anthropic/OpenAI/Google) are a read-only
         // projection of the models.dev catalog — there is no live endpoint to
@@ -1754,6 +1840,98 @@ impl App {
         self.has_credentials = true;
         self.status_message = Some(format!("{} {}.", status_prefix, provider_name));
         self.open_model_picker_for_provider(&provider_id, Some(picker_title));
+    }
+
+    /// Check if a provider is connected (has credentials, is a keyless
+    /// local/subprocess provider, or is a configured custom provider with
+    /// a non-empty apiBase — even without an API key for internal gateways).
+    fn is_provider_connected(&self, provider_id: &str) -> bool {
+        match provider_id {
+"ollama" | "lmstudio" | "lm-studio"
+            | "llamacpp" | "llama-cpp" | "llama-server" | "free" => true,
+            _ => {
+                // Has an API key configured → connected.
+                if self.config.resolve_provider_api_key(provider_id).is_some() {
+                    return true;
+                }
+                // Custom provider with a non-empty apiBase → connected
+                // (internal gateways / local proxies may not need auth).
+                if let Ok(settings) = claurst_core::Settings::load_sync() {
+                    if let Some(def) = settings.custom_providers.get(provider_id) {
+                        return !def.api_base.trim().is_empty();
+                    }
+                }
+                false
+            }
+        }
+    }
+
+    /// Open the model picker showing models from all connected providers,
+    /// grouped by provider name.
+    fn open_model_picker_all_providers(&mut self) {
+        self.dismiss_error_notifications();
+
+        // Collect models from all connected providers.
+        let mut all_models: Vec<crate::model_picker::ModelEntry> = Vec::new();
+
+        // Get ALL provider IDs from the registry (for the full model list).
+        let all_provider_ids: Vec<String> = if let Some(ref registry) = self.provider_registry {
+            registry.provider_ids().iter().map(|id| id.to_string()).collect()
+        } else {
+            Vec::new()
+        };
+
+        // Also include current provider if not in registry.
+        let mut provider_ids = all_provider_ids;
+        if let Some(ref current) = self.config.provider {
+            if !provider_ids.contains(current) {
+                provider_ids.push(current.clone());
+            }
+        }
+
+        // Determine which providers are connected.
+        let connected_ids: std::collections::HashSet<String> = provider_ids
+            .iter()
+            .filter(|pid| self.is_provider_connected(pid))
+            .cloned()
+            .collect();
+
+        // Pass the connected set to the picker for runtime filtering.
+        self.model_picker.connected_provider_ids = connected_ids;
+
+        // Collect models from ALL providers (filtering happens at display time).
+        let mut provider_names = std::collections::HashMap::new();
+        for pid in &provider_ids {
+            // Look up the provider display name from the registry.
+            if let Some(entry) = self.model_registry.list_providers()
+                .iter()
+                .find(|p| &*p.id == pid)
+            {
+                provider_names.insert(pid.clone(), entry.name.clone());
+            }
+            let models = crate::model_picker::models_for_provider_from_registry(
+                pid,
+                &self.model_registry,
+            );
+            for mut m in models {
+                m.provider_id = pid.clone();
+                all_models.push(m);
+            }
+        }
+
+        self.model_picker.provider_names = provider_names;
+        self.model_picker.set_models(all_models);
+        self.model_picker_provider_id = None; // All providers mode
+        self.model_picker.all_providers_mode = true;
+        // Trigger background model discovery.
+        self.model_picker.loading_models = true;
+        self.model_picker_fetch_pending = true;
+
+        self.model_picker.open_all_providers(
+            &self.model_name,
+            self.effort_level,
+            self.fast_mode,
+        );
     }
 
     fn persist_custom_provider_base_url(&self, base_url: &str) {
@@ -1812,6 +1990,12 @@ impl App {
             ];
             if known.contains(&provider) {
                 return Some(provider.to_string());
+            }
+            // Check custom providers at runtime.
+            if let Ok(settings) = Settings::load_sync() {
+                if settings.custom_providers.contains_key(provider) {
+                    return Some(provider.to_string());
+                }
             }
         }
 
@@ -1980,6 +2164,8 @@ impl App {
         self.model_registry = claurst_api::ModelRegistry::new();
         // Re-layer user metadata overrides (issue #309) onto the fresh registry.
         self.model_registry.apply_model_overrides(&self.config.model_overrides);
+        let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+        self.model_registry.apply_custom_providers(&settings.custom_providers);
         self.auth_store = auth_store;
         self.connect_dialog = DialogSelectState::new("Connect a provider", provider_picker_items());
         self.import_config_picker = DialogSelectState::new("Import config", import_config_picker_items());
@@ -2004,6 +2190,33 @@ impl App {
     /// Handle slash commands that should open UI screens rather than execute
     /// as normal commands. Returns `true` if the command was intercepted.
     pub fn intercept_slash_command_with_args(&mut self, cmd: &str, args: &str) -> bool {
+        if cmd == "turns" {
+            let args = args.trim();
+            if args.is_empty() {
+                let current = self.max_turns_override;
+                let msg = match current {
+                    Some(n) if n == u32::MAX => "Max turns: disabled (no limit).".to_string(),
+                    Some(n) => format!("Max turns: {} (override active).", n),
+                    None => "Max turns: using config/agent default.".to_string(),
+                };
+                self.status_message = Some(msg);
+            } else if args == "off" || args == "disable" || args == "0" {
+                self.max_turns_override = Some(u32::MAX);
+                self.status_message = Some("Max turns disabled (no limit).".to_string());
+            } else if let Ok(n) = args.parse::<u32>() {
+                if n == 0 {
+                    self.max_turns_override = Some(u32::MAX);
+                    self.status_message = Some("Max turns disabled (no limit).".to_string());
+                } else {
+                    self.max_turns_override = Some(n);
+                    self.status_message = Some(format!("Max turns set to {}.", n));
+                }
+            } else {
+                self.status_message =
+                    Some("Usage: /turns <number> | off | (blank to show current).".to_string());
+            }
+            return true;
+        }
         if cmd == "mcp" && !args.trim().is_empty() {
             return false;
         }
@@ -2084,12 +2297,7 @@ impl App {
                     self.status_message = Some("Connect a provider to choose a model.".to_string());
                     return true;
                 }
-                let provider = self
-                    .config
-                    .provider
-                    .clone()
-                    .unwrap_or_else(|| "anthropic".to_string());
-                self.open_model_picker_for_provider(&provider, None);
+                self.open_model_picker_all_providers();
                 true
             }
             "session" | "resume" => {
@@ -2981,6 +3189,103 @@ impl App {
         self.refresh_prompt_input();
     }
 
+    /// Execute a `!` bang command directly, without sending to the model.
+    /// Output is displayed in the transcript (display_messages only) — the
+    /// model never sees it. Zero token consumption.
+    pub fn execute_bang_command(&mut self, command: String) {
+        // Check if bang commands are enabled.
+        let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+        if !settings.bang_commands.enabled {
+            self.push_notification(
+                crate::notifications::NotificationKind::Warning,
+                "Bang commands are disabled. Enable with \"bangCommands\": {\"enabled\": true} in settings.json.".to_string(),
+                None,
+            );
+            return;
+        }
+
+        // Block in plan mode.
+        if self.config.permission_mode == claurst_core::PermissionMode::Plan {
+            self.push_notification(
+                crate::notifications::NotificationKind::Warning,
+                "Bang commands disabled in plan mode.".to_string(),
+                None,
+            );
+            return;
+        }
+
+        // Display the command.
+        if settings.bang_commands.show_in_transcript {
+            self.display_messages.push(DisplayMessage::BangCommand {
+                command: command.clone(),
+            });
+        }
+
+        // Resolve working directory: prefer project dir, fall back to current dir.
+        let working_dir = self
+            .config
+            .project_dir
+            .clone()
+            .or_else(|| {
+                self.current_dir
+                    .as_ref()
+                    .map(|s| std::path::PathBuf::from(s))
+            })
+            .unwrap_or_else(|| std::path::PathBuf::from("."));
+
+        // Execute via std::process::Command — NO model round-trip, NO PTY.
+        let result = std::process::Command::new("bash")
+            .arg("-c")
+            .arg(&command)
+            .current_dir(&working_dir)
+            .output();
+
+        match result {
+            Ok(output) => {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let exit_code = output.status.code();
+
+                let display = if stderr.is_empty() {
+                    stdout.to_string()
+                } else if stdout.is_empty() {
+                    stderr.to_string()
+                } else {
+                    format!("{}\n--- stderr ---\n{}", stdout, stderr)
+                };
+
+                if settings.bang_commands.show_in_transcript {
+                    if exit_code.is_some_and(|c| c != 0) {
+                        let full = format!("{}\n[exit: {}]", display, exit_code.unwrap());
+                        self.display_messages.push(DisplayMessage::BangOutput {
+                            text: full,
+                            exit_code,
+                        });
+                    } else {
+                        self.display_messages.push(DisplayMessage::BangOutput {
+                            text: display,
+                            exit_code,
+                        });
+                    }
+                }
+
+                // Add to separate history if enabled.
+                if settings.bang_commands.add_to_history {
+                    self.bang_command_history.push(command);
+                }
+            }
+            Err(e) => {
+                if settings.bang_commands.show_in_transcript {
+                    self.display_messages.push(DisplayMessage::BangError {
+                        text: format!("Error: {}", e),
+                    });
+                }
+            }
+        }
+
+        self.invalidate_transcript();
+    }
+
     fn refresh_turn_diff_from_history(&mut self) {
         let Some(file_history) = self.file_history.as_ref() else {
             self.diff_viewer.set_turn_diff(Vec::new());
@@ -3478,6 +3783,7 @@ impl App {
 
                         match selected.id.as_str() {
                             // Local providers — activate immediately, no key needed
+                            // Local providers — activate immediately, no key needed
                             "ollama" | "lmstudio" | "llamacpp" => {
                                 self.activate_provider(selected.id.clone(), selected.title.clone(), "Switched to");
                             }
@@ -3537,6 +3843,23 @@ impl App {
                             "amazon-bedrock" => {
                                 self.key_input_dialog
                                     .open(selected.id.clone(), selected.title.clone());
+                            }
+                            // Custom providers from Settings — may need API key
+                            id if {
+                                let settings = Settings::load_sync().unwrap_or_default();
+                                settings.custom_providers.contains_key(id)
+                            } => {
+                                // Check if the custom provider has an API key resolved.
+                                let settings = Settings::load_sync().unwrap_or_default();
+                                let def = settings.custom_providers.get(&selected.id).unwrap();
+                                if def.resolve_api_key().is_some() {
+                                    // Key available — activate directly.
+                                    self.activate_provider(selected.id.clone(), selected.title.clone(), "Switched to");
+                                } else {
+                                    // No key — open key input dialog.
+                                    self.key_input_dialog
+                                        .open(selected.id.clone(), selected.title.clone());
+                                }
                             }
                             // All other providers — open API key input dialog
                             _ => {
@@ -3640,8 +3963,37 @@ impl App {
                 KeyCode::Right => self.model_picker.effort_next(),
                 KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => self.model_picker.select_prev(),
                 KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => self.model_picker.select_next(),
+                KeyCode::Tab => self.model_picker.select_next_provider(),
+                KeyCode::BackTab => self.model_picker.select_prev_provider(),
                 KeyCode::Enter => {
+                    // Capture all-providers mode AND the selected entry's
+                    // provider_id BEFORE confirm() — confirm() calls close()
+                    // which resets all_providers_mode to false AND clears the
+                    // filter, changing the grouped list and invalidating
+                    // selected_idx.
+                    let was_all_providers = self.model_picker.all_providers_mode;
+                    let selected_provider_id = if was_all_providers {
+                        self.model_picker
+                            .filtered_models_grouped()
+                            .get(self.model_picker.selected_idx)
+                            .map(|(m, _)| m.provider_id.clone())
+                    } else {
+                        None
+                    };
                     if let Some((model_id, effort)) = self.model_picker.confirm() {
+                        // Default sentinel — clear explicit model override.
+                        if model_id == crate::model_picker::DEFAULT_MODEL_SENTINEL {
+                            self.config.model = None;
+                            let provider = self.config.provider.as_deref().unwrap_or("anthropic");
+                            let best = self.display_default_model_for_provider(provider);
+                            self.model_name = best.clone();
+                            self.cost_tracker.set_model(&best);
+                            self.refresh_context_window_size();
+                            self.context_used_tokens = 0;
+                            self.persist_provider_and_model();
+                            self.status_message = Some(format!("Model: {} (default)", best));
+                            return false;
+                        }
                         // If user picked a model other than the fast-mode model
                         // while fast mode was active, turn fast mode off.
                         if self.fast_mode && !self.model_picker.is_selected_fast_mode_model(&model_id) {
@@ -3656,11 +4008,27 @@ impl App {
                         // a routing prefix (`free/…`, `zen/…`, `openrouter/…`)
                         // so re-prefixing would produce nonsense like
                         // `free/free/auto`.
-                        let provider = self.config.provider.as_deref().unwrap_or("anthropic");
-                        let full_model = if provider == "anthropic" || provider == "free" {
-                            model_id.clone()
+                        //
+                        // In all-providers mode the provider is inferred from
+                        // the selected entry's `provider_id` field rather than
+                        // the current config provider.
+                        let full_model = if was_all_providers {
+                            if let Some(ref provider) = selected_provider_id {
+                                if provider == "anthropic" || provider == "free" {
+                                    model_id.clone()
+                                } else {
+                                    format!("{}/{}", provider, model_id)
+                                }
+                            } else {
+                                model_id.clone()
+                            }
                         } else {
-                            format!("{}/{}", provider, model_id)
+                            let provider = self.config.provider.as_deref().unwrap_or("anthropic");
+                            if provider == "anthropic" || provider == "free" {
+                                model_id.clone()
+                            } else {
+                                format!("{}/{}", provider, model_id)
+                            }
                         };
                         self.set_model(full_model.clone());
                         self.persist_provider_and_model();
@@ -3669,6 +4037,20 @@ impl App {
                     }
                 }
                 KeyCode::Backspace => self.model_picker.pop_filter_char(),
+                KeyCode::Char('f') | KeyCode::Char('*') => {
+                    // Toggle favorite on the currently selected model.
+                    let grouped = self.model_picker.filtered_models_grouped();
+                    if let Some((m, _)) = grouped.get(self.model_picker.selected_idx) {
+                        let provider = self.config.provider.as_deref().unwrap_or("anthropic");
+                        let model_key = if provider == "anthropic" || provider == "free" {
+                            m.id.clone()
+                        } else {
+                            format!("{}/{}", provider, m.id)
+                        };
+                        self.model_picker.toggle_favorite(&model_key);
+                    }
+                }
+                KeyCode::Char('a') => self.model_picker.toggle_show_all_providers(),
                 KeyCode::Char(c) => self.model_picker.push_filter_char(c),
                 _ => {}
             }
@@ -4090,6 +4472,114 @@ impl App {
             self.keybindings.cancel_chord();
         }
 
+        // ---- Keyboard selection mode -------------------------------
+        if self.kb_select_mode {
+            match key.code {
+                KeyCode::Esc => {
+                    self.kb_select_mode = false;
+                    self.clear_selection();
+                    self.status_message = Some("Selection cancelled.".to_string());
+                    return false;
+                }
+                // Copy selection and exit
+                KeyCode::Char('y') | KeyCode::Char('Y') => {
+                    let text = self.selection_text.borrow().clone();
+                    if !text.is_empty() {
+                        let copied = crate::image_paste::write_clipboard_text(&text);
+                        if copied {
+                            self.push_notification(NotificationKind::Info, "Copied to clipboard".to_string(), Some(2));
+                        }
+                    }
+                    self.kb_select_mode = false;
+                    self.clear_selection();
+                    return false;
+                }
+                // Ctrl+C also copies in selection mode
+                KeyCode::Char(c) if (c == 'c' || c == 'C') && key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    let text = self.selection_text.borrow().clone();
+                    if !text.is_empty() {
+                        let copied = crate::image_paste::write_clipboard_text(&text);
+                        if copied {
+                            self.push_notification(NotificationKind::Info, "Copied to clipboard".to_string(), Some(2));
+                        }
+                    }
+                    self.kb_select_mode = false;
+                    self.clear_selection();
+                    return false;
+                }
+                // Movement: extend selection
+                KeyCode::Up => {
+                    if self.kb_cursor_row > self.last_selectable_area.get().y {
+                        self.kb_cursor_row -= 1;
+                        // Scroll up if cursor goes above visible area
+                        let area = self.last_selectable_area.get();
+                        if self.kb_cursor_row < area.y {
+                            let step = self.scroll_step();
+                            self.scroll_offset = self.scroll_offset.saturating_add(step);
+                        }
+                    }
+                    self.update_kb_selection();
+                    return false;
+                }
+                KeyCode::Down => {
+                    let area = self.last_selectable_area.get();
+                    let max_row = area.y + area.height.saturating_sub(1);
+                    if self.kb_cursor_row < max_row {
+                        self.kb_cursor_row += 1;
+                        // Scroll down if cursor goes below visible area
+                        if self.kb_cursor_row >= area.y + area.height {
+                            let step = self.scroll_step();
+                            let new_off = self.scroll_offset.saturating_sub(step);
+                            self.scroll_offset = new_off;
+                            if new_off == 0 {
+                                self.auto_scroll = true;
+                            }
+                        }
+                    }
+                    self.update_kb_selection();
+                    return false;
+                }
+                KeyCode::Home => {
+                    let area = self.last_selectable_area.get();
+                    self.kb_cursor_row = area.y;
+                    // Scroll to top
+                    self.scroll_offset = self.total_message_lines.get().saturating_sub(area.height as usize);
+                    self.auto_scroll = false;
+                    self.update_kb_selection();
+                    return false;
+                }
+                KeyCode::End => {
+                    let area = self.last_selectable_area.get();
+                    self.kb_cursor_row = area.y + area.height.saturating_sub(1);
+                    // Scroll to bottom
+                    self.scroll_offset = 0;
+                    self.auto_scroll = true;
+                    self.update_kb_selection();
+                    return false;
+                }
+                KeyCode::PageUp => {
+                    let area = self.last_selectable_area.get();
+                    let step = area.height;
+                    self.kb_cursor_row = self.kb_cursor_row.saturating_sub(step).max(area.y);
+                    self.scroll_offset = self.scroll_offset.saturating_add(step as usize);
+                    self.update_kb_selection();
+                    return false;
+                }
+                KeyCode::PageDown => {
+                    let area = self.last_selectable_area.get();
+                    let max_row = area.y + area.height.saturating_sub(1);
+                    let step = area.height;
+                    self.kb_cursor_row = (self.kb_cursor_row + step).min(max_row);
+                    let new_off = self.scroll_offset.saturating_sub(step as usize);
+                    self.scroll_offset = new_off;
+                    if new_off == 0 { self.auto_scroll = true; }
+                    self.update_kb_selection();
+                    return false;
+                }
+                _ => return false, // Swallow all other keys in selection mode
+            }
+        }
+
         // Clear any active text selection on key press (except Ctrl+C which copies it).
         let is_copy = key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL);
         if !is_copy && self.selection_anchor.is_some() {
@@ -4386,6 +4876,23 @@ impl App {
             KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::ALT) => {
                 self.prompt_input.delete_word_at_cursor();
                 self.refresh_prompt_input();
+            }
+
+            // ---- Enter keyboard selection mode ------------------------
+            KeyCode::Char('v') if !key.modifiers.contains(KeyModifiers::CONTROL)
+                && !key.modifiers.contains(KeyModifiers::ALT)
+                && self.prompt_input.is_empty() =>
+            {
+                self.kb_select_mode = true;
+                let area = self.last_selectable_area.get();
+                // Start cursor at the bottom of the visible area
+                self.kb_cursor_row = area.y + area.height.saturating_sub(1);
+                // Set anchor at current cursor, focus at same point (empty selection)
+                let col = area.x;
+                self.selection_anchor = Some((col, self.kb_cursor_row));
+                self.selection_focus = Some((col, self.kb_cursor_row));
+                self.status_message = Some("Selection mode: Arrows select, y/Ctrl+C copy, Esc cancel".to_string());
+                return false;
             }
 
             // ---- Text entry (allowed while streaming so users can queue
@@ -5550,7 +6057,28 @@ impl App {
     fn clear_selection(&mut self) {
         self.selection_anchor = None;
         self.selection_focus = None;
+        self.kb_select_mode = false;
         *self.selection_text.borrow_mut() = String::new();
+    }
+
+    /// Update the selection from keyboard cursor position.
+    fn update_kb_selection(&mut self) {
+        if !self.kb_select_mode {
+            return;
+        }
+        let area = self.last_selectable_area.get();
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        // Anchor stays at original position, focus follows cursor.
+        // The render code in render.rs already handles extracting text between
+        // anchor and focus in row-major order.
+        let col = area.x;
+        self.selection_focus = Some((col, self.kb_cursor_row));
+        // If anchor is None (shouldn't happen), set it.
+        if self.selection_anchor.is_none() {
+            self.selection_anchor = Some((col, self.kb_cursor_row));
+        }
     }
 
     /// Show context menu at the given position.
@@ -6146,17 +6674,22 @@ impl App {
                 let input_area = self.last_input_area.get();
                 let selectable_area = self.last_selectable_area.get();
 
+                // When an error modal is showing, the selectable area covers
+                // the entire terminal — the modal text is selectable for copy.
+                let error_modal_active = self.notifications.current_is_error();
+
                 let in_input = input_area.width > 0 && input_area.height > 0
                     && mouse_event.row >= input_area.y
                     && mouse_event.row < input_area.y.saturating_add(input_area.height)
                     && mouse_event.column >= input_area.x
                     && mouse_event.column < input_area.x.saturating_add(input_area.width);
 
-                let in_selectable = selectable_area.width > 0 && selectable_area.height > 0
-                    && mouse_event.row >= selectable_area.y
-                    && mouse_event.row < selectable_area.y.saturating_add(selectable_area.height)
-                    && mouse_event.column >= selectable_area.x
-                    && mouse_event.column < selectable_area.x.saturating_add(selectable_area.width);
+                let in_selectable = error_modal_active
+                    || (selectable_area.width > 0 && selectable_area.height > 0
+                        && mouse_event.row >= selectable_area.y
+                        && mouse_event.row < selectable_area.y.saturating_add(selectable_area.height)
+                        && mouse_event.column >= selectable_area.x
+                        && mouse_event.column < selectable_area.x.saturating_add(selectable_area.width));
 
                 // Check for click on a thinking block header (takes priority over text selection).
                 if let Some(&hash) = self.thinking_row_map.borrow().get(&mouse_event.row) {
@@ -6169,11 +6702,11 @@ impl App {
                     return;
                 }
 
-                if in_input {
+                if in_input && !error_modal_active {
                     self.focus = FocusTarget::Input;
                     self.clear_selection();
                     self.handle_prompt_click(mouse_event.column, mouse_event.row);
-                } else if selectable_area.width == 0 || selectable_area.height == 0 {
+                } else if !error_modal_active && (selectable_area.width == 0 || selectable_area.height == 0) {
                     self.click_count = 0;
                 } else if in_selectable {
                     self.focus = FocusTarget::Transcript;
@@ -6312,6 +6845,11 @@ impl App {
                         self.stall_start = None;
                         match delta {
                             claurst_api::streaming::ContentDelta::TextDelta { text } => {
+                                let now = std::time::Instant::now();
+                                if self.stream_first_token.is_none() {
+                                    self.stream_first_token = Some(now);
+                                }
+                                self.stream_last_token = Some(now);
                                 self.streaming_text.push_str(&text);
                                 self.invalidate_transcript();
                             }
@@ -6413,17 +6951,58 @@ impl App {
                 }
                 // Record elapsed time and pick a completion verb
                 let seed = self.frame_count as usize ^ (self.messages.len() * 7);
+                // Track tokens per second for the status indicator (before take()).
+                // Prefer real usage; fall back to a rough char-based estimate
+// (~4 chars/token) for providers that never report usage.
+                let reported_output = usage.as_ref().map(|u| u.output_tokens).unwrap_or(0);
+                let output_tokens = if reported_output > 0 {
+                    reported_output
+                } else {
+                    (self.streaming_text.len() / 4).max(if self.streaming_text.is_empty() { 0 } else { 1 }) as u64
+                };
+                // Active streaming throughput: time between first and last
+                // token arrival, excluding TTFT and post-stream idle.
+                if output_tokens > 0 {
+                    if let (Some(first), Some(last)) =
+                        (self.stream_first_token, self.stream_last_token)
+                    {
+                        let active_secs = last.duration_since(first).as_secs_f64();
+                        if active_secs > 0.0 {
+                            let rate = output_tokens as f64 / active_secs;
+                            self.recent_token_rates.push(rate);
+                            if self.recent_token_rates.len() > 5 {
+                                self.recent_token_rates.remove(0);
+                            }
+                        }
+                    } else if let Some(start) = self.turn_start {
+                        // Fallback for turns with no streamed text deltas
+                        // (e.g. non-streaming / cached): use submit-to-complete.
+                        let elapsed_secs = start.elapsed().as_secs_f64();
+                        if elapsed_secs > 0.0 {
+                            let rate = output_tokens as f64 / elapsed_secs;
+                            self.recent_token_rates.push(rate);
+                            if self.recent_token_rates.len() > 5 {
+                                self.recent_token_rates.remove(0);
+                            }
+                        }
+                    }
+                }
                 let elapsed = self.turn_start.take()
                     .map(|start| format_elapsed_ms(start.elapsed().as_millis()));
                 self.last_turn_elapsed = Some(
                     elapsed.unwrap_or_else(|| "0s".to_string())
                 );
                 self.last_turn_verb = Some(sample_completion_verb(seed));
+                self.stream_first_token = None;
+                self.stream_last_token = None;
                 self.flush_streamed_assistant_message();
                 self.tool_use_blocks.retain(|b| b.status != ToolStatus::Running);
                 self.complete_current_turn_snapshot(stop_reason.contains("abort") || stop_reason.contains("cancel"));
                 self.invalidate_transcript();
                 self.refresh_turn_diff_from_history();
+
+                // Auto-poke: check for incomplete todos and queue continuation.
+                self.check_auto_poke();
             }
 
             QueryEvent::Status(msg) => {
@@ -6435,6 +7014,8 @@ impl App {
                 self.spinner_verb = None;
                 self.streaming_text.clear();
                 self.streaming_thinking.clear();
+                self.stream_first_token = None;
+                self.stream_last_token = None;
                 self.invalidate_transcript();
                 let err_msg = format!("Error: {}", msg);
                 self.push_assistant_message(err_msg.clone());
@@ -6473,6 +7054,65 @@ impl App {
 
         // Update token count from tracker.
         self.token_count = self.cost_tracker.total_tokens() as u32;
+    }
+
+    // -------------------------------------------------------------------
+    // Auto-poke
+    // -------------------------------------------------------------------
+
+    /// Check whether auto-poke should fire after a model turn.
+    /// If the model stopped with incomplete todos, queue a synthetic
+    /// continuation message via the existing `queued_messages` mechanism.
+    fn check_auto_poke(&mut self) {
+        // Don't poke if the turn was aborted/cancelled.
+        if !self.last_turn_elapsed.is_some() && self.tool_use_blocks.is_empty() {
+            // Likely a fresh state — still allow poke.
+        }
+
+        // Don't poke if auto-poke is disabled (check settings).
+        let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+        if !settings.auto_poke_enabled {
+            return;
+        }
+
+        // Check poke budget.
+        if self.auto_poke_count >= claurst_tools::todo_write::MAX_AUTO_POKES {
+            self.status_message = Some(format!(
+                "Auto-poke stopped: budget of {} reached.",
+                claurst_tools::todo_write::MAX_AUTO_POKES
+            ));
+            return;
+        }
+
+        // Count incomplete todos.
+        let incomplete = claurst_tools::todo_write::count_incomplete_todos(&self.session_id);
+        if incomplete == 0 {
+            return; // All done — no poke needed.
+        }
+
+        // No-progress detection: hash the todo state.
+        let current_hash = claurst_tools::todo_write::todo_state_hash(&self.session_id);
+        if current_hash == self.last_todo_hash {
+            self.no_progress_turns += 1;
+        } else {
+            self.no_progress_turns = 0;
+            self.last_todo_hash = current_hash;
+        }
+
+        if self.no_progress_turns >= claurst_tools::todo_write::NO_PROGRESS_THRESHOLD {
+            self.status_message = Some(
+                "Auto-poke stopped: no progress for 3 turns.".to_string()
+            );
+            return;
+        }
+
+        // Queue the auto-poke message via the existing queued_messages
+        // infrastructure so the main loop submits it on the next iteration.
+        let poke_msg = claurst_tools::todo_write::build_auto_poke_message(incomplete);
+        self.auto_poke_count += 1;
+        self.status_message = Some(format!("Auto-poking... ({} incomplete todos)", incomplete));
+        self.queued_messages.push_back(poke_msg);
+        self.pending_auto_submit = true;
     }
 
     // -------------------------------------------------------------------
@@ -6717,6 +7357,15 @@ impl App {
                         if should_submit {
                             // Dismiss any active error modal when the user sends a message
                             self.dismiss_error_notifications();
+                            // Check for bang command (! prefix) — execute directly, no model.
+                            if crate::input::is_bang_command(&self.prompt_input.text) {
+                                let command = self.prompt_input.text[1..].trim().to_string();
+                                self.clear_prompt();
+                                if !command.is_empty() {
+                                    self.execute_bang_command(command);
+                                }
+                                continue;
+                            }
                             // Check if this is a slash command that should open a UI screen
                             if crate::input::is_slash_command(&self.prompt_input.text) {
                                 let slash_input = self.prompt_input.text.clone();
@@ -7803,5 +8452,19 @@ mod tests {
         assert!(!app.should_exit);
         app.handle_key_event(press_key(KeyCode::Char('c'), KeyModifiers::CONTROL));
         assert!(app.should_exit);
+    }
+
+    #[test]
+    fn kb_select_mode_starts_and_cancels() {
+        let mut app = make_app();
+        app.kb_select_mode = true;
+        app.selection_anchor = Some((0, 5));
+        app.selection_focus = Some((0, 5));
+        app.kb_cursor_row = 5;
+        // Simulate Esc by testing state directly via clear_selection.
+        app.clear_selection();
+        assert!(!app.kb_select_mode);
+        assert!(app.selection_anchor.is_none());
+        assert!(app.selection_focus.is_none());
     }
 }

--- a/src-rust/crates/tui/src/input.rs
+++ b/src-rust/crates/tui/src/input.rs
@@ -5,6 +5,13 @@ pub fn is_slash_command(input: &str) -> bool {
     input.starts_with('/') && !input.starts_with("//")
 }
 
+/// Check if the input is a bang command (! prefix).
+/// A single `!` is a bang command only when followed by at least one
+/// non-whitespace character; `!!` (double bang) is NOT a bang command.
+pub fn is_bang_command(input: &str) -> bool {
+    input.starts_with('!') && !input.starts_with("!!") && input.len() > 1
+}
+
 /// Parse a slash command into `(command_name, args)`.
 /// Returns `("", "")` if the input is not a slash command.
 pub fn parse_slash_command(input: &str) -> (&str, &str) {
@@ -54,5 +61,21 @@ mod tests {
         let (cmd, args) = parse_slash_command("hello world");
         assert_eq!(cmd, "");
         assert_eq!(args, "");
+    }
+
+    #[test]
+    fn is_bang_command_true() {
+        assert!(is_bang_command("!ls"));
+        assert!(is_bang_command("! git status"));
+        assert!(is_bang_command("!echo hello"));
+    }
+
+    #[test]
+    fn is_bang_command_false() {
+        assert!(!is_bang_command("ls"));
+        assert!(!is_bang_command("/help"));
+        assert!(!is_bang_command("!! multi-line"));
+        assert!(!is_bang_command("hello"));
+        assert!(!is_bang_command(""));
     }
 }

--- a/src-rust/crates/tui/src/model_picker.rs
+++ b/src-rust/crates/tui/src/model_picker.rs
@@ -24,6 +24,10 @@ use crate::overlays::{centered_rect, modal_search_line, CLAURST_PANEL_BG};
 /// support reasoning honour it.
 pub use claurst_core::effort::EffortLevel;
 
+/// Sentinel model id for the "Default" picker entry. When the user selects
+/// this, the app clears the explicit model override so the provider's best
+/// model is used.
+pub const DEFAULT_MODEL_SENTINEL: &str = "__default__";
 
 // ---------------------------------------------------------------------------
 // Model capability helpers — driven by the opencode variants() ladder
@@ -221,6 +225,8 @@ pub struct ModelEntry {
     pub description: String,
     /// Whether this is the currently active model.
     pub is_current: bool,
+    /// Provider ID this model belongs to (for all-providers mode).
+    pub provider_id: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -228,12 +234,13 @@ pub struct ModelEntry {
 // ---------------------------------------------------------------------------
 
 /// Helper to build a `ModelEntry` with `is_current = false`.
-fn model_entry(id: &str, name: &str, desc: &str) -> ModelEntry {
+fn model_entry(id: &str, name: &str, desc: &str, provider_id: &str) -> ModelEntry {
     ModelEntry {
         id: id.to_string(),
         display_name: name.to_string(),
         description: desc.to_string(),
         is_current: false,
+        provider_id: provider_id.to_string(),
     }
 }
 
@@ -254,7 +261,7 @@ pub fn models_for_provider_from_registry(
     // directly.  `free/auto` is the default routing entry; the rest pin a
     // specific upstream model for users who care.
     if provider_id == "free" {
-        return free_provider_models();
+        return free_provider_models(provider_id);
     }
     // Codex (ChatGPT-authenticated OpenAI) is not in the models.dev catalog —
     // serve the curated CODEX_MODELS list so the picker isn't empty.  Accept
@@ -262,7 +269,7 @@ pub fn models_for_provider_from_registry(
     // ("openai-codex"); without the alias a fresh Codex login lands on the
     // empty-registry fallback and the picker shows no models.
     if is_codex_provider(provider_id) {
-        return codex_provider_models(registry);
+        return codex_provider_models(registry, provider_id);
     }
 
     let mut entries = registry.list_visible_by_provider(provider_id);
@@ -280,6 +287,7 @@ pub fn models_for_provider_from_registry(
             "default",
             "Default model",
             "no catalog entry for this provider",
+            provider_id,
         )];
     }
 
@@ -307,6 +315,7 @@ pub fn models_for_provider_from_registry(
                 display_name: e.info.name.clone(),
                 description: cost_str,
                 is_current: false,
+                provider_id: provider_id.to_string(),
             }
         })
         .collect()
@@ -377,10 +386,23 @@ pub fn default_model_for_provider(
 /// event loop either replaces or merges the projection according to
 /// [`provider_has_authoritative_live_models`].
 pub fn provider_uses_catalog_projection(provider_id: &str) -> bool {
-    matches!(
+    if matches!(
         provider_id,
         "openai" | "google" | "azure" | "amazon-bedrock" | "cohere" | "minimax"
-    )
+    ) {
+        return true;
+    }
+    // Custom providers have a curated model list in settings — no live
+    // endpoint to fetch from, so skip the background fetch.
+    if let Ok(settings) = claurst_core::Settings::load_sync() {
+        if settings.custom_providers.contains_key(provider_id) {
+            return true;
+        }
+    }
+if provider_id == "ollama" || provider_id == "lmstudio" || provider_id == "lm-studio" {
+        return true;
+    }
+    false
 }
 
 /// Whether live discovery is the complete set of models usable through a local
@@ -417,7 +439,7 @@ fn is_codex_provider(provider_id: &str) -> bool {
 /// catalog yields nothing (e.g. an empty/old snapshot).
 ///
 /// [`codex_model_allowed`]: claurst_core::codex_oauth::codex_model_allowed
-fn codex_provider_models(registry: &claurst_api::ModelRegistry) -> Vec<ModelEntry> {
+fn codex_provider_models(registry: &claurst_api::ModelRegistry, provider_id: &str) -> Vec<ModelEntry> {
     use claurst_core::codex_oauth::{codex_limit_override, codex_model_allowed};
 
     let mut entries: Vec<&claurst_api::ModelEntry> = registry
@@ -427,7 +449,7 @@ fn codex_provider_models(registry: &claurst_api::ModelRegistry) -> Vec<ModelEntr
         .collect();
 
     if entries.is_empty() {
-        return codex_fallback_models();
+        return codex_fallback_models(provider_id);
     }
 
     // Newest release first, then by id for stability — matches the picker's
@@ -455,13 +477,14 @@ fn codex_provider_models(registry: &claurst_api::ModelRegistry) -> Vec<ModelEntr
                     format_context_window(ctx)
                 ),
                 is_current: false,
+                provider_id: provider_id.to_string(),
             }
         })
         .collect()
 }
 
 /// Static fallback used when the models.dev `openai` catalog is unavailable.
-fn codex_fallback_models() -> Vec<ModelEntry> {
+fn codex_fallback_models(provider_id: &str) -> Vec<ModelEntry> {
     use claurst_core::codex_oauth::codex_limit_override;
     claurst_core::codex_oauth::CODEX_MODELS
         .iter()
@@ -477,6 +500,7 @@ fn codex_fallback_models() -> Vec<ModelEntry> {
                     format_context_window(ctx)
                 ),
                 is_current: false,
+                provider_id: provider_id.to_string(),
             }
         })
         .collect()
@@ -485,12 +509,13 @@ fn codex_fallback_models() -> Vec<ModelEntry> {
 /// Curated free-mode model list used by `models_for_provider_from_registry`.
 /// Always shows `free/auto` first; one pin entry per catalog upstream so the
 /// user can target a specific provider when they need to.
-fn free_provider_models() -> Vec<ModelEntry> {
+fn free_provider_models(provider_id: &str) -> Vec<ModelEntry> {
     let mut entries = vec![ModelEntry {
         id: "free/auto".to_string(),
         display_name: "Auto (round-robin across configured providers)".to_string(),
         description: "stacks every free-tier key you've added · $0.00 per M".to_string(),
         is_current: false,
+        provider_id: provider_id.to_string(),
     }];
 
     for upstream in claurst_api::FREE_CATALOG {
@@ -499,6 +524,7 @@ fn free_provider_models() -> Vec<ModelEntry> {
             display_name: format!("{} \u{2014} {}", upstream.title, upstream.default_model),
             description: format!("{} · $0.00 per M", upstream.note),
             is_current: false,
+            provider_id: provider_id.to_string(),
         });
     }
 
@@ -523,6 +549,25 @@ pub struct ModelPickerState {
     pub models_loaded: bool,
     /// `true` while the background fetch is in flight.
     pub loading_models: bool,
+    /// Favorited model keys ("provider/model" format), loaded from Settings.
+    pub favorites: Vec<String>,
+    /// Synthetic "Default" entry prepended to the model list.
+    default_entry: ModelEntry,
+    /// When true, the picker shows models from all connected providers
+    /// grouped by provider name.
+    pub all_providers_mode: bool,
+    /// Provider ID → display name map, populated from the model registry
+    /// when the all-providers picker opens. Used for group headers so
+    /// built-in providers (nvidia, deepinfra, etc.) show their real name
+    /// instead of "Other".
+    pub provider_names: std::collections::HashMap<String, String>,
+    /// When true, show ALL providers (including unconfigured) in the picker.
+    /// Default false — only connected providers shown.
+    pub show_all_providers: bool,
+    /// Set of connected provider IDs. When `show_all_providers` is false,
+    /// only models whose provider_id is in this set are shown (plus the
+    /// default entry). Populated by `open_model_picker_all_providers`.
+    pub connected_provider_ids: std::collections::HashSet<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -551,6 +596,18 @@ impl ModelPickerState {
             fast_mode_model: None,
             models_loaded: false,
             loading_models: false,
+            favorites: Vec::new(),
+            default_entry: ModelEntry {
+                id: DEFAULT_MODEL_SENTINEL.to_string(),
+                display_name: "Default".to_string(),
+                description: "Provider's recommended model (auto-selects best)".to_string(),
+                is_current: false,
+                provider_id: String::new(),
+            },
+            all_providers_mode: false,
+            provider_names: std::collections::HashMap::new(),
+            show_all_providers: false,
+            connected_provider_ids: std::collections::HashSet::new(),
         }
     }
 
@@ -568,6 +625,48 @@ impl ModelPickerState {
         self.open_with_title("Select model", current_model, effort, fast_mode);
     }
 
+    /// Open in all-providers mode — shows models from all connected
+    /// providers grouped by provider name.
+    pub fn open_all_providers(&mut self, current_model: &str, effort: EffortLevel, fast_mode: bool) {
+        self.all_providers_mode = true;
+        self.open_with_title("Select model (all providers)", current_model, effort, fast_mode);
+    }
+
+    /// Get the display name for a provider ID (for all-providers mode).
+    pub fn provider_group_name(provider_id: &str) -> String {
+        // Custom providers: use the user-configured display name from settings.
+        if let Ok(settings) = claurst_core::Settings::load_sync() {
+            if let Some(def) = settings.custom_providers.get(provider_id) {
+                return def.name.clone();
+            }
+        }
+        match provider_id {
+            "anthropic" => "Anthropic".to_string(),
+            "openai" => "OpenAI".to_string(),
+            "google" => "Google".to_string(),
+            "groq" => "Groq".to_string(),
+            "openrouter" => "OpenRouter".to_string(),
+            "deepseek" => "DeepSeek".to_string(),
+            "ollama" => "Ollama".to_string(),
+            "lmstudio" => "LM Studio".to_string(),
+            "llamacpp" | "llama-cpp" | "llama-server" => "llama.cpp".to_string(),
+            "github-copilot" => "GitHub Copilot".to_string(),
+            "codex" | "openai-codex" => "OpenAI Codex".to_string(),
+            "cohere" => "Cohere".to_string(),
+            "xai" => "xAI".to_string(),
+            "free" => "Free Mode".to_string(),
+            "cerebras" => "Cerebras".to_string(),
+            "sambanova" => "SambaNova".to_string(),
+            "together-ai" | "togetherai" => "Together AI".to_string(),
+            "mistral" => "Mistral".to_string(),
+            "perplexity" => "Perplexity".to_string(),
+            "azure" => "Azure OpenAI".to_string(),
+            "amazon-bedrock" => "AWS Bedrock".to_string(),
+            "custom-openai" => "Custom OpenAI".to_string(),
+            _ => "Other".to_string(),
+        }
+    }
+
     pub fn open_with_title(
         &mut self,
         title: impl Into<String>,
@@ -576,15 +675,24 @@ impl ModelPickerState {
         fast_mode: bool,
     ) {
         for m in &mut self.models {
-            m.is_current = m.id == current_model;
+            m.is_current = m.id == current_model
+                || current_model == format!("{}/{}", m.provider_id, m.id);
         }
-        self.selected_idx = self
-            .models
-            .iter()
-            .position(|m| m.is_current)
-            .unwrap_or(0);
+        // Mark default entry as current when no explicit model is set.
+        self.default_entry.is_current = current_model.is_empty()
+            || current_model == DEFAULT_MODEL_SENTINEL;
         self.title = title.into();
+        // Clear the filter BEFORE computing selected_idx so a stale filter
+        // can't hide the current model and leave the cursor on row 0.
         self.filter.clear();
+        // Compute selected_idx from the grouped list (default entry at 0,
+        // favorites first, then non-favorites) — not the raw models vec —
+        // so the cursor highlights the correct row.
+        self.selected_idx = self
+            .filtered_models_grouped()
+            .iter()
+            .position(|(m, _)| m.is_current)
+            .unwrap_or(0);
         self.effort_level = effort;
         self.fast_mode = fast_mode;
         self.fast_mode_model = fast_mode.then_some(current_model.to_string());
@@ -595,6 +703,10 @@ impl ModelPickerState {
     pub fn close(&mut self) {
         self.visible = false;
         self.filter.clear();
+        self.all_providers_mode = false;
+        self.provider_names.clear();
+        self.show_all_providers = false;
+        self.connected_provider_ids.clear();
     }
 
     pub fn is_selected_fast_mode_model(&self, model_id: &str) -> bool {
@@ -603,7 +715,7 @@ impl ModelPickerState {
 
     /// Move selection up one row (wraps to last if at top).
     pub fn select_prev(&mut self) {
-        let count = self.filtered_models().len();
+        let count = self.filtered_models_grouped().len();
         if count == 0 { return; }
         if self.selected_idx == 0 {
             self.selected_idx = count - 1;
@@ -614,9 +726,90 @@ impl ModelPickerState {
 
     /// Move selection down one row (wraps to first if at bottom).
     pub fn select_next(&mut self) {
-        let count = self.filtered_models().len();
+        let count = self.filtered_models_grouped().len();
         if count == 0 { return; }
         self.selected_idx = (self.selected_idx + 1) % count;
+    }
+
+    /// Jump to the first model of the next provider group (all-providers mode).
+    /// Wraps around to the default entry (index 0) after the last provider.
+    pub fn select_next_provider(&mut self) {
+        let grouped = self.filtered_models_grouped();
+        if grouped.is_empty() {
+            return;
+        }
+        let current_provider = grouped
+            .get(self.selected_idx)
+            .map(|(m, _)| m.provider_id.as_str())
+            .unwrap_or("");
+        // Find the first entry after the current position with a different
+        // non-empty provider_id. Skip the default entry (empty provider_id).
+        for i in (self.selected_idx + 1)..grouped.len() {
+            let pid = grouped[i].0.provider_id.as_str();
+            if !pid.is_empty() && pid != current_provider {
+                self.selected_idx = i;
+                return;
+            }
+        }
+        // Wrap around: find the first entry with a non-empty provider_id
+        // from the beginning (skips default entry at index 0).
+        for i in 0..self.selected_idx {
+            let pid = grouped[i].0.provider_id.as_str();
+            if !pid.is_empty() && pid != current_provider {
+                self.selected_idx = i;
+                return;
+            }
+        }
+        // No other provider found — stay put.
+    }
+
+    /// Jump to the first model of the previous provider group (all-providers mode).
+    /// Wraps around to the last provider's first model after index 0.
+    pub fn select_prev_provider(&mut self) {
+        let grouped = self.filtered_models_grouped();
+        if grouped.is_empty() {
+            return;
+        }
+        let current_provider = grouped
+            .get(self.selected_idx)
+            .map(|(m, _)| m.provider_id.as_str())
+            .unwrap_or("");
+        // Walk backwards to find the first entry of the previous provider.
+        // We need to find the boundary: the first entry whose provider_id
+        // differs from current AND is non-empty, then from that point find
+        // the FIRST entry of that provider group.
+        let mut prev_provider = None;
+        if self.selected_idx > 0 {
+            for i in (0..self.selected_idx).rev() {
+                let pid = grouped[i].0.provider_id.as_str();
+                if !pid.is_empty() && pid != current_provider {
+                    prev_provider = Some(pid);
+                    // Now find the first entry of this provider group.
+                    for j in 0..=i {
+                        if grouped[j].0.provider_id == pid {
+                            self.selected_idx = j;
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+        // Wrap around: find the last provider group's first entry.
+        if prev_provider.is_none() {
+            // Find the last distinct provider group.
+            let mut last_provider = "";
+            let mut last_provider_first_idx = 0;
+            for (i, (m, _)) in grouped.iter().enumerate() {
+                let pid = m.provider_id.as_str();
+                if !pid.is_empty() && pid != last_provider {
+                    last_provider = pid;
+                    last_provider_first_idx = i;
+                }
+            }
+            if !last_provider.is_empty() && last_provider != current_provider {
+                self.selected_idx = last_provider_first_idx;
+            }
+        }
     }
 
     pub fn select_first(&mut self) {
@@ -624,17 +817,27 @@ impl ModelPickerState {
     }
 
     pub fn select_last(&mut self) {
-        let count = self.filtered_models().len();
+        let count = self.filtered_models_grouped().len();
         self.selected_idx = count.saturating_sub(1);
+    }
+
+    /// Toggle showing all providers vs only connected ones.
+    pub fn toggle_show_all_providers(&mut self) {
+        self.show_all_providers = !self.show_all_providers;
+        // Reset selection to stay in bounds.
+        let count = self.filtered_models_grouped().len();
+        if count > 0 && self.selected_idx >= count {
+            self.selected_idx = count - 1;
+        }
     }
 
     /// The reasoning-effort ladder of the currently highlighted model (ascending,
     /// no ultracode). Empty when nothing is highlighted or the model is
     /// non-reasoning.
     fn selected_ladder(&self) -> Vec<EffortLevel> {
-        let filtered = self.filtered_models();
+        let filtered = self.filtered_models_grouped();
         match filtered.get(self.selected_idx) {
-            Some(m) => picker_variant_ladder(&m.id),
+            Some((m, _)) => picker_variant_ladder(&m.id),
             None => Vec::new(),
         }
     }
@@ -671,7 +874,7 @@ impl ModelPickerState {
     /// Returns the selected model; the caller is responsible for persisting it
     /// in the correct provider-aware format.
     pub fn confirm(&mut self) -> Option<(String, Option<EffortLevel>)> {
-        let filtered = self.filtered_models();
+        let filtered = self.filtered_models_grouped();
         let custom = self.filter.trim();
         if filtered.is_empty() {
             if custom.is_empty() {
@@ -681,8 +884,12 @@ impl ModelPickerState {
             self.close();
             return Some((id, None));
         }
-        let entry = filtered.get(self.selected_idx)?;
+        let (entry, _is_fav) = filtered.get(self.selected_idx)?;
         let id = entry.id.clone();
+        if id == DEFAULT_MODEL_SENTINEL {
+            self.close();
+            return Some((id, None));
+        }
         let ladder = picker_variant_ladder(&id);
         let effort = if ladder.len() > 1 {
             Some(clamp_to_ladder(&ladder, self.effort_level))
@@ -723,6 +930,133 @@ impl ModelPickerState {
             .collect()
     }
 
+    /// Load favorites from Settings into the picker state.
+    pub fn load_favorites(&mut self) {
+        if let Ok(settings) = claurst_core::Settings::load_sync() {
+            self.favorites = settings.favorite_models;
+        }
+    }
+
+    /// Toggle favorite status on a model key. Saves to Settings immediately.
+    pub fn toggle_favorite(&mut self, model_key: &str) {
+        if self.favorites.contains(&model_key.to_string()) {
+            self.favorites.retain(|f| f != model_key);
+        } else {
+            self.favorites.push(model_key.to_string());
+        }
+        // Persist to settings.
+        if let Ok(mut settings) = claurst_core::Settings::load_sync() {
+            settings.favorite_models = self.favorites.clone();
+            let _ = settings.save_sync();
+        }
+    }
+
+    /// Check if a model key is favorited.
+    pub fn is_favorite(&self, model_key: &str) -> bool {
+        self.favorites.contains(&model_key.to_string())
+    }
+
+    /// Get the list of valid favorites — those present in the picker's
+    /// current model list. Stale favorites (model removed from catalog)
+    /// are silently excluded from display but NOT removed from settings.
+    pub fn valid_favorites(&self) -> Vec<String> {
+        let model_ids: std::collections::HashSet<&str> =
+            self.models.iter().map(|m| m.id.as_str()).collect();
+        self.favorites
+            .iter()
+            .filter(|f| {
+                // Favorites are in "provider/model" format. The picker's
+                // models list has bare model ids (no provider prefix) since
+                // the picker is scoped to one provider. So we match on the
+                // model portion after the slash.
+                if let Some((_, model)) = f.split_once('/') {
+                    model_ids.contains(model)
+                } else {
+                    model_ids.contains(f.as_str())
+                }
+            })
+            .cloned()
+            .collect()
+    }
+
+    /// Returns model entries for display: favorites first (marked with ★),
+    /// then all other models. Applies the current filter to both sections.
+    pub fn filtered_models_grouped(&self) -> Vec<(&ModelEntry, bool)> {
+        let valid_favs = self.valid_favorites();
+        let fav_model_ids: std::collections::HashSet<String> = valid_favs
+            .iter()
+            .map(|f| f.split_once('/').map(|(_, m)| m.to_string()).unwrap_or(f.clone()))
+            .collect();
+
+        // Connected-providers filter: when show_all_providers is false AND
+        // we're in all-providers mode, only show models whose provider_id is
+        // in the connected set. The default entry (empty provider_id) always
+        // passes.
+        let connected_filter = |m: &&ModelEntry| -> bool {
+            if m.provider_id.is_empty() {
+                return true;
+            }
+            if self.show_all_providers || !self.all_providers_mode {
+                return true;
+            }
+            self.connected_provider_ids.contains(&m.provider_id)
+        };
+
+        if self.filter.is_empty() {
+            // No filter: favorites section, then all models
+            let mut result = Vec::new();
+            // Default entry always at top.
+            result.push((&self.default_entry, false));
+            // Favorites first
+            for m in &self.models {
+                if fav_model_ids.contains(&m.id) && connected_filter(&m) {
+                    result.push((m, true));
+                }
+            }
+            // Then non-favorites
+            for m in &self.models {
+                if !fav_model_ids.contains(&m.id) && connected_filter(&m) {
+                    result.push((m, false));
+                }
+            }
+            result
+        } else {
+            let needle = self.filter.to_lowercase();
+            let mut result = Vec::new();
+            // Default entry — always show if filter matches or is empty.
+            if self.filter.is_empty()
+                || "default".contains(&needle)
+                || self.default_entry.display_name.to_lowercase().contains(&needle)
+                || self.default_entry.description.to_lowercase().contains(&needle)
+            {
+                result.push((&self.default_entry, false));
+            }
+            // Favorites matching filter
+            for m in &self.models {
+                if fav_model_ids.contains(&m.id)
+                    && (m.id.to_lowercase().contains(&needle)
+                        || m.display_name.to_lowercase().contains(&needle)
+                        || m.description.to_lowercase().contains(&needle))
+                    && connected_filter(&m)
+                {
+                    result.push((m, true));
+                }
+            }
+            // Non-favorites matching filter
+            for m in &self.models {
+                if !fav_model_ids.contains(&m.id)
+                    && (m.id.to_lowercase().contains(&needle)
+                        || m.display_name.to_lowercase().contains(&needle)
+                        || m.description.to_lowercase().contains(&needle))
+                    && connected_filter(&m)
+                {
+                    result.push((m, false));
+                }
+            }
+            result
+        }
+    }
+
     /// Replace the model list with dynamically loaded entries.
     ///
     /// Called by the app event loop when the background fetch completes.
@@ -731,8 +1065,8 @@ impl ModelPickerState {
         self.models = entries;
         self.loading_models = false;
         self.models_loaded = true;
-        // Keep selected_idx in bounds.
-        let count = self.filtered_models().len();
+        // Keep selected_idx in bounds (grouped view includes default entry).
+        let count = self.filtered_models_grouped().len();
         if count > 0 && self.selected_idx >= count {
             self.selected_idx = count - 1;
         }
@@ -769,8 +1103,8 @@ impl ModelPickerState {
         }
         self.loading_models = false;
         self.models_loaded = true;
-        // Keep selected_idx in bounds.
-        let count = self.filtered_models().len();
+        // Keep selected_idx in bounds (grouped view includes default entry).
+        let count = self.filtered_models_grouped().len();
         if count > 0 && self.selected_idx >= count {
             self.selected_idx = count - 1;
         }
@@ -820,8 +1154,8 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
     // ── Dialog size ──
     let width = 65u16.min(area.width.saturating_sub(6));
     let max_height = (area.height as f32 * 0.75) as u16;
-    let filtered = state.filtered_models();
-    let content_h = (filtered.len() as u16 + 6).min(max_height).max(8);
+    let grouped = state.filtered_models_grouped();
+    let content_h = (grouped.len() as u16 + 6).min(max_height).max(8);
     let dialog_area = centered_rect(width, content_h, area);
 
     // ── Fill dialog bg (no border) ──
@@ -909,7 +1243,7 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
         lines.push(Line::from(""));
     }
 
-    if filtered.is_empty() {
+    if grouped.is_empty() {
         lines.push(Line::from(vec![Span::styled(" No results found", Style::default().fg(dim))]));
         if !state.filter.trim().is_empty() {
             lines.push(Line::from(vec![Span::styled(
@@ -918,7 +1252,24 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
             )]));
         }
     } else {
-        for (i, model) in filtered.iter().enumerate() {
+        let mut last_provider: Option<&str> = None;
+        for (i, (model, is_fav)) in grouped.iter().enumerate() {
+            // Provider group header in all-providers mode — skip for the
+            // synthetic default entry (empty provider_id).
+            if state.all_providers_mode
+                && model.id != DEFAULT_MODEL_SENTINEL
+                && last_provider != Some(&model.provider_id) {
+                last_provider = Some(&model.provider_id);
+                let group_name = state
+                    .provider_names
+                    .get(&model.provider_id)
+                    .cloned()
+                    .unwrap_or_else(|| ModelPickerState::provider_group_name(&model.provider_id));
+                lines.push(Line::from(vec![Span::styled(
+                    format!(" {} ", group_name),
+                    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                )]));
+            }
             let is_selected = i == state.selected_idx;
             let supports_effort = model_supports_effort(&model.id);
 
@@ -934,12 +1285,18 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
 
             let mut spans: Vec<Span<'static>> = Vec::new();
 
-            // Current model indicator
-            if model.is_current {
+            // Default entry gets a star (★); active model gets a green dot (●).
+            if model.id == DEFAULT_MODEL_SENTINEL {
+                spans.push(Span::styled(" \u{2605} ", Style::default().fg(Color::Cyan).bg(bg)));
+            } else if model.is_current {
                 spans.push(Span::styled(" \u{25cf} ", Style::default().fg(Color::Green).bg(bg)));
             } else {
                 spans.push(Span::styled("   ", Style::default().bg(bg)));
             }
+
+            // Favorite indicator — heart (♥) when favorited.
+            let heart = if *is_fav { "\u{2665} " } else { "  " };
+            spans.push(Span::styled(heart.to_string(), Style::default().fg(Color::Yellow).bg(bg)));
 
             spans.push(Span::styled(model.display_name.clone(), Style::default().fg(fg).bg(bg)));
 
@@ -990,11 +1347,37 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
 
     para.render(body_area, buf);
 
-    let mut footer_spans = vec![
-        Span::styled(" enter", Style::default().fg(dim)),
-        Span::styled(" select", Style::default().fg(dim)),
-    ];
-    if let Some(model) = filtered.get(state.selected_idx) {
+    let mut footer_spans = vec![];
+    // Show "enter set default" when the default sentinel is selected,
+    // otherwise "enter select".
+    let is_on_default = grouped
+        .get(state.selected_idx)
+        .map(|(m, _)| m.id == DEFAULT_MODEL_SENTINEL)
+        .unwrap_or(false);
+    if is_on_default {
+        footer_spans.push(Span::styled(" enter", Style::default().fg(dim)));
+        footer_spans.push(Span::styled(" set default", Style::default().fg(dim)));
+    } else {
+        footer_spans.push(Span::styled(" enter", Style::default().fg(dim)));
+        footer_spans.push(Span::styled(" select", Style::default().fg(dim)));
+    }
+    // Favorite toggle shortcut.
+    footer_spans.push(Span::raw("  "));
+    footer_spans.push(Span::styled("f", Style::default().fg(dim)));
+    footer_spans.push(Span::styled(" favorite", Style::default().fg(dim)));
+    // Tab to jump between provider groups.
+    footer_spans.push(Span::raw("  "));
+    footer_spans.push(Span::styled("Tab", Style::default().fg(dim)));
+    footer_spans.push(Span::styled(" providers", Style::default().fg(dim)));
+    // Show-all toggle shortcut.
+    footer_spans.push(Span::raw("  "));
+    footer_spans.push(Span::styled("a", Style::default().fg(dim)));
+    if state.show_all_providers {
+        footer_spans.push(Span::styled(" connected", Style::default().fg(dim)));
+    } else {
+        footer_spans.push(Span::styled(" all", Style::default().fg(dim)));
+    }
+    if let Some((model, _)) = grouped.get(state.selected_idx) {
         if model_supports_effort(&model.id) {
             footer_spans.push(Span::raw("  "));
             footer_spans.push(Span::styled("\u{2190}/\u{2192}", Style::default().fg(dim)));
@@ -1026,18 +1409,21 @@ mod tests {
                 display_name: "Claude Opus 4.6".to_string(),
                 description: "200K context".to_string(),
                 is_current: false,
+                provider_id: "anthropic".to_string(),
             },
             ModelEntry {
                 id: "claude-sonnet-4-6".to_string(),
                 display_name: "Claude Sonnet 4.6".to_string(),
                 description: "200K context".to_string(),
                 is_current: false,
+                provider_id: "anthropic".to_string(),
             },
             ModelEntry {
                 id: "claude-haiku-4-5".to_string(),
                 display_name: "Claude Haiku 4.5".to_string(),
                 description: "200K context".to_string(),
                 is_current: false,
+                provider_id: "anthropic".to_string(),
             },
         ]
     }
@@ -1137,7 +1523,7 @@ mod tests {
     #[test]
     fn select_next_wraps() {
         let mut p = make_picker_with_current("claude-opus-4-6");
-        let total = p.filtered_models().len();
+        let total = p.filtered_models_grouped().len();
         p.selected_idx = total - 1;
         p.select_next();
         assert_eq!(p.selected_idx, 0);
@@ -1149,7 +1535,7 @@ mod tests {
         let mut p = make_picker_with_current("claude-opus-4-6");
         p.selected_idx = 0;
         p.select_prev();
-        let total = p.filtered_models().len();
+        let total = p.filtered_models_grouped().len();
         assert_eq!(p.selected_idx, total - 1);
     }
 
@@ -1182,10 +1568,10 @@ mod tests {
     #[test]
     fn confirm_returns_id_and_closes() {
         let mut p = make_picker_with_current("claude-opus-4-6");
-        p.selected_idx = 0;
-        let first_id = p.filtered_models()[0].id.clone();
+        p.selected_idx = 1; // skip Default sentinel at index 0
+        let first_model_id = p.filtered_models()[0].id.clone();
         let result = p.confirm();
-        assert_eq!(result.map(|(id, _)| id), Some(first_id));
+        assert_eq!(result.map(|(id, _)| id), Some(first_model_id));
         assert!(!p.visible, "picker should be closed after confirm");
     }
 
@@ -1478,6 +1864,7 @@ mod tests {
                 display_name: "LIVE OVERWRITE".to_string(),
                 description: "live desc".to_string(),
                 is_current: false,
+                provider_id: "anthropic".to_string(),
             },
             // A brand-new live id absent from the catalog — must be appended.
             ModelEntry {
@@ -1485,6 +1872,7 @@ mod tests {
                 display_name: "GPT-5.5 (live)".to_string(),
                 description: "live only".to_string(),
                 is_current: false,
+                provider_id: "anthropic".to_string(),
             },
         ];
         p.merge_models(live);
@@ -1530,12 +1918,14 @@ mod tests {
             "default",
             "Default model",
             "no catalog entry for this provider",
+            "anthropic",
         )]);
         p.merge_models(vec![ModelEntry {
             id: "llama3.3".to_string(),
             display_name: "Llama 3.3".to_string(),
             description: "local".to_string(),
             is_current: false,
+            provider_id: "anthropic".to_string(),
         }]);
         assert!(
             !p.models.iter().any(|m| m.id == "default"),
@@ -1581,5 +1971,530 @@ mod tests {
         }
         assert!(!provider_has_authoritative_live_models("github-copilot"));
         assert!(!provider_has_authoritative_live_models("openrouter"));
+    }
+
+    #[test]
+    fn valid_favorites_filters_stale_entries() {
+        let mut state = ModelPickerState::new();
+        state.models = vec![
+            ModelEntry { id: "model-a".to_string(), display_name: "A".to_string(), description: "".to_string(), is_current: false, provider_id: String::new() },
+            ModelEntry { id: "model-b".to_string(), display_name: "B".to_string(), description: "".to_string(), is_current: false, provider_id: String::new() },
+        ];
+        state.favorites = vec![
+            "provider/model-a".to_string(),  // valid
+            "provider/model-c".to_string(),  // stale (not in models list)
+            "model-b".to_string(),           // valid (no provider prefix)
+        ];
+        let valid = state.valid_favorites();
+        assert_eq!(valid.len(), 2);
+        assert!(valid.contains(&"provider/model-a".to_string()));
+        assert!(valid.contains(&"model-b".to_string()));
+    }
+
+    #[test]
+    fn filtered_models_grouped_puts_favorites_first() {
+        let mut state = ModelPickerState::new();
+        state.models = vec![
+            ModelEntry { id: "regular".to_string(), display_name: "Regular".to_string(), description: "".to_string(), is_current: false, provider_id: String::new() },
+            ModelEntry { id: "pinned".to_string(), display_name: "Pinned".to_string(), description: "".to_string(), is_current: false, provider_id: String::new() },
+            ModelEntry { id: "other".to_string(), display_name: "Other".to_string(), description: "".to_string(), is_current: false, provider_id: String::new() },
+        ];
+        state.favorites = vec!["provider/pinned".to_string()];
+        let grouped = state.filtered_models_grouped();
+        assert_eq!(grouped.len(), 4);
+        // Default sentinel at top.
+        assert_eq!(grouped[0].0.id, DEFAULT_MODEL_SENTINEL);
+        // Favorite must come next.
+        assert_eq!(grouped[1].0.id, "pinned");
+        assert!(grouped[1].1);
+        // Rest are non-favorites, preserve source order.
+        assert_eq!(grouped[2].0.id, "regular");
+        assert!(!grouped[2].1);
+        assert_eq!(grouped[3].0.id, "other");
+        assert!(!grouped[3].1);
+    }
+
+    #[test]
+    fn filtered_models_grouped_respects_filter() {
+        let mut state = ModelPickerState::new();
+        state.models = vec![
+            ModelEntry { id: "pinned-a".to_string(), display_name: "Pinned A".to_string(), description: "".to_string(), is_current: false, provider_id: String::new() },
+            ModelEntry { id: "pinned-b".to_string(), display_name: "Other B".to_string(), description: "".to_string(), is_current: false, provider_id: String::new() },
+        ];
+        state.favorites = vec![
+            "provider/pinned-a".to_string(),
+            "provider/pinned-b".to_string(),
+        ];
+        for c in "pinned a".chars() {
+            state.push_filter_char(c);
+        }
+        let grouped = state.filtered_models_grouped();
+        // Only the favorite matching the filter appears, on top.
+        assert_eq!(grouped.len(), 1);
+        assert_eq!(grouped[0].0.id, "pinned-a");
+        assert!(grouped[0].1);
+    }
+
+    #[test]
+    fn is_favorite_roundtrips_without_persist() {
+        let mut state = ModelPickerState::new();
+        state.favorites = vec!["anthropic/claude-sonnet-4-6".to_string()];
+        assert!(state.is_favorite("anthropic/claude-sonnet-4-6"));
+        assert!(!state.is_favorite("openai/gpt-4o"));
+    }
+
+    #[test]
+    fn default_entry_appears_at_top() {
+        let mut picker = ModelPickerState::new();
+        picker.set_models(vec![
+            ModelEntry {
+                id: "model-a".to_string(),
+                display_name: "Model A".to_string(),
+                description: "desc".to_string(),
+                is_current: false,
+                provider_id: String::new(),
+            },
+            ModelEntry {
+                id: "model-b".to_string(),
+                display_name: "Model B".to_string(),
+                description: "desc".to_string(),
+                is_current: false,
+                provider_id: String::new(),
+            },
+        ]);
+        picker.open("model-a");
+        let grouped = picker.filtered_models_grouped();
+        assert_eq!(grouped.len(), 3);
+        assert_eq!(grouped[0].0.id, DEFAULT_MODEL_SENTINEL);
+        assert_eq!(grouped[1].0.id, "model-a");
+    }
+
+    #[test]
+    fn default_entry_is_current_when_no_model() {
+        let mut picker = ModelPickerState::new();
+        picker.set_models(vec![
+            ModelEntry {
+                id: "model-a".to_string(),
+                display_name: "Model A".to_string(),
+                description: "desc".to_string(),
+                is_current: false,
+                provider_id: String::new(),
+            },
+        ]);
+        picker.open_with_title("Test", "", EffortLevel::Medium, false);
+        assert!(picker.default_entry.is_current);
+    }
+
+    #[test]
+    fn confirm_returns_default_sentinel() {
+        let mut picker = ModelPickerState::new();
+        picker.set_models(vec![
+            ModelEntry {
+                id: "model-a".to_string(),
+                display_name: "Model A".to_string(),
+                description: "desc".to_string(),
+                is_current: false,
+                provider_id: String::new(),
+            },
+        ]);
+        picker.open("model-a");
+        picker.selected_idx = 0; // Default entry
+        let result = picker.confirm();
+        assert_eq!(result.unwrap().0, DEFAULT_MODEL_SENTINEL);
+    }
+
+    // --- selected_idx preselection from grouped order (Bug 1 + Bug 2) ---
+
+    #[test]
+    fn open_with_title_preselects_current_in_grouped_order() {
+        let mut p = make_picker();
+        // Set the model at raw index 1 (claude-sonnet-4-6) as current.
+        // Grouped order: [default, opus, sonnet, haiku] (no favorites).
+        // The grouped index of sonnet should be 2 (default=0, opus=1, sonnet=2).
+        p.open_with_title("Test", "claude-sonnet-4-6", EffortLevel::Medium, false);
+        let grouped = p.filtered_models_grouped();
+        let expected_idx = grouped
+            .iter()
+            .position(|(m, _)| m.id == "claude-sonnet-4-6")
+            .unwrap();
+        assert_eq!(
+            p.selected_idx, expected_idx,
+            "selected_idx must match grouped position, not raw models position"
+        );
+        // Sanity: grouped includes default entry at 0.
+        assert_eq!(grouped[0].0.id, DEFAULT_MODEL_SENTINEL);
+        assert!(p.models.iter().find(|m| m.id == "claude-sonnet-4-6").unwrap().is_current);
+    }
+
+    #[test]
+    fn open_with_title_preselects_default_entry_when_no_model() {
+        let mut p = make_picker();
+        p.open_with_title("Test", "", EffortLevel::Medium, false);
+        assert!(p.default_entry.is_current);
+        assert_eq!(p.selected_idx, 0);
+    }
+
+    #[test]
+    fn open_with_title_preselects_with_provider_prefixed_current() {
+        let models = vec![
+            ModelEntry {
+                id: "revolut-ca/glm-5-2".to_string(),
+                display_name: "GLM 5.2".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "together-ai-coding".to_string(),
+            },
+            ModelEntry {
+                id: "some-other-model".to_string(),
+                display_name: "Other".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "together-ai-coding".to_string(),
+            },
+        ];
+        let mut p = ModelPickerState::new();
+        p.set_models(models);
+        p.open_with_title(
+            "Test",
+            "together-ai-coding/revolut-ca/glm-5-2",
+            EffortLevel::Medium,
+            false,
+        );
+        let glm = p
+            .models
+            .iter()
+            .find(|m| m.id == "revolut-ca/glm-5-2")
+            .unwrap();
+        assert!(glm.is_current, "provider-prefixed current must set is_current");
+        // Other model must NOT be current.
+        assert!(!p
+            .models
+            .iter()
+            .find(|m| m.id == "some-other-model")
+            .unwrap()
+            .is_current);
+        let grouped = p.filtered_models_grouped();
+        let expected_idx = grouped
+            .iter()
+            .position(|(m, _)| m.id == "revolut-ca/glm-5-2")
+            .unwrap();
+        assert_eq!(p.selected_idx, expected_idx);
+    }
+
+    #[test]
+    fn open_with_title_preselects_correct_row_with_favorites() {
+        // Build a picker where a NON-current model is a favorite.
+        // sample_models: [opus, sonnet, haiku] (all anthropic).
+        // Favorite: anthropic/claude-sonnet-4-6
+        // Current:  claude-opus-4-6
+        // Grouped order: [default, sonnet(fav), opus, haiku]
+        // So opus is at grouped index 2, not raw index 0.
+        let mut p = make_picker();
+        p.favorites = vec!["anthropic/claude-sonnet-4-6".to_string()];
+        p.open_with_title("Test", "claude-opus-4-6", EffortLevel::Medium, false);
+        let grouped = p.filtered_models_grouped();
+        // Verify grouped order: default, sonnet (favorite), opus, haiku.
+        assert_eq!(grouped.len(), 4);
+        assert_eq!(grouped[0].0.id, DEFAULT_MODEL_SENTINEL);
+        assert_eq!(grouped[1].0.id, "claude-sonnet-4-6");
+        assert!(grouped[1].1, "sonnet should be favorite");
+        assert_eq!(grouped[2].0.id, "claude-opus-4-6");
+        assert!(!grouped[2].1, "opus should not be favorite");
+        assert_eq!(grouped[3].0.id, "claude-haiku-4-5");
+        // selected_idx must point to opus in grouped order (index 2).
+        assert_eq!(
+            p.selected_idx, 2,
+            "selected_idx must be the grouped position of the current model, not the raw index"
+        );
+    }
+
+    #[test]
+    fn open_all_providers_preselects_provider_prefixed_model() {
+        let models = vec![
+            ModelEntry {
+                id: "revolut-ca/glm-5-2".to_string(),
+                display_name: "GLM 5.2".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "together-ai-coding".to_string(),
+            },
+            ModelEntry {
+                id: "another-model".to_string(),
+                display_name: "Another".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "together-ai-coding".to_string(),
+            },
+        ];
+        let mut p = ModelPickerState::new();
+        p.set_models(models);
+        p.connected_provider_ids =
+            ["together-ai-coding".to_string()].into_iter().collect();
+        p.open_all_providers(
+            "together-ai-coding/revolut-ca/glm-5-2",
+            EffortLevel::Medium,
+            false,
+        );
+        assert!(p.all_providers_mode);
+        let glm = p
+            .models
+            .iter()
+            .find(|m| m.id == "revolut-ca/glm-5-2")
+            .unwrap();
+        assert!(glm.is_current, "all-providers mode must match provider-prefixed current");
+        let grouped = p.filtered_models_grouped();
+        let expected_idx = grouped
+            .iter()
+            .position(|(m, _)| m.id == "revolut-ca/glm-5-2")
+            .unwrap();
+        assert_eq!(p.selected_idx, expected_idx);
+    }
+
+    #[test]
+    fn default_entry_does_not_get_group_header() {
+        let entry = ModelEntry {
+            id: DEFAULT_MODEL_SENTINEL.to_string(),
+            display_name: "Default".to_string(),
+            description: "".to_string(),
+            is_current: false,
+            provider_id: String::new(),
+        };
+        // The render condition checks model.id != DEFAULT_MODEL_SENTINEL
+        // before pushing a group header. The default entry must NOT pass.
+        assert!(entry.id == DEFAULT_MODEL_SENTINEL);
+    }
+
+    #[test]
+    fn selected_provider_id_captured_before_close() {
+        // When a filter is active and the user navigates + confirms,
+        // the provider_id must be captured BEFORE close() clears the filter.
+        let mut picker = ModelPickerState::new();
+        picker.all_providers_mode = true;
+        picker.connected_provider_ids =
+["together-ai-coding".to_string(), "ollama".to_string()]
+                .into_iter()
+                .collect();
+        picker.set_models(vec![
+            ModelEntry {
+                id: "glm-5-2".to_string(),
+                display_name: "GLM 5.2".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "together-ai-coding".to_string(),
+            },
+            ModelEntry {
+                id: "opus-4-8".to_string(),
+                display_name: "Opus 4.8".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "ollama".to_string(),
+            },
+        ]);
+        // Type filter "glm" so only the glm model shows (default entry is
+        // filtered out because "glm" does not match "default").
+        for c in "glm".chars() {
+            picker.push_filter_char(c);
+        }
+        // glm is the only filtered result → grouped index 0.
+        picker.selected_idx = 0;
+        // Capture provider BEFORE confirm (as the fixed Enter handler does).
+        let captured_provider = picker
+            .filtered_models_grouped()
+            .get(picker.selected_idx)
+            .map(|(m, _)| m.provider_id.clone());
+        // Now confirm — this closes and clears the filter.
+        let confirmed_id = picker.confirm();
+        // After close, the filter is cleared — unfiltered list is different.
+        // But we captured the provider BEFORE close.
+        assert_eq!(confirmed_id, Some(("glm-5-2".to_string(), None)));
+        assert_eq!(captured_provider, Some("together-ai-coding".to_string()));
+        // If we had re-read AFTER close, selected_idx=0 would point to the
+        // default entry (provider_id="") in the unfiltered list — the bug.
+        assert_ne!(
+            picker
+                .filtered_models_grouped()
+                .get(0)
+                .map(|(m, _)| m.provider_id.clone()),
+            Some("together-ai-coding".to_string())
+        );
+    }
+
+    // --- Tab / BackTab provider-group navigation (all-providers mode) ---
+
+    /// Two providers with two models each — the basic multi-provider fixture.
+    fn two_provider_models() -> Vec<ModelEntry> {
+        vec![
+            ModelEntry {
+                id: "model-a1".to_string(),
+                display_name: "Model A1".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "provider-a".to_string(),
+            },
+            ModelEntry {
+                id: "model-a2".to_string(),
+                display_name: "Model A2".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "provider-a".to_string(),
+            },
+            ModelEntry {
+                id: "model-b1".to_string(),
+                display_name: "Model B1".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "provider-b".to_string(),
+            },
+            ModelEntry {
+                id: "model-b2".to_string(),
+                display_name: "Model B2".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "provider-b".to_string(),
+            },
+        ]
+    }
+
+    #[test]
+    fn select_next_provider_jumps_to_next_group() {
+        let mut p = ModelPickerState::new();
+        p.set_models(two_provider_models());
+        p.connected_provider_ids =
+            ["provider-a".to_string(), "provider-b".to_string()]
+                .into_iter()
+                .collect();
+        p.open_all_providers("model-a1", EffortLevel::Medium, false);
+        // Default entry at index 0, then provider-a models, then provider-b.
+        let grouped = p.filtered_models_grouped();
+        let a1_idx = grouped.iter().position(|(m, _)| m.id == "model-a1").unwrap();
+        let b1_idx = grouped.iter().position(|(m, _)| m.id == "model-b1").unwrap();
+        p.selected_idx = a1_idx;
+        p.select_next_provider();
+        assert_eq!(
+            p.selected_idx, b1_idx,
+            "Tab from provider A should jump to provider B's first model"
+        );
+    }
+
+    #[test]
+    fn select_prev_provider_jumps_to_previous_group() {
+        let mut p = ModelPickerState::new();
+        p.set_models(two_provider_models());
+        p.connected_provider_ids =
+            ["provider-a".to_string(), "provider-b".to_string()]
+                .into_iter()
+                .collect();
+        p.open_all_providers("model-b1", EffortLevel::Medium, false);
+        let grouped = p.filtered_models_grouped();
+        let a1_idx = grouped.iter().position(|(m, _)| m.id == "model-a1").unwrap();
+        let b1_idx = grouped.iter().position(|(m, _)| m.id == "model-b1").unwrap();
+        p.selected_idx = b1_idx;
+        p.select_prev_provider();
+        assert_eq!(
+            p.selected_idx, a1_idx,
+            "BackTab from provider B should jump to provider A's first model"
+        );
+    }
+
+    #[test]
+    fn select_next_provider_wraps_around() {
+        let mut p = ModelPickerState::new();
+        p.set_models(two_provider_models());
+        p.connected_provider_ids =
+            ["provider-a".to_string(), "provider-b".to_string()]
+                .into_iter()
+                .collect();
+        p.open_all_providers("model-b2", EffortLevel::Medium, false);
+        let grouped = p.filtered_models_grouped();
+        let b2_idx = grouped.iter().position(|(m, _)| m.id == "model-b2").unwrap();
+        let a1_idx = grouped.iter().position(|(m, _)| m.id == "model-a1").unwrap();
+        p.selected_idx = b2_idx;
+        p.select_next_provider();
+        assert_eq!(
+            p.selected_idx, a1_idx,
+            "Tab from last provider should wrap to first provider's first model"
+        );
+    }
+
+    #[test]
+    fn select_next_provider_skips_default_entry() {
+        let mut p = ModelPickerState::new();
+        p.set_models(two_provider_models());
+        p.connected_provider_ids =
+            ["provider-a".to_string(), "provider-b".to_string()]
+                .into_iter()
+                .collect();
+        p.open_all_providers("", EffortLevel::Medium, false);
+        // No current model → default entry (index 0) is selected.
+        {
+            let grouped = p.filtered_models_grouped();
+            assert_eq!(p.selected_idx, 0, "default entry should be at index 0");
+            assert_eq!(grouped[0].0.id, DEFAULT_MODEL_SENTINEL);
+            assert_eq!(grouped[0].0.provider_id, "");
+        }
+        p.select_next_provider();
+        // Tab must skip the default entry and land on the first real
+        // provider's first model — never back on the default entry.
+        assert_ne!(
+            p.selected_idx, 0,
+            "Tab must never select the default entry"
+        );
+        let selected_pid = p.filtered_models_grouped()[p.selected_idx].0.provider_id.clone();
+        assert!(
+            !selected_pid.is_empty(),
+            "Tab must land on a real provider, not the default entry"
+        );
+    }
+
+    #[test]
+    fn connected_filter_hides_unconnected_providers() {
+        let mut state = ModelPickerState::new();
+        state.all_providers_mode = true;
+        state.connected_provider_ids =
+            ["provider-a".to_string()].into_iter().collect();
+        state.set_models(vec![
+            ModelEntry { id: "model-a1".to_string(), display_name: "A1".to_string(), description: "".to_string(), is_current: false, provider_id: "provider-a".to_string() },
+            ModelEntry { id: "model-a2".to_string(), display_name: "A2".to_string(), description: "".to_string(), is_current: false, provider_id: "provider-a".to_string() },
+            ModelEntry { id: "model-b1".to_string(), display_name: "B1".to_string(), description: "".to_string(), is_current: false, provider_id: "provider-b".to_string() },
+            ModelEntry { id: "model-b2".to_string(), display_name: "B2".to_string(), description: "".to_string(), is_current: false, provider_id: "provider-b".to_string() },
+        ]);
+        let grouped = state.filtered_models_grouped();
+        // Default entry + 2 provider-a models. Provider-b filtered out.
+        assert_eq!(grouped.len(), 3);
+        assert_eq!(grouped[0].0.id, DEFAULT_MODEL_SENTINEL);
+        let provider_ids: std::collections::HashSet<&str> =
+            grouped.iter().map(|(m, _)| m.provider_id.as_str()).collect();
+        assert!(!provider_ids.contains("provider-b"));
+        assert!(provider_ids.contains("provider-a"));
+    }
+
+    #[test]
+    fn show_all_providers_shows_everyone() {
+        let mut state = ModelPickerState::new();
+        state.all_providers_mode = true;
+        state.show_all_providers = true;
+        state.connected_provider_ids =
+            ["provider-a".to_string()].into_iter().collect();
+        state.set_models(vec![
+            ModelEntry { id: "model-a1".to_string(), display_name: "A1".to_string(), description: "".to_string(), is_current: false, provider_id: "provider-a".to_string() },
+            ModelEntry { id: "model-b1".to_string(), display_name: "B1".to_string(), description: "".to_string(), is_current: false, provider_id: "provider-b".to_string() },
+        ]);
+        let grouped = state.filtered_models_grouped();
+        // Default entry + 1 from provider-a + 1 from provider-b.
+        assert_eq!(grouped.len(), 3);
+        let provider_ids: std::collections::HashSet<&str> =
+            grouped.iter().map(|(m, _)| m.provider_id.as_str()).collect();
+        assert!(provider_ids.contains("provider-a"));
+        assert!(provider_ids.contains("provider-b"));
+    }
+
+    #[test]
+    fn toggle_show_all_providers_flips_state() {
+        let mut state = ModelPickerState::new();
+        assert!(!state.show_all_providers);
+        state.toggle_show_all_providers();
+        assert!(state.show_all_providers);
+        state.toggle_show_all_providers();
+        assert!(!state.show_all_providers);
     }
 }

--- a/src-rust/crates/tui/src/render.rs
+++ b/src-rust/crates/tui/src/render.rs
@@ -3,54 +3,55 @@
 use std::cell::RefCell;
 
 use crate::agents_view::render_agents_menu;
+use crate::app::{
+    App, ContextMenuKind, DisplayMessage, SystemAnnotation, SystemMessageStyle, ToolStatus,
+};
+use crate::ask_user_dialog::render_ask_user_dialog;
+use crate::bypass_permissions_dialog::render_bypass_permissions_dialog;
 use crate::context_viz::render_context_viz;
-use crate::export_dialog::render_export_dialog;
-use crate::app::{App, ContextMenuKind, SystemAnnotation, SystemMessageStyle, ToolStatus};
-use crate::rustle::rustle_lines;
-use crate::diff_viewer::render_diff_dialog;
-use crate::model_picker::render_model_picker;
-use crate::session_browser::render_session_browser;
-use crate::session_branching::render_session_branching;
-use crate::tasks_overlay::render_tasks_overlay;
-use crate::dialogs::{render_mcp_approval_dialog, render_permission_dialog};
-use crate::feedback_survey::render_feedback_survey;
-use crate::overage_upsell::render_overage_upsell;
-use crate::voice_mode_notice::render_voice_mode_notice;
+use crate::custom_provider_dialog::render_custom_provider_dialog;
 use crate::desktop_upsell_startup::render_desktop_upsell_startup;
-use crate::memory_update_notification::render_memory_update_notification;
+use crate::device_auth_dialog::render_device_auth_dialog;
+use crate::dialog_select::render_dialog_select;
+use crate::dialogs::{render_mcp_approval_dialog, render_permission_dialog};
+use crate::diff_viewer::render_diff_dialog;
+use crate::elicitation_dialog::render_elicitation_dialog;
+use crate::export_dialog::render_export_dialog;
+use crate::feedback_survey::render_feedback_survey;
+use crate::figures;
+use crate::file_injection_dialog::render_file_injection_dialog;
+use crate::hooks_config_menu::render_hooks_config_menu;
 use crate::import_config_dialog::render_import_config_dialog;
 use crate::invalid_config_dialog::render_invalid_config_dialog;
-use crate::bypass_permissions_dialog::render_bypass_permissions_dialog;
-use crate::file_injection_dialog::render_file_injection_dialog;
-use crate::ask_user_dialog::render_ask_user_dialog;
-use crate::onboarding_dialog::render_onboarding_dialog;
-use crate::dialog_select::render_dialog_select;
 use crate::key_input_dialog::render_key_input_dialog;
-use crate::custom_provider_dialog::render_custom_provider_dialog;
-use crate::device_auth_dialog::render_device_auth_dialog;
-use crate::elicitation_dialog::render_elicitation_dialog;
-use crate::figures;
-use crate::hooks_config_menu::render_hooks_config_menu;
 use crate::mcp_view::render_mcp_view;
 use crate::memory_file_selector::render_memory_file_selector;
+use crate::memory_update_notification::render_memory_update_notification;
 use crate::messages::{
-    render_transcript_assistant_message_tagged,
+    render_thinking_live_content, render_transcript_assistant_message_tagged,
     render_transcript_assistant_meta, render_transcript_live_text, render_transcript_user_message,
-    render_thinking_live_content,
     RenderContext,
 };
+use crate::model_picker::render_model_picker;
 use crate::notifications::{render_notification_banner, Notification, NotificationKind};
+use crate::onboarding_dialog::render_onboarding_dialog;
+use crate::overage_upsell::render_overage_upsell;
 use crate::overlays::{
     render_global_search, render_help_overlay, render_history_search_overlay, render_rewind_flow,
     CLAURST_ACCENT,
 };
 use crate::plugin_views::render_plugin_hints;
-use crate::prompt_input::{InputMode, TypeaheadSource, VimMode, input_height, render_prompt_input};
+use crate::prompt_input::{input_height, render_prompt_input, InputMode, TypeaheadSource, VimMode};
+use crate::rustle::rustle_lines;
+use crate::session_branching::render_session_branching;
+use crate::session_browser::render_session_browser;
 use crate::settings_screen::render_settings_screen;
 use crate::stats_dialog::render_stats_dialog;
+use crate::tasks_overlay::render_tasks_overlay;
 use crate::theme_screen::render_theme_screen;
 use crate::transcript_turn::{build_transcript_turns, TranscriptTurn};
 use crate::virtual_list::{VirtualItem, VirtualList};
+use crate::voice_mode_notice::render_voice_mode_notice;
 use claurst_core::constants::APP_VERSION;
 use claurst_core::types::Role;
 use ratatui::buffer::Buffer;
@@ -65,11 +66,15 @@ use unicode_width::UnicodeWidthStr;
 // characters mirrored (forward + reverse) for a smooth pulse effect.
 // Windows uses '*' instead of '✳'/'✽' for better font coverage.
 #[cfg(target_os = "windows")]
-const SPINNER: &[char] = &['\u{00b7}', '\u{2722}', '*', '\u{2736}', '\u{273b}', '\u{273d}',
-                            '\u{273d}', '\u{273b}', '\u{2736}', '*', '\u{2722}', '\u{00b7}'];
+const SPINNER: &[char] = &[
+    '\u{00b7}', '\u{2722}', '*', '\u{2736}', '\u{273b}', '\u{273d}', '\u{273d}', '\u{273b}',
+    '\u{2736}', '*', '\u{2722}', '\u{00b7}',
+];
 #[cfg(not(target_os = "windows"))]
-const SPINNER: &[char] = &['\u{00b7}', '\u{2722}', '\u{2733}', '\u{2736}', '\u{273b}', '\u{273d}',
-                            '\u{273d}', '\u{273b}', '\u{2736}', '\u{2733}', '\u{2722}', '\u{00b7}'];
+const SPINNER: &[char] = &[
+    '\u{00b7}', '\u{2722}', '\u{2733}', '\u{2736}', '\u{273b}', '\u{273d}', '\u{273d}', '\u{273b}',
+    '\u{2736}', '\u{2733}', '\u{2722}', '\u{00b7}',
+];
 const CLAUDE_ORANGE: Color = Color::Rgb(233, 30, 99);
 const WELCOME_BOX_HEIGHT: u16 = 9;
 const STATUS_THINKING: &str = "thinking";
@@ -99,7 +104,14 @@ fn is_modal_open(app: &App) -> bool {
 // -----------------------------------------------------------------------
 
 /// Render an error modal dialog with wrapped content.
-fn render_error_modal(frame: &mut Frame, area: Rect, notification: &Notification, _scroll_offset: usize, footer_area: Rect, is_welcome_screen: bool) {
+fn render_error_modal(
+    frame: &mut Frame,
+    area: Rect,
+    notification: &Notification,
+    _scroll_offset: usize,
+    footer_area: Rect,
+    is_welcome_screen: bool,
+) {
     // When the footer anchor is inside the welcome box (y < WELCOME_BOX_HEIGHT), or explicitly on
     // the welcome screen, center the modal so it doesn't awkwardly overlap the welcome box.
     let anchored_in_welcome_box = footer_area.width > 0 && footer_area.y < WELCOME_BOX_HEIGHT;
@@ -113,7 +125,8 @@ fn render_error_modal(frame: &mut Frame, area: Rect, notification: &Notification
             height: modal_height,
         }
     } else if footer_area.width > 0 {
-        let desired_height = (area.height / 3).max(8)
+        let desired_height = (area.height / 3)
+            .max(8)
             .min(area.height.saturating_sub(footer_area.y));
         Rect {
             x: footer_area.x,
@@ -147,8 +160,8 @@ fn render_error_modal(frame: &mut Frame, area: Rect, notification: &Notification
         height: 1,
     };
     let header_style = Style::default().bg(Color::Rgb(60, 15, 15)).fg(Color::Red);
-    let header_para = Paragraph::new("  ⚠ Error  ")
-        .style(header_style.add_modifier(Modifier::BOLD));
+    let header_para =
+        Paragraph::new("  ⚠ Error  ").style(header_style.add_modifier(Modifier::BOLD));
     frame.render_widget(header_para, header_bg_area);
 
     let sep_area = Rect {
@@ -317,7 +330,9 @@ fn startup_notice_lines(app: &App, width: u16) -> Vec<Line<'static>> {
         lines.push(Line::from(vec![
             Span::styled(
                 format!(" {} ", crate::figures::REFERENCE_MARK),
-                Style::default().fg(CLAUDE_ORANGE).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(CLAUDE_ORANGE)
+                    .add_modifier(Modifier::BOLD),
             ),
             Span::styled(
                 truncate_end(summary, max_width),
@@ -329,7 +344,11 @@ fn startup_notice_lines(app: &App, width: u16) -> Vec<Line<'static>> {
     match &app.bridge_state {
         crate::bridge_state::BridgeConnectionState::Connected { peer_count, .. } => {
             let label = if *peer_count > 0 {
-                format!("Remote session active \u{00b7} {} peer{}", peer_count, if *peer_count == 1 { "" } else { "s" })
+                format!(
+                    "Remote session active \u{00b7} {} peer{}",
+                    peer_count,
+                    if *peer_count == 1 { "" } else { "s" }
+                )
             } else {
                 "Remote session active".to_string()
             };
@@ -543,8 +562,7 @@ pub fn render_app(frame: &mut Frame, app: &App) {
         size,
     );
 
-    let prompt_focused =
-        app.permission_request.is_none() && !app.history_search_overlay.visible;
+    let prompt_focused = app.permission_request.is_none() && !app.history_search_overlay.visible;
     // Suggestions popup tracks whether the prompt accepts input, not whether
     // it is the focused widget. Text entry is allowed during streaming so the
     // user can queue the next message, so the typeahead popup must follow
@@ -715,7 +733,12 @@ pub fn render_app(frame: &mut Frame, app: &App) {
     if app.overage_upsell.visible {
         let banner_h = app.overage_upsell.height();
         if size.height > banner_h + 4 {
-            let banner_area = Rect { x: size.x, y: size.y, width: size.width, height: banner_h };
+            let banner_area = Rect {
+                x: size.x,
+                y: size.y,
+                width: size.width,
+                height: banner_h,
+            };
             render_overage_upsell(&app.overage_upsell, banner_area, frame.buffer_mut());
         }
     }
@@ -724,7 +747,12 @@ pub fn render_app(frame: &mut Frame, app: &App) {
     if app.voice_mode_notice.visible {
         let notice_h = app.voice_mode_notice.height();
         if size.height > notice_h + 4 {
-            let notice_area = Rect { x: size.x, y: size.y, width: size.width, height: notice_h };
+            let notice_area = Rect {
+                x: size.x,
+                y: size.y,
+                width: size.width,
+                height: notice_h,
+            };
             render_voice_mode_notice(&app.voice_mode_notice, notice_area, frame.buffer_mut());
         }
     }
@@ -735,7 +763,12 @@ pub fn render_app(frame: &mut Frame, app: &App) {
         if size.height > notif_h + 4 {
             // Place at the bottom of the screen, just above the prompt bar area
             let notif_y = size.y + size.height.saturating_sub(notif_h + 4);
-            let notif_area = Rect { x: size.x, y: notif_y, width: size.width, height: notif_h };
+            let notif_area = Rect {
+                x: size.x,
+                y: notif_y,
+                width: size.width,
+                height: notif_h,
+            };
             render_memory_update_notification(
                 &app.memory_update_notification,
                 notif_area,
@@ -862,6 +895,15 @@ pub fn render_app(frame: &mut Frame, app: &App) {
         render_mcp_approval_dialog(&app.mcp_approval, size, frame.buffer_mut());
     }
 
+    // When error modal is showing, selectable area = full terminal
+    if app.notifications.current_is_error() {
+        app.last_selectable_area.set(size);
+    }
+
+    // ---- Text selection highlight (applied before modal overlay) ----------
+    apply_selection_highlight(frame, app);
+    cache_selectable_row_text(frame, app);
+
     // Always show error modals on top of everything (highest priority)
     if let Some(notif) = app.notifications.current() {
         if notif.kind == NotificationKind::Error {
@@ -869,7 +911,15 @@ pub fn render_app(frame: &mut Frame, app: &App) {
                 && app.streaming_text.is_empty()
                 && app.streaming_thinking.is_empty()
                 && app.tool_use_blocks.is_empty();
-            render_error_modal(frame, size, notif, app.error_modal_scroll_offset, app.footer_right_column_area.get(), is_welcome_screen);
+            render_error_modal(
+                frame,
+                size,
+                notif,
+                app.error_modal_scroll_offset,
+                app.footer_right_column_area.get(),
+                is_welcome_screen,
+            );
+            render_context_menu(frame, app);
             return; // Don't render other overlays/notifications when error modal is showing
         }
     }
@@ -881,9 +931,6 @@ pub fn render_app(frame: &mut Frame, app: &App) {
         render_notification_banner(frame, &app.notifications, size);
     }
 
-    // ---- Text selection highlight (topmost post-pass) ---------------------
-    apply_selection_highlight(frame, app);
-    cache_selectable_row_text(frame, app);
     render_context_menu(frame, app);
 }
 
@@ -978,12 +1025,20 @@ fn apply_selection_highlight(frame: &mut Frame, app: &App) {
     let mut text = String::new();
     let last_row = end.1.min(max_row);
     for row in start.1..=last_row {
-        let col_from = if row == start.1 { start.0 } else { selectable_area.x };
+        let col_from = if row == start.1 {
+            start.0
+        } else {
+            selectable_area.x
+        };
         let col_to = if row == end.1 { end.0 } else { max_col };
         for col in col_from..=col_to {
             if let Some(cell) = buf.cell_mut((col, row)) {
                 let sym = cell.symbol().to_owned();
-                text.push_str(if sym.is_empty() || sym == "\0" { " " } else { &sym });
+                text.push_str(if sym.is_empty() || sym == "\0" {
+                    " "
+                } else {
+                    &sym
+                });
                 // Highlight: white background, black foreground
                 let new_style = Style::default()
                     .fg(Color::Black)
@@ -993,11 +1048,15 @@ fn apply_selection_highlight(frame: &mut Frame, app: &App) {
         }
         if row < last_row {
             // Trim trailing spaces from line before newline
-            while text.ends_with(' ') { text.pop(); }
+            while text.ends_with(' ') {
+                text.pop();
+            }
             text.push('\n');
         }
     }
-    while text.ends_with(|c: char| c.is_whitespace()) { text.pop(); }
+    while text.ends_with(|c: char| c.is_whitespace()) {
+        text.pop();
+    }
     *app.selection_text.borrow_mut() = text;
 }
 
@@ -1058,20 +1117,31 @@ fn render_context_menu(frame: &mut Frame, app: &App) {
             let is_selected = idx == menu.selected_index;
 
             let fg_color = if *enabled {
-                if is_selected { Color::Black } else { Color::White }
+                if is_selected {
+                    Color::Black
+                } else {
+                    Color::White
+                }
             } else {
                 Color::DarkGray
             };
 
             let bg_color = if is_selected {
-                if *enabled { CLAURST_ACCENT } else { Color::Rgb(24, 24, 30) }
+                if *enabled {
+                    CLAURST_ACCENT
+                } else {
+                    Color::Rgb(24, 24, 30)
+                }
             } else {
                 Color::Rgb(24, 24, 30)
             };
 
             let style = Style::default().fg(fg_color).bg(bg_color);
-            let padded_label =
-                format!(" {:<width$} ", label, width = menu_width.saturating_sub(2) as usize);
+            let padded_label = format!(
+                " {:<width$} ",
+                label,
+                width = menu_width.saturating_sub(2) as usize
+            );
 
             if let Some(cell) = frame.buffer_mut().cell_mut((inner.x, y)) {
                 cell.set_symbol(&padded_label[0..1.min(padded_label.len())]);
@@ -1082,7 +1152,10 @@ fn render_context_menu(frame: &mut Frame, app: &App) {
                 if col_offset >= inner.width as usize {
                     break;
                 }
-                if let Some(cell) = frame.buffer_mut().cell_mut((inner.x + col_offset as u16, y)) {
+                if let Some(cell) = frame
+                    .buffer_mut()
+                    .cell_mut((inner.x + col_offset as u16, y))
+                {
                     cell.set_symbol(&ch.to_string());
                     cell.set_style(style);
                 }
@@ -1126,7 +1199,8 @@ fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
     let transcript_empty = app.messages.is_empty()
         && app.streaming_text.is_empty()
         && app.streaming_thinking.is_empty()
-        && app.tool_use_blocks.is_empty();
+        && app.tool_use_blocks.is_empty()
+        && app.display_messages.is_empty();
 
     if transcript_empty {
         app.last_msg_area.set(Rect::default());
@@ -1162,23 +1236,31 @@ fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
     // Highlight search matches in transcript when global search is active
     let lines = if app.global_search.visible && !app.global_search.query.is_empty() {
         let query_lc = app.global_search.query.to_lowercase();
-        lines.into_iter().map(|mut item| {
-            if item.search_text.to_lowercase().contains(query_lc.as_str()) {
-                // Re-render the line with yellow highlight on matching spans
-                let highlighted_spans: Vec<Span<'static>> = item.line.spans.into_iter().map(|span| {
-                    if span.content.to_lowercase().contains(query_lc.as_str()) {
-                        Span::styled(
-                            span.content,
-                            span.style.bg(Color::Rgb(60, 50, 0)).fg(Color::Yellow),
-                        )
-                    } else {
-                        span
-                    }
-                }).collect();
-                item.line = ratatui::text::Line::from(highlighted_spans);
-            }
-            item
-        }).collect()
+        lines
+            .into_iter()
+            .map(|mut item| {
+                if item.search_text.to_lowercase().contains(query_lc.as_str()) {
+                    // Re-render the line with yellow highlight on matching spans
+                    let highlighted_spans: Vec<Span<'static>> = item
+                        .line
+                        .spans
+                        .into_iter()
+                        .map(|span| {
+                            if span.content.to_lowercase().contains(query_lc.as_str()) {
+                                Span::styled(
+                                    span.content,
+                                    span.style.bg(Color::Rgb(60, 50, 0)).fg(Color::Yellow),
+                                )
+                            } else {
+                                span
+                            }
+                        })
+                        .collect();
+                    item.line = ratatui::text::Line::from(highlighted_spans);
+                }
+                item
+            })
+            .collect()
     } else {
         lines
     };
@@ -1187,7 +1269,7 @@ fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
     // When auto_scroll is on we always show the tail; otherwise we respect
     // the user's scroll_offset.
     let content_height = lines.len() as u16;
-    let visible_height = msg_area.height;  // no borders, full height available
+    let visible_height = msg_area.height; // no borders, full height available
     let max_scroll = content_height.saturating_sub(visible_height) as usize;
     // Publish the max meaningful scroll offset so the next scroll event can
     // clamp `scroll_offset` against it (the content height is only known here,
@@ -1205,8 +1287,15 @@ fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
 
     let mut visible_rows: std::collections::HashMap<u16, usize> = std::collections::HashMap::new();
     let mut thinking_rows: std::collections::HashMap<u16, u64> = std::collections::HashMap::new();
-    for (idx, item) in lines.iter().enumerate().skip(scroll).take(msg_area.height as usize) {
-        let screen_row = msg_area.y.saturating_add((idx.saturating_sub(scroll)) as u16);
+    for (idx, item) in lines
+        .iter()
+        .enumerate()
+        .skip(scroll)
+        .take(msg_area.height as usize)
+    {
+        let screen_row = msg_area
+            .y
+            .saturating_add((idx.saturating_sub(scroll)) as u16);
         if let Some(message_index) = item.message_index {
             visible_rows.insert(screen_row, message_index);
         }
@@ -1262,7 +1351,11 @@ fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
         let indicator = format!(
             " \u{2193} {} new message{} ",
             app.new_messages_while_scrolled,
-            if app.new_messages_while_scrolled == 1 { "" } else { "s" }
+            if app.new_messages_while_scrolled == 1 {
+                ""
+            } else {
+                "s"
+            }
         );
         let ind_len = indicator.len() as u16;
         let ind_x = msg_area
@@ -1325,7 +1418,11 @@ fn push_blank_item(items: &mut Vec<RenderedLineItem>) {
     push_rendered_items(items, vec![Line::from("")], None, false);
 }
 
-fn render_live_thinking_lines(turn: &TranscriptTurn<'_>, frame_count: u64, width: u16) -> Vec<Line<'static>> {
+fn render_live_thinking_lines(
+    turn: &TranscriptTurn<'_>,
+    frame_count: u64,
+    width: u16,
+) -> Vec<Line<'static>> {
     let mut header_spans = vec![Span::raw("  ▼ ")];
     header_spans.extend(shimmer_spans("Thinking", frame_count));
     if let Some(heading) = turn.reasoning_heading() {
@@ -1375,7 +1472,10 @@ fn append_turn_items(
         let mut lines = Vec::new();
         render_tool_block_lines(&mut lines, block, frame_count);
         if !lines.is_empty() {
-            sections.push((SectionContent::Plain(lines), Some(turn.primary_message_index())));
+            sections.push((
+                SectionContent::Plain(lines),
+                Some(turn.primary_message_index()),
+            ));
         }
     }
 
@@ -1392,7 +1492,10 @@ fn append_turn_items(
     if turn.active
         && turn.live_text.is_none()
         && turn.live_thinking.is_none()
-        && turn.tool_blocks.iter().all(|b| b.status != ToolStatus::Running)
+        && turn
+            .tool_blocks
+            .iter()
+            .all(|b| b.status != ToolStatus::Running)
     {
         let mut spans = vec![Span::raw("  ")];
         spans.extend(shimmer_spans("Thinking", frame_count));
@@ -1405,14 +1508,20 @@ fn append_turn_items(
     if let Some(text) = turn.live_text {
         let lines = render_transcript_live_text(text, width);
         if !lines.is_empty() {
-            sections.push((SectionContent::Plain(lines), Some(turn.primary_message_index())));
+            sections.push((
+                SectionContent::Plain(lines),
+                Some(turn.primary_message_index()),
+            ));
         }
     }
 
     if !turn.active {
         if let Some(meta_line) = render_transcript_assistant_meta(turn.metadata, accent) {
             if turn.has_visible_assistant_content() {
-                sections.push((SectionContent::Plain(vec![meta_line]), Some(turn.primary_message_index())));
+                sections.push((
+                    SectionContent::Plain(vec![meta_line]),
+                    Some(turn.primary_message_index()),
+                ));
             }
         }
     }
@@ -1422,8 +1531,12 @@ fn append_turn_items(
         let total_sections = sections.len();
         for (index, (content, message_index)) in sections.into_iter().enumerate() {
             match content {
-                SectionContent::Plain(lines) => push_rendered_items(items, lines, message_index, false),
-                SectionContent::Tagged(tagged) => push_rendered_items_tagged(items, tagged, message_index),
+                SectionContent::Plain(lines) => {
+                    push_rendered_items(items, lines, message_index, false)
+                }
+                SectionContent::Tagged(tagged) => {
+                    push_rendered_items_tagged(items, tagged, message_index)
+                }
             }
             if index + 1 < total_sections {
                 push_blank_item(items);
@@ -1461,7 +1574,11 @@ fn build_message_items_range(
 ) {
     let mut index = start;
     while index < end {
-        for ann in app.system_annotations.iter().filter(|ann| ann.after_index == index) {
+        for ann in app
+            .system_annotations
+            .iter()
+            .filter(|ann| ann.after_index == index)
+        {
             let mut lines = Vec::new();
             render_system_annotation_lines(&mut lines, ann, width as usize);
             push_rendered_items(items, lines, None, false);
@@ -1483,7 +1600,11 @@ fn build_message_items_range(
     }
 
     if emit_end_annotations {
-        for ann in app.system_annotations.iter().filter(|ann| ann.after_index == end) {
+        for ann in app
+            .system_annotations
+            .iter()
+            .filter(|ann| ann.after_index == end)
+        {
             let mut lines = Vec::new();
             render_system_annotation_lines(&mut lines, ann, width as usize);
             push_rendered_items(items, lines, None, false);
@@ -1528,13 +1649,61 @@ fn build_all_items(app: &App, width: u16) -> Vec<RenderedLineItem> {
         }
     }
 
+    // Append display-only bang command output (never sent to the model).
+    let bang_lines = render_bang_display_lines(app);
+    if !bang_lines.is_empty() {
+        push_rendered_items(&mut items, bang_lines, None, false);
+    }
+
     items
 }
 
+/// Render display-only `!` bang command entries (command, output, error).
+/// These are appended at the end of the transcript and never sent to the model.
+fn render_bang_display_lines(app: &App) -> Vec<Line<'static>> {
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let mut found = false;
+    for msg in &app.display_messages {
+        match msg {
+            DisplayMessage::BangCommand { command } => {
+                found = true;
+                if !lines.is_empty() {
+                    lines.push(Line::from(""));
+                }
+                lines.push(Line::styled(
+                    format!("$ {}", command),
+                    Style::default()
+                        .fg(Color::DarkGray)
+                        .add_modifier(Modifier::BOLD),
+                ));
+            }
+            DisplayMessage::BangOutput { text, exit_code } => {
+                found = true;
+                let color = if exit_code.unwrap_or(0) != 0 {
+                    Color::Red
+                } else {
+                    Color::Gray
+                };
+                for line in text.lines() {
+                    lines.push(Line::styled(line.to_string(), Style::default().fg(color)));
+                }
+            }
+            DisplayMessage::BangError { text } => {
+                found = true;
+                lines.push(Line::styled(text.clone(), Style::default().fg(Color::Red)));
+            }
+            _ => {}
+        }
+    }
+    if found {
+        lines.push(Line::from(""));
+    }
+    lines
+}
+
 fn render_message_items(app: &App, width: u16) -> Vec<RenderedLineItem> {
-    let streaming = app.is_streaming
-        || !app.streaming_text.is_empty()
-        || !app.streaming_thinking.is_empty();
+    let streaming =
+        app.is_streaming || !app.streaming_text.is_empty() || !app.streaming_thinking.is_empty();
     let has_running_tool_blocks = app
         .tool_use_blocks
         .iter()
@@ -1639,7 +1808,16 @@ fn render_streaming_items(app: &App, width: u16) -> Vec<RenderedLineItem> {
     } else {
         record_prefix_cache_miss();
         let mut prefix = Vec::new();
-        build_message_items_range(app, width, &ctx, &turn_map, 0, split_idx, false, &mut prefix);
+        build_message_items_range(
+            app,
+            width,
+            &ctx,
+            &turn_map,
+            0,
+            split_idx,
+            false,
+            &mut prefix,
+        );
         COMPLETED_MSG_CACHE.with(|cache| {
             *cache.borrow_mut() = Some(CompletedMsgCache {
                 key: prefix_key,
@@ -1657,7 +1835,9 @@ fn render_streaming_items(app: &App, width: u16) -> Vec<RenderedLineItem> {
     items.extend(prefix);
 
     // Live tail: the actively-streaming turn, rebuilt fresh every frame.
-    build_message_items_range(app, width, &ctx, &turn_map, split_idx, total, true, &mut items);
+    build_message_items_range(
+        app, width, &ctx, &turn_map, split_idx, total, true, &mut items,
+    );
     items
 }
 
@@ -1665,7 +1845,6 @@ fn render_streaming_items(app: &App, width: u16) -> Vec<RenderedLineItem> {
 
 /// Render the two-column orange round-bordered welcome box (matches TS LogoV2).
 fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
-
     // --- Box dimensions ---
     // The box should be at most the full area width, and a fixed height.
     let box_width = area.width;
@@ -1673,13 +1852,26 @@ fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
     if area.height < box_height || box_width < 30 {
         // Too small: fall back to a single line
         let line = Line::from(vec![
-            Span::styled("Claurst ", Style::default().fg(CLAUDE_ORANGE).add_modifier(Modifier::BOLD)),
-            Span::styled(format!("v{}", APP_VERSION), Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                "Claurst ",
+                Style::default()
+                    .fg(CLAUDE_ORANGE)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!("v{}", APP_VERSION),
+                Style::default().fg(Color::DarkGray),
+            ),
         ]);
         frame.render_widget(Paragraph::new(vec![line]), area);
         return;
     }
-    let box_area = Rect { x: area.x, y: area.y, width: box_width, height: box_height };
+    let box_area = Rect {
+        x: area.x,
+        y: area.y,
+        width: box_width,
+        height: box_height,
+    };
 
     // Outer border with title "Claurst vX.Y"
     let accent = app.accent_color;
@@ -1688,8 +1880,14 @@ fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(accent))
         .title(Line::from(vec![
-            Span::styled(" Claurst ", Style::default().fg(accent).add_modifier(Modifier::BOLD)),
-            Span::styled(format!("v{} ", APP_VERSION), Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                " Claurst ",
+                Style::default().fg(accent).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!("v{} ", APP_VERSION),
+                Style::default().fg(Color::DarkGray),
+            ),
         ]));
     frame.render_widget(outer_block, box_area);
 
@@ -1703,7 +1901,9 @@ fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
 
     // Split inner into left | divider(1) | right
     // Left width: ~28 chars or half the inner width, whichever is smaller
-    let left_w = (inner.width / 2).clamp(22, 32).min(inner.width.saturating_sub(3));
+    let left_w = (inner.width / 2)
+        .clamp(22, 32)
+        .min(inner.width.saturating_sub(3));
     let right_w = inner.width.saturating_sub(left_w + 1);
     let h_chunks = Layout::default()
         .direction(Direction::Horizontal)
@@ -1737,7 +1937,9 @@ fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
     let mut left_lines: Vec<Line> = Vec::new();
     left_lines.push(Line::from(Span::styled(
         welcome_msg,
-        Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(Color::White)
+            .add_modifier(Modifier::BOLD),
     )));
     left_lines.push(Line::from(""));
     // Center mascot in left column
@@ -1748,7 +1950,10 @@ fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
         spans.extend(cl.spans.iter().cloned());
         left_lines.push(Line::from(spans));
     }
-    frame.render_widget(Paragraph::new(left_lines).wrap(Wrap { trim: false }), h_chunks[0]);
+    frame.render_widget(
+        Paragraph::new(left_lines).wrap(Wrap { trim: false }),
+        h_chunks[0],
+    );
 
     // --- Right column ---
     let tip_text = claurst_core::tips::select_tip(0)
@@ -1762,7 +1967,11 @@ fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
     )));
     // Word-wrap the tip text into the right column width
     let right_w_usize = right_w.saturating_sub(1) as usize;
-    for chunk in tip_text.chars().collect::<Vec<_>>().chunks(right_w_usize.max(1)) {
+    for chunk in tip_text
+        .chars()
+        .collect::<Vec<_>>()
+        .chunks(right_w_usize.max(1))
+    {
         right_lines.push(Line::from(chunk.iter().collect::<String>()));
     }
     right_lines.push(Line::from(""));
@@ -1772,7 +1981,10 @@ fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
     )));
     right_lines.extend(recent_activity_lines(&app.recent_sessions, right_w_usize));
 
-    frame.render_widget(Paragraph::new(right_lines).wrap(Wrap { trim: false }), h_chunks[2]);
+    frame.render_widget(
+        Paragraph::new(right_lines).wrap(Wrap { trim: false }),
+        h_chunks[2],
+    );
 }
 
 /// Build the compact welcome banner shown at the very top of the transcript.
@@ -1851,7 +2063,10 @@ fn welcome_banner_lines(app: &App, width: u16) -> Vec<Line<'static>> {
     };
 
     let bottom = Line::from(Span::styled(
-        format!("\u{2570}{}\u{256f}", "\u{2500}".repeat(box_w.saturating_sub(2))),
+        format!(
+            "\u{2570}{}\u{256f}",
+            "\u{2500}".repeat(box_w.saturating_sub(2))
+        ),
         Style::default().fg(accent),
     ));
 
@@ -1859,7 +2074,9 @@ fn welcome_banner_lines(app: &App, width: u16) -> Vec<Line<'static>> {
         top,
         content_row(
             greeting,
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         ),
         content_row(
             "/help for commands  \u{00b7}  ? for shortcuts".to_string(),
@@ -1876,7 +2093,9 @@ fn welcome_banner_lines(app: &App, width: u16) -> Vec<Line<'static>> {
 
 /// Build a tool_use_id → tool_name lookup from all messages in the transcript.
 /// This allows ToolResult blocks to dispatch to tool-specific renderers.
-fn build_tool_names(messages: &[claurst_core::types::Message]) -> std::collections::HashMap<String, String> {
+fn build_tool_names(
+    messages: &[claurst_core::types::Message],
+) -> std::collections::HashMap<String, String> {
     let mut map = std::collections::HashMap::new();
     for msg in messages {
         for block in msg.content_blocks() {
@@ -1917,6 +2136,7 @@ fn render_system_annotation_lines(
         SystemMessageStyle::Info => (Color::DarkGray, Color::DarkGray),
         SystemMessageStyle::Warning => (Color::Yellow, Color::Yellow),
         SystemMessageStyle::Compact => unreachable!(),
+        SystemMessageStyle::TodoCard => (Color::Cyan, Color::Cyan),
     };
 
     // Centred, padded rule: "â”€â”€â”€ text â”€â”€â”€"
@@ -1936,10 +2156,7 @@ fn render_system_annotation_lines(
             format!("\u{2500} {} \u{2500}", text),
             Style::default().fg(text_color).add_modifier(Modifier::DIM),
         ),
-        Span::styled(
-            "\u{2500}".repeat(right),
-            Style::default().fg(border_color),
-        ),
+        Span::styled("\u{2500}".repeat(right), Style::default().fg(border_color)),
     ]));
     lines.push(Line::from(""));
 }
@@ -2001,7 +2218,11 @@ fn tool_running_label(normalized: &str, fallback: &str) -> String {
     .to_string()
 }
 
-fn render_tool_block_lines(lines: &mut Vec<Line<'static>>, block: &crate::app::ToolUseBlock, frame_count: u64) {
+fn render_tool_block_lines(
+    lines: &mut Vec<Line<'static>>,
+    block: &crate::app::ToolUseBlock,
+    frame_count: u64,
+) {
     let input_val: serde_json::Value =
         serde_json::from_str(&block.input_json).unwrap_or(serde_json::Value::Null);
     let normalized = block.name.to_ascii_lowercase();
@@ -2023,7 +2244,10 @@ fn render_tool_block_lines(lines: &mut Vec<Line<'static>>, block: &crate::app::T
     // Primary argument shown on the header line (icon + arg), opencode-style.
     let mut summary = crate::messages::extract_tool_summary(&block.name, &input_val);
     let running_label = if normalized == "task" || normalized == "agent" {
-        if let Some(description) = input_val.get("description").and_then(|value| value.as_str()) {
+        if let Some(description) = input_val
+            .get("description")
+            .and_then(|value| value.as_str())
+        {
             summary = description.to_string();
         }
         crate::messages::subagent_title(&input_val)
@@ -2039,7 +2263,10 @@ fn render_tool_block_lines(lines: &mut Vec<Line<'static>>, block: &crate::app::T
         summary = shorten_home_path(&summary);
     }
 
-    let mut header_spans = vec![Span::styled(format!("   {} ", icon), Style::default().fg(accent))];
+    let mut header_spans = vec![Span::styled(
+        format!("   {} ", icon),
+        Style::default().fg(accent),
+    )];
     if running {
         header_spans.extend(shimmer_spans(&running_label, frame_count));
     } else {
@@ -2052,7 +2279,11 @@ fn render_tool_block_lines(lines: &mut Vec<Line<'static>>, block: &crate::app::T
         header_spans.push(Span::styled(
             primary,
             Style::default()
-                .fg(if block.status == ToolStatus::Error { accent } else { Color::White })
+                .fg(if block.status == ToolStatus::Error {
+                    accent
+                } else {
+                    Color::White
+                })
                 .add_modifier(Modifier::BOLD),
         ));
     }
@@ -2085,59 +2316,6 @@ fn render_tool_block_lines(lines: &mut Vec<Line<'static>>, block: &crate::app::T
     }
 }
 
-/// Extract the confidence score used by the TodoWrite checklist.
-fn todo_confidence(todo: &serde_json::Value) -> Option<u8> {
-    let value = if todo.get("status").and_then(|status| status.as_str()) == Some("completed") {
-        todo.get("completion_confidence")
-            .filter(|value| !value.is_null())
-            .or_else(|| todo.get("confidence"))
-    } else {
-        todo.get("confidence")
-    }?;
-
-    match value {
-        serde_json::Value::Number(number) => number
-            .as_f64()
-            .filter(|score| score.is_finite() && score.fract() == 0.0)
-            .filter(|score| (0.0..=100.0).contains(score))
-            .map(|score| score as u8),
-        serde_json::Value::String(raw) => raw
-            .trim()
-            .parse::<f64>()
-            .ok()
-            .filter(|score| score.is_finite() && score.fract() == 0.0)
-            .filter(|score| (0.0..=100.0).contains(score))
-            .map(|score| score as u8),
-        _ => None,
-    }
-}
-
-fn aggregate_todo_confidence(todos: &[serde_json::Value]) -> Option<u8> {
-    let mut weighted_sum = 0u32;
-    let mut total_weight = 0u32;
-    for todo in todos {
-        let Some(score) = todo_confidence(todo) else {
-            continue;
-        };
-        let weight = match todo.get("priority").and_then(|priority| priority.as_str()) {
-            Some("high") => 3,
-            Some("medium") => 2,
-            _ => 1,
-        };
-        weighted_sum += u32::from(score) * weight;
-        total_weight += weight;
-    }
-    (total_weight > 0).then_some(((weighted_sum + total_weight / 2) / total_weight) as u8)
-}
-
-fn confidence_color(score: u8) -> Color {
-    match score {
-        80..=100 => Color::Rgb(120, 200, 120),
-        50..=79 => Color::Rgb(220, 190, 100),
-        _ => Color::Rgb(220, 120, 100),
-    }
-}
-
 /// Render a TodoWrite call as a checklist. Returns `false` (so the caller can
 /// fall back to the generic block) when the input carries no `todos` array.
 fn render_todo_block(
@@ -2156,30 +2334,31 @@ fn render_todo_block(
     }
 
     fn status_of(t: &serde_json::Value) -> &str {
-        t.get("status").and_then(|s| s.as_str()).unwrap_or("pending")
+        t.get("status")
+            .and_then(|s| s.as_str())
+            .unwrap_or("pending")
     }
     let done = todos.iter().filter(|t| status_of(t) == "completed").count();
     let total = todos.len();
 
     // Header: ☰ Todos   <done>/<total>
-    let mut header = vec![Span::styled(format!("   {} ", icon), Style::default().fg(accent))];
+    let mut header = vec![Span::styled(
+        format!("   {} ", icon),
+        Style::default().fg(accent),
+    )];
     if running {
         header.extend(shimmer_spans("Updating todos", frame_count));
     } else {
         header.push(Span::styled(
             "Todos".to_string(),
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         ));
         header.push(Span::styled(
             format!("  {}/{} done", done, total),
             Style::default().fg(Color::DarkGray),
         ));
-        if let Some(confidence) = aggregate_todo_confidence(todos) {
-            header.push(Span::styled(
-                format!(" · confidence {}%", confidence),
-                Style::default().fg(confidence_color(confidence)),
-            ));
-        }
     }
     lines.push(Line::from(header));
 
@@ -2200,7 +2379,9 @@ fn render_todo_block(
             "completed" => (
                 "[x]",
                 Color::Rgb(120, 200, 120),
-                Style::default().fg(Color::DarkGray).add_modifier(Modifier::DIM),
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::DIM),
             ),
             "in_progress" => (
                 "[>]",
@@ -2213,19 +2394,9 @@ fn render_todo_block(
                 Style::default().fg(Color::Rgb(170, 170, 170)),
             ),
         };
-        let confidence = todo_confidence(t);
         lines.push(Line::from(vec![
             Span::styled(format!("     {} ", glyph), Style::default().fg(glyph_color)),
             Span::styled(content.to_string(), text_style),
-            Span::styled(
-                confidence
-                    .map(|score| format!(" [{}%]", score))
-                    .unwrap_or_default(),
-                confidence
-                    .map(confidence_color)
-                    .map(|color| Style::default().fg(color))
-                    .unwrap_or_default(),
-            ),
         ]));
     }
     if total > MAX_ITEMS {
@@ -2233,7 +2404,9 @@ fn render_todo_block(
             Span::raw("     "),
             Span::styled(
                 format!("... {} more", total - MAX_ITEMS),
-                Style::default().fg(Color::DarkGray).add_modifier(Modifier::DIM),
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::DIM),
             ),
         ]));
     }
@@ -2269,15 +2442,19 @@ fn render_input(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
         let dim = Color::Rgb(110, 110, 124);
         let chunks = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints([Constraint::Min(1), Constraint::Length(status_area.width.min(50))])
+            .constraints([
+                Constraint::Min(1),
+                Constraint::Length(status_area.width.min(50)),
+            ])
             .split(status_area);
 
         let left_line = if app.has_credentials {
-            let (provider, model_short) = if let Some((provider, model)) = app.model_name.split_once('/') {
-                (provider.to_string(), model.to_string())
-            } else {
-                ("local".to_string(), app.model_name.clone())
-            };
+            let (provider, model_short) =
+                if let Some((provider, model)) = app.model_name.split_once('/') {
+                    (provider.to_string(), model.to_string())
+                } else {
+                    ("local".to_string(), app.model_name.clone())
+                };
             let mut spans = vec![
                 Span::styled(
                     format!(" {} ", agent_mode.to_uppercase()),
@@ -2289,7 +2466,9 @@ fn render_input(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
                 Span::raw(" "),
                 Span::styled(
                     model_short,
-                    Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::White)
+                        .add_modifier(Modifier::BOLD),
                 ),
             ];
             spans.push(Span::styled(
@@ -2321,15 +2500,14 @@ fn render_input(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
         // also suppressed once the prompt has text, so the hint doesn't compete
         // with what the user is typing (matches the footer contract).
         let right_hint = if app.has_credentials && app.prompt_input.text.is_empty() {
-            Line::from(vec![
-                Span::styled("? shortcuts", Style::default().fg(dim)),
-            ])
+            Line::from(vec![Span::styled("? shortcuts", Style::default().fg(dim))])
         } else if app.prompt_input.has_expandable_paste_ref() {
             // A [Pasted text #N ...] placeholder is in the buffer — tell the
             // user how to view the full pasted body before submitting.
-            Line::from(vec![
-                Span::styled("click to view paste · alt+e expands", Style::default().fg(dim)),
-            ])
+            Line::from(vec![Span::styled(
+                "click to view paste · alt+e expands",
+                Style::default().fg(dim),
+            )])
         } else {
             Line::from(Vec::<Span>::new())
         };
@@ -2399,14 +2577,19 @@ fn render_status_row(frame: &mut Frame, app: &App, area: Rect) {
 
     let spans = if app.voice_recording {
         vec![Span::styled(
-            format!("{} Recording... press Alt+V to transcribe", figures::black_circle()),
+            format!(
+                "{} Recording... press Alt+V to transcribe",
+                figures::black_circle()
+            ),
             Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
         )]
     } else if app.is_streaming {
         // Pick a label: use the status message if it has real content,
         // otherwise show a default "Thinking" shimmer so the user always
         // sees that the model is working.
-        let raw_label = app.status_message.as_deref()
+        let raw_label = app
+            .status_message
+            .as_deref()
             .filter(|s| {
                 let t = s.trim();
                 !t.is_empty()
@@ -2418,21 +2601,30 @@ fn render_status_row(frame: &mut Frame, app: &App, area: Rect) {
 
         let mut s = vec![Span::styled(
             spinner_char(app.frame_count).to_string(),
-            Style::default().fg(spinner_color(app)).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(spinner_color(app))
+                .add_modifier(Modifier::BOLD),
         )];
         let label = format!("{}…", raw_label.trim_end_matches('…'));
 
         s.push(Span::raw(" "));
         s.extend(shimmer_spans(&label, app.frame_count));
         s
-    } else if let (Some(verb), Some(elapsed)) = (app.last_turn_verb, app.last_turn_elapsed.as_deref()) {
+    } else if let (Some(verb), Some(elapsed)) =
+        (app.last_turn_verb, app.last_turn_elapsed.as_deref())
+    {
         // "✽ Worked for 2m 5s" — mirrors TS TeammateSpinnerLine idle state
         vec![Span::styled(
             format!("{} {} for {}", figures::TEARDROP_ASTERISK, verb, elapsed),
-            Style::default().fg(Color::DarkGray).add_modifier(Modifier::DIM),
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::DIM),
         )]
     } else if let Some(status) = app.status_message.as_deref() {
-        vec![Span::styled(status.to_string(), Style::default().fg(Color::DarkGray))]
+        vec![Span::styled(
+            status.to_string(),
+            Style::default().fg(Color::DarkGray),
+        )]
     } else {
         Vec::new()
     };
@@ -2442,8 +2634,7 @@ fn render_status_row(frame: &mut Frame, app: &App, area: Rect) {
     }
 
     frame.render_widget(
-        Paragraph::new(Line::from(spans))
-            .wrap(ratatui::widgets::Wrap { trim: false }),
+        Paragraph::new(Line::from(spans)).wrap(ratatui::widgets::Wrap { trim: false }),
         area,
     );
 }
@@ -2480,7 +2671,10 @@ fn shimmer_spans(text: &str, frame_count: u64) -> Vec<Span<'static>> {
             && glimmer_center < len as isize;
 
         if is_bright != run_bright && !run.is_empty() {
-            spans.push(Span::styled(run.clone(), if run_bright { bright } else { base }));
+            spans.push(Span::styled(
+                run.clone(),
+                if run_bright { bright } else { base },
+            ));
             run.clear();
         }
         run_bright = is_bright;
@@ -2523,7 +2717,9 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
         if let Some(ref badge) = app.agent_type_badge {
             spans.push(Span::styled(
                 format!("\u{2699} {}", badge),
-                Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
             ));
         }
 
@@ -2566,10 +2762,7 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
             } else {
                 format!("\u{27f3} {} tasks", app.background_task_count)
             };
-            spans.push(Span::styled(
-                label,
-                Style::default().fg(Color::Yellow),
-            ));
+            spans.push(Span::styled(label, Style::default().fg(Color::Yellow)));
         } else if let Some(ref task_status) = app.background_task_status {
             if !spans.is_empty() {
                 spans.push(Span::raw("  "));
@@ -2587,13 +2780,43 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
                 spans.push(Span::raw("  "));
             }
             let (label, style) = match app.prompt_input.vim_mode {
-                VimMode::Insert      => ("-- INSERT --",       Style::default().fg(Color::DarkGray)),
-                VimMode::Normal      => ("-- NORMAL --",       Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
-                VimMode::Visual      => ("-- VISUAL --",       Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD)),
-                VimMode::VisualLine  => ("-- VISUAL LINE --",  Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD)),
-                VimMode::VisualBlock => ("-- VISUAL BLOCK --", Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD)),
-                VimMode::Command     => ("-- COMMAND --",      Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
-                VimMode::Search      => ("-- SEARCH --",       Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+                VimMode::Insert => ("-- INSERT --", Style::default().fg(Color::DarkGray)),
+                VimMode::Normal => (
+                    "-- NORMAL --",
+                    Style::default()
+                        .fg(Color::Green)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                VimMode::Visual => (
+                    "-- VISUAL --",
+                    Style::default()
+                        .fg(Color::Magenta)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                VimMode::VisualLine => (
+                    "-- VISUAL LINE --",
+                    Style::default()
+                        .fg(Color::Magenta)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                VimMode::VisualBlock => (
+                    "-- VISUAL BLOCK --",
+                    Style::default()
+                        .fg(Color::Magenta)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                VimMode::Command => (
+                    "-- COMMAND --",
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                VimMode::Search => (
+                    "-- SEARCH --",
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                ),
             };
             spans.push(Span::styled(label, style));
         }
@@ -2605,7 +2828,9 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
             }
             spans.push(Span::styled(
                 "[BASH]",
-                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
             ));
         }
 
@@ -2615,25 +2840,28 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
             use claurst_core::config::PermissionMode;
             match &app.config.permission_mode {
                 PermissionMode::BypassPermissions => {
-                    if !spans.is_empty() { spans.push(Span::raw("  ")); }
+                    if !spans.is_empty() {
+                        spans.push(Span::raw("  "));
+                    }
                     spans.push(Span::styled(
                         "\u{23f5}\u{23f5} bypass",
                         Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
                     ));
                 }
                 PermissionMode::AcceptEdits => {
-                    if !spans.is_empty() { spans.push(Span::raw("  ")); }
+                    if !spans.is_empty() {
+                        spans.push(Span::raw("  "));
+                    }
                     spans.push(Span::styled(
                         "accept-edits",
                         Style::default().fg(Color::Yellow),
                     ));
                 }
                 PermissionMode::Plan => {
-                    if !spans.is_empty() { spans.push(Span::raw("  ")); }
-                    spans.push(Span::styled(
-                        "plan",
-                        Style::default().fg(Color::Blue),
-                    ));
+                    if !spans.is_empty() {
+                        spans.push(Span::raw("  "));
+                    }
+                    spans.push(Span::styled("plan", Style::default().fg(Color::Blue)));
                 }
                 PermissionMode::Default => {}
             }
@@ -2660,7 +2888,8 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
         //    When an update is available and context is below 85%, show the update notification
         //    instead to keep the status bar uncluttered.
         if app.context_window_size > 0 {
-            let used_pct = (app.context_used_tokens as f64 / app.context_window_size as f64 * 100.0) as u64;
+            let used_pct =
+                (app.context_used_tokens as f64 / app.context_window_size as f64 * 100.0) as u64;
             let left_pct = 100u64.saturating_sub(used_pct);
 
             if !parts.is_empty() {
@@ -2684,7 +2913,9 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
                 // Update available and context is fine — show update nudge in bottom-right.
                 parts.push(Span::styled(
                     format!("⬆ v{} available  Run: /update", version),
-                    Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
                 ));
             } else if used_pct >= 70 {
                 // 70–84%: mild warning.
@@ -2714,10 +2945,7 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
             } else {
                 format!("${:.2}", app.cost_usd)
             };
-            parts.push(Span::styled(
-                cost_str,
-                Style::default().fg(Color::DarkGray),
-            ));
+            parts.push(Span::styled(cost_str, Style::default().fg(Color::DarkGray)));
         }
 
         // 3b. Token budget (feature-gated)
@@ -2746,13 +2974,76 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
             ));
         }
 
+        // Tokens per second average (from last 5 turns).
+        if !app.recent_token_rates.is_empty() {
+            if !parts.is_empty() {
+                parts.push(Span::raw("  "));
+            }
+            let avg_tps =
+                app.recent_token_rates.iter().sum::<f64>() / app.recent_token_rates.len() as f64;
+            parts.push(Span::styled(
+                format!("{:.0} tok/s", avg_tps),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+
+        // Todo progress (done/total).
+        let todos = claurst_tools::todo_write::load_todos(&app.session_id);
+        if !todos.is_empty() {
+            if !parts.is_empty() {
+                parts.push(Span::raw("  "));
+            }
+            let total = todos.len();
+            let completed = todos
+                .iter()
+                .filter(|t| t.get("status").and_then(|s| s.as_str()) == Some("completed"))
+                .count();
+            parts.push(Span::styled(
+                format!("{}/{} TODOS", completed, total),
+                Style::default().fg(if completed == total {
+                    Color::Green
+                } else {
+                    Color::Yellow
+                }),
+            ));
+        }
+
+        // Git branch indicator — shown unconditionally when detected.
+        if let Some(branch) = &app.git_branch {
+            if !parts.is_empty() {
+                parts.push(Span::raw("  "));
+            }
+            parts.push(Span::styled(
+                format!("\u{2387} {}", branch),
+                Style::default().fg(Color::Cyan),
+            ));
+        }
+
+        // Skills + MCP count indicator.
+        if app.skill_count > 0 || app.mcp_server_count > 0 {
+            if !parts.is_empty() {
+                parts.push(Span::raw("  "));
+            }
+            parts.push(Span::styled(
+                format!(
+                    "{} skills \u{00b7} {} mcp",
+                    app.skill_count, app.mcp_server_count
+                ),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+
         // 4. Rate limits
         if let Some(pct) = app.rate_limit_5h_pct {
             if pct > 0.0 {
                 if !parts.is_empty() {
                     parts.push(Span::raw("  "));
                 }
-                let color = if pct >= 90.0 { Color::Red } else { Color::Yellow };
+                let color = if pct >= 90.0 {
+                    Color::Red
+                } else {
+                    Color::Yellow
+                };
                 parts.push(Span::styled(
                     format!("5h:{:.0}%", pct),
                     Style::default().fg(color),
@@ -2764,7 +3055,11 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
                 if !parts.is_empty() {
                     parts.push(Span::raw("  "));
                 }
-                let color = if pct >= 90.0 { Color::Red } else { Color::Yellow };
+                let color = if pct >= 90.0 {
+                    Color::Red
+                } else {
+                    Color::Yellow
+                };
                 parts.push(Span::styled(
                     format!("7d:{:.0}%", pct),
                     Style::default().fg(color),
@@ -2781,7 +3076,9 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
             }
             parts.push(Span::styled(
                 format!("[goal: {}]", badge),
-                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
             ));
         }
 
@@ -2805,19 +3102,6 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
                 format!("[{}]", branch),
                 Style::default().fg(Color::Green),
             ));
-        }
-
-        // Git branch (if settings enabled)
-        if app.settings_screen.show_git_branch {
-            if let Some(ref branch) = app.git_branch {
-                if !parts.is_empty() {
-                    parts.push(Span::raw("  "));
-                }
-                parts.push(Span::styled(
-                    format!("⎇ {}", branch),
-                    Style::default().fg(Color::Cyan),
-                ));
-            }
         }
 
         // Current directory (if settings enabled)
@@ -2930,12 +3214,16 @@ fn render_prompt_suggestions(frame: &mut Frame, app: &App, area: Rect) {
     for (row, suggestion) in suggestions[start..end].iter().enumerate() {
         let is_selected = start + row == selected;
         let accent_style = if is_selected {
-            Style::default().fg(CLAUDE_ORANGE).add_modifier(Modifier::BOLD)
+            Style::default()
+                .fg(CLAUDE_ORANGE)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(Color::DarkGray)
         };
         let label_style = if is_selected {
-            Style::default().fg(CLAUDE_ORANGE).add_modifier(Modifier::BOLD)
+            Style::default()
+                .fg(CLAUDE_ORANGE)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(Color::White)
         };
@@ -2944,7 +3232,10 @@ fn render_prompt_suggestions(frame: &mut Frame, app: &App, area: Rect) {
         } else {
             Style::default().fg(Color::DarkGray)
         };
-        let mut spans = vec![Span::styled(if is_selected { "\u{203a} " } else { "  " }, accent_style)];
+        let mut spans = vec![Span::styled(
+            if is_selected { "\u{203a} " } else { "  " },
+            accent_style,
+        )];
         match suggestion.source {
             TypeaheadSource::SlashCommand => {
                 let display_name = truncate_text(&suggestion.text, label_width);
@@ -2952,7 +3243,10 @@ fn render_prompt_suggestions(frame: &mut Frame, app: &App, area: Rect) {
                     format!("{display_name:<width$}", width = label_width),
                     label_style,
                 ));
-                spans.push(Span::styled(" [cmd] ", Style::default().fg(Color::DarkGray)));
+                spans.push(Span::styled(
+                    " [cmd] ",
+                    Style::default().fg(Color::DarkGray),
+                ));
                 if !suggestion.description.is_empty() {
                     spans.push(Span::styled(
                         truncate_text(
@@ -2970,7 +3264,10 @@ fn render_prompt_suggestions(frame: &mut Frame, app: &App, area: Rect) {
                     label_style,
                 ));
                 if !suggestion.description.is_empty() {
-                    spans.push(Span::styled(" \u{2014} ", Style::default().fg(Color::DarkGray)));
+                    spans.push(Span::styled(
+                        " \u{2014} ",
+                        Style::default().fg(Color::DarkGray),
+                    ));
                     spans.push(Span::styled(
                         truncate_text(&suggestion.description, area.width as usize / 2),
                         detail_style,
@@ -2983,7 +3280,10 @@ fn render_prompt_suggestions(frame: &mut Frame, app: &App, area: Rect) {
                     format!("{display_name:<width$}", width = label_width),
                     label_style,
                 ));
-                spans.push(Span::styled(" [history] ", Style::default().fg(Color::DarkGray)));
+                spans.push(Span::styled(
+                    " [history] ",
+                    Style::default().fg(Color::DarkGray),
+                ));
                 if !suggestion.description.is_empty() {
                     spans.push(Span::styled(
                         truncate_text(&suggestion.description, area.width as usize / 2),
@@ -3088,8 +3388,8 @@ fn render_legacy_history_search(
 ) {
     let dialog_width = 60u16.min(area.width.saturating_sub(4));
     let visible_matches = 8usize;
-    let dialog_height =
-        (4 + visible_matches.min(hs.matches.len().max(1)) as u16).min(area.height.saturating_sub(4));
+    let dialog_height = (4 + visible_matches.min(hs.matches.len().max(1)) as u16)
+        .min(area.height.saturating_sub(4));
     let dialog_area = crate::overlays::centered_rect(dialog_width, dialog_height, area);
 
     frame.render_widget(Clear, dialog_area);
@@ -3099,7 +3399,9 @@ fn render_legacy_history_search(
         Span::raw("  Search: "),
         Span::styled(
             hs.query.clone(),
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled("\u{2588}", Style::default().fg(Color::White)),
     ]));
@@ -3168,8 +3470,8 @@ pub struct StatusLineData {
     pub tokens_used: u64,
     pub tokens_total: u64,
     pub cost_cents: f64,
-    pub compact_warning_pct: Option<f64>,  // None = no warning; Some(pct) = show warning
-    pub vim_mode: Option<String>,           // None = no vim mode; Some("NORMAL") etc.
+    pub compact_warning_pct: Option<f64>, // None = no warning; Some(pct) = show warning
+    pub vim_mode: Option<String>,         // None = no vim mode; Some("NORMAL") etc.
     pub bridge_connected: bool,
     pub session_id: Option<String>,
     pub worktree: Option<String>,
@@ -3180,7 +3482,11 @@ pub struct StatusLineData {
     pub goal_badge: Option<String>,
 }
 
-pub fn render_full_status_line(data: &StatusLineData, area: Rect, buf: &mut ratatui::buffer::Buffer) {
+pub fn render_full_status_line(
+    data: &StatusLineData,
+    area: Rect,
+    buf: &mut ratatui::buffer::Buffer,
+) {
     use ratatui::{
         style::{Color, Modifier, Style},
         text::{Line, Span},
@@ -3201,7 +3507,13 @@ pub fn render_full_status_line(data: &StatusLineData, area: Rect, buf: &mut rata
     // Context window
     if data.tokens_total > 0 {
         let pct = data.tokens_used as f64 / data.tokens_total as f64;
-        let ctx_color = if pct >= 0.95 { Color::Red } else if pct >= 0.80 { Color::Yellow } else { Color::Green };
+        let ctx_color = if pct >= 0.95 {
+            Color::Red
+        } else if pct >= 0.80 {
+            Color::Yellow
+        } else {
+            Color::Green
+        };
         let used_k = data.tokens_used / 1000;
         let total_k = data.tokens_total / 1000;
         spans.push(Span::styled(
@@ -3223,7 +3535,11 @@ pub fn render_full_status_line(data: &StatusLineData, area: Rect, buf: &mut rata
     // Compact warning
     if let Some(pct) = data.compact_warning_pct {
         if pct >= 0.80 {
-            let color = if pct >= 0.95 { Color::Red } else { Color::Yellow };
+            let color = if pct >= 0.95 {
+                Color::Red
+            } else {
+                Color::Yellow
+            };
             spans.push(Span::styled(
                 format!("âš  ctx {:.0}% ", pct * 100.0),
                 Style::default().fg(color).add_modifier(Modifier::BOLD),
@@ -3259,17 +3575,16 @@ pub fn render_full_status_line(data: &StatusLineData, area: Rect, buf: &mut rata
     if let Some(goal) = &data.goal_badge {
         spans.push(Span::styled(
             format!("[goal: {}]", goal),
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
         ));
         spans.push(Span::styled(" ", Style::default()));
     }
 
     // Bridge connected
     if data.bridge_connected {
-        spans.push(Span::styled(
-            "ðŸ”— ",
-            Style::default().fg(Color::Green),
-        ));
+        spans.push(Span::styled("ðŸ”— ", Style::default().fg(Color::Green)));
     }
 
     // Session ID
@@ -3294,7 +3609,6 @@ pub fn render_full_status_line(data: &StatusLineData, area: Rect, buf: &mut rata
         .style(Style::default().bg(Color::Black))
         .render(area, buf);
 }
-
 
 // ---------------------------------------------------------------------------
 // Multi-agent UI components
@@ -3323,15 +3637,10 @@ pub fn render_agent_progress_line(
     let mut spans = vec![
         Span::styled(
             format!("[agent-{}]", agent_id),
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::DIM),
+            Style::default().fg(Color::Cyan).add_modifier(Modifier::DIM),
         ),
         Span::raw(" "),
-        Span::styled(
-            status.to_string(),
-            Style::default().fg(status_color),
-        ),
+        Span::styled(status.to_string(), Style::default().fg(status_color)),
     ];
 
     if let Some(tool) = current_tool {
@@ -3374,12 +3683,13 @@ pub fn render_coordinator_status_lines(
                 .fg(Color::Cyan)
                 .add_modifier(Modifier::BOLD),
         ),
+        Span::styled(" · ".to_string(), Style::default().fg(Color::DarkGray)),
         Span::styled(
-            " · ".to_string(),
-            Style::default().fg(Color::DarkGray),
-        ),
-        Span::styled(
-            format!("{} agent{}", agent_count, if agent_count == 1 { "" } else { "s" }),
+            format!(
+                "{} agent{}",
+                agent_count,
+                if agent_count == 1 { "" } else { "s" }
+            ),
             Style::default().fg(Color::White),
         ),
         Span::styled(
@@ -3416,10 +3726,7 @@ pub fn render_coordinator_status_lines(
 /// # Arguments
 /// * `teammate_id`  — teammate identifier string
 /// * `session_info` — optional session info snippet to append
-pub fn render_teammate_header(
-    teammate_id: &str,
-    session_info: Option<&str>,
-) -> Line<'static> {
+pub fn render_teammate_header(teammate_id: &str, session_info: Option<&str>) -> Line<'static> {
     let mut spans = vec![
         Span::styled(
             "┤ teammate: ".to_string(),
@@ -3431,10 +3738,7 @@ pub fn render_teammate_header(
                 .fg(Color::Magenta)
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::styled(
-            " ├".to_string(),
-            Style::default().fg(Color::Magenta),
-        ),
+        Span::styled(" ├".to_string(), Style::default().fg(Color::Magenta)),
     ];
 
     if let Some(info) = session_info {
@@ -3489,7 +3793,18 @@ mod tool_block_tests {
         assert_eq!(tool_icon("todowrite"), ":");
         assert_eq!(tool_icon("something-unknown"), "~");
         // All markers must be single-byte ASCII (guaranteed one terminal cell).
-        for t in ["bash", "read", "write", "glob", "grep", "webfetch", "websearch", "todo", "task", "x"] {
+        for t in [
+            "bash",
+            "read",
+            "write",
+            "glob",
+            "grep",
+            "webfetch",
+            "websearch",
+            "todo",
+            "task",
+            "x",
+        ] {
             let icon = tool_icon(t);
             assert_eq!(icon.len(), 1, "{t} icon {icon:?} must be 1 ASCII byte");
             assert!(icon.is_ascii(), "{t} icon {icon:?} must be ASCII");
@@ -3519,11 +3834,23 @@ mod tool_block_tests {
         );
         let lines = render(&b);
         // Header: "$ python3 - <<'PY'"
-        assert!(lines[0].contains('$'), "header should be icon-led: {:?}", lines[0]);
-        assert!(lines[0].contains("python3 - <<'PY'"), "header shows command: {:?}", lines[0]);
+        assert!(
+            lines[0].contains('$'),
+            "header should be icon-led: {:?}",
+            lines[0]
+        );
+        assert!(
+            lines[0].contains("python3 - <<'PY'"),
+            "header shows command: {:?}",
+            lines[0]
+        );
         // The command must appear exactly once (no summary + $-line duplication).
         let joined = lines.join("\n");
-        assert_eq!(joined.matches("python3 - <<'PY'").count(), 1, "no dup: {joined:?}");
+        assert_eq!(
+            joined.matches("python3 - <<'PY'").count(),
+            1,
+            "no dup: {joined:?}"
+        );
         // Output preview still shown.
         assert!(joined.contains("218183"));
     }
@@ -3550,9 +3877,9 @@ mod tool_block_tests {
             "TodoWrite",
             ToolStatus::Done,
             r#"{"todos":[
-                {"content":"Locate files","status":"completed","completion_confidence":90},
-                {"content":"Build importer","status":"in_progress","confidence":70},
-                {"content":"Wire adapter","status":"pending","confidence":50}
+                {"content":"Locate files","status":"completed"},
+                {"content":"Build importer","status":"in_progress"},
+                {"content":"Wire adapter","status":"pending"}
             ]}"#,
             Some("Todo list updated (3 total)"),
         );
@@ -3561,13 +3888,24 @@ mod tool_block_tests {
         // Header shows count, not the raw "Todo list updated (...)".
         assert!(joined.contains("Todos"), "{joined:?}");
         assert!(joined.contains("1/3 done"), "{joined:?}");
-        assert!(joined.contains("confidence 70%"), "{joined:?}");
         // Each status has its ASCII checkbox + content.
-        assert!(joined.contains("[x] Locate files [90%]"), "done marker: {joined:?}");
-        assert!(joined.contains("[>] Build importer [70%]"), "in-progress marker: {joined:?}");
-        assert!(joined.contains("[ ] Wire adapter [50%]"), "pending marker: {joined:?}");
+        assert!(
+            joined.contains("[x] Locate files"),
+            "done marker: {joined:?}"
+        );
+        assert!(
+            joined.contains("[>] Build importer"),
+            "in-progress marker: {joined:?}"
+        );
+        assert!(
+            joined.contains("[ ] Wire adapter"),
+            "pending marker: {joined:?}"
+        );
         // The raw result-preview string must NOT leak into the checklist view.
-        assert!(!joined.contains("Todo list updated"), "preview suppressed: {joined:?}");
+        assert!(
+            !joined.contains("Todo list updated"),
+            "preview suppressed: {joined:?}"
+        );
     }
 
     #[test]
@@ -3639,7 +3977,8 @@ mod stream_cache_tests {
         let mut app = test_app();
         // Turn 0 is fully committed; turn 1 is the live/streaming turn.
         app.messages.push(Message::user("user one prompt"));
-        app.messages.push(Message::assistant("assistant one committed reply"));
+        app.messages
+            .push(Message::assistant("assistant one committed reply"));
         app.messages.push(Message::user("user two prompt"));
         app.is_streaming = true;
         app.streaming_text = "streaming tail alpha".to_string();
@@ -3648,7 +3987,11 @@ mod stream_cache_tests {
 
         // First render: prefix is built fresh (a miss).
         let render1 = render_message_items(&app, WIDTH);
-        assert_eq!(prefix_cache_counts(), (0, 1), "first render builds the prefix");
+        assert_eq!(
+            prefix_cache_counts(),
+            (0, 1),
+            "first render builds the prefix"
+        );
 
         // A streaming delta arrives: only the live text grows. Real code bumps
         // transcript_version on every delta — assert that does NOT evict the
@@ -3691,7 +4034,10 @@ mod stream_cache_tests {
         let text2 = joined_text(&render2);
         assert!(text1.contains("streaming tail alpha"));
         assert!(!text1.contains("streaming tail alpha beta"));
-        assert!(text2.contains("streaming tail alpha beta"), "tail rebuilt with the delta");
+        assert!(
+            text2.contains("streaming tail alpha beta"),
+            "tail rebuilt with the delta"
+        );
     }
 
     /// Streaming render (cached prefix + rebuilt tail) is byte-identical to a
@@ -3701,9 +4047,12 @@ mod stream_cache_tests {
     fn streaming_render_matches_full_rebuild() {
         let mut app = test_app();
         app.messages.push(Message::user("first user question"));
-        app.messages.push(Message::assistant("first assistant answer with **markdown**"));
+        app.messages.push(Message::assistant(
+            "first assistant answer with **markdown**",
+        ));
         app.messages.push(Message::user("second user question"));
-        app.messages.push(Message::assistant("second assistant answer"));
+        app.messages
+            .push(Message::assistant("second assistant answer"));
         app.messages.push(Message::user("third user question"));
         app.is_streaming = true;
         app.streaming_thinking = "pondering the third answer".to_string();
@@ -3741,7 +4090,8 @@ mod stream_cache_tests {
     fn transcript_swap_does_not_ghost_stale_prefix() {
         let mut app = test_app();
         app.messages.push(Message::user("session A user"));
-        app.messages.push(Message::assistant("session A assistant reply"));
+        app.messages
+            .push(Message::assistant("session A assistant reply"));
         app.messages.push(Message::user("session A live turn"));
         app.is_streaming = true;
         app.streaming_text = "A tail".to_string();
@@ -3763,7 +4113,10 @@ mod stream_cache_tests {
 
         let render_b = render_message_items(&app, WIDTH);
         let text_b = joined_text(&render_b);
-        assert!(text_b.contains("session B assistant reply"), "shows swapped content");
+        assert!(
+            text_b.contains("session B assistant reply"),
+            "shows swapped content"
+        );
         assert!(
             !text_b.contains("session A"),
             "no stale session-A content ghosts through: {text_b:?}"
@@ -3936,13 +4289,17 @@ mod recent_activity_tests {
         assert!(out.contains("Wire up onboarding"), "second title: {out:?}");
         assert!(out.contains("3d ago"), "second time: {out:?}");
         // The placeholder must NOT appear when there is real activity.
-        assert!(!out.contains("No recent activity"), "no placeholder: {out:?}");
+        assert!(
+            !out.contains("No recent activity"),
+            "no placeholder: {out:?}"
+        );
     }
 
     #[test]
     fn caps_at_five_entries() {
-        let sessions: Vec<RecentSession> =
-            (0..8).map(|i| recent(&format!("session {i}"), 60)).collect();
+        let sessions: Vec<RecentSession> = (0..8)
+            .map(|i| recent(&format!("session {i}"), 60))
+            .collect();
         assert_eq!(recent_activity_lines(&sessions, 40).len(), 5);
     }
 
@@ -3977,7 +4334,10 @@ mod recent_activity_tests {
             .iter()
             .map(|c| c.symbol().chars().next().unwrap_or(' '))
             .collect();
-        assert!(screen.contains("Recent activity"), "header rendered: present");
+        assert!(
+            screen.contains("Recent activity"),
+            "header rendered: present"
+        );
         assert!(screen.contains("Sortable label"), "session label rendered");
     }
 }

--- a/src-rust/crates/tui/src/render.rs
+++ b/src-rust/crates/tui/src/render.rs
@@ -2085,6 +2085,59 @@ fn render_tool_block_lines(lines: &mut Vec<Line<'static>>, block: &crate::app::T
     }
 }
 
+/// Extract the confidence score used by the TodoWrite checklist.
+fn todo_confidence(todo: &serde_json::Value) -> Option<u8> {
+    let value = if todo.get("status").and_then(|status| status.as_str()) == Some("completed") {
+        todo.get("completion_confidence")
+            .filter(|value| !value.is_null())
+            .or_else(|| todo.get("confidence"))
+    } else {
+        todo.get("confidence")
+    }?;
+
+    match value {
+        serde_json::Value::Number(number) => number
+            .as_f64()
+            .filter(|score| score.is_finite() && score.fract() == 0.0)
+            .filter(|score| (0.0..=100.0).contains(score))
+            .map(|score| score as u8),
+        serde_json::Value::String(raw) => raw
+            .trim()
+            .parse::<f64>()
+            .ok()
+            .filter(|score| score.is_finite() && score.fract() == 0.0)
+            .filter(|score| (0.0..=100.0).contains(score))
+            .map(|score| score as u8),
+        _ => None,
+    }
+}
+
+fn aggregate_todo_confidence(todos: &[serde_json::Value]) -> Option<u8> {
+    let mut weighted_sum = 0u32;
+    let mut total_weight = 0u32;
+    for todo in todos {
+        let Some(score) = todo_confidence(todo) else {
+            continue;
+        };
+        let weight = match todo.get("priority").and_then(|priority| priority.as_str()) {
+            Some("high") => 3,
+            Some("medium") => 2,
+            _ => 1,
+        };
+        weighted_sum += u32::from(score) * weight;
+        total_weight += weight;
+    }
+    (total_weight > 0).then_some(((weighted_sum + total_weight / 2) / total_weight) as u8)
+}
+
+fn confidence_color(score: u8) -> Color {
+    match score {
+        80..=100 => Color::Rgb(120, 200, 120),
+        50..=79 => Color::Rgb(220, 190, 100),
+        _ => Color::Rgb(220, 120, 100),
+    }
+}
+
 /// Render a TodoWrite call as a checklist. Returns `false` (so the caller can
 /// fall back to the generic block) when the input carries no `todos` array.
 fn render_todo_block(
@@ -2121,6 +2174,12 @@ fn render_todo_block(
             format!("  {}/{} done", done, total),
             Style::default().fg(Color::DarkGray),
         ));
+        if let Some(confidence) = aggregate_todo_confidence(todos) {
+            header.push(Span::styled(
+                format!(" · confidence {}%", confidence),
+                Style::default().fg(confidence_color(confidence)),
+            ));
+        }
     }
     lines.push(Line::from(header));
 
@@ -2154,9 +2213,19 @@ fn render_todo_block(
                 Style::default().fg(Color::Rgb(170, 170, 170)),
             ),
         };
+        let confidence = todo_confidence(t);
         lines.push(Line::from(vec![
             Span::styled(format!("     {} ", glyph), Style::default().fg(glyph_color)),
             Span::styled(content.to_string(), text_style),
+            Span::styled(
+                confidence
+                    .map(|score| format!(" [{}%]", score))
+                    .unwrap_or_default(),
+                confidence
+                    .map(confidence_color)
+                    .map(|color| Style::default().fg(color))
+                    .unwrap_or_default(),
+            ),
         ]));
     }
     if total > MAX_ITEMS {
@@ -3481,9 +3550,9 @@ mod tool_block_tests {
             "TodoWrite",
             ToolStatus::Done,
             r#"{"todos":[
-                {"content":"Locate files","status":"completed"},
-                {"content":"Build importer","status":"in_progress"},
-                {"content":"Wire adapter","status":"pending"}
+                {"content":"Locate files","status":"completed","completion_confidence":90},
+                {"content":"Build importer","status":"in_progress","confidence":70},
+                {"content":"Wire adapter","status":"pending","confidence":50}
             ]}"#,
             Some("Todo list updated (3 total)"),
         );
@@ -3492,10 +3561,11 @@ mod tool_block_tests {
         // Header shows count, not the raw "Todo list updated (...)".
         assert!(joined.contains("Todos"), "{joined:?}");
         assert!(joined.contains("1/3 done"), "{joined:?}");
+        assert!(joined.contains("confidence 70%"), "{joined:?}");
         // Each status has its ASCII checkbox + content.
-        assert!(joined.contains("[x] Locate files"), "done marker: {joined:?}");
-        assert!(joined.contains("[>] Build importer"), "in-progress marker: {joined:?}");
-        assert!(joined.contains("[ ] Wire adapter"), "pending marker: {joined:?}");
+        assert!(joined.contains("[x] Locate files [90%]"), "done marker: {joined:?}");
+        assert!(joined.contains("[>] Build importer [70%]"), "in-progress marker: {joined:?}");
+        assert!(joined.contains("[ ] Wire adapter [50%]"), "pending marker: {joined:?}");
         // The raw result-preview string must NOT leak into the checklist view.
         assert!(!joined.contains("Todo list updated"), "preview suppressed: {joined:?}");
     }


### PR DESCRIPTION
## Summary

Shows TODOs label and git branch in the info panel. Removes duplicate git branch rendering from the bottom bar footer (info panel keeps it).

## Changes

- Info panel: Shows `x/y TODOS` label (changed from `✓x/y` for clarity)
- Info panel: Git branch indicator (`⎇ branch`, cyan) shown unconditionally when detected
- Bottom bar: Removed duplicate git branch rendering (was shown in both info panel and bottom bar)
- Footer: `worktree_branch` badge (`[branch]`, green) still shown in bottom bar

## Testing

- `cargo check --workspace` clean
- `cargo fmt --all` clean
