### PR TITLE
fix(tui): hide tool content shows command but hides results

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1255,3 +1255,44 @@ Some commands are available only under certain account or platform conditions:
 ### Feature-Flagged Commands
 
 Some commands check `isEnabled()` at runtime. For example, voice-related commands check for audio device availability; the desktop command checks for a display server.
+
+## Bang Commands (`!`)
+
+Execute shell commands directly from the input prompt without going through
+the model. Zero token consumption. Output is display-only — the model never
+sees it.
+
+### Usage
+
+```
+! ls -la
+! git status
+! echo "hello"
+```
+
+Type `!` followed by a shell command. The command runs via `bash -c` in the
+project working directory and the result is shown inline in the transcript.
+
+### Configuration (`settings.json`)
+
+```json
+"bangCommands": {
+  "enabled": true,
+  "addToHistory": true,
+  "showInTranscript": true
+}
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `enabled` | `false` (opt-in) | Toggle the feature |
+| `addToHistory` | `false` | Store `!` commands in a separate shell-command history |
+| `showInTranscript` | `true` | Display command + output in the chat transcript |
+
+### Notes
+
+- Output is display-only — the model never sees it (zero token consumption).
+- Blocked in plan mode (read-only restriction).
+- Uses `bash -c` for execution (not the PTY-based Bash tool).
+- `!!` (double bang) is NOT treated as a bang command.
+- A single `!` with no command is ignored.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,7 @@ values. Keys absent from the project file fall back to the global value.
   "config": { ... },
   "providers": { ... },
   "modelOverrides": { ... },
+  "favoriteModels": [ ... ],
   "projects": { ... },
   "commands": { ... },
   "formatter": { ... },
@@ -380,6 +381,69 @@ and `api_base` override the corresponding environment variables.
 | `models_blacklist` | array | These model IDs are never offered. |
 | `options` | object | Provider-specific passthrough options. |
 
+### Custom OpenAI-Compatible Providers
+
+For OpenAI-compatible endpoints not in the built-in provider list (e.g.
+self-hosted gateways, internal LLM proxies), define them under the
+`customProviders` map. Each entry is a self-contained provider with its
+own base URL, API key, custom headers, and model catalog.
+
+```json
+"customProviders": {
+  "my-gateway": {
+    "name": "My Gateway",
+    "apiBase": "https://gateway.example.com/v1",
+    "apiKey": "{env:GATEWAY_API_KEY}",
+    "headers": {
+      "X-Custom-Header": "value"
+    },
+    "models": {
+      "model-1": {
+        "name": "Model One",
+        "contextWindow": 128000,
+        "maxOutputTokens": 8192,
+        "reasoningEffort": "high",
+        "variants": {
+          "max": { "reasoningEffort": "max" },
+          "none": { "reasoningEffort": "none" }
+        }
+      }
+    },
+    "requestTimeoutSecs": 300
+  }
+}
+```
+
+`CustomProviderDef` fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Display name shown in the provider picker. |
+| `apiBase` | string | OpenAI-compatible base URL. Claurst appends `/chat/completions`. |
+| `apiKey` | string \| null | API key. Supports `{env:VAR}` substitution. `null` = no key. |
+| `headers` | object | Custom HTTP headers sent on every request. |
+| `models` | object | Model catalog local to this provider, keyed by model id. |
+| `requestTimeoutSecs` | number \| null | Per-provider request timeout override in seconds. |
+
+`CustomModelDef` fields (inside `models`):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string \| null | Display name shown in the model picker. |
+| `contextWindow` | number \| null | Total context window size in tokens. |
+| `maxOutputTokens` | number \| null | Maximum tokens the model can emit in one response. |
+| `reasoningEffort` | string \| null | Reasoning effort level (`"high"`, `"max"`, `"none"`). |
+| `variants` | object | Named variants that override specific fields. |
+
+Adding a provider via the `/add` command:
+
+```
+/add my-gateway https://gateway.example.com/v1 {env:GATEWAY_API_KEY}
+```
+
+The map key (e.g. `"my-gateway"`) becomes the provider id used in
+`provider/model` routing (e.g. `my-gateway/model-1`).
+
 ---
 
 ## Environment Variables
@@ -639,6 +703,13 @@ matches. They are defined in the `formatter` map:
     }
   },
 
+  // Pin frequently-used models to the top of the /model picker.
+  "favoriteModels": [
+    "anthropic/claude-sonnet-4-6",
+    "openai/gpt-4o",
+    "nvidia/z-ai/glm-5.2"
+  ],
+
   // Custom slash commands
   "commands": {
     "test": {
@@ -657,3 +728,29 @@ matches. They are defined in the `formatter` map:
   }
 }
 ```
+
+---
+
+## Favorite Models
+
+Pin frequently-used models to the top of the `/model` picker by adding them to
+the `favoriteModels` array in `settings.json`:
+
+```json
+"favoriteModels": [
+  "anthropic/claude-sonnet-4-6",
+  "openai/gpt-4o",
+  "nvidia/z-ai/glm-5.2"
+]
+```
+
+Entries use the canonical `"provider/model"` format (the same key used by
+`modelOverrides`). For the `anthropic` and `free` composite providers, the
+provider prefix is optional — the bare model id (`"claude-sonnet-4-6"`) is
+accepted too.
+
+In the model picker, press `f` (or `*`) to toggle favorite status on the
+highlighted model. Favorited models appear with a ★ prefix at the top of the
+list and persist across sessions in `~/.claurst/settings.json`. Stale
+favorites (models no longer in the catalog) are hidden from the picker but
+kept in settings until you un-favorite them.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -767,3 +767,63 @@ When the keyed model exists in the catalog, the override patches it in place.
 When it does not (a self-hosted alias), Claurst materialises a synthetic entry
 so the corrected values flow everywhere the metadata is read: the `/model`
 picker, the token-usage warnings, and the auto-compact thresholds.
+
+## Cursor ACP (`cursor-acp`)
+
+Connect to Cursor's CLI agent via the Agent Client Protocol (ACP).
+
+### Setup
+
+1. Install Cursor CLI (`agent` must be on PATH)
+2. Set `cursor-acp` as your provider:
+```json
+{
+  "provider": "cursor-acp"
+}
+```
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CLAURST_CURSOR_ACP_PATH` | `agent` | Path to the Cursor CLI executable |
+| `CLAURST_CURSOR_ACP_ARGS` | `acp` | ACP subcommand argument |
+| `CLAURST_CURSOR_ACP_EXTRA_ARGS` | `--force --trust` | Permission arguments before `acp` |
+| `CLAURST_CURSOR_ACP_MODEL` | (empty) | Default model ID |
+
+The provider spawns `agent --force --trust acp` as a subprocess and
+communicates via newline-delimited JSON-RPC 2.0 over stdin/stdout.
+
+---
+
+## Custom OpenAI-Compatible Providers (from OpenCode config)
+
+The following custom providers are configured in `~/.claurst/settings.json` under
+`customProviders`, mirroring the OpenCode configuration:
+
+| Provider ID | Display Name | Base URL | Models |
+|-------------|-------------|----------|--------|
+| `llmg-coding` | LLMG Coding | `https://llm-gateway-coding.revolut.com/proxy/openai/opencode/` | `together_ai/revolut-ca/glm-5-2` (with max/high/none variants) |
+| `llmg-non-coding` | LLMG Non-Coding | `https://llm-gateway-coding.revolut.com/proxy/openai/opencode/` | `fireworks_revolut-non-coding/...hxjsp23w` (with max/high/none variants) |
+| `together-ai-coding` | Together AI Coding | `https://api.together.xyz/v1` | `revolut-ca/glm-5-2` (with high/max/none variants) |
+| `openai-custom` | OpenAI (Custom) | `https://api.openai.com/v1` | `gpt-5.5` |
+| `nvidia-custom` | Nvidia (Custom) | `https://integrate.api.nvidia.com/v1` | `z-ai/glm-5.2`, `nvidia/nemotron-3-ultra-550b-a55b` |
+| `cursor-acp-rest` | Cursor ACP (REST) | `http://127.0.0.1:32124/v1` | 14 models (Auto, Composer 2.5, Opus variants, GPT variants, GLM 5.2) |
+
+API keys use `{env:VAR_NAME}` substitution:
+- `TOGETHER_AI_CODING_API_KEY` for `together-ai-coding`
+- `OPENAI_API_KEY` for `openai-custom`
+- `NVIDIA_API_KEY` for `nvidia-custom`
+
+Select a custom provider:
+```json
+{
+  "provider": "llmg-coding",
+  "config": {
+    "model": "llmg-coding/together_ai/revolut-ca/glm-5-2"
+  }
+}
+```
+
+All custom providers appear in the `/model` picker and the `/providers` command.
+Use `Ctrl+F` or `*` in the picker to toggle ★ favorite status.

--- a/src-rust/crates/api/src/model_registry.rs
+++ b/src-rust/crates/api/src/model_registry.rs
@@ -1243,6 +1243,66 @@ impl ModelRegistry {
         }
         apply_overrides_to_entries(&mut self.entries, &self.overrides);
     }
+
+    /// Register user-defined custom provider models into the registry.
+    /// Each model is keyed as `<provider_id>/<model_id>` and a synthetic
+    /// `ModelEntry` is created from the `CustomModelDef` metadata.
+    /// A `ProviderEntry` is also created for each custom provider so it
+    /// appears in `/providers` listing.
+    pub fn apply_custom_providers(
+        &mut self,
+        custom_providers: &HashMap<String, claurst_core::config::CustomProviderDef>,
+    ) {
+        for (provider_id, def) in custom_providers {
+            // Register the provider entry so it shows up in /providers.
+            self.providers.entry(provider_id.clone()).or_insert(ProviderEntry {
+                id: ProviderId::new(provider_id),
+                name: def.name.clone(),
+                env: Vec::new(),
+                api: Some(def.api_base.clone()),
+                npm: None,
+                doc: None,
+            });
+
+            for (model_id, model_def) in &def.models {
+                let key = format!("{}/{}", provider_id, model_id);
+                self.entries.insert(key, ModelEntry {
+                    info: ModelInfo {
+                        id: ModelId::new(model_id),
+                        provider_id: ProviderId::new(provider_id),
+                        name: model_def.name.clone().unwrap_or_else(|| model_id.to_string()),
+                        context_window: model_def.context_window.unwrap_or(0),
+                        max_output_tokens: model_def.max_output_tokens.unwrap_or(0),
+                        release_date: None,
+                        status: None,
+                    },
+                    family: None,
+                    status: Default::default(),
+                    release_date: None,
+                    last_updated: None,
+                    knowledge: None,
+                    open_weights: false,
+                    tool_calling: true,
+                    reasoning: model_def.reasoning_effort.is_some(),
+                    structured_output: false,
+                    temperature: true,
+                    attachment: false,
+                    interleaved: None,
+                    modalities_input: vec![Modality::Text],
+                    modalities_output: vec![Modality::Text],
+                    cost_input: None,
+                    cost_output: None,
+                    cost_cache_read: None,
+                    cost_cache_write: None,
+                    cost: Default::default(),
+                    provider_override: None,
+                    experimental_modes: Default::default(),
+                    options: Default::default(),
+                    headers: Default::default(),
+                });
+            }
+        }
+    }
 }
 
 /// Layer `overrides` onto `entries`: patch existing catalog rows in place and

--- a/src-rust/crates/api/src/providers/mod.rs
+++ b/src-rust/crates/api/src/providers/mod.rs
@@ -41,3 +41,5 @@ pub use copilot::CopilotProvider;
 
 pub mod codex;
 pub use codex::CodexProvider;
+
+

--- a/src-rust/crates/api/src/providers/openai_compat.rs
+++ b/src-rust/crates/api/src/providers/openai_compat.rs
@@ -32,8 +32,12 @@ use super::request_options::merge_openai_compatible_options;
 
 /// Provider-specific behavioural quirks that alter how the generic adapter
 /// builds and interprets requests/responses.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct ProviderQuirks {
+    /// Whether this provider supports SSE streaming.  Default: `true`.
+    /// When `false`, the query engine falls back to non-streaming requests.
+    pub streaming: bool,
+
     /// Truncate tool call IDs to at most this many characters before sending.
     /// For example, Mistral requires tool IDs of at most 9 characters.
     pub tool_id_max_len: Option<usize>,
@@ -93,6 +97,26 @@ pub struct ProviderQuirks {
     /// Native LM Studio host used to discover loaded model instances and their
     /// configured context lengths from `/api/v1/models`.
     pub lm_studio_native_host: Option<String>,
+}
+
+impl Default for ProviderQuirks {
+    fn default() -> Self {
+        Self {
+            streaming: true,
+            tool_id_max_len: None,
+            tool_id_alphanumeric_only: false,
+            overflow_patterns: Vec::new(),
+            include_usage_in_stream: false,
+            default_temperature: None,
+            fix_tool_user_sequence: false,
+            reasoning_field: None,
+            requires_reasoning_roundtrip: false,
+            max_tokens_cap: None,
+            no_api_key_required: false,
+            ollama_native_host: None,
+            lm_studio_native_host: None,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1141,7 +1165,7 @@ impl LlmProvider for OpenAiCompatProvider {
 
     fn capabilities(&self) -> ProviderCapabilities {
         ProviderCapabilities {
-            streaming: true,
+            streaming: self.quirks.streaming,
             tool_calling: true,
             thinking: self.quirks.reasoning_field.is_some(),
             image_input: true,

--- a/src-rust/crates/api/src/providers/openai_compat_providers.rs
+++ b/src-rust/crates/api/src/providers/openai_compat_providers.rs
@@ -12,6 +12,10 @@ use claurst_core::provider_id::ProviderId;
 use super::openai_compat::{OpenAiCompatProvider, ProviderQuirks};
 
 pub fn provider_for_id(provider_id: &str) -> Option<OpenAiCompatProvider> {
+    // Custom providers take priority — check before the fixed-id match.
+    if let Some(custom) = provider_for_custom_id(provider_id) {
+        return Some(custom);
+    }
     match provider_id {
         "ollama" => Some(ollama()),
         "lmstudio" | "lm-studio" => Some(lm_studio()),
@@ -162,6 +166,36 @@ pub fn custom_openai() -> OpenAiCompatProvider {
         .unwrap_or("http://localhost:11434/v1");
 
     custom_openai_with_url(base_url)
+}
+
+/// Build an [`OpenAiCompatProvider`] from a user-defined custom provider in
+/// `Settings::custom_providers`, looked up by id.
+///
+/// Returns `None` when the id is not in the custom providers map, or when
+/// `apiBase` is empty. Custom headers from the definition are applied via
+/// the builder API. API key is resolved via `resolve_api_key()` (supports
+/// `{env:VAR}` substitution).
+pub fn provider_for_custom_id(id: &str) -> Option<OpenAiCompatProvider> {
+    let settings = Settings::load_sync().unwrap_or_default();
+    let def = settings.custom_providers.get(id)?;
+    if def.api_base.trim().is_empty() {
+        return None;
+    }
+    let mut provider = OpenAiCompatProvider::new(id, &def.name, &def.api_base);
+    if let Some(key) = def.resolve_api_key() {
+        provider = provider.with_api_key(key);
+    }
+    for (name, value) in &def.headers {
+        provider = provider.with_header(name, value);
+    }
+    // Apply streaming / reasoning settings from the custom provider definition.
+    provider = provider.with_quirks(ProviderQuirks {
+        streaming: def.streaming.unwrap_or(true),
+        include_usage_in_stream: def.include_usage_in_stream.unwrap_or(true),
+        reasoning_field: def.reasoning_field.clone(),
+        ..Default::default()
+    });
+    Some(provider)
 }
 
 /// DeepSeek V4 — supports reasoning output via `reasoning_content` field.
@@ -629,5 +663,20 @@ mod tests {
         let qwen = provider_for_id("qwen").expect("qwen should resolve");
         assert_eq!(alibaba.id(), qwen.id());
         assert_eq!(alibaba.name(), qwen.name());
+    }
+
+    #[test]
+    fn provider_for_custom_id_returns_none_for_unknown() {
+        // "nonexistent-custom-provider-12345" is not a real custom provider.
+        assert!(provider_for_custom_id("nonexistent-custom-provider-12345").is_none());
+    }
+
+    #[test]
+    fn provider_for_custom_id_returns_none_for_known_fixed_provider() {
+        // Fixed providers like "ollama" should not match as custom providers.
+        // This test verifies that provider_for_custom_id doesn't accidentally
+        // return Some for a fixed provider id when no custom provider is
+        // registered with that id.
+        assert!(provider_for_custom_id("ollama").is_none());
     }
 }

--- a/src-rust/crates/api/src/registry.rs
+++ b/src-rust/crates/api/src/registry.rs
@@ -67,6 +67,13 @@ pub struct ProviderRegistry {
 fn provider_from_key(provider_id: &str, key: String) -> Option<Arc<dyn LlmProvider>> {
     use crate::providers::openai_compat_providers as p;
 
+    // Custom providers from Settings take priority — their API key is
+    // already resolved via resolve_api_key() inside provider_for_custom_id,
+    // so we must NOT re-apply the auth-store key here.
+    if let Some(provider) = p::provider_for_custom_id(provider_id) {
+        return Some(Arc::new(provider));
+    }
+
     if let Some(provider) = p::provider_for_id(provider_id) {
         return Some(Arc::new(provider.with_api_key(key)));
     }
@@ -272,6 +279,12 @@ pub fn provider_from_config(
 
 pub fn runtime_provider_for(provider_id: &str) -> Option<Arc<dyn LlmProvider>> {
     use crate::providers::openai_compat_providers as p;
+
+    // Custom providers from Settings take priority — their API key is
+    // already resolved via resolve_api_key() inside provider_for_custom_id.
+    if let Some(provider) = p::provider_for_custom_id(provider_id) {
+        return Some(Arc::new(provider));
+    }
 
     // Local providers never require an API key — build them directly so that
     // the auth-store bypass below doesn't silently drop them.

--- a/src-rust/crates/api/tests/test_custom_providers.rs
+++ b/src-rust/crates/api/tests/test_custom_providers.rs
@@ -1,0 +1,32 @@
+use claurst_core::Settings;
+use claurst_api::ModelRegistry;
+
+#[test]
+fn custom_providers_appear_in_registry() {
+    let settings = Settings::load_sync().unwrap_or_default();
+    eprintln!("Custom providers: {}", settings.custom_providers.len());
+
+    let mut registry = ModelRegistry::new();
+    registry.apply_custom_providers(&settings.custom_providers);
+
+    for (id, _) in &settings.custom_providers {
+        let models = registry.list_by_provider(id);
+        eprintln!("Provider '{}': {} models", id, models.len());
+        assert!(!models.is_empty(), "Provider '{}' has 0 models in registry!", id);
+    }
+}
+
+#[test]
+fn custom_provider_models_keyed_correctly() {
+    let settings = Settings::load_sync().unwrap_or_default();
+    if let Some(llmg) = settings.custom_providers.get("llmg-coding") {
+        let mut registry = ModelRegistry::new();
+        registry.apply_custom_providers(&settings.custom_providers);
+
+        let models = registry.list_by_provider("llmg-coding");
+        eprintln!("list_by_provider('llmg-coding'): {} models", models.len());
+        for m in &models {
+            eprintln!("  id={}, provider_id={}", m.info.id, m.info.provider_id);
+        }
+    }
+}

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -1049,6 +1049,8 @@ async fn run_models_command(args: &[String]) -> anyhow::Result<()> {
         .map(|s| s.effective_config().model_overrides)
         .unwrap_or_default();
     registry.apply_model_overrides(&overrides);
+    let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+    registry.apply_custom_providers(&settings.custom_providers);
 
     let mut entries: Vec<&claurst_api::ModelEntry> = match &provider_filter {
         Some(pid) => registry.list_by_provider(pid),
@@ -1191,6 +1193,8 @@ fn load_cached_model_registry(config: &Config) -> Arc<claurst_api::ModelRegistry
     // Layer user metadata overrides on top of the catalog (issue #309). Stored
     // in the registry, so any later cache reload re-asserts them automatically.
     reg.apply_model_overrides(&config.model_overrides);
+    let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+    reg.apply_custom_providers(&settings.custom_providers);
     Arc::new(reg)
 }
 
@@ -1884,6 +1888,8 @@ async fn run_interactive(
     // arrive as their final character, so re-shifting them would corrupt input
     // (issue #183: typing `/` produced `?`).
     app.kitty_keyboard_active = claurst_tui::keyboard_enhancement_active();
+    // Wire session ID so auto-poke + todo persistence can find the right list.
+    app.session_id = session.id.clone();
     // Seed the project-MCP approval queue: untrusted project servers that the
     // user must approve before they are allowed to launch (issue #123).
     app.mcp_project_root = mcp_project_root;
@@ -2344,6 +2350,16 @@ async fn run_interactive(
                             continue;
                         }
 
+                        // Check for bang command (! prefix) — execute directly in
+                        // the shell, no model dispatch, zero token consumption.
+                        if claurst_tui::input::is_bang_command(&input) {
+                            let command = input[1..].trim().to_string();
+                            if !command.is_empty() {
+                                app.execute_bang_command(command);
+                            }
+                            continue;
+                        }
+
                         // Check for slash command
                         if input.starts_with('/') {
                             let (cmd_name, cmd_args) =
@@ -2427,6 +2443,7 @@ async fn run_interactive(
                                     tool_ctx.session_id = session.id.clone();
                                     cmd_ctx.session_id = session.id.clone();
                                     cmd_ctx.session_title = None;
+                                    app.session_id = session.id.clone();
                                     // Reset per-turn diff/turn bookkeeping, as
                                     // ResumeSession does when swapping sessions.
                                     tool_ctx.file_history = Arc::new(ParkingMutex::new(
@@ -2527,6 +2544,7 @@ async fn run_interactive(
                                     tool_ctx.config.model = Some(session.model.clone());
                                     app.model_name = session.model.clone();
                                     tool_ctx.session_id = session.id.clone();
+                                    app.session_id = session.id.clone();
                                     tool_ctx.file_history = Arc::new(ParkingMutex::new(
                                         claurst_core::file_history::FileHistory::new(),
                                     ));
@@ -3144,6 +3162,10 @@ async fn run_interactive(
                             tools_arc = all_tools_arc.clone();
                         }
                     }
+                    // Apply /turns override if set (takes precedence over agent defaults).
+                    if let Some(turns) = app.max_turns_override {
+                        base_query_config.max_turns = turns;
+                    }
                     if !app.is_streaming && app.messages.len() < messages.len() {
                         messages = app.messages.clone();
                         session.messages = messages.clone();
@@ -3690,8 +3712,14 @@ async fn run_interactive(
                     } else {
                         app.model_picker.merge_models(entries);
                     }
-                    for m in &mut app.model_picker.models {
-                        m.is_current = m.id == current;
+                    // In all-providers mode, open_with_title already set
+                    // is_current correctly (dual-match: bare id OR
+                    // provider-prefixed form). Don't override it with a
+                    // single-provider strip that would wipe the preselection.
+                    if !app.model_picker.all_providers_mode {
+                        for m in &mut app.model_picker.models {
+                            m.is_current = m.id == current;
+                        }
                     }
                     app.model_picker.loading_models = false;
                     app.model_fetch_rx = None;
@@ -3797,6 +3825,7 @@ async fn run_interactive(
                                                                 ctx_for(&id, m.context_window),
                                                             ),
                                                         is_current: false,
+                                                        provider_id: provider_key.clone(),
                                                     }
                                                 })
                                             })
@@ -3814,6 +3843,7 @@ async fn run_interactive(
                                                         ),
                                                     id,
                                                     is_current: false,
+                                                    provider_id: provider_key.clone(),
                                                 }
                                             })
                                             .collect()

--- a/src-rust/crates/commands/src/lib.rs
+++ b/src-rust/crates/commands/src/lib.rs
@@ -1138,6 +1138,66 @@ impl SlashCommand for NamedCommandAdapter {
 }
 
 // ---------------------------------------------------------------------------
+// /todos — todo list status + auto-poke toggle
+// ---------------------------------------------------------------------------
+
+pub struct TodosCommand;
+
+#[async_trait]
+impl SlashCommand for TodosCommand {
+    fn name(&self) -> &str { "todos" }
+    fn description(&self) -> &str { "Show todo list status and toggle inline card" }
+    fn help(&self) -> &str {
+        "Usage: /todos [auto-poke on|off]\n\n\
+         Without arguments: toggles the inline todo card in the transcript.\n\n\
+         /todos auto-poke on   — enable auto-poke (default)\n\
+         /todos auto-poke off  — disable auto-poke"
+    }
+
+    async fn execute(&self, args: &str, ctx: &mut CommandContext) -> CommandResult {
+        let args = args.trim();
+        if args.starts_with("auto-poke") {
+            let parts: Vec<&str> = args.split_whitespace().collect();
+            if parts.len() < 2 {
+                return CommandResult::Message("Usage: /todos auto-poke on|off".to_string());
+            }
+            let enabled = match parts[1] {
+                "on" | "true" | "yes" => true,
+                "off" | "false" | "no" => false,
+                _ => return CommandResult::Message("Usage: /todos auto-poke on|off".to_string()),
+            };
+            // Update settings.
+            if let Ok(mut settings) = claurst_core::Settings::load_sync() {
+                settings.auto_poke_enabled = enabled;
+                let _ = settings.save_sync();
+            }
+            return CommandResult::Message(format!(
+                "Auto-poke {}.",
+                if enabled { "enabled" } else { "disabled" }
+            ));
+        }
+
+        // Show current todo status.
+        let todos = claurst_tools::todo_write::load_todos(&ctx.session_id);
+        if todos.is_empty() {
+            return CommandResult::Message("No todos for this session.".to_string());
+        }
+        let total = todos.len();
+        let completed = todos.iter().filter(|t| t.get("status").and_then(|s| s.as_str()) == Some("completed")).count();
+        let in_progress = todos.iter().filter(|t| t.get("status").and_then(|s| s.as_str()) == Some("in_progress")).count();
+        let pending = total - completed - in_progress;
+        let mut output = format!("Todos: {} total — {} pending, {} in_progress, {} completed\n\n", total, pending, in_progress, completed);
+        for t in &todos {
+            let status = t.get("status").and_then(|s| s.as_str()).unwrap_or("?");
+            let content = t.get("content").and_then(|c| c.as_str()).unwrap_or("");
+            let icon = match status { "pending" => "[ ]", "in_progress" => "[~]", "completed" => "[x]", _ => "[?]" };
+            output.push_str(&format!("{} {}\n", icon, content));
+        }
+        CommandResult::Message(output)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Registry
 // ---------------------------------------------------------------------------
 
@@ -1318,6 +1378,7 @@ pub fn all_commands() -> Vec<Box<dyn SlashCommand>> {
         // Multi-provider support
         Box::new(ProvidersCommand),
         Box::new(ConnectCommand),
+        Box::new(AddCustomProviderCommand),
         // Named agent system
         Box::new(AgentCommand),
         // Session search (SQLite)
@@ -1329,6 +1390,8 @@ pub fn all_commands() -> Vec<Box<dyn SlashCommand>> {
         // Session navigation ported from opencode: /new (lazy home) + /move.
         Box::new(NewCommand),
         Box::new(MoveCommand),
+        // Todo management
+        Box::new(TodosCommand),
     ]
 }
 

--- a/src-rust/crates/commands/src/providers.rs
+++ b/src-rust/crates/commands/src/providers.rs
@@ -154,3 +154,111 @@ impl SlashCommand for AgentCommand {
         }
     }
 }
+
+// ---- /add -------------------------------------------------------------
+
+/// Add a custom OpenAI-compatible provider to settings.
+///
+/// Usage: `/add <id> <apiBase> [apiKey]`
+///
+/// The `id` becomes the provider id used in `provider/model` routing.
+/// The `apiBase` is the OpenAI-compatible base URL.
+/// The optional `apiKey` supports `{env:VAR}` substitution.
+pub struct AddCustomProviderCommand;
+
+#[async_trait]
+impl SlashCommand for AddCustomProviderCommand {
+    fn name(&self) -> &str { "add" }
+    fn description(&self) -> &str { "Add a custom OpenAI-compatible provider" }
+    fn help(&self) -> &str {
+        "Usage: /add <id> <apiBase> [apiKey]\n\n\
+         Add a custom OpenAI-compatible provider to settings.json.\n\n\
+         Arguments:\n  \
+         id       \u{2014} unique provider id (e.g. \"my-gateway\")\n  \
+         apiBase  \u{2014} OpenAI-compatible base URL\n  \
+         apiKey   \u{2014} optional API key or {env:VAR} pattern\n\n\
+         Example:\n  \
+         /add my-gw https://gw.example.com/v1 {env:GW_API_KEY}\n\n\
+         The provider appears in /providers after restart. Models can be\
+         added via the customProviders.models map in settings.json."
+    }
+
+    async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
+        let parts: Vec<&str> = args.split_whitespace().collect();
+        if parts.len() < 2 {
+            return CommandResult::Message(
+                "Usage: /add <id> <apiBase> [apiKey]\n\
+                 Example: /add my-gw https://gw.example.com/v1"
+                    .to_string(),
+            );
+        }
+
+        let id = parts[0].trim();
+        let api_base = parts[1].trim();
+        let api_key = parts.get(2).map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
+
+        if id.is_empty() {
+            return CommandResult::Message("Error: provider id must not be empty.".to_string());
+        }
+        if api_base.is_empty() {
+            return CommandResult::Message("Error: apiBase must not be empty.".to_string());
+        }
+
+        // Basic URL validation.
+        if !api_base.starts_with("http://") && !api_base.starts_with("https://") {
+            return CommandResult::Message(format!(
+                "Error: apiBase must start with http:// or https:// (got: {})",
+                api_base
+            ));
+        }
+
+        // Load current settings from disk (fresh read, not in-memory cache).
+        let mut settings = match claurst_core::Settings::load_sync() {
+            Ok(s) => s,
+            Err(e) => {
+                return CommandResult::Message(format!(
+                    "Error loading settings: {}",
+                    e
+                ));
+            }
+        };
+
+        // Check for duplicate id.
+        if settings.custom_providers.contains_key(id) {
+            return CommandResult::Message(format!(
+                "Error: custom provider '{}' already exists. Use a different id or remove it from settings.json first.",
+                id
+            ));
+        }
+
+        // Use the id as the display name if no explicit name is provided.
+        let display_name = id.to_string();
+
+        // Insert the new provider.
+        let provider_def = claurst_core::config::CustomProviderDef {
+            name: display_name,
+            api_base: api_base.to_string(),
+            api_key,
+            headers: std::collections::HashMap::new(),
+            models: std::collections::HashMap::new(),
+            request_timeout_secs: None,
+            streaming: None,
+            include_usage_in_stream: None,
+            reasoning_field: None,
+        };
+        settings.custom_providers.insert(id.to_string(), provider_def);
+
+        // Save atomically.
+        if let Err(e) = settings.save_sync() {
+            return CommandResult::Message(format!("Error saving settings: {}", e));
+        }
+
+        CommandResult::Message(format!(
+            "Added custom provider '{}'.\n\
+             Base URL: {}\n\
+             Restart or reload settings to use it. Add models via the\n\
+             customProviders.{}.models map in settings.json.",
+            id, api_base, id
+        ))
+    }
+}

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -13,14 +13,14 @@
 
 // Branded provider / model identifier newtypes.
 pub mod provider_id;
-pub use provider_id::{ProviderId, ModelId};
+pub use provider_id::{ModelId, ProviderId};
 
 // Session transcript persistence (JSONL, matches TS sessionStorage.ts schema).
 pub mod session_storage;
 
 // SQLite-backed session storage (faster alternative to JSONL).
 pub mod sqlite_storage;
-pub use sqlite_storage::{SqliteSessionStore, SessionSummary};
+pub use sqlite_storage::{SessionSummary, SqliteSessionStore};
 
 // Attachment pipeline — assembles per-turn context attachments (T1-6).
 pub mod attachments;
@@ -36,18 +36,20 @@ pub use auth_store::{AuthStore, StoredCredential};
 pub mod device_code;
 
 // Utility modules ported from src/utils/
+pub mod auto_mode;
+pub mod crypto_utils;
+pub mod format_utils;
+pub mod spinner;
+pub mod status_notices;
 pub mod token_budget;
 pub mod truncate;
-pub mod format_utils;
-pub mod crypto_utils;
-pub mod status_notices;
-pub mod auto_mode;
-pub mod spinner;
-pub use spinner::{SPINNER_VERBS, TURN_COMPLETION_VERBS, sample_spinner_verb, sample_completion_verb};
+pub use spinner::{
+    sample_completion_verb, sample_spinner_verb, SPINNER_VERBS, TURN_COMPLETION_VERBS,
+};
 
 // Remote session sync and cloud session API (T3-1, T3-2).
-pub mod remote_session;
 pub mod cloud_session;
+pub mod remote_session;
 
 // AGENTS.md hierarchical memory loading (T4-1).
 pub mod claudemd;
@@ -63,8 +65,10 @@ pub mod snapshot;
 
 // Per-session durable objectives (/goal feature).
 pub mod goal;
-pub use goal::{Goal, GoalError, GoalStatus, GoalStore, MAX_GOAL_TURNS, MAX_OBJECTIVE_CHARS,
-               goal_continuation_message, goal_kickoff_message, goal_system_prompt_addendum, goals_enabled};
+pub use goal::{
+    goal_continuation_message, goal_kickoff_message, goal_system_prompt_addendum, goals_enabled,
+    Goal, GoalError, GoalStatus, GoalStore, MAX_GOAL_TURNS, MAX_OBJECTIVE_CHARS,
+};
 
 // Feature flag management via GrowthBook.
 pub mod feature_flags;
@@ -74,7 +78,7 @@ pub mod mcp_templates;
 
 // IDE environment detection (VS Code, Cursor, JetBrains, …).
 pub mod ide;
-pub use ide::{IdeKind, detect_ide};
+pub use ide::{detect_ide, IdeKind};
 
 // Background update checker — compares running version against GitHub releases.
 pub mod update_check;
@@ -84,29 +88,37 @@ pub use update_check::{check_for_updates, UpdateInfo};
 pub mod share_export;
 
 // Re-export commonly used types at the crate root
+pub use config::{
+    builtin_managed_agent_presets, default_agents, strip_jsonc_comments, substitute_env_vars,
+    AgentDefinition, BangCommandsConfig, BudgetSplitPolicy, CommandTemplate, Config,
+    CustomModelDef, CustomProviderDef, FormatterConfig, ManagedAgentConfig, ManagedAgentPreset,
+    McpServerConfig, McpServerOrigin, ModelVariant, OutputFormat, PermissionMode, ProviderConfig,
+    Settings, SkillsConfig, Theme,
+};
 pub use error::{ClaudeError, Result};
+pub use import_config::{
+    build_import_preview, execute_import, summarize_import_result, ClaudeMdPreview,
+    ImportExecutionResult, ImportPaths, ImportPreview, ImportSelection, PreviewAction,
+    PreviewField, SettingsPreview,
+};
 pub use types::{
-    ContentBlock, ImageSource, DocumentSource, CitationsConfig, Message, MessageContent,
+    CitationsConfig, ContentBlock, DocumentSource, ImageSource, Message, MessageContent,
     MessageCost, Role, ToolDefinition, ToolResultContent, UsageInfo,
 };
-pub use config::{AgentDefinition, BudgetSplitPolicy, Config, CommandTemplate, FormatterConfig, ManagedAgentConfig, ManagedAgentPreset, McpServerConfig, McpServerOrigin, OutputFormat, PermissionMode, ProviderConfig, Settings, SkillsConfig, Theme, builtin_managed_agent_presets, default_agents, strip_jsonc_comments, substitute_env_vars};
-pub use import_config::{ClaudeMdPreview, ImportExecutionResult, ImportPaths, ImportPreview, ImportSelection, PreviewAction, PreviewField, SettingsPreview, build_import_preview, execute_import, summarize_import_result};
 
 // Skill discovery: filesystem and git URL skill loading.
 pub mod skill_discovery;
-pub use skill_discovery::{DiscoveredSkill, discover_skills, parse_skill_file};
 pub use cost::CostTracker;
-pub use history::ConversationSession;
 pub use feature_flags::FeatureFlagManager;
+pub use history::ConversationSession;
 pub use paths::claurst_home;
 pub use permissions::{
-    AutoPermissionHandler, InteractivePermissionHandler,
-    ManagedAutoPermissionHandler, ManagedInteractivePermissionHandler,
-    PermissionAction, PermissionDecision, PermissionHandler,
-    PermissionLevel, PermissionManager, PermissionRequest,
+    format_permission_reason, AutoPermissionHandler, InteractivePermissionHandler,
+    ManagedAutoPermissionHandler, ManagedInteractivePermissionHandler, PermissionAction,
+    PermissionDecision, PermissionHandler, PermissionLevel, PermissionManager, PermissionRequest,
     PermissionRule, PermissionScope, SerializedPermissionRule,
-    format_permission_reason,
 };
+pub use skill_discovery::{discover_skills, parse_skill_file, DiscoveredSkill};
 
 // ---------------------------------------------------------------------------
 // error module
@@ -474,7 +486,10 @@ pub mod types {
         }
 
         /// Create a user message representing a `!`-prefixed local shell command with output.
-        pub fn user_local_command_output(command: impl Into<String>, output: impl Into<String>) -> Self {
+        pub fn user_local_command_output(
+            command: impl Into<String>,
+            output: impl Into<String>,
+        ) -> Self {
             Self {
                 role: Role::User,
                 content: MessageContent::Blocks(vec![ContentBlock::UserLocalCommandOutput {
@@ -664,7 +679,7 @@ pub mod config {
     }
 
     fn default_file_injection_max_size() -> usize {
-        100  // 100 KB
+        100 // 100 KB
     }
 
     /// Default total request timeout (seconds) when the user has not configured
@@ -803,8 +818,6 @@ pub mod config {
         FixedCaps { manager_usd: f64, executor_usd: f64 },
     }
 
-    
-
     /// Configuration for manager-executor agent architecture.
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct ManagedAgentConfig {
@@ -827,8 +840,12 @@ pub mod config {
         pub executor_isolation: bool,
     }
 
-    fn default_executor_max_turns() -> u32 { 10 }
-    fn default_max_concurrent_executors() -> u32 { 4 }
+    fn default_executor_max_turns() -> u32 {
+        10
+    }
+    fn default_max_concurrent_executors() -> u32 {
+        4
+    }
 
     /// A named preset for common manager-executor configurations.
     pub struct ManagedAgentPreset {
@@ -947,17 +964,6 @@ pub mod config {
             }
         }
     }
-
-    // ---- ModelOverride ---------------------------------------------------
-
-    /// User-supplied metadata override for a single model, keyed by the
-    /// `"provider/model"` string in [`Config::model_overrides`].
-    ///
-    /// Every field is optional: a `Some` value takes precedence over the
-    /// models.dev catalog entry (and over any built-in default), while a `None`
-    /// leaves the catalog value untouched. When the keyed model is absent from
-    /// the catalog entirely (a self-hosted alias, or an id models.dev does not
-    /// know), the override is materialised into a synthetic registry entry so
     /// the model picker, token warnings, and auto-compact thresholds size it
     /// correctly instead of mismatching it to an unrelated catalog model.
     ///
@@ -1006,6 +1012,141 @@ pub mod config {
                 && self.name.is_none()
                 && self.release_date.is_none()
                 && self.status.is_none()
+        }
+    }
+
+    // ---- ModelVariant ----------------------------------------------------
+
+    /// A model variant that overrides specific fields from its parent model
+    /// definition (e.g. a "max" variant that changes only `reasoning_effort`).
+    #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+    pub struct ModelVariant {
+        /// Override for reasoning effort level.
+        #[serde(
+            default,
+            rename = "reasoningEffort",
+            alias = "reasoning_effort",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub reasoning_effort: Option<String>,
+    }
+
+    // ---- CustomModelDef -------------------------------------------------
+
+    /// A model definition within a custom OpenAI-compatible provider.
+    #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+    pub struct CustomModelDef {
+        /// Total context window size in tokens.
+        #[serde(
+            default,
+            rename = "contextWindow",
+            alias = "context_window",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub context_window: Option<u32>,
+        /// Maximum tokens the model can emit in a single response.
+        #[serde(
+            default,
+            rename = "maxOutputTokens",
+            alias = "max_output_tokens",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub max_output_tokens: Option<u32>,
+        /// Human-readable display name shown in the model picker.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub name: Option<String>,
+        /// Reasoning effort level (e.g. "high", "max", "none").
+        #[serde(
+            default,
+            rename = "reasoningEffort",
+            alias = "reasoning_effort",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub reasoning_effort: Option<String>,
+        /// Named variants that override specific fields from this model definition.
+        #[serde(default)]
+        pub variants: HashMap<String, ModelVariant>,
+    }
+
+    // ---- CustomProviderDef ----------------------------------------------
+
+    /// A user-defined OpenAI-compatible provider, stored in
+    /// [`Settings::custom_providers`] keyed by its unique id.
+    ///
+    /// Unlike [`ProviderConfig`] (which tweaks built-in providers), this is a
+    /// fully self-contained provider definition with its own base URL, API key,
+    /// custom headers, and model catalog. The id (map key) becomes the provider
+    /// id used in `provider/model` routing.
+    #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+    pub struct CustomProviderDef {
+        /// Human-readable display name shown in the provider picker.
+        #[serde(default)]
+        pub name: String,
+        /// OpenAI-compatible base URL (claurst appends `/chat/completions`).
+        #[serde(rename = "apiBase", alias = "api_base")]
+        pub api_base: String,
+        /// API key. Supports `{env:VAR_NAME}` substitution at load time.
+        /// `None` means no key — provider is registered but health_check
+        /// returns `Unavailable`.
+        #[serde(
+            rename = "apiKey",
+            alias = "api_key",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub api_key: Option<String>,
+        /// Custom HTTP headers sent on every request to this provider.
+        #[serde(default)]
+        pub headers: HashMap<String, String>,
+        /// Model catalog local to this provider, keyed by model id.
+        #[serde(default)]
+        pub models: HashMap<String, CustomModelDef>,
+        /// Per-provider request timeout override in seconds.
+        #[serde(
+            default,
+            rename = "requestTimeoutSecs",
+            alias = "request_timeout_secs",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub request_timeout_secs: Option<u64>,
+        /// Whether streaming is enabled for this provider. Default: true
+        /// (streaming). Set to false for providers that don't support SSE.
+        #[serde(default, rename = "streaming", skip_serializing_if = "Option::is_none")]
+        pub streaming: Option<bool>,
+        /// Whether to send stream_options.include_usage when streaming.
+        /// Default: true. Set to false for providers that don't support it.
+        #[serde(
+            default,
+            rename = "includeUsageInStream",
+            alias = "include_usage_in_stream",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub include_usage_in_stream: Option<bool>,
+        /// JSON field name for reasoning/thinking content (e.g.
+        /// "reasoning_content" for DeepSeek). None means no reasoning field.
+        #[serde(
+            default,
+            rename = "reasoningField",
+            alias = "reasoning_field",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub reasoning_field: Option<String>,
+    }
+
+    impl CustomProviderDef {
+        /// Resolve the API key, substituting `{env:VAR_NAME}` patterns with
+        /// the corresponding environment variable value. Returns `None` if
+        /// the key is absent or the env var is unset.
+        pub fn resolve_api_key(&self) -> Option<String> {
+            self.api_key.as_ref().and_then(|raw| {
+                if let Some(var) = raw.strip_prefix("{env:").and_then(|s| s.strip_suffix('}')) {
+                    std::env::var(var).ok().filter(|v| !v.is_empty())
+                } else if raw.is_empty() {
+                    None
+                } else {
+                    Some(raw.clone())
+                }
+            })
         }
     }
 
@@ -1072,13 +1213,24 @@ pub mod config {
         pub managed_agents: Option<ManagedAgentConfig>,
         /// Shadow-git auto-commit snapshot system.  `Some(true)` = enabled.  `None` or `Some(false)` = disabled (default).
         /// Set via `--auto-commits` flag or `"autoCommits": true` in settings.json.
-        #[serde(default, rename = "autoCommits", skip_serializing_if = "Option::is_none")]
+        #[serde(
+            default,
+            rename = "autoCommits",
+            skip_serializing_if = "Option::is_none"
+        )]
         pub auto_commits: Option<bool>,
         /// Enable cursor blinking in the chat prompt. Defaults to false (disabled).
-        #[serde(default, rename = "cursorBlinkEnabled", skip_serializing_if = "is_false")]
+        #[serde(
+            default,
+            rename = "cursorBlinkEnabled",
+            skip_serializing_if = "is_false"
+        )]
         pub cursor_blink_enabled: bool,
         /// Maximum number of file suggestions shown in autocomplete. Defaults to 15.
-        #[serde(default = "default_file_autocomplete_limit", rename = "fileAutocompleteLimit")]
+        #[serde(
+            default = "default_file_autocomplete_limit",
+            rename = "fileAutocompleteLimit"
+        )]
         pub file_autocomplete_limit: usize,
         /// Whether to show hidden files in file autocomplete. Defaults to false.
         #[serde(default, rename = "fileAutocompleteShowHiddenFiles")]
@@ -1092,7 +1244,10 @@ pub mod config {
         /// Maximum file size to auto-inject (in KB). Defaults to 100. Set to 0 for no limit.
         /// When a file exceeds this limit, users get a warning and can choose to override or cancel.
         /// Note: @include in CLAUDE.md/AGENTS.md always injects regardless of this limit.
-        #[serde(default = "default_file_injection_max_size", rename = "fileInjectionMaxSize")]
+        #[serde(
+            default = "default_file_injection_max_size",
+            rename = "fileInjectionMaxSize"
+        )]
         pub file_injection_max_size: usize,
         /// Total request timeout in seconds applied to provider HTTP clients.
         /// Slow local models (CPU inference, large MoE) can take several minutes
@@ -1112,8 +1267,22 @@ pub mod config {
         /// `"mouseCapture": false` to release the mouse to the terminal so native
         /// click-drag selection and copy/paste work without lag (issue #104).
         /// Keyboard scrolling (PageUp/PageDown, etc.) is unaffected either way.
-        #[serde(default, rename = "mouseCapture", skip_serializing_if = "Option::is_none")]
+        #[serde(
+            default,
+            rename = "mouseCapture",
+            skip_serializing_if = "Option::is_none"
+        )]
         pub mouse_capture: Option<bool>,
+        /// Whether the max-steps graceful degradation summary turn is enabled.
+        /// When `true` (default), exceeding `max_turns` runs one final
+        /// tool-less turn asking the model to summarize progress. When `false`,
+        /// the loop returns cold (last assistant message) immediately.
+        #[serde(default = "default_true", rename = "degradationSummaryEnabled")]
+        pub degradation_summary_enabled: bool,
+        /// When true, the TUI log shows only the tool type (e.g. "Running
+        /// command") without the command content or summary.
+        #[serde(default, rename = "hideToolContent")]
+        pub hide_tool_content: bool,
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -1202,6 +1371,32 @@ pub mod config {
         pub urls: Vec<String>,
     }
 
+    // ---- BangCommandsConfig ---------------------------------------------
+
+    /// Configuration for the `!` batch command feature.
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    pub struct BangCommandsConfig {
+        /// Whether the feature is enabled. Default: false (opt-in).
+        #[serde(default)]
+        pub enabled: bool,
+        /// Whether to add `!` commands to a separate shell-command history.
+        #[serde(default, rename = "addToHistory")]
+        pub add_to_history: bool,
+        /// Whether to display command + output in the chat transcript.
+        #[serde(default = "default_true", rename = "showInTranscript")]
+        pub show_in_transcript: bool,
+    }
+
+    impl Default for BangCommandsConfig {
+        fn default() -> Self {
+            Self {
+                enabled: false,
+                add_to_history: false,
+                show_in_transcript: default_true(),
+            }
+        }
+    }
+
     // ---- Settings --------------------------------------------------------
 
     #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -1252,6 +1447,16 @@ pub mod config {
         /// Per-provider configurations stored in settings.json.
         #[serde(default)]
         pub providers: HashMap<String, ProviderConfig>,
+        /// User-defined OpenAI-compatible providers, keyed by unique id.
+        /// Each entry is a self-contained provider with its own base URL,
+        /// API key, headers, and model catalog. The id becomes the provider
+        /// id used in `provider/model` routing.
+        #[serde(default, rename = "customProviders", alias = "custom_providers")]
+        pub custom_providers: HashMap<String, CustomProviderDef>,
+        /// User-favorited model keys ("provider/model" format). Shown in a
+        /// dedicated section at the top of the /model picker.
+        #[serde(default, rename = "favoriteModels", alias = "favorite_models")]
+        pub favorite_models: Vec<String>,
         /// User-supplied model metadata overrides stored in settings.json,
         /// keyed by `"provider/model"`. Merged into
         /// [`Config::model_overrides`] by [`Settings::effective_config`] and
@@ -1301,7 +1506,10 @@ pub mod config {
         #[serde(default = "default_true", rename = "autoCompact")]
         pub auto_compact: bool,
         /// Maximum number of file suggestions shown in autocomplete. Defaults to 15.
-        #[serde(default = "default_file_autocomplete_limit", rename = "fileAutocompleteLimit")]
+        #[serde(
+            default = "default_file_autocomplete_limit",
+            rename = "fileAutocompleteLimit"
+        )]
         pub file_autocomplete_limit: usize,
         /// Whether to show hidden files in file autocomplete. Defaults to false.
         #[serde(default, rename = "fileAutocompleteShowHiddenFiles")]
@@ -1315,8 +1523,22 @@ pub mod config {
         /// Maximum file size to auto-inject (in KB). Defaults to 100. Set to 0 for no limit.
         /// When a file exceeds this limit, users get a warning and can choose to override or cancel.
         /// Note: @include in CLAUDE.md/AGENTS.md always injects regardless of this limit.
-        #[serde(default = "default_file_injection_max_size", rename = "fileInjectionMaxSize")]
+        #[serde(
+            default = "default_file_injection_max_size",
+            rename = "fileInjectionMaxSize"
+        )]
         pub file_injection_max_size: usize,
+        /// Whether auto-poke is enabled. When true, the model is automatically
+        /// continued when it stops with incomplete todos. Default: true.
+        #[serde(default = "default_true", rename = "autoPokeEnabled")]
+        pub auto_poke_enabled: bool,
+        /// Configuration for the `!` batch command feature.
+        #[serde(default, rename = "bangCommands")]
+        pub bang_commands: BangCommandsConfig,
+        /// When true, the TUI log shows only the tool type (e.g. "Running
+        /// command") without the command content or summary. Defaults to false.
+        #[serde(default, rename = "hideToolContent")]
+        pub hide_tool_content: bool,
     }
 
     /// A user-defined slash command template.
@@ -1333,8 +1555,7 @@ pub mod config {
     }
 
     /// Configuration for a file formatter tool.
-    #[derive(Debug, Clone, Serialize, Deserialize)]
-    #[derive(Default)]
+    #[derive(Debug, Clone, Serialize, Deserialize, Default)]
     pub struct FormatterConfig {
         /// Command to run, e.g. `["prettier", "--write"]`.
         pub command: Vec<String>,
@@ -1344,8 +1565,6 @@ pub mod config {
         #[serde(default)]
         pub disabled: bool,
     }
-
-    
 
     #[derive(Debug, Clone, Serialize, Deserialize, Default)]
     pub struct ProjectSettings {
@@ -1435,7 +1654,9 @@ pub mod config {
                 Some("mistral") => "mistral-large-latest",
                 Some("xai") => "grok-2",
                 Some("openrouter") => "anthropic/claude-sonnet-4",
-                Some("togetherai") | Some("together-ai") => "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                Some("togetherai") | Some("together-ai") => {
+                    "meta-llama/Llama-3.3-70B-Instruct-Turbo"
+                }
                 Some("perplexity") => "sonar-pro",
                 Some("cohere") => "command-r-plus",
                 // DashScope runs as "qwen" at runtime but is "alibaba" in the
@@ -1454,7 +1675,6 @@ pub mod config {
                 _ => crate::constants::DEFAULT_MODEL, // Anthropic default
             }
         }
-
 
         /// Resolve the effective max-tokens.
         pub fn effective_max_tokens(&self) -> u32 {
@@ -1578,25 +1798,43 @@ pub mod config {
                     let refreshed = 'refresh: {
                         let Ok(client) = reqwest::Client::builder()
                             .timeout(std::time::Duration::from_secs(30))
-                            .build() else { break 'refresh None; };
+                            .build()
+                        else {
+                            break 'refresh None;
+                        };
                         let Ok(resp) = client
                             .post(crate::oauth::TOKEN_URL)
                             .header("content-type", "application/json")
                             .json(&body)
                             .send()
-                            .await else { break 'refresh None; };
-                        if !resp.status().is_success() { break 'refresh None; }
-                        let Ok(data) = resp.json::<serde_json::Value>().await else { break 'refresh None; };
+                            .await
+                        else {
+                            break 'refresh None;
+                        };
+                        if !resp.status().is_success() {
+                            break 'refresh None;
+                        }
+                        let Ok(data) = resp.json::<serde_json::Value>().await else {
+                            break 'refresh None;
+                        };
                         let new_at = data["access_token"].as_str().unwrap_or("").to_string();
-                        if new_at.is_empty() { break 'refresh None; }
+                        if new_at.is_empty() {
+                            break 'refresh None;
+                        }
                         let new_rt = data["refresh_token"].as_str().map(String::from);
                         let exp_in = data["expires_in"].as_u64().unwrap_or(3600);
                         let exp_ms = chrono::Utc::now().timestamp_millis() + (exp_in as i64 * 1000);
                         let scopes: Vec<String> = data["scope"]
-                            .as_str().unwrap_or("").split_whitespace().map(String::from).collect();
+                            .as_str()
+                            .unwrap_or("")
+                            .split_whitespace()
+                            .map(String::from)
+                            .collect();
                         let mut r = tokens.clone();
                         r.access_token = new_at;
-                        if let Some(nrt) = new_rt { r.refresh_token = Some(nrt); }
+                        if let Some(nrt) = new_rt {
+                            r.refresh_token = Some(nrt);
+                        }
                         r.expires_at_ms = Some(exp_ms);
                         r.scopes = scopes;
                         let _ = r.save().await;
@@ -1610,7 +1848,9 @@ pub mod config {
                 tokens
             };
 
-            tokens.effective_credential().map(|cred| (cred.to_string(), tokens.uses_bearer_auth()))
+            tokens
+                .effective_credential()
+                .map(|cred| (cred.to_string(), tokens.uses_bearer_auth()))
         }
 
         pub fn resolve_provider_api_base(&self, provider_id: &str) -> Option<String> {
@@ -1772,7 +2012,11 @@ pub mod config {
                 std::fs::create_dir_all(parent)?;
             }
             let content = serde_json::to_string_pretty(self)?;
-            std::fs::write(path, content)?;
+            // Atomic write: serialize to a temp file, then rename into place.
+            // On Unix, rename() is atomic — readers never see a partial file.
+            let tmp_path = path.with_extension("json.tmp");
+            std::fs::write(&tmp_path, &content)?;
+            std::fs::rename(&tmp_path, path)?;
             Ok(())
         }
 
@@ -1818,19 +2062,44 @@ pub mod config {
             }
             // Merge top-level `providers` map into config.provider_configs.
             for (id, pc) in &self.providers {
-                config.provider_configs.entry(id.clone()).or_insert_with(|| pc.clone());
+                config
+                    .provider_configs
+                    .entry(id.clone())
+                    .or_insert_with(|| pc.clone());
+            }
+            // Merge custom providers' API keys and base URLs into
+            // provider_configs so resolve_provider_api_key() can find them.
+            for (id, cp) in &self.custom_providers {
+                config
+                    .provider_configs
+                    .entry(id.clone())
+                    .or_insert_with(|| ProviderConfig {
+                        api_key: cp.api_key.clone(),
+                        api_base: Some(cp.api_base.clone()),
+                        enabled: true,
+                        ..Default::default()
+                    });
             }
             // Merge top-level `modelOverrides` into config.model_overrides
             // (nested `config` block wins for keys present in both).
             for (id, ov) in &self.model_overrides {
-                config.model_overrides.entry(id.clone()).or_insert_with(|| ov.clone());
+                config
+                    .model_overrides
+                    .entry(id.clone())
+                    .or_insert_with(|| ov.clone());
             }
             // Copy top-level formatters and commands into config.
             for (k, v) in &self.formatter {
-                config.formatter.entry(k.clone()).or_insert_with(|| v.clone());
+                config
+                    .formatter
+                    .entry(k.clone())
+                    .or_insert_with(|| v.clone());
             }
             for (k, v) in &self.commands {
-                config.commands.entry(k.clone()).or_insert_with(|| v.clone());
+                config
+                    .commands
+                    .entry(k.clone())
+                    .or_insert_with(|| v.clone());
             }
             // Copy top-level agent definitions into config.
             for (k, v) in &self.agents {
@@ -1862,6 +2131,9 @@ pub mod config {
             }
             if self.file_injection_max_size != default_file_injection_max_size() {
                 config.file_injection_max_size = self.file_injection_max_size;
+            }
+            if self.hide_tool_content {
+                config.hide_tool_content = true;
             }
             config
         }
@@ -1928,7 +2200,9 @@ pub mod config {
                 mut base: HashMap<K, V>,
                 over: HashMap<K, V>,
             ) -> HashMap<K, V> {
-                for (k, v) in over { base.insert(k, v); }
+                for (k, v) in over {
+                    base.insert(k, v);
+                }
                 base
             }
             // Merge the embedded Config structs.
@@ -1947,47 +2221,115 @@ pub mod config {
                 },
                 verbose: over.config.verbose || base.config.verbose,
                 output_format: over.config.output_format,
-                mcp_servers: { let mut v = base.config.mcp_servers; v.extend(over.config.mcp_servers); v },
-                lsp_servers: { let mut v = base.config.lsp_servers; v.extend(over.config.lsp_servers); v },
-                allowed_tools: { let mut v = base.config.allowed_tools; v.extend(over.config.allowed_tools); v.dedup(); v },
-                disallowed_tools: { let mut v = base.config.disallowed_tools; v.extend(over.config.disallowed_tools); v.dedup(); v },
+                mcp_servers: {
+                    let mut v = base.config.mcp_servers;
+                    v.extend(over.config.mcp_servers);
+                    v
+                },
+                lsp_servers: {
+                    let mut v = base.config.lsp_servers;
+                    v.extend(over.config.lsp_servers);
+                    v
+                },
+                allowed_tools: {
+                    let mut v = base.config.allowed_tools;
+                    v.extend(over.config.allowed_tools);
+                    v.dedup();
+                    v
+                },
+                disallowed_tools: {
+                    let mut v = base.config.disallowed_tools;
+                    v.extend(over.config.disallowed_tools);
+                    v.dedup();
+                    v
+                },
                 env: merge_map(base.config.env, over.config.env),
-                enable_all_mcp_servers: over.config.enable_all_mcp_servers || base.config.enable_all_mcp_servers,
-                custom_system_prompt: over.config.custom_system_prompt.or(base.config.custom_system_prompt),
-                append_system_prompt: over.config.append_system_prompt.or(base.config.append_system_prompt),
-                disable_claude_mds: over.config.disable_claude_mds || base.config.disable_claude_mds,
+                enable_all_mcp_servers: over.config.enable_all_mcp_servers
+                    || base.config.enable_all_mcp_servers,
+                custom_system_prompt: over
+                    .config
+                    .custom_system_prompt
+                    .or(base.config.custom_system_prompt),
+                append_system_prompt: over
+                    .config
+                    .append_system_prompt
+                    .or(base.config.append_system_prompt),
+                disable_claude_mds: over.config.disable_claude_mds
+                    || base.config.disable_claude_mds,
                 project_dir: over.config.project_dir.or(base.config.project_dir),
-                workspace_paths: { let mut v = base.config.workspace_paths; v.extend(over.config.workspace_paths); v },
-                additional_dirs: { let mut v = base.config.additional_dirs; v.extend(over.config.additional_dirs); v },
+                workspace_paths: {
+                    let mut v = base.config.workspace_paths;
+                    v.extend(over.config.workspace_paths);
+                    v
+                },
+                additional_dirs: {
+                    let mut v = base.config.additional_dirs;
+                    v.extend(over.config.additional_dirs);
+                    v
+                },
                 hooks: merge_map(base.config.hooks, over.config.hooks),
                 provider: over.config.provider.or(base.config.provider),
-                provider_configs: merge_map(base.config.provider_configs, over.config.provider_configs),
-                model_overrides: merge_map(base.config.model_overrides, over.config.model_overrides),
+                provider_configs: merge_map(
+                    base.config.provider_configs,
+                    over.config.provider_configs,
+                ),
+                model_overrides: merge_map(
+                    base.config.model_overrides,
+                    over.config.model_overrides,
+                ),
                 formatter: merge_map(base.config.formatter, over.config.formatter),
                 commands: merge_map(base.config.commands, over.config.commands),
                 agents: merge_map(base.config.agents, over.config.agents),
                 skills: {
                     let mut paths = base.config.skills.paths;
-                    for p in over.config.skills.paths { if !paths.contains(&p) { paths.push(p); } }
+                    for p in over.config.skills.paths {
+                        if !paths.contains(&p) {
+                            paths.push(p);
+                        }
+                    }
                     let mut urls = base.config.skills.urls;
-                    for u in over.config.skills.urls { if !urls.contains(&u) { urls.push(u); } }
+                    for u in over.config.skills.urls {
+                        if !urls.contains(&u) {
+                            urls.push(u);
+                        }
+                    }
                     SkillsConfig { paths, urls }
                 },
                 managed_agents: over.config.managed_agents.or(base.config.managed_agents),
                 auto_commits: over.config.auto_commits.or(base.config.auto_commits),
                 mouse_capture: over.config.mouse_capture.or(base.config.mouse_capture),
-                cursor_blink_enabled: over.config.cursor_blink_enabled || base.config.cursor_blink_enabled,
-                file_autocomplete_limit: if over.config.file_autocomplete_limit != 0 { over.config.file_autocomplete_limit } else { base.config.file_autocomplete_limit },
-                file_autocomplete_show_hidden_files: over.config.file_autocomplete_show_hidden_files || base.config.file_autocomplete_show_hidden_files,
-                file_injection_enabled: over.config.file_injection_enabled || base.config.file_injection_enabled,
-                file_injection_max_size: if over.config.file_injection_max_size != 0 { over.config.file_injection_max_size } else { base.config.file_injection_max_size },
-                request_timeout_secs: over.config.request_timeout_secs.or(base.config.request_timeout_secs),
+                cursor_blink_enabled: over.config.cursor_blink_enabled
+                    || base.config.cursor_blink_enabled,
+                file_autocomplete_limit: if over.config.file_autocomplete_limit != 0 {
+                    over.config.file_autocomplete_limit
+                } else {
+                    base.config.file_autocomplete_limit
+                },
+                file_autocomplete_show_hidden_files: over
+                    .config
+                    .file_autocomplete_show_hidden_files
+                    || base.config.file_autocomplete_show_hidden_files,
+                file_injection_enabled: over.config.file_injection_enabled
+                    || base.config.file_injection_enabled,
+                file_injection_max_size: if over.config.file_injection_max_size != 0 {
+                    over.config.file_injection_max_size
+                } else {
+                    base.config.file_injection_max_size
+                },
+                request_timeout_secs: over
+                    .config
+                    .request_timeout_secs
+                    .or(base.config.request_timeout_secs),
+                degradation_summary_enabled: over.config.degradation_summary_enabled
+                    && base.config.degradation_summary_enabled,
+                hide_tool_content: over.config.hide_tool_content || base.config.hide_tool_content,
             };
             Self {
                 config: merged_config,
                 version: over.version.or(base.version),
                 projects: merge_map(base.projects, over.projects),
-                remote_control_at_startup: over.remote_control_at_startup || base.remote_control_at_startup,
+                remote_control_at_startup: over.remote_control_at_startup
+                    || base.remote_control_at_startup,
                 // SECURITY: only the user's global settings may grant blanket
                 // trust to project MCP servers. A project's own settings file
                 // (`over`) must NOT be able to flip this on — otherwise a
@@ -2000,22 +2342,53 @@ pub mod config {
                 // pre-approve bash command prefixes.
                 skip_dangerous_mode_permission_prompt: base.skip_dangerous_mode_permission_prompt,
                 allowed_bash_prefixes: base.allowed_bash_prefixes,
-                permission_rules: { let mut v = base.permission_rules; v.extend(over.permission_rules); v },
-                enabled_plugins: { let mut s = base.enabled_plugins; s.extend(over.enabled_plugins); s },
-                disabled_plugins: { let mut s = base.disabled_plugins; s.extend(over.disabled_plugins); s },
-                has_completed_onboarding: over.has_completed_onboarding || base.has_completed_onboarding,
+                permission_rules: {
+                    let mut v = base.permission_rules;
+                    v.extend(over.permission_rules);
+                    v
+                },
+                enabled_plugins: {
+                    let mut s = base.enabled_plugins;
+                    s.extend(over.enabled_plugins);
+                    s
+                },
+                disabled_plugins: {
+                    let mut s = base.disabled_plugins;
+                    s.extend(over.disabled_plugins);
+                    s
+                },
+                has_completed_onboarding: over.has_completed_onboarding
+                    || base.has_completed_onboarding,
                 last_seen_version: over.last_seen_version.or(base.last_seen_version),
                 provider: over.provider.or(base.provider),
                 providers: merge_map(base.providers, over.providers),
+                custom_providers: merge_map(base.custom_providers, over.custom_providers),
+                favorite_models: {
+                    let mut v = base.favorite_models;
+                    for f in over.favorite_models {
+                        if !v.contains(&f) {
+                            v.push(f);
+                        }
+                    }
+                    v
+                },
                 model_overrides: merge_map(base.model_overrides, over.model_overrides),
                 commands: merge_map(base.commands, over.commands),
                 formatter: merge_map(base.formatter, over.formatter),
                 agents: merge_map(base.agents, over.agents),
                 skills: {
                     let mut paths = base.skills.paths;
-                    for p in over.skills.paths { if !paths.contains(&p) { paths.push(p); } }
+                    for p in over.skills.paths {
+                        if !paths.contains(&p) {
+                            paths.push(p);
+                        }
+                    }
                     let mut urls = base.skills.urls;
-                    for u in over.skills.urls { if !urls.contains(&u) { urls.push(u); } }
+                    for u in over.skills.urls {
+                        if !urls.contains(&u) {
+                            urls.push(u);
+                        }
+                    }
                     SkillsConfig { paths, urls }
                 },
                 managed_agents: over.managed_agents.or(base.managed_agents),
@@ -2027,10 +2400,28 @@ pub mod config {
                 show_cwd: over.show_cwd || base.show_cwd,
                 show_git_branch: over.show_git_branch || base.show_git_branch,
                 auto_compact: over.auto_compact || base.auto_compact,
-                file_autocomplete_limit: if over.file_autocomplete_limit != 0 { over.file_autocomplete_limit } else { base.file_autocomplete_limit },
-                file_autocomplete_show_hidden_files: over.file_autocomplete_show_hidden_files || base.file_autocomplete_show_hidden_files,
+                file_autocomplete_limit: if over.file_autocomplete_limit != 0 {
+                    over.file_autocomplete_limit
+                } else {
+                    base.file_autocomplete_limit
+                },
+                file_autocomplete_show_hidden_files: over.file_autocomplete_show_hidden_files
+                    || base.file_autocomplete_show_hidden_files,
                 file_injection_enabled: over.file_injection_enabled || base.file_injection_enabled,
-                file_injection_max_size: if over.file_injection_max_size != 0 { over.file_injection_max_size } else { base.file_injection_max_size },
+                file_injection_max_size: if over.file_injection_max_size != 0 {
+                    over.file_injection_max_size
+                } else {
+                    base.file_injection_max_size
+                },
+                auto_poke_enabled: over.auto_poke_enabled || base.auto_poke_enabled,
+                bang_commands: BangCommandsConfig {
+                    enabled: over.bang_commands.enabled || base.bang_commands.enabled,
+                    add_to_history: over.bang_commands.add_to_history
+                        || base.bang_commands.add_to_history,
+                    show_in_transcript: over.bang_commands.show_in_transcript
+                        && base.bang_commands.show_in_transcript,
+                },
+                hide_tool_content: over.hide_tool_content || base.hide_tool_content,
             }
         }
     }
@@ -2045,7 +2436,9 @@ pub mod config {
 
         while let Some(ch) = chars.next() {
             if in_string {
-                if ch == '"' && prev_char != '\\' { in_string = false; }
+                if ch == '"' && prev_char != '\\' {
+                    in_string = false;
+                }
                 result.push(ch);
                 prev_char = ch;
                 continue;
@@ -2060,15 +2453,24 @@ pub mod config {
                 match chars.peek() {
                     Some('/') => {
                         // Line comment — skip to end of line.
-                        for c in chars.by_ref() { if c == '\n' { result.push('\n'); break; } }
+                        for c in chars.by_ref() {
+                            if c == '\n' {
+                                result.push('\n');
+                                break;
+                            }
+                        }
                     }
                     Some('*') => {
                         // Block comment — skip until `*/`.
                         chars.next();
                         let mut prev = '\0';
                         for c in chars.by_ref() {
-                            if prev == '*' && c == '/' { break; }
-                            if c == '\n' { result.push('\n'); }
+                            if prev == '*' && c == '/' {
+                                break;
+                            }
+                            if c == '\n' {
+                                result.push('\n');
+                            }
                             prev = c;
                         }
                     }
@@ -2090,16 +2492,14 @@ pub mod config {
         loop {
             match result.find("{env:") {
                 None => break,
-                Some(start) => {
-                    match result[start..].find('}') {
-                        None => break,
-                        Some(rel_end) => {
-                            let var_name = result[start + 5..start + rel_end].to_string();
-                            let value = std::env::var(&var_name).unwrap_or_default();
-                            result.replace_range(start..start + rel_end + 1, &value);
-                        }
+                Some(start) => match result[start..].find('}') {
+                    None => break,
+                    Some(rel_end) => {
+                        let var_name = result[start + 5..start + rel_end].to_string();
+                        let value = std::env::var(&var_name).unwrap_or_default();
+                        result.replace_range(start..start + rel_end + 1, &value);
                     }
-                }
+                },
             }
         }
         result
@@ -2135,11 +2535,9 @@ pub mod config {
 
             let error = replacement.save_to_path_sync(&path).unwrap_err();
 
-            assert!(
-                error
-                    .to_string()
-                    .contains("Refusing to overwrite malformed settings file")
-            );
+            assert!(error
+                .to_string()
+                .contains("Refusing to overwrite malformed settings file"));
             assert_eq!(std::fs::read_to_string(path).unwrap(), MALFORMED_SETTINGS);
         }
 
@@ -2150,14 +2548,14 @@ pub mod config {
             tokio::fs::write(&path, MALFORMED_SETTINGS).await.unwrap();
 
             let load_error = Settings::load_from_path(&path).await.unwrap_err();
-            assert!(load_error.to_string().contains("Failed to parse settings file"));
+            assert!(load_error
+                .to_string()
+                .contains("Failed to parse settings file"));
 
             let save_error = Settings::default().save_to_path(&path).await.unwrap_err();
-            assert!(
-                save_error
-                    .to_string()
-                    .contains("Refusing to overwrite malformed settings file")
-            );
+            assert!(save_error
+                .to_string()
+                .contains("Refusing to overwrite malformed settings file"));
             assert_eq!(
                 tokio::fs::read_to_string(path).await.unwrap(),
                 MALFORMED_SETTINGS
@@ -2182,7 +2580,10 @@ pub mod config {
 
         #[test]
         fn global_request_timeout_serde_roundtrips_with_camelcase_key() {
-            let config = Config { request_timeout_secs: Some(1800), ..Default::default() };
+            let config = Config {
+                request_timeout_secs: Some(1800),
+                ..Default::default()
+            };
             // Serialises with the documented camelCase key.
             let json = serde_json::to_string(&config).expect("serialise");
             assert!(
@@ -2199,23 +2600,24 @@ pub mod config {
         fn snake_case_alias_also_parses() {
             // Patch a fully-serialised config to use the snake_case alias and
             // confirm it still deserialises (back-compat with snake_case keys).
-            let mut value =
-                serde_json::to_value(Config::default()).expect("to_value");
+            let mut value = serde_json::to_value(Config::default()).expect("to_value");
             let obj = value.as_object_mut().unwrap();
             obj.remove("requestTimeoutSecs");
-            obj.insert(
-                "request_timeout_secs".to_string(),
-                serde_json::json!(900),
-            );
-            let parsed: Config =
-                serde_json::from_value(value).expect("alias should parse");
+            obj.insert("request_timeout_secs".to_string(), serde_json::json!(900));
+            let parsed: Config = serde_json::from_value(value).expect("alias should parse");
             assert_eq!(parsed.request_timeout_secs, Some(900));
         }
 
         #[test]
         fn per_provider_override_wins_over_global() {
-            let mut config = Config { request_timeout_secs: Some(1200), ..Default::default() };
-            let provider = ProviderConfig { request_timeout_secs: Some(3600), ..Default::default() };
+            let mut config = Config {
+                request_timeout_secs: Some(1200),
+                ..Default::default()
+            };
+            let provider = ProviderConfig {
+                request_timeout_secs: Some(3600),
+                ..Default::default()
+            };
             config
                 .provider_configs
                 .insert("ollama".to_string(), provider);
@@ -2229,7 +2631,10 @@ pub mod config {
         fn effective_config_merges_top_level_provider_timeout() {
             let mut settings = Settings::default();
             settings.config.request_timeout_secs = Some(1200);
-            let provider = ProviderConfig { request_timeout_secs: Some(3600), ..Default::default() };
+            let provider = ProviderConfig {
+                request_timeout_secs: Some(3600),
+                ..Default::default()
+            };
             settings.providers.insert("ollama".to_string(), provider);
             let config = settings.effective_config();
             assert_eq!(config.resolve_request_timeout_secs("ollama"), 3600);
@@ -2242,20 +2647,35 @@ pub mod config {
             // Nested `config` block wins for a key present in both.
             settings.config.model_overrides.insert(
                 "custom-openai/a".to_string(),
-                ModelOverride { context_window: Some(111), ..Default::default() },
+                ModelOverride {
+                    context_window: Some(111),
+                    ..Default::default()
+                },
             );
             settings.model_overrides.insert(
                 "custom-openai/a".to_string(),
-                ModelOverride { context_window: Some(999), ..Default::default() },
+                ModelOverride {
+                    context_window: Some(999),
+                    ..Default::default()
+                },
             );
             // Top-level-only key is folded in.
             settings.model_overrides.insert(
                 "custom-openai/b".to_string(),
-                ModelOverride { context_window: Some(222), ..Default::default() },
+                ModelOverride {
+                    context_window: Some(222),
+                    ..Default::default()
+                },
             );
             let config = settings.effective_config();
-            assert_eq!(config.model_overrides["custom-openai/a"].context_window, Some(111));
-            assert_eq!(config.model_overrides["custom-openai/b"].context_window, Some(222));
+            assert_eq!(
+                config.model_overrides["custom-openai/a"].context_window,
+                Some(111)
+            );
+            assert_eq!(
+                config.model_overrides["custom-openai/b"].context_window,
+                Some(222)
+            );
         }
 
         #[test]
@@ -2285,12 +2705,57 @@ pub mod config {
         }
 
         #[test]
+        fn favorite_models_deserialize() {
+            let json = r#"{"favoriteModels": ["anthropic/claude-sonnet-4-6", "openai/gpt-4o"]}"#;
+            let settings: Settings = serde_json::from_str(json).unwrap();
+            assert_eq!(settings.favorite_models.len(), 2);
+            assert_eq!(settings.favorite_models[0], "anthropic/claude-sonnet-4-6");
+            assert_eq!(settings.favorite_models[1], "openai/gpt-4o");
+        }
+
+        #[test]
+        fn favorite_models_snake_alias() {
+            let json = r#"{"favorite_models": ["anthropic/claude-opus-4-6"]}"#;
+            let settings: Settings = serde_json::from_str(json).unwrap();
+            assert_eq!(settings.favorite_models.len(), 1);
+            assert_eq!(settings.favorite_models[0], "anthropic/claude-opus-4-6");
+        }
+
+        #[test]
+        fn favorite_models_default_empty() {
+            let json = r#"{}"#;
+            let settings: Settings = serde_json::from_str(json).unwrap();
+            assert!(settings.favorite_models.is_empty());
+        }
+
+        #[test]
         fn zero_is_treated_as_unset() {
-            let config = Config { request_timeout_secs: Some(0), ..Default::default() };
+            let config = Config {
+                request_timeout_secs: Some(0),
+                ..Default::default()
+            };
             assert_eq!(
                 config.resolve_request_timeout_secs("openai"),
                 DEFAULT_REQUEST_TIMEOUT_SECS
             );
+        }
+
+        #[test]
+        fn bang_commands_default_disabled() {
+            let json = r#"{}"#;
+            let settings: Settings = serde_json::from_str(json).unwrap();
+            assert!(!settings.bang_commands.enabled);
+            assert!(!settings.bang_commands.add_to_history);
+            assert!(settings.bang_commands.show_in_transcript);
+        }
+
+        #[test]
+        fn bang_commands_deserialize() {
+            let json = r#"{"bangCommands": {"enabled": true, "addToHistory": true, "showInTranscript": false}}"#;
+            let settings: Settings = serde_json::from_str(json).unwrap();
+            assert!(settings.bang_commands.enabled);
+            assert!(settings.bang_commands.add_to_history);
+            assert!(!settings.bang_commands.show_in_transcript);
         }
     }
 }
@@ -2400,10 +2865,7 @@ pub mod context {
 
             // Platform information
             parts.push(format!("Platform: {}", std::env::consts::OS));
-            parts.push(format!(
-                "Working directory: {}",
-                self.cwd.display()
-            ));
+            parts.push(format!("Working directory: {}", self.cwd.display()));
 
             if let Some(git_context) = self.get_git_context().await {
                 parts.push(git_context);
@@ -2422,9 +2884,7 @@ pub mod context {
         pub async fn build_user_context(&self) -> String {
             let mut parts = vec![];
 
-            let date = chrono::Local::now()
-                .format("%A, %B %d, %Y")
-                .to_string();
+            let date = chrono::Local::now().format("%A, %B %d, %Y").to_string();
             parts.push(format!("Today's date is {}.", date));
 
             if !self.disable_claude_mds {
@@ -2700,10 +3160,7 @@ pub mod permissions {
                 } else {
                     "\nThis will write to the filesystem."
                 };
-                format!(
-                    "{} wants to write to `{}`{}",
-                    tool_name, target, extra
-                )
+                format!("{} wants to write to `{}`{}", tool_name, target, extra)
             }
             PermissionLevel::Network => {
                 let url = path.unwrap_or(description);
@@ -2729,8 +3186,8 @@ pub mod permissions {
         working_dir: Option<&std::path::Path>,
         allowed_roots: &[std::path::PathBuf],
     ) -> bool {
-        let canonical_path = std::fs::canonicalize(path)
-            .unwrap_or_else(|_| std::path::PathBuf::from(path));
+        let canonical_path =
+            std::fs::canonicalize(path).unwrap_or_else(|_| std::path::PathBuf::from(path));
 
         let mut roots: Vec<std::path::PathBuf> = Vec::new();
         if let Some(root) = working_dir {
@@ -2851,8 +3308,17 @@ pub mod permissions {
                 PermissionLevel::Read
                     if !matches!(
                         tool_name,
-                        "Read" | "Glob" | "Grep" | "ListMcpResources" | "ReadMcpResource" | "LSP" | "Skill"
-                    ) => PermissionLevel::Execute,
+                        "Read"
+                            | "Glob"
+                            | "Grep"
+                            | "ListMcpResources"
+                            | "ReadMcpResource"
+                            | "LSP"
+                            | "Skill"
+                    ) =>
+                {
+                    PermissionLevel::Execute
+                }
                 other => other,
             };
             let read_in_workspace = path.is_some_and(|target| {
@@ -2884,8 +3350,7 @@ pub mod permissions {
                 | PermissionLevel::Write
                 | PermissionLevel::Execute
                 | PermissionLevel::Network => {
-                    let reason =
-                        format_permission_reason(tool_name, description, path, level);
+                    let reason = format_permission_reason(tool_name, description, path, level);
                     PermissionDecision::Ask { reason }
                 }
             }
@@ -3065,13 +3530,13 @@ pub mod permissions {
             use crate::config::PermissionMode;
             match self.mode {
                 PermissionMode::BypassPermissions => PermissionDecision::Allow,
-                    PermissionMode::AcceptEdits => {
-                        if request.tool_name == "Edit" || request.is_read_only {
-                            PermissionDecision::Allow
-                        } else {
-                            PermissionDecision::Deny
-                        }
+                PermissionMode::AcceptEdits => {
+                    if request.tool_name == "Edit" || request.is_read_only {
+                        PermissionDecision::Allow
+                    } else {
+                        PermissionDecision::Deny
                     }
+                }
                 PermissionMode::Plan => {
                     if request.is_read_only {
                         PermissionDecision::Allow
@@ -3316,7 +3781,10 @@ pub mod permissions {
                 action: PermissionAction::Deny,
                 scope: PermissionScope::Session,
             });
-            assert_eq!(m.evaluate("Bash", "echo hi", None, None, &[]), PermissionDecision::Deny);
+            assert_eq!(
+                m.evaluate("Bash", "echo hi", None, None, &[]),
+                PermissionDecision::Deny
+            );
         }
 
         #[test]
@@ -3341,7 +3809,13 @@ pub mod permissions {
         fn accept_edits_only_allows_edit() {
             let m = mgr(PermissionMode::AcceptEdits);
             assert_eq!(
-                m.evaluate("Edit", "edit file", Some("/workspace/src/lib.rs"), None, &[]),
+                m.evaluate(
+                    "Edit",
+                    "edit file",
+                    Some("/workspace/src/lib.rs"),
+                    None,
+                    &[]
+                ),
                 PermissionDecision::Allow
             );
             match m.evaluate("Bash", "rm -rf /tmp", None, None, &[]) {
@@ -3382,8 +3856,12 @@ pub mod permissions {
 
         #[test]
         fn format_reason_bash() {
-            let s =
-                format_permission_reason("Bash", "This will execute a shell command.", None, PermissionLevel::Execute);
+            let s = format_permission_reason(
+                "Bash",
+                "This will execute a shell command.",
+                None,
+                PermissionLevel::Execute,
+            );
             assert_eq!(s, "This will execute a shell command.");
         }
 
@@ -3395,7 +3873,10 @@ pub mod permissions {
                 None,
                 PermissionLevel::Execute,
             );
-            assert_eq!(s, "[High risk] This may modify system-wide security policy.");
+            assert_eq!(
+                s,
+                "[High risk] This may modify system-wide security policy."
+            );
         }
 
         #[test]
@@ -3599,9 +4080,7 @@ pub mod history {
                 let path = entry.path();
                 if path.extension().and_then(|s| s.to_str()) == Some("json") {
                     if let Ok(content) = tokio::fs::read_to_string(&path).await {
-                        if let Ok(session) =
-                            serde_json::from_str::<ConversationSession>(&content)
-                        {
+                        if let Ok(session) = serde_json::from_str::<ConversationSession>(&content) {
                             sessions.push(session);
                         }
                     }
@@ -3800,7 +4279,10 @@ pub mod cost {
         /// Pick pricing based on model name substring matching.
         pub fn for_model(model: &str) -> Self {
             // Check for free models first (those with "-free" suffix, "free/" prefix, or upstream-prefixed free model)
-            if model.ends_with("-free") || model.starts_with("free/") || is_free_upstream_model(model) {
+            if model.ends_with("-free")
+                || model.starts_with("free/")
+                || is_free_upstream_model(model)
+            {
                 Self::FREE
             } else if model.contains("opus") {
                 Self::OPUS
@@ -3849,13 +4331,7 @@ pub mod cost {
             *self.pricing.write() = ModelPricing::for_model(model);
         }
 
-        pub fn add_usage(
-            &self,
-            input: u64,
-            output: u64,
-            cache_creation: u64,
-            cache_read: u64,
-        ) {
+        pub fn add_usage(&self, input: u64, output: u64, cache_creation: u64, cache_read: u64) {
             self.input_tokens.fetch_add(input, Ordering::Relaxed);
             self.output_tokens.fetch_add(output, Ordering::Relaxed);
             self.cache_creation_tokens
@@ -4062,10 +4538,8 @@ pub mod oauth {
     pub const CONSOLE_AUTHORIZE_URL: &str = "https://platform.claude.com/oauth/authorize";
     pub const CLAUDE_AI_AUTHORIZE_URL: &str = "https://claude.com/cai/oauth/authorize";
     pub const TOKEN_URL: &str = "https://platform.claude.com/v1/oauth/token";
-    pub const API_KEY_URL: &str =
-        "https://api.anthropic.com/api/oauth/claude_cli/create_api_key";
-    pub const MANUAL_REDIRECT_URL: &str =
-        "https://platform.claude.com/oauth/code/callback";
+    pub const API_KEY_URL: &str = "https://api.anthropic.com/api/oauth/claude_cli/create_api_key";
+    pub const MANUAL_REDIRECT_URL: &str = "https://platform.claude.com/oauth/code/callback";
     pub const CLAUDEAI_SUCCESS_URL: &str =
         "https://platform.claude.com/oauth/code/success?app=claude-code";
     pub const CONSOLE_SUCCESS_URL: &str = "https://platform.claude.com/buy_credits\
@@ -4121,7 +4595,11 @@ pub mod oauth {
         /// - Claude.ai flow: the `access_token` itself (Bearer)
         pub fn effective_credential(&self) -> Option<&str> {
             if self.uses_bearer_auth() {
-                if self.access_token.is_empty() { None } else { Some(&self.access_token) }
+                if self.access_token.is_empty() {
+                    None
+                } else {
+                    Some(&self.access_token)
+                }
             } else {
                 self.api_key.as_deref()
             }
@@ -4172,8 +4650,8 @@ pub mod oauth {
         /// If `label` is None, derives the id from email/account_uuid.
         pub async fn save_and_register(&self, label: Option<&str>) -> anyhow::Result<String> {
             use crate::accounts::{
-                AccountProfile, AccountRegistry, ensure_unique_profile_id,
-                slugify_profile_id, PROVIDER_ANTHROPIC,
+                ensure_unique_profile_id, slugify_profile_id, AccountProfile, AccountRegistry,
+                PROVIDER_ANTHROPIC,
             };
 
             let mut registry = AccountRegistry::load();
@@ -4186,8 +4664,7 @@ pub mod oauth {
                 .into_iter()
                 .find(|p| {
                     (self.email.is_some() && p.email == self.email)
-                        || (self.account_uuid.is_some()
-                            && p.account_id == self.account_uuid)
+                        || (self.account_uuid.is_some() && p.account_id == self.account_uuid)
                 })
                 .map(|p| p.id);
 
@@ -4265,7 +4742,10 @@ pub mod oauth {
         /// `purge_all` is true) and drop the profile from the registry.
         pub async fn clear() -> anyhow::Result<()> {
             let mut registry = crate::accounts::AccountRegistry::load();
-            if let Some(active) = registry.active(crate::accounts::PROVIDER_ANTHROPIC).map(String::from) {
+            if let Some(active) = registry
+                .active(crate::accounts::PROVIDER_ANTHROPIC)
+                .map(String::from)
+            {
                 registry.remove(crate::accounts::PROVIDER_ANTHROPIC, &active)?;
             }
             // Also remove any legacy file.
@@ -4319,8 +4799,7 @@ pub mod oauth {
         callback_port: u16,
         is_manual: bool,
     ) -> String {
-        let mut u = url::Url::parse(authorize_base)
-            .expect("valid OAuth authorize base URL");
+        let mut u = url::Url::parse(authorize_base).expect("valid OAuth authorize base URL");
         {
             let mut q = u.query_pairs_mut();
             q.append_pair("code", "true"); // tells the login page to show Claude Max upsell
@@ -4388,32 +4867,32 @@ pub use oauth::OAuthTokens;
 // New modules: keybindings, voice, analytics, lsp, team_memory_sync,
 //              system_prompt, memdir, oauth_config
 // ---------------------------------------------------------------------------
-pub mod keybindings;
-pub mod voice;
-pub mod analytics;
-pub mod lsp;
-pub mod session_tracing;
-pub mod context_collapse;
-pub mod team_memory_sync;
-pub mod system_prompt;
-pub mod memdir;
-pub mod oauth_config;
-pub mod codex_oauth;
 pub mod accounts;
-pub mod migrations;
-pub mod output_styles;
-pub mod feature_gates;
-pub mod tips;
-pub mod remote_settings;
-pub mod settings_sync;
-pub mod import_config;
-pub mod effort;
-pub mod keywords;
-pub mod prompt_history;
+pub mod analytics;
 pub mod bash_classifier;
-pub mod ps_classifier;
+pub mod codex_oauth;
+pub mod context_collapse;
+pub mod effort;
+pub mod feature_gates;
+pub mod import_config;
+pub mod keybindings;
+pub mod keywords;
+pub mod lsp;
 pub mod mcp_trust;
+pub mod memdir;
+pub mod migrations;
+pub mod oauth_config;
+pub mod output_styles;
 pub mod paths;
+pub mod prompt_history;
+pub mod ps_classifier;
+pub mod remote_settings;
+pub mod session_tracing;
+pub mod settings_sync;
+pub mod system_prompt;
+pub mod team_memory_sync;
+pub mod tips;
+pub mod voice;
 
 // ---------------------------------------------------------------------------
 // tasks module — background task registry
@@ -4723,7 +5202,10 @@ mod tests {
 
     #[test]
     fn test_config_mouse_capture_explicit_off() {
-        let mut cfg = crate::config::Config { mouse_capture: Some(false), ..Default::default() };
+        let mut cfg = crate::config::Config {
+            mouse_capture: Some(false),
+            ..Default::default()
+        };
         assert!(!cfg.mouse_capture_enabled());
         cfg.mouse_capture = Some(true);
         assert!(cfg.mouse_capture_enabled());
@@ -4741,7 +5223,10 @@ mod tests {
         assert!(back.mouse_capture_enabled());
 
         // Explicit off serializes the key and round-trips as disabled.
-        let cfg = crate::config::Config { mouse_capture: Some(false), ..Default::default() };
+        let cfg = crate::config::Config {
+            mouse_capture: Some(false),
+            ..Default::default()
+        };
         let json = serde_json::to_string(&cfg).unwrap();
         assert!(json.contains("\"mouseCapture\":false"));
         let back: crate::config::Config = serde_json::from_str(&json).unwrap();
@@ -4757,19 +5242,28 @@ mod tests {
 
     #[test]
     fn test_config_effective_model_override() {
-        let cfg = crate::config::Config { model: Some("claude-haiku-4-5-20251001".to_string()), ..Default::default() };
+        let cfg = crate::config::Config {
+            model: Some("claude-haiku-4-5-20251001".to_string()),
+            ..Default::default()
+        };
         assert_eq!(cfg.effective_model(), "claude-haiku-4-5-20251001");
     }
 
     #[test]
     fn test_config_effective_max_tokens_default() {
         let cfg = crate::config::Config::default();
-        assert_eq!(cfg.effective_max_tokens(), crate::constants::DEFAULT_MAX_TOKENS);
+        assert_eq!(
+            cfg.effective_max_tokens(),
+            crate::constants::DEFAULT_MAX_TOKENS
+        );
     }
 
     #[test]
     fn test_config_effective_max_tokens_override() {
-        let cfg = crate::config::Config { max_tokens: Some(8192), ..Default::default() };
+        let cfg = crate::config::Config {
+            max_tokens: Some(8192),
+            ..Default::default()
+        };
         assert_eq!(cfg.effective_max_tokens(), 8192);
     }
 
@@ -4780,7 +5274,10 @@ mod tests {
         let orig = std::env::var("ANTHROPIC_API_KEY").ok();
         std::env::remove_var("ANTHROPIC_API_KEY");
 
-        let cfg = crate::config::Config { api_key: Some("sk-ant-config-key".to_string()), ..Default::default() };
+        let cfg = crate::config::Config {
+            api_key: Some("sk-ant-config-key".to_string()),
+            ..Default::default()
+        };
         assert_eq!(cfg.resolve_api_key(), Some("sk-ant-config-key".to_string()));
 
         if let Some(k) = orig {
@@ -4827,7 +5324,10 @@ mod tests {
             expires_at_ms: None,
             ..Default::default()
         };
-        assert!(!tokens.is_expired(), "Token with no expiry should not be considered expired");
+        assert!(
+            !tokens.is_expired(),
+            "Token with no expiry should not be considered expired"
+        );
     }
 
     #[test]
@@ -4860,7 +5360,10 @@ mod tests {
             expires_at_ms: Some(chrono::Utc::now().timestamp_millis() + 3 * 60 * 1000),
             ..Default::default()
         };
-        assert!(tokens.is_expired(), "Token within 5-min buffer should be considered expired");
+        assert!(
+            tokens.is_expired(),
+            "Token within 5-min buffer should be considered expired"
+        );
     }
 
     #[test]
@@ -4930,9 +5433,15 @@ mod tests {
     fn test_pkce_code_verifier_length() {
         let verifier = crate::oauth::generate_code_verifier();
         // 32 bytes base64url-encoded (no padding) = ceil(32 * 4/3) = 43 chars
-        assert_eq!(verifier.len(), 43, "Code verifier should be 43 base64url chars (32 bytes)");
+        assert_eq!(
+            verifier.len(),
+            43,
+            "Code verifier should be 43 base64url chars (32 bytes)"
+        );
         // Must only contain URL-safe base64 chars
-        assert!(verifier.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
+        assert!(verifier
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
     }
 
     #[test]
@@ -4940,8 +5449,14 @@ mod tests {
         let verifier = crate::oauth::generate_code_verifier();
         let challenge = crate::oauth::generate_code_challenge(&verifier);
         // SHA256 = 32 bytes → 43 base64url chars
-        assert_eq!(challenge.len(), 43, "Code challenge should be 43 base64url chars (SHA256 = 32 bytes)");
-        assert!(challenge.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
+        assert_eq!(
+            challenge.len(),
+            43,
+            "Code challenge should be 43 base64url chars (SHA256 = 32 bytes)"
+        );
+        assert!(challenge
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
     }
 
     #[test]
@@ -4964,7 +5479,9 @@ mod tests {
     fn test_pkce_state_length_and_format() {
         let state = crate::oauth::generate_state();
         assert_eq!(state.len(), 43);
-        assert!(state.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
+        assert!(state
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
     }
 
     // ---- Auth URL building tests --------------------------------------------
@@ -5001,10 +5518,7 @@ mod tests {
             9999,
             true, // manual
         );
-        assert!(
-            url.contains("redirect_uri="),
-            "URL must have redirect_uri"
-        );
+        assert!(url.contains("redirect_uri="), "URL must have redirect_uri");
         // Manual redirect should NOT be localhost
         assert!(
             !url.contains("localhost"),
@@ -5125,8 +5639,12 @@ mod tests {
     #[test]
     fn test_message_get_all_text_multiple_blocks() {
         let msg = Message::assistant_blocks(vec![
-            ContentBlock::Text { text: "First ".into() },
-            ContentBlock::Text { text: "Second".into() },
+            ContentBlock::Text {
+                text: "First ".into(),
+            },
+            ContentBlock::Text {
+                text: "Second".into(),
+            },
         ]);
         assert_eq!(msg.get_all_text(), "First Second");
     }
@@ -5138,7 +5656,9 @@ mod tests {
                 thinking: "reasoning".into(),
                 signature: "sig".into(),
             },
-            ContentBlock::Text { text: "answer".into() },
+            ContentBlock::Text {
+                text: "answer".into(),
+            },
         ]);
         assert_eq!(msg.get_text(), Some("answer"));
     }
@@ -5177,30 +5697,84 @@ mod tests {
     #[test]
     fn test_model_pricing_free_variants() {
         // Test that models ending with -free use FREE pricing
-        assert_eq!(cost::ModelPricing::for_model("deepseek-v4-flash-free"), cost::ModelPricing::FREE);
-        assert_eq!(cost::ModelPricing::for_model("zen/minimax-m2.5-free"), cost::ModelPricing::FREE);
+        assert_eq!(
+            cost::ModelPricing::for_model("deepseek-v4-flash-free"),
+            cost::ModelPricing::FREE
+        );
+        assert_eq!(
+            cost::ModelPricing::for_model("zen/minimax-m2.5-free"),
+            cost::ModelPricing::FREE
+        );
 
         // Test that models starting with free/ use FREE pricing
-        assert_eq!(cost::ModelPricing::for_model("free/auto"), cost::ModelPricing::FREE);
-        assert_eq!(cost::ModelPricing::for_model("free/some-model"), cost::ModelPricing::FREE);
+        assert_eq!(
+            cost::ModelPricing::for_model("free/auto"),
+            cost::ModelPricing::FREE
+        );
+        assert_eq!(
+            cost::ModelPricing::for_model("free/some-model"),
+            cost::ModelPricing::FREE
+        );
 
         // Test that upstream-prefixed free models use FREE pricing
-        assert_eq!(cost::ModelPricing::for_model("groq/llama-3.3-70b-versatile"), cost::ModelPricing::FREE);
-        assert_eq!(cost::ModelPricing::for_model("cerebras/qwen-3-235b-a22b-instruct-2507"), cost::ModelPricing::FREE);
-        assert_eq!(cost::ModelPricing::for_model("google/gemini-2.5-flash"), cost::ModelPricing::FREE);
-        assert_eq!(cost::ModelPricing::for_model("mistral/mistral-large-latest"), cost::ModelPricing::FREE);
-        assert_eq!(cost::ModelPricing::for_model("sambanova/Meta-Llama-3.3-70B-Instruct"), cost::ModelPricing::FREE);
-        assert_eq!(cost::ModelPricing::for_model("nvidia/meta/llama-3.3-70b-instruct"), cost::ModelPricing::FREE);
-        assert_eq!(cost::ModelPricing::for_model("cohere/command-r-plus"), cost::ModelPricing::FREE);
-        assert_eq!(cost::ModelPricing::for_model("openrouter/free"), cost::ModelPricing::FREE);
-        assert_eq!(cost::ModelPricing::for_model("opencode-zen/minimax-m2.5-free"), cost::ModelPricing::FREE);
-        assert_eq!(cost::ModelPricing::for_model("zai/glm-4.6"), cost::ModelPricing::FREE);
-        assert_eq!(cost::ModelPricing::for_model("zhipuai/glm-4.5"), cost::ModelPricing::FREE);
+        assert_eq!(
+            cost::ModelPricing::for_model("groq/llama-3.3-70b-versatile"),
+            cost::ModelPricing::FREE
+        );
+        assert_eq!(
+            cost::ModelPricing::for_model("cerebras/qwen-3-235b-a22b-instruct-2507"),
+            cost::ModelPricing::FREE
+        );
+        assert_eq!(
+            cost::ModelPricing::for_model("google/gemini-2.5-flash"),
+            cost::ModelPricing::FREE
+        );
+        assert_eq!(
+            cost::ModelPricing::for_model("mistral/mistral-large-latest"),
+            cost::ModelPricing::FREE
+        );
+        assert_eq!(
+            cost::ModelPricing::for_model("sambanova/Meta-Llama-3.3-70B-Instruct"),
+            cost::ModelPricing::FREE
+        );
+        assert_eq!(
+            cost::ModelPricing::for_model("nvidia/meta/llama-3.3-70b-instruct"),
+            cost::ModelPricing::FREE
+        );
+        assert_eq!(
+            cost::ModelPricing::for_model("cohere/command-r-plus"),
+            cost::ModelPricing::FREE
+        );
+        assert_eq!(
+            cost::ModelPricing::for_model("openrouter/free"),
+            cost::ModelPricing::FREE
+        );
+        assert_eq!(
+            cost::ModelPricing::for_model("opencode-zen/minimax-m2.5-free"),
+            cost::ModelPricing::FREE
+        );
+        assert_eq!(
+            cost::ModelPricing::for_model("zai/glm-4.6"),
+            cost::ModelPricing::FREE
+        );
+        assert_eq!(
+            cost::ModelPricing::for_model("zhipuai/glm-4.5"),
+            cost::ModelPricing::FREE
+        );
 
         // Test that other models use their appropriate pricing
-        assert_eq!(cost::ModelPricing::for_model("claude-opus"), cost::ModelPricing::OPUS);
-        assert_eq!(cost::ModelPricing::for_model("claude-haiku"), cost::ModelPricing::HAIKU);
-        assert_eq!(cost::ModelPricing::for_model("claude-sonnet"), cost::ModelPricing::SONNET);
+        assert_eq!(
+            cost::ModelPricing::for_model("claude-opus"),
+            cost::ModelPricing::OPUS
+        );
+        assert_eq!(
+            cost::ModelPricing::for_model("claude-haiku"),
+            cost::ModelPricing::HAIKU
+        );
+        assert_eq!(
+            cost::ModelPricing::for_model("claude-sonnet"),
+            cost::ModelPricing::SONNET
+        );
     }
 
     #[test]
@@ -5233,10 +5807,16 @@ mod tests {
     #[test]
     fn builtin_presets_all_have_valid_model_format() {
         for preset in builtin_managed_agent_presets() {
-            assert!(preset.manager_model.contains('/'),
-                "Preset {} manager_model must be provider/model", preset.name);
-            assert!(preset.executor_model.contains('/'),
-                "Preset {} executor_model must be provider/model", preset.name);
+            assert!(
+                preset.manager_model.contains('/'),
+                "Preset {} manager_model must be provider/model",
+                preset.name
+            );
+            assert!(
+                preset.executor_model.contains('/'),
+                "Preset {} executor_model must be provider/model",
+                preset.name
+            );
         }
     }
 
@@ -5314,5 +5894,153 @@ mod tests {
             registry.get(&id).unwrap().status,
             tasks::TaskStatus::Cancelled
         );
+    }
+
+    #[test]
+    fn custom_provider_def_deserialize_camel_case() {
+        let json = r#"{
+            "name": "Test Gateway",
+            "apiBase": "https://gateway.example.com/v1",
+            "apiKey": "secret-key",
+            "headers": { "X-Custom-Header": "value" },
+            "models": {
+                "model-1": {
+                    "name": "Model One",
+                    "contextWindow": 128000,
+                    "maxOutputTokens": 8192,
+                    "reasoningEffort": "high"
+                }
+            },
+            "requestTimeoutSecs": 300
+        }"#;
+        let def: CustomProviderDef = serde_json::from_str(json).unwrap();
+        assert_eq!(def.name, "Test Gateway");
+        assert_eq!(def.api_base, "https://gateway.example.com/v1");
+        assert_eq!(def.api_key.as_deref(), Some("secret-key"));
+        assert_eq!(def.headers.get("X-Custom-Header").unwrap(), "value");
+        assert_eq!(def.models.len(), 1);
+        let model = def.models.get("model-1").unwrap();
+        assert_eq!(model.context_window, Some(128000));
+        assert_eq!(model.max_output_tokens, Some(8192));
+        assert_eq!(model.name.as_deref(), Some("Model One"));
+        assert_eq!(model.reasoning_effort.as_deref(), Some("high"));
+        assert_eq!(def.request_timeout_secs, Some(300));
+    }
+
+    #[test]
+    fn custom_provider_def_deserialize_snake_case() {
+        let json = r#"{
+            "name": "Test",
+            "api_base": "https://example.com",
+            "api_key": "key",
+            "models": {}
+        }"#;
+        let def: CustomProviderDef = serde_json::from_str(json).unwrap();
+        assert_eq!(def.api_base, "https://example.com");
+        assert_eq!(def.api_key.as_deref(), Some("key"));
+    }
+
+    #[test]
+    fn custom_provider_def_resolve_api_key_env_substitution() {
+        std::env::set_var("TEST_CUSTOM_PROVIDER_KEY", "env-key-value");
+        let def = CustomProviderDef {
+            api_key: Some("{env:TEST_CUSTOM_PROVIDER_KEY}".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(def.resolve_api_key().as_deref(), Some("env-key-value"));
+        std::env::remove_var("TEST_CUSTOM_PROVIDER_KEY");
+    }
+
+    #[test]
+    fn custom_provider_def_resolve_api_key_empty_env() {
+        let def = CustomProviderDef {
+            api_key: Some("{env:NONEXISTENT_VAR_12345}".to_string()),
+            ..Default::default()
+        };
+        assert!(def.resolve_api_key().is_none());
+    }
+
+    #[test]
+    fn custom_provider_def_resolve_api_key_none() {
+        let def = CustomProviderDef {
+            api_key: None,
+            ..Default::default()
+        };
+        assert!(def.resolve_api_key().is_none());
+    }
+
+    #[test]
+    fn custom_provider_def_resolve_api_key_plain() {
+        let def = CustomProviderDef {
+            api_key: Some("plain-key".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(def.resolve_api_key().as_deref(), Some("plain-key"));
+    }
+
+    #[test]
+    fn custom_provider_def_with_streaming_settings() {
+        let json = r#"{
+            "name": "Test",
+            "apiBase": "https://example.com/v1",
+            "streaming": false,
+            "includeUsageInStream": false,
+            "reasoningField": "reasoning_content"
+        }"#;
+        let def: CustomProviderDef = serde_json::from_str(json).unwrap();
+        assert_eq!(def.streaming, Some(false));
+        assert_eq!(def.include_usage_in_stream, Some(false));
+        assert_eq!(def.reasoning_field.as_deref(), Some("reasoning_content"));
+    }
+
+    #[test]
+    fn custom_model_def_with_variants() {
+        let json = r#"{
+            "contextWindow": 230000,
+            "maxOutputTokens": 32072,
+            "variants": {
+                "max": { "reasoningEffort": "max" },
+                "none": { "reasoningEffort": "none" }
+            }
+        }"#;
+        let model: CustomModelDef = serde_json::from_str(json).unwrap();
+        assert_eq!(model.context_window, Some(230000));
+        assert_eq!(model.variants.len(), 2);
+        assert_eq!(
+            model
+                .variants
+                .get("max")
+                .unwrap()
+                .reasoning_effort
+                .as_deref(),
+            Some("max")
+        );
+    }
+
+    #[test]
+    fn settings_deserialize_with_custom_providers() {
+        let json = r#"{
+            "customProviders": {
+                "my-gateway": {
+                    "name": "My Gateway",
+                    "apiBase": "https://gw.example.com/v1",
+                    "models": {
+                        "model-a": { "name": "Model A" }
+                    }
+                }
+            }
+        }"#;
+        let settings: Settings = serde_json::from_str(json).unwrap();
+        assert_eq!(settings.custom_providers.len(), 1);
+        let provider = settings.custom_providers.get("my-gateway").unwrap();
+        assert_eq!(provider.name, "My Gateway");
+        assert_eq!(provider.models.len(), 1);
+    }
+
+    #[test]
+    fn auto_poke_enabled_default_true() {
+        let json = r#"{}"#;
+        let settings: Settings = serde_json::from_str(json).unwrap();
+        assert!(settings.auto_poke_enabled);
     }
 }

--- a/src-rust/crates/query/src/agent_tool.rs
+++ b/src-rust/crates/query/src/agent_tool.rs
@@ -372,6 +372,7 @@ impl Tool for AgentTool {
             // Sub-agents run to their own completion and never drive goal
             // continuation — stop after one turn like every non-goal run.
             continuation: crate::continuation::ContinuationMode::Default,
+            degradation_enabled: true,
         };
         // -----------------------------------------------------------------------
         // Background mode: spawn and return agent_id immediately.

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -95,6 +95,10 @@ pub struct QueryConfig {
     pub model: String,
     pub max_tokens: u32,
     pub max_turns: u32,
+    /// Whether the max-steps graceful degradation summary turn is enabled.
+    /// When `false`, exceeding `max_turns` returns cold (last assistant
+    /// message) instead of running a final tool-less summary turn.
+    pub degradation_enabled: bool,
     pub system_prompt: Option<String>,
     pub append_system_prompt: Option<String>,
     pub output_style: claurst_core::system_prompt::OutputStyle,
@@ -174,6 +178,7 @@ impl Default for QueryConfig {
             model: claurst_core::constants::DEFAULT_MODEL.to_string(),
             max_tokens: claurst_core::constants::DEFAULT_MAX_TOKENS,
             max_turns: claurst_core::constants::MAX_TURNS_DEFAULT,
+            degradation_enabled: true,
             system_prompt: None,
             append_system_prompt: None,
             output_style: claurst_core::system_prompt::OutputStyle::Default,
@@ -210,6 +215,7 @@ impl QueryConfig {
                 .as_ref()
                 .map(|p| p.display().to_string()),
             managed_agents: cfg.managed_agents.clone(),
+            degradation_enabled: cfg.degradation_summary_enabled,
             ..Default::default()
         }
     }
@@ -231,6 +237,7 @@ impl QueryConfig {
                 .as_ref()
                 .map(|p| p.display().to_string()),
             managed_agents: cfg.managed_agents.clone(),
+            degradation_enabled: cfg.degradation_summary_enabled,
             ..Default::default()
         }
     }
@@ -471,6 +478,21 @@ pub async fn run_query_loop(
         // dispatched exactly once, and re-exceeding the cap afterwards returns
         // cold. Applies to both goal and non-goal runs.
         let degradation_turn = if turn > effective_max_turns {
+            if !config.degradation_enabled {
+                info!(
+                    turns = turn,
+                    max = effective_max_turns,
+                    "Max turns reached — degradation disabled, returning cold"
+                );
+                let last_msg = messages
+                    .last()
+                    .cloned()
+                    .unwrap_or_else(|| Message::assistant("Max turns reached."));
+                return QueryOutcome::EndTurn {
+                    message: last_msg,
+                    usage: UsageInfo::default(),
+                };
+            }
             if degradation_done {
                 info!(
                     turns = turn,
@@ -835,10 +857,16 @@ pub async fn run_query_loop(
                 if known_providers.contains(&p) {
                     (p.to_string(), m.to_string())
                 } else {
-                    // Treat the whole string as the model ID, fall through
-                    // to auto-detection below.
-                    let fallback_provider = tool_ctx.config.provider.as_deref().unwrap_or("anthropic");
-                    (fallback_provider.to_string(), effective_model.clone())
+                    // Check whether `p` is a user-defined custom provider id.
+                    let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+                    if settings.custom_providers.contains_key(p) {
+                        (p.to_string(), m.to_string())
+                    } else {
+                        // Treat the whole string as the model ID, fall through
+                        // to auto-detection below.
+                        let fallback_provider = tool_ctx.config.provider.as_deref().unwrap_or("anthropic");
+                        (fallback_provider.to_string(), effective_model.clone())
+                    }
                 }
             } else {
                 // No explicit provider set (or set to "anthropic"): try the
@@ -971,12 +999,28 @@ pub async fn run_query_loop(
                         })
                         .collect();
 
+                    // Cap max_tokens by the custom model's `maxOutputTokens`
+                    // when the model belongs to a user-defined custom provider.
+                    let effective_max_tokens = {
+                        let mut tok = config.max_tokens;
+                        if let Ok(settings) = claurst_core::Settings::load_sync() {
+                            if let Some(cp) = settings.custom_providers.get(&provider_id_str) {
+                                if let Some(model_def) = cp.models.get(&model_id_str) {
+                                    if let Some(cap) = model_def.max_output_tokens {
+                                        tok = tok.min(cap);
+                                    }
+                                }
+                            }
+                        }
+                        tok
+                    };
+
                     let provider_request = claurst_api::ProviderRequest {
                         model: model_id_str.to_owned(),
                         messages: provider_messages,
                         system_prompt: Some(system_for_provider.clone()),
                         tools: provider_tools,
-                        max_tokens: config.max_tokens,
+                        max_tokens: effective_max_tokens,
                         temperature: effective_temperature.map(|t| t as f64),
                         top_p: None,
                         top_k: None,
@@ -2413,6 +2457,79 @@ mod tests {
         // both must be treated as OpenAI-compatible providers.
         assert!(is_openaiish_provider("alibaba"));
         assert!(is_openaiish_provider("qwen"));
+    }
+
+    #[test]
+    fn is_openaiish_provider_unknown_id_returns_false() {
+        // When a custom provider is registered in settings, is_openaiish_provider
+        // should return true even though it's not in the hardcoded list.
+        // This test uses a unique id unlikely to collide with real settings.
+        // Note: This test depends on no settings.json having this id;
+        // it verifies the fallback (no custom provider → matches! list).
+        let result = is_openaiish_provider("definitely-not-a-real-provider-99999");
+        assert!(!result);
+    }
+
+    #[test]
+    fn known_providers_includes_custom_provider_runtime_check() {
+        // The runtime check for custom providers should not crash and
+        // should not return true for arbitrary unknown strings.
+        // This is a negative test — no custom provider "fake-provider-xyz"
+        // should exist in settings.
+        let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+        assert!(!settings.custom_providers.contains_key("fake-provider-xyz-12345"));
+    }
+
+#[test]
+    fn build_provider_options_custom_provider_reasoning_effort_fallback() {
+        // Bug 2: reasoningEffort from CustomModelDef should be sent for
+        // non-GPT models on custom providers. We set CLAURST_HOME to a
+        // temp dir with a settings.json containing a custom provider whose
+        // model has reasoningEffort: "high", then verify build_provider_options
+        // emits it even though the model is not a GPT reasoning model.
+        use std::sync::Mutex as StdMutex;
+
+        static ENV_LOCK: StdMutex<()> = StdMutex::new(());
+        let _guard = ENV_LOCK.lock().unwrap();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let settings_json = serde_json::json!({
+            "customProviders": {
+                "test-cp-reasoning": {
+                    "name": "Test CP",
+                    "apiBase": "https://example.com/v1",
+                    "models": {
+                        "revolut-ca/glm-5-2": {
+                            "reasoningEffort": "high",
+                            "maxOutputTokens": 32000
+                        }
+                    }
+                }
+            }
+        });
+        std::fs::write(
+            tmp.path().join("settings.json"),
+            serde_json::to_string_pretty(&settings_json).unwrap(),
+        )
+        .unwrap();
+
+        let old = std::env::var_os("CLAURST_HOME");
+        std::env::set_var("CLAURST_HOME", tmp.path());
+
+        let options = build_provider_options(
+            "test-cp-reasoning",
+            "revolut-ca/glm-5-2",
+            None,
+            None,
+        );
+
+        // Restore env immediately.
+        match old {
+            Some(v) => std::env::set_var("CLAURST_HOME", v),
+            None => std::env::remove_var("CLAURST_HOME"),
+        }
+
+        assert_eq!(options["reasoningEffort"], serde_json::json!("high"));
     }
 
     // ---- apply_compact_result / #213 data-loss guard ------------------------

--- a/src-rust/crates/query/src/runner/provider_options.rs
+++ b/src-rust/crates/query/src/runner/provider_options.rs
@@ -52,6 +52,12 @@ pub(crate) fn is_openai_reasoning_model(model_id: &str) -> bool {
 }
 
 pub(crate) fn is_openaiish_provider(provider_id: &str) -> bool {
+    // Custom providers from Settings are always OpenAI-compatible.
+    if let Ok(settings) = claurst_core::Settings::load_sync() {
+        if settings.custom_providers.contains_key(provider_id) {
+            return true;
+        }
+    }
     matches!(
         provider_id,
         "openai"
@@ -262,6 +268,26 @@ pub(crate) fn build_provider_options(
                         options.insert(
                             "thinking".to_string(),
                             serde_json::json!({"type": "disabled"}),
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    // Fallback for custom (user-defined) providers: when the model is not a
+    // GPT reasoning model (so the block above did not insert `reasoningEffort`),
+    // check the model definition in Settings for a `reasoningEffort` override
+    // and apply it. This lets non-GPT models on custom providers (e.g. GLM-5.2)
+    // still send `reasoningEffort` to the API.
+    if !options.contains_key("reasoningEffort") {
+        if let Ok(settings) = claurst_core::Settings::load_sync() {
+            if let Some(cp) = settings.custom_providers.get(provider_id) {
+                if let Some(model_def) = cp.models.get(&model_id) {
+                    if let Some(ref effort) = model_def.reasoning_effort {
+                        options.insert(
+                            "reasoningEffort".to_string(),
+                            serde_json::json!(effort),
                         );
                     }
                 }

--- a/src-rust/crates/tools/src/config_tool.rs
+++ b/src-rust/crates/tools/src/config_tool.rs
@@ -20,13 +20,21 @@ static SUPPORTED_SETTINGS: &[(&str, &str)] = &[
     ("model", "LLM model to use (e.g. 'claude-opus-4-6')"),
     ("max_tokens", "Maximum output tokens per response"),
     ("verbose", "Enable verbose logging (true/false)"),
-    ("permission_mode", "Permission mode: default | accept_edits | bypass_permissions | plan"),
-    ("auto_compact", "Auto-compact conversation when context fills (true/false)"),
+    (
+        "permission_mode",
+        "Permission mode: default | accept_edits | bypass_permissions | plan",
+    ),
+    (
+        "auto_compact",
+        "Auto-compact conversation when context fills (true/false)",
+    ),
 ];
 
 #[async_trait]
 impl Tool for ConfigTool {
-    fn name(&self) -> &str { "Config" }
+    fn name(&self) -> &str {
+        "Config"
+    }
 
     fn description(&self) -> &str {
         "Get or set Claurst configuration settings. Omit 'value' to read the current value. \
@@ -34,7 +42,9 @@ impl Tool for ConfigTool {
          Changes persist to ~/.claurst/settings.json."
     }
 
-    fn permission_level(&self) -> PermissionLevel { PermissionLevel::Write }
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::Write
+    }
 
     fn input_schema(&self) -> Value {
         json!({
@@ -66,10 +76,7 @@ impl Tool for ConfigTool {
                 .iter()
                 .map(|(k, d)| format!("  {} — {}", k, d))
                 .collect();
-            return ToolResult::success(format!(
-                "Supported settings:\n{}",
-                lines.join("\n")
-            ));
+            return ToolResult::success(format!("Supported settings:\n{}", lines.join("\n")));
         }
 
         // Load current settings
@@ -95,7 +102,11 @@ impl Tool for ConfigTool {
                 "max_tokens" => {
                     let n = match new_value.as_u64() {
                         Some(n) => n as u32,
-                        None => return ToolResult::error("'max_tokens' must be a positive integer".to_string()),
+                        None => {
+                            return ToolResult::error(
+                                "'max_tokens' must be a positive integer".to_string(),
+                            )
+                        }
                     };
                     settings.config.max_tokens = Some(n);
                     if let Err(e) = settings.save().await {
@@ -106,7 +117,9 @@ impl Tool for ConfigTool {
                 "verbose" => {
                     let b = match new_value.as_bool() {
                         Some(b) => b,
-                        None => return ToolResult::error("'verbose' must be true or false".to_string()),
+                        None => {
+                            return ToolResult::error("'verbose' must be true or false".to_string())
+                        }
                     };
                     settings.config.verbose = b;
                     if let Err(e) = settings.save().await {
@@ -117,7 +130,11 @@ impl Tool for ConfigTool {
                 "auto_compact" => {
                     let b = match new_value.as_bool() {
                         Some(b) => b,
-                        None => return ToolResult::error("'auto_compact' must be true or false".to_string()),
+                        None => {
+                            return ToolResult::error(
+                                "'auto_compact' must be true or false".to_string(),
+                            )
+                        }
                     };
                     settings.config.auto_compact = b;
                     if let Err(e) = settings.save().await {
@@ -129,7 +146,11 @@ impl Tool for ConfigTool {
                     use claurst_core::config::PermissionMode;
                     let s = match new_value.as_str() {
                         Some(s) => s,
-                        None => return ToolResult::error("'permission_mode' must be a string".to_string()),
+                        None => {
+                            return ToolResult::error(
+                                "'permission_mode' must be a string".to_string(),
+                            )
+                        }
                     };
                     let mode = match s {
                         "default" => PermissionMode::Default,
@@ -167,14 +188,10 @@ impl Tool for ConfigTool {
                     "max_tokens = {}",
                     settings.config.effective_max_tokens()
                 )),
-                "verbose" => ToolResult::success(format!(
-                    "verbose = {}",
-                    settings.config.verbose
-                )),
-                "auto_compact" => ToolResult::success(format!(
-                    "auto_compact = {}",
-                    settings.config.auto_compact
-                )),
+                "verbose" => ToolResult::success(format!("verbose = {}", settings.config.verbose)),
+                "auto_compact" => {
+                    ToolResult::success(format!("auto_compact = {}", settings.config.auto_compact))
+                }
                 "permission_mode" => ToolResult::success(format!(
                     "permission_mode = \"{}\"",
                     permission_mode_str(&settings.config.permission_mode)

--- a/src-rust/crates/tools/src/todo_write.rs
+++ b/src-rust/crates/tools/src/todo_write.rs
@@ -139,6 +139,33 @@ struct TodoItem {
     #[serde(default)]
     #[allow(dead_code)]
     priority: Option<String>,
+    /// Optional 0-100 estimate of the evidence that this task can be
+    /// completed correctly.
+    #[serde(default, deserialize_with = "deserialize_confidence")]
+    confidence: Option<u8>,
+    /// Optional 0-100 estimate recorded when a task is completed.
+    #[serde(default, deserialize_with = "deserialize_confidence")]
+    completion_confidence: Option<u8>,
+}
+
+fn deserialize_confidence<'de, D>(deserializer: D) -> Result<Option<u8>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Value::deserialize(deserializer)?;
+    let score = match value {
+        Value::Null => return Ok(None),
+        Value::Number(number) => number.as_f64(),
+        Value::String(raw) if raw.trim().is_empty() => return Ok(None),
+        Value::String(raw) => raw.trim().parse::<f64>().ok(),
+        _ => None,
+    };
+    let score = score
+        .filter(|score| {
+            score.is_finite() && score.fract() == 0.0 && (0.0..=100.0).contains(score)
+        })
+        .ok_or_else(|| serde::de::Error::custom("confidence must be an integer from 0 to 100"))?;
+    Ok(Some(score as u8))
 }
 
 // ---------------------------------------------------------------------------
@@ -189,7 +216,8 @@ impl Tool for TodoWriteTool {
     fn description(&self) -> &str {
         "Write and manage a todo/task list. Provide the complete list of todos \
          each time (this replaces the entire list). Use this to track progress \
-         on multi-step tasks."
+         on multi-step tasks. Each item may include a confidence percentage from \
+         0 to 100, plus a completion_confidence percentage when completed."
     }
 
     fn permission_level(&self) -> PermissionLevel {
@@ -211,7 +239,19 @@ impl Tool for TodoWriteTool {
                                 "type": "string",
                                 "enum": ["pending", "in_progress", "completed"]
                             },
-                            "priority": { "type": "string" }
+                            "priority": { "type": "string" },
+                            "confidence": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 100,
+                                "description": "Optional confidence percentage that this task can be completed correctly."
+                            },
+                            "completion_confidence": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 100,
+                                "description": "Optional confidence percentage recorded when this task is completed."
+                            }
                         },
                         "required": ["id", "content", "status"]
                     },
@@ -310,6 +350,12 @@ impl Tool for TodoWriteTool {
                 TodoStatus::Completed => "[x]",
             };
             output.push_str(&format!("{} {} ({})\n", icon, item.content, item.id));
+            if let Some(confidence) = item.confidence {
+                output.push_str(&format!("    confidence: {}%\n", confidence));
+            }
+            if let Some(confidence) = item.completion_confidence {
+                output.push_str(&format!("    completion confidence: {}%\n", confidence));
+            }
         }
 
         // --- 6. Persist to disk ----------------------------------------------
@@ -324,6 +370,12 @@ impl Tool for TodoWriteTool {
                 });
                 if let Some(ref p) = t.priority {
                     obj["priority"] = json!(p);
+                }
+                if let Some(confidence) = t.confidence {
+                    obj["confidence"] = json!(confidence);
+                }
+                if let Some(confidence) = t.completion_confidence {
+                    obj["completion_confidence"] = json!(confidence);
                 }
                 obj
             })
@@ -425,6 +477,46 @@ mod tests {
         assert_eq!(loaded[0]["id"].as_str(), Some("1"));
         assert_eq!(loaded[1]["status"].as_str(), Some("completed"));
         // tempdir cleans up automatically.
+    }
+
+    #[test]
+    fn test_confidence_accepts_integer_and_numeric_string() {
+        let input: TodoWriteInput = serde_json::from_value(json!({
+            "todos": [
+                {
+                    "id": "1",
+                    "content": "Task one",
+                    "status": "pending",
+                    "confidence": 80
+                },
+                {
+                    "id": "2",
+                    "content": "Task two",
+                    "status": "completed",
+                    "confidence": "70",
+                    "completion_confidence": 95.0
+                }
+            ]
+        }))
+        .expect("valid confidence values should parse");
+
+        assert_eq!(input.todos[0].confidence, Some(80));
+        assert_eq!(input.todos[1].confidence, Some(70));
+        assert_eq!(input.todos[1].completion_confidence, Some(95));
+    }
+
+    #[test]
+    fn test_confidence_rejects_values_outside_percentage_range() {
+        let result = serde_json::from_value::<TodoWriteInput>(json!({
+            "todos": [{
+                "id": "1",
+                "content": "Task",
+                "status": "pending",
+                "confidence": 101
+            }]
+        }));
+
+        assert!(result.is_err());
     }
 
     // --- Status parsing ------------------------------------------------------

--- a/src-rust/crates/tools/src/todo_write.rs
+++ b/src-rust/crates/tools/src/todo_write.rs
@@ -139,33 +139,28 @@ struct TodoItem {
     #[serde(default)]
     #[allow(dead_code)]
     priority: Option<String>,
-    /// Optional 0-100 estimate of the evidence that this task can be
-    /// completed correctly.
-    #[serde(default, deserialize_with = "deserialize_confidence")]
+    // --- NEW FIELDS ---
+    #[serde(default)]
+    #[allow(dead_code)]
+    group: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
     confidence: Option<u8>,
-    /// Optional 0-100 estimate recorded when a task is completed.
-    #[serde(default, deserialize_with = "deserialize_confidence")]
+    #[serde(default)]
+    #[allow(dead_code)]
     completion_confidence: Option<u8>,
-}
-
-fn deserialize_confidence<'de, D>(deserializer: D) -> Result<Option<u8>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value = Value::deserialize(deserializer)?;
-    let score = match value {
-        Value::Null => return Ok(None),
-        Value::Number(number) => number.as_f64(),
-        Value::String(raw) if raw.trim().is_empty() => return Ok(None),
-        Value::String(raw) => raw.trim().parse::<f64>().ok(),
-        _ => None,
-    };
-    let score = score
-        .filter(|score| {
-            score.is_finite() && score.fract() == 0.0 && (0.0..=100.0).contains(score)
-        })
-        .ok_or_else(|| serde::de::Error::custom("confidence must be an integer from 0 to 100"))?;
-    Ok(Some(score as u8))
+    #[serde(default)]
+    #[allow(dead_code)]
+    confidence_history: Vec<u8>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    blocked_by: Vec<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    assigned_to: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    force_reopen: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -182,23 +177,20 @@ where
 /// Forbidden:
 ///   completed   → anything      ✗  (completed tasks cannot be reopened)
 ///   in_progress → pending       ✗  (cannot move backwards)
-fn validate_transition(id: &str, old: &TodoStatus, new: &TodoStatus) -> Result<(), String> {
+fn validate_transition(id: &str, old: &TodoStatus, new: &TodoStatus, force_reopen: bool) -> Result<(), String> {
     if old == new {
         return Ok(());
     }
     match (old, new) {
-        // Completed tasks are immutable.
-        (TodoStatus::Completed, _) => Err(format!(
-            "Task {:?}: cannot change status of a completed task (currently \"completed\" → \"{}\").",
+        (TodoStatus::Completed, _) if !force_reopen => Err(format!(
+            "Task {:?}: cannot change status of a completed task (currently \"completed\" → \"{}\"). Use force_reopen: true if poke verification found a false completion.",
             id, new
         )),
-        // Cannot move in_progress backwards to pending.
+        (TodoStatus::Completed, _) if force_reopen => Ok(()), // Force reopen allowed
         (TodoStatus::InProgress, TodoStatus::Pending) => Err(format!(
             "Task {:?}: cannot move status backwards (\"in_progress\" → \"pending\").",
             id
         )),
-        // All other transitions (pending→in_progress, pending→completed,
-        // in_progress→completed) are valid.
         _ => Ok(()),
     }
 }
@@ -216,8 +208,7 @@ impl Tool for TodoWriteTool {
     fn description(&self) -> &str {
         "Write and manage a todo/task list. Provide the complete list of todos \
          each time (this replaces the entire list). Use this to track progress \
-         on multi-step tasks. Each item may include a confidence percentage from \
-         0 to 100, plus a completion_confidence percentage when completed."
+         on multi-step tasks."
     }
 
     fn permission_level(&self) -> PermissionLevel {
@@ -240,18 +231,13 @@ impl Tool for TodoWriteTool {
                                 "enum": ["pending", "in_progress", "completed"]
                             },
                             "priority": { "type": "string" },
-                            "confidence": {
-                                "type": "integer",
-                                "minimum": 0,
-                                "maximum": 100,
-                                "description": "Optional confidence percentage that this task can be completed correctly."
-                            },
-                            "completion_confidence": {
-                                "type": "integer",
-                                "minimum": 0,
-                                "maximum": 100,
-                                "description": "Optional confidence percentage recorded when this task is completed."
-                            }
+                            "group": { "type": "string" },
+                            "confidence": { "type": "integer", "minimum": 0, "maximum": 100 },
+                            "completion_confidence": { "type": "integer", "minimum": 0, "maximum": 100 },
+                            "confidence_history": { "type": "array", "items": { "type": "integer" } },
+                            "blocked_by": { "type": "array", "items": { "type": "string" } },
+                            "assigned_to": { "type": "string" },
+                            "force_reopen": { "type": "boolean" }
                         },
                         "required": ["id", "content", "status"]
                     },
@@ -307,7 +293,7 @@ impl Tool for TodoWriteTool {
             match existing.get(item.id.as_str()) {
                 Some(old_status) => {
                     // Existing task — validate the transition.
-                    if let Err(e) = validate_transition(&item.id, old_status, &item.status) {
+                    if let Err(e) = validate_transition(&item.id, old_status, &item.status, item.force_reopen) {
                         return ToolResult::error(e);
                     }
                     if old_status != &TodoStatus::Completed
@@ -350,12 +336,6 @@ impl Tool for TodoWriteTool {
                 TodoStatus::Completed => "[x]",
             };
             output.push_str(&format!("{} {} ({})\n", icon, item.content, item.id));
-            if let Some(confidence) = item.confidence {
-                output.push_str(&format!("    confidence: {}%\n", confidence));
-            }
-            if let Some(confidence) = item.completion_confidence {
-                output.push_str(&format!("    completion confidence: {}%\n", confidence));
-            }
         }
 
         // --- 6. Persist to disk ----------------------------------------------
@@ -371,11 +351,25 @@ impl Tool for TodoWriteTool {
                 if let Some(ref p) = t.priority {
                     obj["priority"] = json!(p);
                 }
-                if let Some(confidence) = t.confidence {
-                    obj["confidence"] = json!(confidence);
+                if let Some(ref g) = t.group {
+                    obj["group"] = json!(g);
                 }
-                if let Some(confidence) = t.completion_confidence {
-                    obj["completion_confidence"] = json!(confidence);
+                if let Some(c) = t.confidence {
+                    obj["confidence"] = json!(c);
+                }
+                if let Some(c) = t.completion_confidence {
+                    obj["completion_confidence"] = json!(c);
+                }
+                if !t.confidence_history.is_empty() {
+                    // Cap at 20 entries (ring buffer).
+                    let history: Vec<u8> = t.confidence_history.iter().rev().take(20).copied().collect::<Vec<u8>>().into_iter().rev().collect();
+                    obj["confidence_history"] = json!(history);
+                }
+                if !t.blocked_by.is_empty() {
+                    obj["blocked_by"] = json!(t.blocked_by);
+                }
+                if let Some(ref a) = t.assigned_to {
+                    obj["assigned_to"] = json!(a);
                 }
                 obj
             })
@@ -420,6 +414,62 @@ impl Tool for TodoWriteTool {
         }))
     }
 }
+
+// ---------------------------------------------------------------------------
+// Auto-poke mechanism (ported from jcode)
+// ---------------------------------------------------------------------------
+
+/// Build the synthetic continuation message sent when the model stops with
+/// incomplete todos. The message instructs the model to continue working.
+pub fn build_auto_poke_message(incomplete_count: usize) -> String {
+    format!(
+        "You have {} incomplete todo{}. Continue working, or update the todo tool.",
+        incomplete_count,
+        if incomplete_count == 1 { "" } else { "s" },
+    )
+}
+
+/// Check whether a message is an auto-poke synthetic continuation prompt.
+/// Used by the TUI to hide the raw message and show "Auto-poking..." instead.
+pub fn is_auto_poke_message(message: &str) -> bool {
+    message.starts_with("You have ")
+        && message.contains(" incomplete todo")
+        && message.contains("Continue working, or update the todo tool.")
+}
+
+/// Count incomplete (pending + in_progress) todos for a session.
+pub fn count_incomplete_todos(session_id: &str) -> usize {
+    let todos = load_todos(session_id);
+    todos
+        .iter()
+        .filter_map(|t| t.get("status").and_then(|s| s.as_str()))
+        .filter(|s| *s == "pending" || *s == "in_progress")
+        .count()
+}
+
+/// Compute a hash of the current todo state (sorted [(id, status)] pairs).
+/// Used for no-progress detection: if the hash is unchanged for 3 consecutive
+/// turns, auto-poking stops.
+pub fn todo_state_hash(session_id: &str) -> String {
+    let todos = load_todos(session_id);
+    let mut pairs: Vec<(String, String)> = todos
+        .iter()
+        .filter_map(|t| {
+            let id = t.get("id").and_then(|v| v.as_str())?.to_string();
+            let status = t.get("status").and_then(|v| v.as_str())?.to_string();
+            Some((id, status))
+        })
+        .collect();
+    pairs.sort_by(|a, b| a.0.cmp(&b.0));
+    // Simple hash: concatenate id:status pairs.
+    pairs.iter().map(|(id, s)| format!("{}:{}", id, s)).collect::<Vec<_>>().join("|")
+}
+
+/// Maximum auto-pokes per session (safety budget).
+pub const MAX_AUTO_POKES: u32 = 48;
+
+/// No-progress threshold: stop after this many consecutive no-progress turns.
+pub const NO_PROGRESS_THRESHOLD: u32 = 3;
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -479,46 +529,6 @@ mod tests {
         // tempdir cleans up automatically.
     }
 
-    #[test]
-    fn test_confidence_accepts_integer_and_numeric_string() {
-        let input: TodoWriteInput = serde_json::from_value(json!({
-            "todos": [
-                {
-                    "id": "1",
-                    "content": "Task one",
-                    "status": "pending",
-                    "confidence": 80
-                },
-                {
-                    "id": "2",
-                    "content": "Task two",
-                    "status": "completed",
-                    "confidence": "70",
-                    "completion_confidence": 95.0
-                }
-            ]
-        }))
-        .expect("valid confidence values should parse");
-
-        assert_eq!(input.todos[0].confidence, Some(80));
-        assert_eq!(input.todos[1].confidence, Some(70));
-        assert_eq!(input.todos[1].completion_confidence, Some(95));
-    }
-
-    #[test]
-    fn test_confidence_rejects_values_outside_percentage_range() {
-        let result = serde_json::from_value::<TodoWriteInput>(json!({
-            "todos": [{
-                "id": "1",
-                "content": "Task",
-                "status": "pending",
-                "confidence": 101
-            }]
-        }));
-
-        assert!(result.is_err());
-    }
-
     // --- Status parsing ------------------------------------------------------
 
     #[test]
@@ -542,26 +552,26 @@ mod tests {
     #[test]
     fn test_valid_transitions() {
         // pending → in_progress
-        assert!(validate_transition("t1", &TodoStatus::Pending, &TodoStatus::InProgress).is_ok());
+        assert!(validate_transition("t1", &TodoStatus::Pending, &TodoStatus::InProgress, false).is_ok());
         // pending → completed
-        assert!(validate_transition("t2", &TodoStatus::Pending, &TodoStatus::Completed).is_ok());
+        assert!(validate_transition("t2", &TodoStatus::Pending, &TodoStatus::Completed, false).is_ok());
         // in_progress → completed
-        assert!(validate_transition("t3", &TodoStatus::InProgress, &TodoStatus::Completed).is_ok());
+        assert!(validate_transition("t3", &TodoStatus::InProgress, &TodoStatus::Completed, false).is_ok());
         // no-op transitions are always fine
-        assert!(validate_transition("t4", &TodoStatus::Pending, &TodoStatus::Pending).is_ok());
-        assert!(validate_transition("t5", &TodoStatus::InProgress, &TodoStatus::InProgress).is_ok());
-        assert!(validate_transition("t6", &TodoStatus::Completed, &TodoStatus::Completed).is_ok());
+        assert!(validate_transition("t4", &TodoStatus::Pending, &TodoStatus::Pending, false).is_ok());
+        assert!(validate_transition("t5", &TodoStatus::InProgress, &TodoStatus::InProgress, false).is_ok());
+        assert!(validate_transition("t6", &TodoStatus::Completed, &TodoStatus::Completed, false).is_ok());
     }
 
     #[test]
     fn test_invalid_transition_completed_to_anything() {
-        assert!(validate_transition("t1", &TodoStatus::Completed, &TodoStatus::Pending).is_err());
-        assert!(validate_transition("t2", &TodoStatus::Completed, &TodoStatus::InProgress).is_err());
+        assert!(validate_transition("t1", &TodoStatus::Completed, &TodoStatus::Pending, false).is_err());
+        assert!(validate_transition("t2", &TodoStatus::Completed, &TodoStatus::InProgress, false).is_err());
     }
 
     #[test]
     fn test_invalid_transition_in_progress_to_pending() {
-        assert!(validate_transition("t1", &TodoStatus::InProgress, &TodoStatus::Pending).is_err());
+        assert!(validate_transition("t1", &TodoStatus::InProgress, &TodoStatus::Pending, false).is_err());
     }
 
     // --- ID uniqueness -------------------------------------------------------
@@ -571,5 +581,78 @@ mod tests {
         let err = TodoStatus::from_str_ci("banana").unwrap_err();
         assert!(err.contains("Invalid status"), "error should mention invalid status");
         assert!(err.contains("banana"), "error should echo the bad value");
+    }
+
+    // --- Auto-poke ----------------------------------------------------------
+
+    #[test]
+    fn build_auto_poke_message_singular() {
+        let msg = build_auto_poke_message(1);
+        assert!(msg.contains("1 incomplete todo"));
+        assert!(!msg.contains("todos"));
+    }
+
+    #[test]
+    fn build_auto_poke_message_plural() {
+        let msg = build_auto_poke_message(5);
+        assert!(msg.contains("5 incomplete todos"));
+    }
+
+    #[test]
+    fn is_auto_poke_message_recognizes_poke() {
+        let msg = build_auto_poke_message(3);
+        assert!(is_auto_poke_message(&msg));
+    }
+
+    #[test]
+    fn is_auto_poke_message_rejects_normal() {
+        assert!(!is_auto_poke_message("Hello, can you help me?"));
+        assert!(!is_auto_poke_message("Continue working on the task."));
+    }
+
+    // --- TodoItem deserialization with new fields ----------------------------
+
+    #[test]
+    fn todo_item_deserialize_with_old_schema() {
+        let json = r#"{"id":"1","content":"Test","status":"pending"}"#;
+        let item: TodoItem = serde_json::from_str(json).unwrap();
+        assert_eq!(item.id, "1");
+        assert!(item.group.is_none());
+        assert!(item.confidence.is_none());
+        assert!(item.confidence_history.is_empty());
+        assert!(item.blocked_by.is_empty());
+        assert!(!item.force_reopen);
+    }
+
+    #[test]
+    fn todo_item_deserialize_with_new_schema() {
+        let json = r#"{
+            "id": "2",
+            "content": "New fields test",
+            "status": "in_progress",
+            "priority": "high",
+            "group": "Phase 1",
+            "confidence": 75,
+            "blocked_by": ["1"],
+            "force_reopen": false
+        }"#;
+        let item: TodoItem = serde_json::from_str(json).unwrap();
+        assert_eq!(item.group.as_deref(), Some("Phase 1"));
+        assert_eq!(item.confidence, Some(75));
+        assert_eq!(item.blocked_by, vec!["1"]);
+    }
+
+    // --- Force reopen transition --------------------------------------------
+
+    #[test]
+    fn validate_transition_force_reopen_allows_completed_to_pending() {
+        let result = validate_transition("test", &TodoStatus::Completed, &TodoStatus::Pending, true);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_transition_without_force_reopen_blocks_completed_to_pending() {
+        let result = validate_transition("test", &TodoStatus::Completed, &TodoStatus::Pending, false);
+        assert!(result.is_err());
     }
 }

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -3,15 +3,13 @@
 use crate::bridge_state::BridgeConnectionState;
 use crate::context_viz::ContextVizState;
 use crate::dialog_select::{DialogSelectState, SelectItem};
+use crate::dialogs::McpApprovalDialogState;
+use crate::dialogs::PermissionRequest;
+use crate::diff_viewer::{build_turn_diff, DiffViewerState};
 use crate::export_dialog::{ExportDialogState, ExportFormat};
 use crate::import_config_dialog::ImportConfigDialogState;
-use crate::dialogs::PermissionRequest;
-use crate::diff_viewer::{DiffViewerState, build_turn_diff};
-use crate::model_picker::{EffortLevel, ModelPickerState};
-use crate::session_browser::SessionBrowserState;
-use crate::tasks_overlay::TasksOverlay;
-use crate::dialogs::McpApprovalDialogState;
 use crate::mcp_view::{McpServerView, McpToolView, McpViewState, McpViewStatus};
+use crate::model_picker::{EffortLevel, ModelPickerState};
 use crate::notifications::{NotificationKind, NotificationQueue};
 use crate::overlays::{
     GlobalSearchState, HelpEntry, HelpOverlay, HistorySearchOverlay, MessageSelectorOverlay,
@@ -20,18 +18,23 @@ use crate::overlays::{
 use crate::plugin_views::PluginHintBanner;
 use crate::prompt_input::{InputMode, PromptInputState, VimMode};
 use crate::render;
+use crate::session_browser::SessionBrowserState;
 use crate::settings_screen::SettingsScreen;
 use crate::stats_dialog::StatsDialogState;
+use crate::tasks_overlay::TasksOverlay;
 use crate::theme_screen::ThemeScreen;
-use crate::{agents_view::{AgentInfo, AgentStatus, AgentsMenuState, AgentsRoute}, diff_viewer::DiffPane};
+use crate::{
+    agents_view::{AgentInfo, AgentStatus, AgentsMenuState, AgentsRoute},
+    diff_viewer::DiffPane,
+};
 use claurst_core::config::{Config, Settings, Theme};
 use claurst_core::cost::CostTracker;
 use claurst_core::file_history::FileHistory;
-use claurst_core::{sample_completion_verb, sample_spinner_verb};
 use claurst_core::keybindings::{
     KeyContext, KeybindingResolver, KeybindingResult, ParsedKeystroke, UserKeybindings,
 };
 use claurst_core::types::{ContentBlock, Message, Role};
+use claurst_core::{sample_completion_verb, sample_spinner_verb};
 use claurst_query::QueryEvent;
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use ratatui::backend::CrosstermBackend;
@@ -65,19 +68,34 @@ const PROMPT_SLASH_COMMANDS: &[(&str, &str)] = &[
     ("heapdump", "Show process memory and diagnostic information"),
     ("help", "Show help"),
     ("hooks", "Browse configured hooks (read-only)"),
-    ("import-config", "Import CLAUDE.md and settings.json from ~/.claude"),
+    (
+        "import-config",
+        "Import CLAUDE.md and settings.json from ~/.claude",
+    ),
     ("init", "Initialize AGENTS.md for this project"),
-    ("insights", "Generate a session analysis report with conversation statistics"),
+    (
+        "insights",
+        "Generate a session analysis report with conversation statistics",
+    ),
     ("keybindings", "Show keybinding configuration"),
     ("links", "Open URLs from this session in your browser"),
     ("login", "Log in to Claurst"),
     ("logout", "Log out of Claurst"),
-    ("managed-agents", "Configure manager-executor managed agent system"),
+    (
+        "managed-agents",
+        "Configure manager-executor managed agent system",
+    ),
     ("mcp", "Browse configured MCP servers"),
     ("memory", "Browse and open AGENTS.md memory files"),
     ("model", "Change the AI model"),
-    ("move", "Re-home this session to another worktree of the same project"),
-    ("new", "Start a fresh session (keeps model, provider & directory)"),
+    (
+        "move",
+        "Re-home this session to another worktree of the same project",
+    ),
+    (
+        "new",
+        "Start a fresh session (keeps model, provider & directory)",
+    ),
     ("output-style", "Show or switch the output style / persona"),
     ("plugin", "Manage plugins (list/info/enable/disable/reload)"),
     ("providers", "List available AI providers and their status"),
@@ -92,21 +110,41 @@ const PROMPT_SLASH_COMMANDS: &[(&str, &str)] = &[
     ("rewind", "Rewind to an earlier turn"),
     ("session", "Browse and manage sessions"),
     ("settings", "Open settings"),
-    ("share", "Upload the current session as a secret gist and get a shareable URL"),
+    (
+        "share",
+        "Upload the current session as a secret gist and get a shareable URL",
+    ),
     ("stats", "Open token and cost stats"),
     ("survey", "Open session feedback survey"),
     ("theme", "Open the theme picker"),
-    ("ultrareview", "Run an exhaustive multi-dimensional code review"),
-    ("update", "Check for updates and upgrade to the latest version"),
-    ("upgrade", "Check for updates and upgrade to the latest version"),
+    (
+        "ultrareview",
+        "Run an exhaustive multi-dimensional code review",
+    ),
+    (
+        "update",
+        "Check for updates and upgrade to the latest version",
+    ),
+    (
+        "upgrade",
+        "Check for updates and upgrade to the latest version",
+    ),
     ("vim", "Toggle vim keybindings"),
     ("voice", "Toggle voice input mode"),
+    (
+        "turns",
+        "Set or disable the max turn limit (e.g. /turns 25, /turns off)",
+    ),
 ];
 
 fn help_command_category(name: &str) -> &'static str {
     match name {
-        "connect" | "model" | "providers" | "refresh" | "fast" | "effort" | "voice" => "Model & Provider",
-        "changes" | "diff" | "review" | "rewind" | "export" | "copy" | "share" | "links" => "Review & History",
+        "connect" | "model" | "providers" | "refresh" | "fast" | "effort" | "voice" | "turns" => {
+            "Model & Provider"
+        }
+        "changes" | "diff" | "review" | "rewind" | "export" | "copy" | "share" | "links" => {
+            "Review & History"
+        }
         "stats" | "cost" | "context" | "insights" | "heapdump" | "doctor" => "Diagnostics",
         "config" | "settings" | "theme" | "keybindings" | "hooks" | "mcp" | "import-config" => {
             "Workspace"
@@ -213,7 +251,6 @@ fn get_url_for_provider(id: &str) -> &'static str {
     }
 }
 
-
 fn import_config_picker_items() -> Vec<SelectItem> {
     vec![
         SelectItem {
@@ -241,63 +278,407 @@ fn import_config_picker_items() -> Vec<SelectItem> {
 }
 
 fn provider_picker_items() -> Vec<SelectItem> {
-    vec![
-        SelectItem { id: "free".into(), title: "Free Mode".into(), description: "OpenCode Zen → OpenRouter free fallback (no spend)".into(), category: "Popular".into(), badge: Some("FREE".into()) },
-        SelectItem { id: "openai".into(), title: "OpenAI".into(), description: "(API key)".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "openai-codex".into(), title: "OpenAI Codex".into(), description: "(ChatGPT Plus/Pro — browser login)".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "github-copilot".into(), title: "GitHub Copilot".into(), description: "(GitHub subscription or token)".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "google".into(), title: "Google".into(), description: "(API key)".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "anthropic".into(), title: "Anthropic".into(), description: "(API key)".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "anthropic-oauth".into(), title: "Anthropic (Claude Pro/Max)".into(), description: "(subscription — browser login; draws from extra-usage)".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "custom-openai".into(), title: "Custom OpenAI-Compatible".into(), description: "Custom URL + API key".into(), category: "Advanced".into(), badge: None },
-        SelectItem { id: "openrouter".into(), title: "OpenRouter".into(), description: "100+ models with one key".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "vercel".into(), title: "Vercel AI Gateway".into(), description: "Gateway for AI SDK models".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "groq".into(), title: "Groq".into(), description: "Fast hosted inference".into(), category: "Popular".into(), badge: Some("FREE".into()) },
-        SelectItem { id: "ollama".into(), title: "Ollama".into(), description: "Local inference + cloud models".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "zai".into(), title: "Z.AI".into(), description: "GLM-5.1 / GLM-5 / GLM-4.7 Coding Plan".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "opencode-go".into(), title: "OpenCode Go".into(), description: "$10/mo flat-rate · Kimi · DeepSeek · GLM · MiniMax".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "opencode-zen".into(), title: "OpenCode Zen".into(), description: "Free models + paid · Nemotron · Ring · MiniMax · DeepSeek".into(), category: "Popular".into(), badge: Some("FREE".into()) },
-        SelectItem { id: "synthetic".into(), title: "Synthetic.dev".into(), description: "Hosted open weights".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "routing".into(), title: "routing.run".into(), description: "Hosted open weights · DeepSeek · Llama · Mixtral · Qwen".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "neuralwatt".into(), title: "NeuralWatt".into(), description: "Hosted open weights - energy-efficient".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "cerebras".into(), title: "Cerebras".into(), description: "Fast hosted inference".into(), category: "Other".into(), badge: Some("FREE".into()) },
-        SelectItem { id: "sambanova".into(), title: "SambaNova".into(), description: "Fast hosted inference".into(), category: "Other".into(), badge: Some("FREE".into()) },
-        SelectItem { id: "lmstudio".into(), title: "LM Studio".into(), description: "Local model server".into(), category: "Other".into(), badge: Some("LOCAL".into()) },
-        SelectItem { id: "llamacpp".into(), title: "llama.cpp".into(), description: "Local inference server".into(), category: "Other".into(), badge: Some("LOCAL".into()) },
-        SelectItem { id: "deepseek".into(), title: "DeepSeek".into(), description: "Reasoning and coding models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "mistral".into(), title: "Mistral".into(), description: "Hosted Mistral models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "togetherai".into(), title: "Together AI".into(), description: "Open model hosting".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "perplexity".into(), title: "Perplexity".into(), description: "Search-augmented models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "cohere".into(), title: "Cohere".into(), description: "Command models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "xai".into(), title: "xAI".into(), description: "Grok models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "deepinfra".into(), title: "DeepInfra".into(), description: "Hosted open models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "azure".into(), title: "Azure OpenAI".into(), description: "Enterprise OpenAI deployments".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "amazon-bedrock".into(), title: "AWS Bedrock".into(), description: "Enterprise foundation models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "google-vertex".into(), title: "Google Vertex AI".into(), description: "Enterprise Google models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "sap-ai-core".into(), title: "SAP AI Core".into(), description: "Enterprise AI platform".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "gitlab".into(), title: "GitLab Duo".into(), description: "AI in GitLab".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "cloudflare-ai-gateway".into(), title: "Cloudflare AI Gateway".into(), description: "Gateway for multiple providers".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "cloudflare-workers-ai".into(), title: "Cloudflare Workers AI".into(), description: "Edge AI inference".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "helicone".into(), title: "Helicone".into(), description: "AI gateway and observability".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "huggingface".into(), title: "Hugging Face".into(), description: "Hosted community models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "nvidia".into(), title: "NVIDIA".into(), description: "Hosted NVIDIA models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "alibaba".into(), title: "Alibaba".into(), description: "Qwen and hosted models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "venice".into(), title: "Venice AI".into(), description: "Privacy-first AI".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "moonshotai".into(), title: "Moonshot AI".into(), description: "Hosted Moonshot models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "zhipuai".into(), title: "Zhipu AI".into(), description: "Hosted GLM models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "siliconflow".into(), title: "SiliconFlow".into(), description: "Hosted open models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "nebius".into(), title: "Nebius".into(), description: "Cloud inference".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "novita".into(), title: "Novita".into(), description: "Cloud inference".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "minimax".into(), title: "MiniMax".into(), description: "Anthropic-compatible (M3)".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "ovhcloud".into(), title: "OVHcloud".into(), description: "EU-hosted AI".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "scaleway".into(), title: "Scaleway".into(), description: "EU cloud AI".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "vultr".into(), title: "Vultr".into(), description: "Cloud inference".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "baseten".into(), title: "Baseten".into(), description: "Model serving".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "friendli".into(), title: "Friendli".into(), description: "Serverless inference".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "upstage".into(), title: "Upstage".into(), description: "Hosted Upstage models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "stepfun".into(), title: "StepFun".into(), description: "Hosted reasoning models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "fireworks".into(), title: "Fireworks AI".into(), description: "Fast inference".into(), category: "Other".into(), badge: None },
-    ]
+    let mut items = vec![
+        SelectItem {
+            id: "free".into(),
+            title: "Free Mode".into(),
+            description: "OpenCode Zen → OpenRouter free fallback (no spend)".into(),
+            category: "Popular".into(),
+            badge: Some("FREE".into()),
+        },
+        SelectItem {
+            id: "openai".into(),
+            title: "OpenAI".into(),
+            description: "(API key)".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "openai-codex".into(),
+            title: "OpenAI Codex".into(),
+            description: "(ChatGPT Plus/Pro — browser login)".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "github-copilot".into(),
+            title: "GitHub Copilot".into(),
+            description: "(GitHub subscription or token)".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "google".into(),
+            title: "Google".into(),
+            description: "(API key)".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "anthropic".into(),
+            title: "Anthropic".into(),
+            description: "(API key)".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "anthropic-oauth".into(),
+            title: "Anthropic (Claude Pro/Max)".into(),
+            description: "(subscription — browser login; draws from extra-usage)".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "custom-openai".into(),
+            title: "Custom OpenAI-Compatible".into(),
+            description: "Custom URL + API key".into(),
+            category: "Advanced".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "openrouter".into(),
+            title: "OpenRouter".into(),
+            description: "100+ models with one key".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "vercel".into(),
+            title: "Vercel AI Gateway".into(),
+            description: "Gateway for AI SDK models".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "groq".into(),
+            title: "Groq".into(),
+            description: "Fast hosted inference".into(),
+            category: "Popular".into(),
+            badge: Some("FREE".into()),
+        },
+        SelectItem {
+            id: "ollama".into(),
+            title: "Ollama".into(),
+            description: "Local inference + cloud models".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "zai".into(),
+            title: "Z.AI".into(),
+            description: "GLM-5.1 / GLM-5 / GLM-4.7 Coding Plan".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "opencode-go".into(),
+            title: "OpenCode Go".into(),
+            description: "$10/mo flat-rate · Kimi · DeepSeek · GLM · MiniMax".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "opencode-zen".into(),
+            title: "OpenCode Zen".into(),
+            description: "Free models + paid · Nemotron · Ring · MiniMax · DeepSeek".into(),
+            category: "Popular".into(),
+            badge: Some("FREE".into()),
+        },
+        SelectItem {
+            id: "synthetic".into(),
+            title: "Synthetic.dev".into(),
+            description: "Hosted open weights".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "routing".into(),
+            title: "routing.run".into(),
+            description: "Hosted open weights · DeepSeek · Llama · Mixtral · Qwen".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "neuralwatt".into(),
+            title: "NeuralWatt".into(),
+            description: "Hosted open weights - energy-efficient".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "cerebras".into(),
+            title: "Cerebras".into(),
+            description: "Fast hosted inference".into(),
+            category: "Other".into(),
+            badge: Some("FREE".into()),
+        },
+        SelectItem {
+            id: "sambanova".into(),
+            title: "SambaNova".into(),
+            description: "Fast hosted inference".into(),
+            category: "Other".into(),
+            badge: Some("FREE".into()),
+        },
+        SelectItem {
+            id: "lmstudio".into(),
+            title: "LM Studio".into(),
+            description: "Local model server".into(),
+            category: "Other".into(),
+            badge: Some("LOCAL".into()),
+        },
+        SelectItem {
+            id: "llamacpp".into(),
+            title: "llama.cpp".into(),
+            description: "Local inference server".into(),
+            category: "Other".into(),
+            badge: Some("LOCAL".into()),
+        },
+        SelectItem {
+            id: "deepseek".into(),
+            title: "DeepSeek".into(),
+            description: "Reasoning and coding models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "mistral".into(),
+            title: "Mistral".into(),
+            description: "Hosted Mistral models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "togetherai".into(),
+            title: "Together AI".into(),
+            description: "Open model hosting".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "perplexity".into(),
+            title: "Perplexity".into(),
+            description: "Search-augmented models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "cohere".into(),
+            title: "Cohere".into(),
+            description: "Command models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "xai".into(),
+            title: "xAI".into(),
+            description: "Grok models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "deepinfra".into(),
+            title: "DeepInfra".into(),
+            description: "Hosted open models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "azure".into(),
+            title: "Azure OpenAI".into(),
+            description: "Enterprise OpenAI deployments".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "amazon-bedrock".into(),
+            title: "AWS Bedrock".into(),
+            description: "Enterprise foundation models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "google-vertex".into(),
+            title: "Google Vertex AI".into(),
+            description: "Enterprise Google models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "sap-ai-core".into(),
+            title: "SAP AI Core".into(),
+            description: "Enterprise AI platform".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "gitlab".into(),
+            title: "GitLab Duo".into(),
+            description: "AI in GitLab".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "cloudflare-ai-gateway".into(),
+            title: "Cloudflare AI Gateway".into(),
+            description: "Gateway for multiple providers".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "cloudflare-workers-ai".into(),
+            title: "Cloudflare Workers AI".into(),
+            description: "Edge AI inference".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "helicone".into(),
+            title: "Helicone".into(),
+            description: "AI gateway and observability".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "huggingface".into(),
+            title: "Hugging Face".into(),
+            description: "Hosted community models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "nvidia".into(),
+            title: "NVIDIA".into(),
+            description: "Hosted NVIDIA models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "alibaba".into(),
+            title: "Alibaba".into(),
+            description: "Qwen and hosted models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "venice".into(),
+            title: "Venice AI".into(),
+            description: "Privacy-first AI".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "moonshotai".into(),
+            title: "Moonshot AI".into(),
+            description: "Hosted Moonshot models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "zhipuai".into(),
+            title: "Zhipu AI".into(),
+            description: "Hosted GLM models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "siliconflow".into(),
+            title: "SiliconFlow".into(),
+            description: "Hosted open models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "nebius".into(),
+            title: "Nebius".into(),
+            description: "Cloud inference".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "novita".into(),
+            title: "Novita".into(),
+            description: "Cloud inference".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "minimax".into(),
+            title: "MiniMax".into(),
+            description: "Anthropic-compatible (M3)".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "ovhcloud".into(),
+            title: "OVHcloud".into(),
+            description: "EU-hosted AI".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "scaleway".into(),
+            title: "Scaleway".into(),
+            description: "EU cloud AI".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "vultr".into(),
+            title: "Vultr".into(),
+            description: "Cloud inference".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "baseten".into(),
+            title: "Baseten".into(),
+            description: "Model serving".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "friendli".into(),
+            title: "Friendli".into(),
+            description: "Serverless inference".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "upstage".into(),
+            title: "Upstage".into(),
+            description: "Hosted Upstage models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "stepfun".into(),
+            title: "StepFun".into(),
+            description: "Hosted reasoning models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "fireworks".into(),
+            title: "Fireworks AI".into(),
+            description: "Fast inference".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+    ];
+
+    // Dynamically append custom providers from Settings.
+    if let Ok(settings) = Settings::load_sync() {
+        for (id, def) in &settings.custom_providers {
+            items.push(SelectItem {
+                id: id.clone(),
+                title: def.name.clone(),
+                description: format!("Custom OpenAI-compatible — {}", def.api_base),
+                category: "Custom".into(),
+                badge: Some("CUSTOM".into()),
+            });
+        }
+    }
+    items
 }
 
 // ---------------------------------------------------------------------------
@@ -311,6 +692,8 @@ pub enum SystemMessageStyle {
     Warning,
     /// Compact / auto-compact boundary marker.
     Compact,
+    /// Inline todo card showing task progress.
+    TodoCard,
 }
 
 /// A synthetic system annotation inserted between conversation messages.
@@ -332,7 +715,19 @@ pub enum DisplayMessage {
     /// A real conversation turn.
     Conversation(Message),
     /// An injected system notice (e.g. compact boundary).
-    System { text: String, style: SystemMessageStyle },
+    System {
+        text: String,
+        style: SystemMessageStyle,
+    },
+    /// A `!` bang command execution — display only, never sent to model.
+    BangCommand { command: String },
+    /// Output from a `!` bang command.
+    BangOutput {
+        text: String,
+        exit_code: Option<i32>,
+    },
+    /// Error from a `!` bang command.
+    BangError { text: String },
 }
 
 /// Context menu state: position and currently selected item index.
@@ -535,7 +930,11 @@ pub fn try_copy_to_clipboard(text: &str) -> bool {
     #[cfg(target_os = "linux")]
     {
         use std::io::Write;
-        for cmd in &["wl-copy", "xclip -selection clipboard", "xsel --clipboard --input"] {
+        for cmd in &[
+            "wl-copy",
+            "xclip -selection clipboard",
+            "xsel --clipboard --input",
+        ] {
             let parts: Vec<&str> = cmd.split_whitespace().collect();
             if let Some((prog, args)) = parts.split_first() {
                 if let Ok(mut child) = std::process::Command::new(prog)
@@ -577,20 +976,38 @@ fn layout_to_latin(c: char) -> String {
     let lower = c.to_lowercase().next().unwrap_or(c);
     let mapped: Option<char> = match lower {
         // Row 1
-        'й' => Some('q'), 'ц' => Some('w'), 'у' => Some('e'),
-        'к' => Some('r'), 'е' => Some('t'), 'н' => Some('y'),
-        'г' => Some('u'), 'ш' => Some('i'), 'щ' => Some('o'),
+        'й' => Some('q'),
+        'ц' => Some('w'),
+        'у' => Some('e'),
+        'к' => Some('r'),
+        'е' => Some('t'),
+        'н' => Some('y'),
+        'г' => Some('u'),
+        'ш' => Some('i'),
+        'щ' => Some('o'),
         'з' => Some('p'),
         // Row 2
-        'ф' => Some('a'), 'ы' => Some('s'), 'в' => Some('d'),
-        'а' => Some('f'), 'п' => Some('g'), 'р' => Some('h'),
-        'о' => Some('j'), 'л' => Some('k'), 'д' => Some('l'),
+        'ф' => Some('a'),
+        'ы' => Some('s'),
+        'в' => Some('d'),
+        'а' => Some('f'),
+        'п' => Some('g'),
+        'р' => Some('h'),
+        'о' => Some('j'),
+        'л' => Some('k'),
+        'д' => Some('l'),
         // Row 3
-        'я' => Some('z'), 'ч' => Some('x'), 'с' => Some('c'),
-        'м' => Some('v'), 'и' => Some('b'), 'т' => Some('n'),
+        'я' => Some('z'),
+        'ч' => Some('x'),
+        'с' => Some('c'),
+        'м' => Some('v'),
+        'и' => Some('b'),
+        'т' => Some('n'),
         'ь' => Some('m'),
         // Ukrainian-specific letters on standard positions
-        'і' => Some('s'), 'ї' => Some(']'), 'є' => Some('\''),
+        'і' => Some('s'),
+        'ї' => Some(']'),
+        'є' => Some('\''),
         _ => None,
     };
     mapped.unwrap_or(lower).to_string()
@@ -646,23 +1063,23 @@ fn normalize_char_with_shift(c: char, modifiers: KeyModifiers) -> char {
 
 fn key_event_to_keystroke(key: &KeyEvent) -> Option<ParsedKeystroke> {
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-    let alt  = key.modifiers.contains(KeyModifiers::ALT);
+    let alt = key.modifiers.contains(KeyModifiers::ALT);
 
     let normalized_key = match key.code {
         KeyCode::Backspace => "backspace".to_string(),
-        KeyCode::Delete    => "delete".to_string(),
-        KeyCode::Down      => "down".to_string(),
-        KeyCode::End       => "end".to_string(),
-        KeyCode::Enter     => "enter".to_string(),
-        KeyCode::Esc       => "escape".to_string(),
-        KeyCode::Home      => "home".to_string(),
-        KeyCode::Left      => "left".to_string(),
-        KeyCode::PageDown  => "pagedown".to_string(),
-        KeyCode::PageUp    => "pageup".to_string(),
-        KeyCode::Right     => "right".to_string(),
-        KeyCode::Tab       => "tab".to_string(),
-        KeyCode::Up        => "up".to_string(),
-        KeyCode::BackTab   => "tab".to_string(),
+        KeyCode::Delete => "delete".to_string(),
+        KeyCode::Down => "down".to_string(),
+        KeyCode::End => "end".to_string(),
+        KeyCode::Enter => "enter".to_string(),
+        KeyCode::Esc => "escape".to_string(),
+        KeyCode::Home => "home".to_string(),
+        KeyCode::Left => "left".to_string(),
+        KeyCode::PageDown => "pagedown".to_string(),
+        KeyCode::PageUp => "pageup".to_string(),
+        KeyCode::Right => "right".to_string(),
+        KeyCode::Tab => "tab".to_string(),
+        KeyCode::Up => "up".to_string(),
+        KeyCode::BackTab => "tab".to_string(),
         KeyCode::Char(' ') => "space".to_string(),
         KeyCode::Char(c) => {
             // For modifier-key combos (Ctrl/Alt + letter), normalize to the
@@ -800,6 +1217,8 @@ pub struct App {
     pub input: String,
     pub prompt_input: PromptInputState,
     pub input_history: Vec<String>,
+    /// Separate history for `!` bang commands (distinct from prompt input history).
+    pub bang_command_history: Vec<String>,
     pub history_index: Option<usize>,
     pub scroll_offset: usize,
     pub is_streaming: bool,
@@ -837,6 +1256,8 @@ pub struct App {
     pub effort_level: EffortLevel,
     /// Whether fast mode is currently active (model locked to FAST_MODE_MODEL).
     pub fast_mode: bool,
+    /// Override for max turns (set via /turns command). None = use config/agent default.
+    pub max_turns_override: Option<u32>,
     /// Current agent mode name: "build", "plan".
     pub agent_mode: Option<String>,
     /// Accent color derived from the current agent mode.
@@ -853,20 +1274,17 @@ pub struct App {
     pub cursor_pos: usize,
 
     // ---- Scrollback / auto-scroll -----------------------------------------
-
     /// When `true`, the message pane follows the latest messages automatically.
     pub auto_scroll: bool,
     /// Count of messages that arrived while the user was scrolled up.
     pub new_messages_while_scrolled: usize,
 
     // ---- Token warning tracking -------------------------------------------
-
     /// Which threshold (0 = none, 80, 95, 100) was last notified so we only
     /// show each banner once.
     pub token_warning_threshold_shown: u8,
 
     // ---- Session timing ---------------------------------------------------
-
     /// Instant the session started (used for elapsed-time in the status bar).
     pub session_start: std::time::Instant,
     /// Current Rustle pose for rendering (updated each frame).
@@ -878,8 +1296,15 @@ pub struct App {
     pub rustle_temp_pose: Option<crate::rustle::RustlePose>,
     /// Frame counter at which the next random eye-shift should fire.
     pub rustle_next_blink: u64,
+    /// Token output rates from recent turns (tokens/sec), for computing
+    /// a rolling average. Last 5 turns kept.
+    pub recent_token_rates: Vec<f64>,
     /// Instant the current turn's streaming began (reset each time streaming starts).
     pub turn_start: Option<std::time::Instant>,
+    /// Instant the first streaming token arrived this turn (for active-throughput TPS).
+    pub stream_first_token: Option<std::time::Instant>,
+    /// Instant of the most recent streaming token this turn.
+    pub stream_last_token: Option<std::time::Instant>,
     /// Elapsed time string for the last completed turn, e.g. "2m 5s".
     pub last_turn_elapsed: Option<String>,
     /// Past-tense verb shown after turn completes, e.g. "Worked" / "Baked".
@@ -891,7 +1316,6 @@ pub struct App {
     pub transcript_version: Cell<u64>,
 
     // ---- New overlay / notification fields --------------------------------
-
     /// Full-screen help overlay (? / F1).
     pub help_overlay: HelpOverlay,
     /// Ctrl+R history search overlay.
@@ -931,7 +1355,6 @@ pub struct App {
     pub current_turn: Option<Arc<std::sync::atomic::AtomicUsize>>,
 
     // ---- Visual mode indicators -------------------------------------------
-
     /// Plan mode — input border turns blue, [PLAN] shown in status bar.
     pub plan_mode: bool,
     /// "While you were away" summary text shown on the welcome screen.
@@ -940,7 +1363,6 @@ pub struct App {
     pub stall_start: Option<std::time::Instant>,
 
     // ---- Settings / theme / privacy screens --------------------------------
-
     /// Full-screen tabbed settings screen (/config, /settings).
     pub settings_screen: SettingsScreen,
     /// Theme picker overlay (/theme).
@@ -970,7 +1392,8 @@ pub struct App {
     /// Startup error dialog for malformed settings.json or AGENTS.md.
     pub invalid_config_dialog: crate::invalid_config_dialog::InvalidConfigDialogState,
     /// Memory update notification banner.
-    pub memory_update_notification: crate::memory_update_notification::MemoryUpdateNotificationState,
+    pub memory_update_notification:
+        crate::memory_update_notification::MemoryUpdateNotificationState,
     /// MCP elicitation dialog (form requested by an MCP server).
     pub elicitation: crate::elicitation_dialog::ElicitationDialogState,
     /// Model picker overlay (/model command).
@@ -1062,6 +1485,19 @@ pub struct App {
     /// When `true`, the main loop will inject a synthetic Enter event on the
     /// next iteration to dequeue and submit the next queued message.
     pub pending_auto_submit: bool,
+    /// Auto-poke counter — how many pokes have been sent this session.
+    pub auto_poke_count: u32,
+    /// Hash of the last todo state for no-progress detection.
+    pub last_todo_hash: String,
+    /// Count of consecutive no-progress turns.
+    pub no_progress_turns: u32,
+    /// Whether the todo card is visible in the transcript.
+    pub todo_card_visible: bool,
+    /// When `true`, the main loop should start a new query turn because
+    /// auto-poke injected a continuation message into `queued_messages`.
+    pub pending_auto_poke: bool,
+    /// Current session ID (used for todo persistence + auto-poke).
+    pub session_id: String,
     /// Connect-a-provider dialog (/connect command).
     pub connect_dialog: DialogSelectState,
     /// Import-config source picker (/import-config command).
@@ -1099,7 +1535,6 @@ pub struct App {
     pub auto_compact_running: bool,
 
     // ---- Voice hold-to-talk ------------------------------------------------
-
     /// The global voice recorder, Some when voice is enabled in config.
     pub voice_recorder: Option<Arc<Mutex<claurst_core::voice::VoiceRecorder>>>,
     /// True while recording is active (Alt+V toggled on).
@@ -1123,7 +1558,6 @@ pub struct App {
     pub ask_user_dialog: crate::ask_user_dialog::AskUserDialogState,
 
     // ---- Context window & rate limit info ----------------------------------
-
     /// Total context window size for the current model (tokens).
     pub context_window_size: u64,
     /// How many tokens are currently used in the context window.
@@ -1141,6 +1575,12 @@ pub struct App {
     /// Goal badge string shown in the footer, e.g. "active · 5m · 3 turns".
     /// None when no goal is active. Updated by the REPL after each turn.
     pub active_goal_badge: Option<String>,
+
+    /// Number of discovered skills (from `.claurst/skills/` etc.) for the
+    /// status-bar indicator.
+    pub skill_count: usize,
+    /// Number of configured MCP servers for the status-bar indicator.
+    pub mcp_server_count: usize,
 
     // ---- Thinking block expansion state ----------------------------------
     /// Set of thinking block content hashes that are expanded.
@@ -1174,6 +1614,10 @@ pub struct App {
     pub selection_anchor: Option<(u16, u16)>,
     /// Selection drag focus (col, row) — updated on mouse-drag / mouse-up.
     pub selection_focus: Option<(u16, u16)>,
+    /// Keyboard selection mode active.
+    pub kb_select_mode: bool,
+    /// Cursor row for keyboard selection (screen coordinate).
+    pub kb_cursor_row: u16,
     /// Text extracted from the current selection (updated each render frame).
     pub selection_text: RefCell<String>,
     /// Cache of row -> rendered text within the selectable area, refreshed
@@ -1268,8 +1712,15 @@ impl App {
                 .join("models.json");
             reg.load_cache(&cache_path);
             reg.apply_model_overrides(&config.model_overrides);
+            let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+            reg.apply_custom_providers(&settings.custom_providers);
             reg
         };
+        let skill_count = {
+            let cwd = std::env::current_dir().unwrap_or_default();
+            claurst_core::discover_skills(&cwd, &config.skills).len()
+        };
+        let mcp_server_count = config.mcp_servers.len();
         Self {
             config,
             cost_tracker,
@@ -1279,6 +1730,7 @@ impl App {
             input: String::new(),
             prompt_input: PromptInputState::new(),
             input_history: Vec::new(),
+            bang_command_history: Vec::new(),
             history_index: None,
             scroll_offset: 0,
             is_streaming: false,
@@ -1299,6 +1751,7 @@ impl App {
             has_credentials: true, // overridden by caller when no key is configured
             effort_level: EffortLevel::Medium,
             fast_mode: false,
+            max_turns_override: None,
             agent_mode: None,
             agent_mode_changed: false,
             accent_color: ACCENT_BUILD,
@@ -1313,11 +1766,16 @@ impl App {
             rustle_current_pose: crate::rustle::RustlePose::Default,
             rustle_pose_until: None,
             rustle_temp_pose: None,
-            rustle_next_blink: 200 + (std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .subsec_nanos() as u64 % 300),
+            rustle_next_blink: 200
+                + (std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .subsec_nanos() as u64
+                    % 300),
             turn_start: None,
+            stream_first_token: None,
+            stream_last_token: None,
+            recent_token_rates: Vec::new(),
             last_turn_elapsed: None,
             last_turn_verb: None,
             turn_metadata: Vec::new(),
@@ -1360,7 +1818,8 @@ impl App {
             voice_mode_notice: crate::voice_mode_notice::VoiceModeNoticeState::new(),
             desktop_upsell: crate::desktop_upsell_startup::DesktopUpsellStartupState::new(),
             invalid_config_dialog: crate::invalid_config_dialog::InvalidConfigDialogState::new(),
-            memory_update_notification: crate::memory_update_notification::MemoryUpdateNotificationState::new(),
+            memory_update_notification:
+                crate::memory_update_notification::MemoryUpdateNotificationState::new(),
             elicitation: crate::elicitation_dialog::ElicitationDialogState::new(),
             model_picker: ModelPickerState::new(),
             session_browser: SessionBrowserState::new(),
@@ -1374,7 +1833,8 @@ impl App {
             mcp_session_trusted: std::collections::HashSet::new(),
             mcp_project_root: None,
             go_to_line_dialog: GoToLineDialog::new(),
-            bypass_permissions_dialog: crate::bypass_permissions_dialog::BypassPermissionsDialogState::new(),
+            bypass_permissions_dialog:
+                crate::bypass_permissions_dialog::BypassPermissionsDialogState::new(),
             bypass_permissions_dialog_shown: false,
             file_injection_dialog: crate::file_injection_dialog::FileInjectionDialogState::new(),
             file_injection_force: false,
@@ -1398,8 +1858,17 @@ impl App {
             auth_store: claurst_core::AuthStore::load(),
             queued_messages: std::collections::VecDeque::new(),
             pending_auto_submit: false,
+            auto_poke_count: 0,
+            last_todo_hash: String::new(),
+            no_progress_turns: 0,
+            todo_card_visible: false,
+            pending_auto_poke: false,
+            session_id: String::new(),
             connect_dialog: DialogSelectState::new("Connect a provider", provider_picker_items()),
-            import_config_picker: DialogSelectState::new("Import config", import_config_picker_items()),
+            import_config_picker: DialogSelectState::new(
+                "Import config",
+                import_config_picker_items(),
+            ),
             import_config_dialog: ImportConfigDialogState::new(),
             command_palette: {
                 let items: Vec<SelectItem> = PROMPT_SLASH_COMMANDS
@@ -1419,12 +1888,15 @@ impl App {
             pr_number: None,
             pr_url: None,
             pr_state: None,
-            current_dir: std::env::current_dir().ok().and_then(|p| {
-                p.to_str().map(|s| s.to_string())
-            }),
+            current_dir: std::env::current_dir()
+                .ok()
+                .and_then(|p| p.to_str().map(|s| s.to_string())),
             git_branch: claurst_core::git_utils::get_repo_root(
-                std::env::current_dir().as_deref().unwrap_or_else(|_| std::path::Path::new("."))
-            ).map(|repo_root| claurst_core::git_utils::get_current_branch(&repo_root)),
+                std::env::current_dir()
+                    .as_deref()
+                    .unwrap_or_else(|_| std::path::Path::new(".")),
+            )
+            .map(|repo_root| claurst_core::git_utils::get_current_branch(&repo_root)),
             background_task_count: 0,
             background_task_status: None,
             status_line_override: None,
@@ -1439,8 +1911,8 @@ impl App {
                     .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
                     .unwrap_or(false)
                     || {
-                        let path = claurst_core::config::Settings::config_dir()
-                            .join("ui-settings.json");
+                        let path =
+                            claurst_core::config::Settings::config_dir().join("ui-settings.json");
                         std::fs::read_to_string(&path)
                             .ok()
                             .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
@@ -1471,6 +1943,8 @@ impl App {
             worktree_branch: None,
             agent_type_badge: None,
             active_goal_badge: None,
+            skill_count,
+            mcp_server_count,
             thinking_expanded: std::collections::HashSet::new(),
             last_msg_area: Cell::new(ratatui::layout::Rect::default()),
             last_selectable_area: Cell::new(ratatui::layout::Rect::default()),
@@ -1484,6 +1958,8 @@ impl App {
             last_max_scroll: Cell::new(0),
             selection_anchor: None,
             selection_focus: None,
+            kb_select_mode: false,
+            kb_cursor_row: 0,
             selection_text: RefCell::new(String::new()),
             last_row_text: RefCell::new(std::collections::HashMap::new()),
             last_click_time: None,
@@ -1522,7 +1998,8 @@ impl App {
     }
 
     pub fn open_import_config_picker(&mut self) {
-        self.import_config_picker = DialogSelectState::new("Import config", import_config_picker_items());
+        self.import_config_picker =
+            DialogSelectState::new("Import config", import_config_picker_items());
         self.import_config_picker.open();
     }
 
@@ -1613,6 +2090,8 @@ impl App {
         // measures actual round-trip time even when the provider buffers its
         // full response before yielding any stream events (e.g. Gemini flash).
         self.turn_start = Some(std::time::Instant::now());
+        self.stream_first_token = None;
+        self.stream_last_token = None;
         self.last_turn_elapsed = None;
         self.last_turn_verb = None;
     }
@@ -1703,6 +2182,11 @@ impl App {
             .join("models.json");
         if cache_path.exists() {
             self.model_registry.load_cache(&cache_path);
+            // Re-apply custom providers after cache merge so custom model
+            // entries survive any catalog overlay.
+            let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+            self.model_registry
+                .apply_custom_providers(&settings.custom_providers);
         }
 
         let models = crate::model_picker::models_for_provider_from_registry(
@@ -1710,6 +2194,7 @@ impl App {
             &self.model_registry,
         );
         self.model_picker.set_models(models);
+        self.model_picker.load_favorites();
         self.model_picker_provider_id = Some(provider_id.to_string());
         // Catalog-backed providers (Anthropic/OpenAI/Google) are a read-only
         // projection of the models.dev catalog — there is no live endpoint to
@@ -1746,7 +2231,12 @@ impl App {
         );
     }
 
-    fn activate_provider(&mut self, provider_id: String, provider_name: String, status_prefix: &str) {
+    fn activate_provider(
+        &mut self,
+        provider_id: String,
+        provider_name: String,
+        status_prefix: &str,
+    ) {
         let picker_title = provider_name.clone();
         self.fast_mode = false;
         self.set_provider_default(provider_id.clone());
@@ -1756,9 +2246,105 @@ impl App {
         self.open_model_picker_for_provider(&provider_id, Some(picker_title));
     }
 
+    /// Check if a provider is connected (has credentials, is a keyless
+    /// local/subprocess provider, or is a configured custom provider with
+    /// a non-empty apiBase — even without an API key for internal gateways).
+    fn is_provider_connected(&self, provider_id: &str) -> bool {
+        match provider_id {
+            "ollama" | "lmstudio" | "lm-studio" | "llamacpp" | "llama-cpp" | "llama-server"
+            | "free" => true,
+            _ => {
+                // Has an API key configured → connected.
+                if self.config.resolve_provider_api_key(provider_id).is_some() {
+                    return true;
+                }
+                // Custom provider with a non-empty apiBase → connected
+                // (internal gateways / local proxies may not need auth).
+                if let Ok(settings) = claurst_core::Settings::load_sync() {
+                    if let Some(def) = settings.custom_providers.get(provider_id) {
+                        return !def.api_base.trim().is_empty();
+                    }
+                }
+                false
+            }
+        }
+    }
+
+    /// Open the model picker showing models from all connected providers,
+    /// grouped by provider name.
+    fn open_model_picker_all_providers(&mut self) {
+        self.dismiss_error_notifications();
+
+        // Collect models from all connected providers.
+        let mut all_models: Vec<crate::model_picker::ModelEntry> = Vec::new();
+
+        // Get ALL provider IDs from the registry (for the full model list).
+        let all_provider_ids: Vec<String> = if let Some(ref registry) = self.provider_registry {
+            registry
+                .provider_ids()
+                .iter()
+                .map(|id| id.to_string())
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        // Also include current provider if not in registry.
+        let mut provider_ids = all_provider_ids;
+        if let Some(ref current) = self.config.provider {
+            if !provider_ids.contains(current) {
+                provider_ids.push(current.clone());
+            }
+        }
+
+        // Determine which providers are connected.
+        let connected_ids: std::collections::HashSet<String> = provider_ids
+            .iter()
+            .filter(|pid| self.is_provider_connected(pid))
+            .cloned()
+            .collect();
+
+        // Pass the connected set to the picker for runtime filtering.
+        self.model_picker.connected_provider_ids = connected_ids;
+
+        // Collect models from ALL providers (filtering happens at display time).
+        let mut provider_names = std::collections::HashMap::new();
+        for pid in &provider_ids {
+            // Look up the provider display name from the registry.
+            if let Some(entry) = self
+                .model_registry
+                .list_providers()
+                .iter()
+                .find(|p| &*p.id == pid)
+            {
+                provider_names.insert(pid.clone(), entry.name.clone());
+            }
+            let models =
+                crate::model_picker::models_for_provider_from_registry(pid, &self.model_registry);
+            for mut m in models {
+                m.provider_id = pid.clone();
+                all_models.push(m);
+            }
+        }
+
+        self.model_picker.provider_names = provider_names;
+        self.model_picker.set_models(all_models);
+        self.model_picker_provider_id = None; // All providers mode
+        self.model_picker.all_providers_mode = true;
+        // Trigger background model discovery.
+        self.model_picker.loading_models = true;
+        self.model_picker_fetch_pending = true;
+
+        self.model_picker
+            .open_all_providers(&self.model_name, self.effort_level, self.fast_mode);
+    }
+
     fn persist_custom_provider_base_url(&self, base_url: &str) {
         let mut settings = Settings::load_sync().unwrap_or_default();
-        let entry = settings.providers.entry("custom-openai".to_string()).or_default();
+        let entry = settings
+            .providers
+            .entry("custom-openai".to_string())
+            .or_default();
         entry.api_base = Some(base_url.to_string());
         entry.enabled = true;
         let _ = settings.save_sync();
@@ -1813,6 +2399,12 @@ impl App {
             if known.contains(&provider) {
                 return Some(provider.to_string());
             }
+            // Check custom providers at runtime.
+            if let Ok(settings) = Settings::load_sync() {
+                if settings.custom_providers.contains_key(provider) {
+                    return Some(provider.to_string());
+                }
+            }
         }
 
         if model.starts_with("claude") {
@@ -1861,7 +2453,9 @@ impl App {
         // Check if a temporary pose is active.
         if let Some(until) = self.rustle_pose_until {
             if std::time::Instant::now() < until {
-                self.rustle_current_pose = self.rustle_temp_pose.clone()
+                self.rustle_current_pose = self
+                    .rustle_temp_pose
+                    .clone()
                     .unwrap_or(crate::rustle::RustlePose::Default);
                 return;
             }
@@ -1873,9 +2467,8 @@ impl App {
         // Random eye-shift: every ~200-500 frames, briefly look right.
         if self.frame_count >= self.rustle_next_blink {
             self.rustle_temp_pose = Some(crate::rustle::RustlePose::LookRight);
-            self.rustle_pose_until = Some(
-                std::time::Instant::now() + std::time::Duration::from_millis(800)
-            );
+            self.rustle_pose_until =
+                Some(std::time::Instant::now() + std::time::Duration::from_millis(800));
             // Schedule next blink 200-500 frames from now (random-ish).
             let jitter = (self.frame_count.wrapping_mul(7) % 300) + 200;
             self.rustle_next_blink = self.frame_count + jitter;
@@ -1889,9 +2482,8 @@ impl App {
     /// Trigger Rustle looking down briefly (called on Tab / mode switch).
     pub fn rustle_look_down(&mut self) {
         self.rustle_temp_pose = Some(crate::rustle::RustlePose::LookDown);
-        self.rustle_pose_until = Some(
-            std::time::Instant::now() + std::time::Duration::from_secs(1)
-        );
+        self.rustle_pose_until =
+            Some(std::time::Instant::now() + std::time::Duration::from_secs(1));
     }
 
     /// Cycle to the next agent mode: build → plan → build.
@@ -1920,7 +2512,8 @@ impl App {
     /// Update the context window size from the model registry for the current model.
     pub fn refresh_context_window_size(&mut self) {
         let provider = self.config.provider.as_deref().unwrap_or("anthropic");
-        let model_id = self.model_name
+        let model_id = self
+            .model_name
             .strip_prefix(&format!("{}/", provider))
             .unwrap_or(&self.model_name);
         if let Some(entry) = self.model_registry.get(provider, model_id) {
@@ -1979,14 +2572,20 @@ impl App {
         self.provider_registry = provider_registry;
         self.model_registry = claurst_api::ModelRegistry::new();
         // Re-layer user metadata overrides (issue #309) onto the fresh registry.
-        self.model_registry.apply_model_overrides(&self.config.model_overrides);
+        self.model_registry
+            .apply_model_overrides(&self.config.model_overrides);
+        let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+        self.model_registry
+            .apply_custom_providers(&settings.custom_providers);
         self.auth_store = auth_store;
         self.connect_dialog = DialogSelectState::new("Connect a provider", provider_picker_items());
-        self.import_config_picker = DialogSelectState::new("Import config", import_config_picker_items());
+        self.import_config_picker =
+            DialogSelectState::new("Import config", import_config_picker_items());
         self.import_config_dialog = ImportConfigDialogState::new();
         self.model_picker = ModelPickerState::new();
         self.key_input_dialog = crate::key_input_dialog::KeyInputDialogState::new();
-        self.custom_provider_dialog = crate::custom_provider_dialog::CustomProviderDialogState::new();
+        self.custom_provider_dialog =
+            crate::custom_provider_dialog::CustomProviderDialogState::new();
         self.free_mode_dialog = crate::free_mode_dialog::FreeModeDialogState::new();
         self.device_auth_dialog = crate::device_auth_dialog::DeviceAuthDialogState::new();
         self.device_auth_pending = None;
@@ -2004,6 +2603,33 @@ impl App {
     /// Handle slash commands that should open UI screens rather than execute
     /// as normal commands. Returns `true` if the command was intercepted.
     pub fn intercept_slash_command_with_args(&mut self, cmd: &str, args: &str) -> bool {
+        if cmd == "turns" {
+            let args = args.trim();
+            if args.is_empty() {
+                let current = self.max_turns_override;
+                let msg = match current {
+                    Some(n) if n == u32::MAX => "Max turns: disabled (no limit).".to_string(),
+                    Some(n) => format!("Max turns: {} (override active).", n),
+                    None => "Max turns: using config/agent default.".to_string(),
+                };
+                self.status_message = Some(msg);
+            } else if args == "off" || args == "disable" || args == "0" {
+                self.max_turns_override = Some(u32::MAX);
+                self.status_message = Some("Max turns disabled (no limit).".to_string());
+            } else if let Ok(n) = args.parse::<u32>() {
+                if n == 0 {
+                    self.max_turns_override = Some(u32::MAX);
+                    self.status_message = Some("Max turns disabled (no limit).".to_string());
+                } else {
+                    self.max_turns_override = Some(n);
+                    self.status_message = Some(format!("Max turns set to {}.", n));
+                }
+            } else {
+                self.status_message =
+                    Some("Usage: /turns <number> | off | (blank to show current).".to_string());
+            }
+            return true;
+        }
         if cmd == "mcp" && !args.trim().is_empty() {
             return false;
         }
@@ -2084,12 +2710,7 @@ impl App {
                     self.status_message = Some("Connect a provider to choose a model.".to_string());
                     return true;
                 }
-                let provider = self
-                    .config
-                    .provider
-                    .clone()
-                    .unwrap_or_else(|| "anthropic".to_string());
-                self.open_model_picker_for_provider(&provider, None);
+                self.open_model_picker_all_providers();
                 true
             }
             "session" | "resume" => {
@@ -2119,14 +2740,22 @@ impl App {
             }
             "vim" => {
                 self.prompt_input.vim_enabled = !self.prompt_input.vim_enabled;
-                let status = if self.prompt_input.vim_enabled { "enabled" } else { "disabled" };
+                let status = if self.prompt_input.vim_enabled {
+                    "enabled"
+                } else {
+                    "disabled"
+                };
                 self.status_message = Some(format!("Vim mode {}.", status));
                 self.refresh_prompt_input();
                 true
             }
             "fast" => {
                 self.fast_mode = !self.fast_mode;
-                let status = if self.fast_mode { "enabled" } else { "disabled" };
+                let status = if self.fast_mode {
+                    "enabled"
+                } else {
+                    "disabled"
+                };
                 self.status_message = Some(format!("Fast mode {}.", status));
                 true
             }
@@ -2152,7 +2781,10 @@ impl App {
             }
             "copy" => {
                 // Copy last assistant message to clipboard. Attempt arboard; fall back to notification.
-                let last = self.messages.iter().rev()
+                let last = self
+                    .messages
+                    .iter()
+                    .rev()
                     .find(|m| m.role == Role::Assistant)
                     .map(|m| m.get_all_text());
                 if let Some(text) = last {
@@ -2167,7 +2799,10 @@ impl App {
                     } else {
                         self.push_notification(
                             NotificationKind::Info,
-                            format!("Last response: {} chars (clipboard unavailable)", text.len()),
+                            format!(
+                                "Last response: {} chars (clipboard unavailable)",
+                                text.len()
+                            ),
                             Some(5),
                         );
                     }
@@ -2199,11 +2834,8 @@ impl App {
                     .model_name
                     .strip_prefix(&format!("{}/", provider))
                     .unwrap_or(&self.model_name);
-                let levels = claurst_api::supported_efforts(
-                    provider,
-                    model_id,
-                    Some(&self.model_registry),
-                );
+                let levels =
+                    claurst_api::supported_efforts(provider, model_id, Some(&self.model_registry));
                 self.effort_picker.open(self.effort_level, levels);
                 true
             }
@@ -2235,9 +2867,8 @@ impl App {
                     }
                     self.voice_recorder = Some(recorder);
                     self.voice_mode_notice = crate::voice_mode_notice::VoiceModeNoticeState::new();
-                    self.status_message = Some(
-                        "Voice mode enabled. Press Alt+V to start recording.".to_string(),
-                    );
+                    self.status_message =
+                        Some("Voice mode enabled. Press Alt+V to start recording.".to_string());
                 }
                 true
             }
@@ -2273,7 +2904,8 @@ impl App {
             }
             "keybindings" => {
                 // Open the keybindings.json file in the external editor
-                let keybindings_path = claurst_core::config::Settings::config_dir().join("keybindings.json");
+                let keybindings_path =
+                    claurst_core::config::Settings::config_dir().join("keybindings.json");
 
                 if let Err(e) = open_file_externally(&keybindings_path) {
                     eprintln!("Failed to open keybindings file: {}", e);
@@ -2594,7 +3226,12 @@ impl App {
     /// It will appear after the current last message.
     /// Push a notification and, for Error-kind notifications, reset the error
     /// modal scroll offset so a newly arrived error is always shown from the top.
-    pub fn push_notification(&mut self, kind: NotificationKind, msg: String, duration_secs: Option<u64>) {
+    pub fn push_notification(
+        &mut self,
+        kind: NotificationKind,
+        msg: String,
+        duration_secs: Option<u64>,
+    ) {
         if kind == NotificationKind::Error {
             self.error_modal_scroll_offset = 0;
         }
@@ -2617,8 +3254,7 @@ impl App {
             // Auto-scroll: keep offset at 0 so render shows the bottom.
             self.scroll_offset = 0;
         } else {
-            self.new_messages_while_scrolled =
-                self.new_messages_while_scrolled.saturating_add(1);
+            self.new_messages_while_scrolled = self.new_messages_while_scrolled.saturating_add(1);
         }
     }
 
@@ -2630,8 +3266,7 @@ impl App {
     /// Check current token usage and push token warning notifications as
     /// appropriate.  Call this after updating `token_count`.
     pub fn check_token_warnings(&mut self) {
-        let window =
-            claurst_query::context_window_for_model(&self.model_name) as u32;
+        let window = claurst_query::context_window_for_model(&self.model_name) as u32;
         if window == 0 {
             return;
         }
@@ -2698,7 +3333,8 @@ impl App {
     /// wheel) stay at the base 3-line step.
     fn scroll_step(&mut self) -> usize {
         let now = std::time::Instant::now();
-        let elapsed_ms = self.scroll_last_time
+        let elapsed_ms = self
+            .scroll_last_time
             .map(|t| now.duration_since(t).as_millis())
             .unwrap_or(u128::MAX);
         self.scroll_last_time = Some(now);
@@ -2770,7 +3406,11 @@ impl App {
         }
         let file_autocomplete_limit = self.config.file_autocomplete_limit;
         let file_autocomplete_show_hidden = self.config.file_autocomplete_show_hidden_files;
-        self.prompt_input.update_suggestions(PROMPT_SLASH_COMMANDS, file_autocomplete_limit, file_autocomplete_show_hidden);
+        self.prompt_input.update_suggestions(
+            PROMPT_SLASH_COMMANDS,
+            file_autocomplete_limit,
+            file_autocomplete_show_hidden,
+        );
         self.sync_legacy_prompt_fields();
     }
 
@@ -2803,7 +3443,8 @@ impl App {
                 }
             });
         }
-        self.status_message = Some("Recording\u{2026} release V or press Enter to transcribe".to_string());
+        self.status_message =
+            Some("Recording\u{2026} release V or press Enter to transcribe".to_string());
     }
 
     /// Stop PTT recording: flip the AtomicBool inside VoiceRecorder so the
@@ -2932,10 +3573,8 @@ impl App {
                 self.pending_mcp_reconnect = true;
             }
             McpApprovalChoice::Deny => {
-                self.status_message = Some(format!(
-                    "Skipped project MCP server '{}'.",
-                    server.name
-                ));
+                self.status_message =
+                    Some(format!("Skipped project MCP server '{}'.", server.name));
             }
         }
     }
@@ -2979,6 +3618,103 @@ impl App {
     fn clear_prompt(&mut self) {
         self.prompt_input.clear();
         self.refresh_prompt_input();
+    }
+
+    /// Execute a `!` bang command directly, without sending to the model.
+    /// Output is displayed in the transcript (display_messages only) — the
+    /// model never sees it. Zero token consumption.
+    pub fn execute_bang_command(&mut self, command: String) {
+        // Check if bang commands are enabled.
+        let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+        if !settings.bang_commands.enabled {
+            self.push_notification(
+                crate::notifications::NotificationKind::Warning,
+                "Bang commands are disabled. Enable with \"bangCommands\": {\"enabled\": true} in settings.json.".to_string(),
+                None,
+            );
+            return;
+        }
+
+        // Block in plan mode.
+        if self.config.permission_mode == claurst_core::PermissionMode::Plan {
+            self.push_notification(
+                crate::notifications::NotificationKind::Warning,
+                "Bang commands disabled in plan mode.".to_string(),
+                None,
+            );
+            return;
+        }
+
+        // Display the command.
+        if settings.bang_commands.show_in_transcript {
+            self.display_messages.push(DisplayMessage::BangCommand {
+                command: command.clone(),
+            });
+        }
+
+        // Resolve working directory: prefer project dir, fall back to current dir.
+        let working_dir = self
+            .config
+            .project_dir
+            .clone()
+            .or_else(|| {
+                self.current_dir
+                    .as_ref()
+                    .map(|s| std::path::PathBuf::from(s))
+            })
+            .unwrap_or_else(|| std::path::PathBuf::from("."));
+
+        // Execute via std::process::Command — NO model round-trip, NO PTY.
+        let result = std::process::Command::new("bash")
+            .arg("-c")
+            .arg(&command)
+            .current_dir(&working_dir)
+            .output();
+
+        match result {
+            Ok(output) => {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let exit_code = output.status.code();
+
+                let display = if stderr.is_empty() {
+                    stdout.to_string()
+                } else if stdout.is_empty() {
+                    stderr.to_string()
+                } else {
+                    format!("{}\n--- stderr ---\n{}", stdout, stderr)
+                };
+
+                if settings.bang_commands.show_in_transcript {
+                    if exit_code.is_some_and(|c| c != 0) {
+                        let full = format!("{}\n[exit: {}]", display, exit_code.unwrap());
+                        self.display_messages.push(DisplayMessage::BangOutput {
+                            text: full,
+                            exit_code,
+                        });
+                    } else {
+                        self.display_messages.push(DisplayMessage::BangOutput {
+                            text: display,
+                            exit_code,
+                        });
+                    }
+                }
+
+                // Add to separate history if enabled.
+                if settings.bang_commands.add_to_history {
+                    self.bang_command_history.push(command);
+                }
+            }
+            Err(e) => {
+                if settings.bang_commands.show_in_transcript {
+                    self.display_messages.push(DisplayMessage::BangError {
+                        text: format!("Error: {}", e),
+                    });
+                }
+            }
+        }
+
+        self.invalidate_transcript();
     }
 
     fn refresh_turn_diff_from_history(&mut self) {
@@ -3106,7 +3842,6 @@ impl App {
             self.dismiss_error_notifications();
             return false;
         }
-
 
         if self.global_search.visible {
             return self.handle_global_search_key(key);
@@ -3242,9 +3977,15 @@ impl App {
                     self.device_auth_dialog.close();
                     self.device_auth_pending = None;
                 }
-                _ if matches!(self.device_auth_dialog.status, crate::device_auth_dialog::DeviceAuthStatus::Success(_)) => {
+                _ if matches!(
+                    self.device_auth_dialog.status,
+                    crate::device_auth_dialog::DeviceAuthStatus::Success(_)
+                ) =>
+                {
                     // Any key after success -> store credential and close
-                    if let crate::device_auth_dialog::DeviceAuthStatus::Success(ref token) = self.device_auth_dialog.status {
+                    if let crate::device_auth_dialog::DeviceAuthStatus::Success(ref token) =
+                        self.device_auth_dialog.status
+                    {
                         let provider_id = self.device_auth_dialog.provider_id.clone();
                         let provider_name = self.device_auth_dialog.provider_name.clone();
                         let token = token.clone();
@@ -3275,17 +4016,18 @@ impl App {
                         } else {
                             claurst_core::StoredCredential::ApiKey { key: token }
                         };
-                        self.auth_store.set(
-                            &provider_id,
-                            credential,
-                        );
+                        self.auth_store.set(&provider_id, credential);
                         self.device_auth_pending = None;
                         self.device_auth_dialog.close();
                         self.activate_provider(provider_id, provider_name, "Connected to");
                         return false;
                     }
                 }
-                _ if matches!(self.device_auth_dialog.status, crate::device_auth_dialog::DeviceAuthStatus::Error(_)) => {
+                _ if matches!(
+                    self.device_auth_dialog.status,
+                    crate::device_auth_dialog::DeviceAuthStatus::Error(_)
+                ) =>
+                {
                     // Any key after error -> close
                     self.device_auth_dialog.close();
                     self.device_auth_pending = None;
@@ -3356,17 +4098,28 @@ impl App {
                 KeyCode::Backspace => {
                     self.key_input_dialog.backspace();
                 }
-                KeyCode::Char('v') if key.modifiers.contains(KeyModifiers::CONTROL) || key.modifiers.contains(KeyModifiers::SUPER) => {
+                KeyCode::Char('v')
+                    if key.modifiers.contains(KeyModifiers::CONTROL)
+                        || key.modifiers.contains(KeyModifiers::SUPER) =>
+                {
                     if let Some(text) = crate::image_paste::read_clipboard_text() {
                         if text.is_empty() {
-                            self.push_notification(NotificationKind::Warning, "Clipboard is empty".to_string(), Some(2));
+                            self.push_notification(
+                                NotificationKind::Warning,
+                                "Clipboard is empty".to_string(),
+                                Some(2),
+                            );
                         } else {
                             for ch in text.chars() {
                                 self.key_input_dialog.insert_char(ch);
                             }
                         }
                     } else {
-                        self.push_notification(NotificationKind::Warning, "Could not read clipboard".to_string(), Some(2));
+                        self.push_notification(
+                            NotificationKind::Warning,
+                            "Could not read clipboard".to_string(),
+                            Some(2),
+                        );
                     }
                 }
                 KeyCode::Char(c) => {
@@ -3395,10 +4148,8 @@ impl App {
                     if self.free_mode_dialog.can_submit() {
                         let values = self.free_mode_dialog.take_values();
                         for (provider_id, key) in values {
-                            self.auth_store.set(
-                                provider_id,
-                                claurst_core::StoredCredential::ApiKey { key },
-                            );
+                            self.auth_store
+                                .set(provider_id, claurst_core::StoredCredential::ApiKey { key });
                         }
                         self.activate_provider(
                             "free".to_string(),
@@ -3463,80 +4214,137 @@ impl App {
         // Connect-a-provider dialog (/connect command)
         if self.connect_dialog.visible {
             match key.code {
-                KeyCode::Esc => { self.connect_dialog.close(); }
-                KeyCode::Home => { self.connect_dialog.move_home(); }
-                KeyCode::End => { self.connect_dialog.move_end(); }
-                KeyCode::Up => { self.connect_dialog.move_up(); }
-                KeyCode::Down => { self.connect_dialog.move_down(); }
-                KeyCode::PageUp => { self.connect_dialog.page_up(); }
-                KeyCode::PageDown => { self.connect_dialog.page_down(); }
-                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => { self.connect_dialog.move_up(); }
-                KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => { self.connect_dialog.move_down(); }
+                KeyCode::Esc => {
+                    self.connect_dialog.close();
+                }
+                KeyCode::Home => {
+                    self.connect_dialog.move_home();
+                }
+                KeyCode::End => {
+                    self.connect_dialog.move_end();
+                }
+                KeyCode::Up => {
+                    self.connect_dialog.move_up();
+                }
+                KeyCode::Down => {
+                    self.connect_dialog.move_down();
+                }
+                KeyCode::PageUp => {
+                    self.connect_dialog.page_up();
+                }
+                KeyCode::PageDown => {
+                    self.connect_dialog.page_down();
+                }
+                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.connect_dialog.move_up();
+                }
+                KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.connect_dialog.move_down();
+                }
                 KeyCode::Enter => {
                     if let Some(selected) = self.connect_dialog.selected().cloned() {
                         self.connect_dialog.close();
 
                         match selected.id.as_str() {
                             // Local providers — activate immediately, no key needed
+                            // Local providers — activate immediately, no key needed
                             "ollama" | "lmstudio" | "llamacpp" => {
-                                self.activate_provider(selected.id.clone(), selected.title.clone(), "Switched to");
+                                self.activate_provider(
+                                    selected.id.clone(),
+                                    selected.title.clone(),
+                                    "Switched to",
+                                );
                             }
                             // "Free" composite mode — collects any subset of the
                             // free-tier upstreams (min 1; more = better availability).
                             "free" => {
-                                let existing: Vec<(&'static str, String)> = claurst_api::FREE_CATALOG
-                                    .iter()
-                                    .filter_map(|upstream| {
-                                        let key = match upstream.id {
-                                            "opencode-zen" => self
-                                                .auth_store
-                                                .api_key_for(claurst_core::ProviderId::OPENCODE_ZEN)
-                                                .or_else(|| {
-                                                    self.auth_store.api_key_for(
-                                                        claurst_core::ProviderId::OPENCODE_GO,
+                                let existing: Vec<(&'static str, String)> =
+                                    claurst_api::FREE_CATALOG
+                                        .iter()
+                                        .filter_map(|upstream| {
+                                            let key = match upstream.id {
+                                                "opencode-zen" => self
+                                                    .auth_store
+                                                    .api_key_for(
+                                                        claurst_core::ProviderId::OPENCODE_ZEN,
                                                     )
-                                                }),
-                                            other => self.auth_store.api_key_for(other),
-                                        };
-                                        key.filter(|k| !k.is_empty())
-                                            .map(|k| (upstream.id, k))
-                                    })
-                                    .collect();
+                                                    .or_else(|| {
+                                                        self.auth_store.api_key_for(
+                                                            claurst_core::ProviderId::OPENCODE_GO,
+                                                        )
+                                                    }),
+                                                other => self.auth_store.api_key_for(other),
+                                            };
+                                            key.filter(|k| !k.is_empty()).map(|k| (upstream.id, k))
+                                        })
+                                        .collect();
                                 self.free_mode_dialog.open(&existing);
                             }
                             "anthropic" => {
                                 // Anthropic: API key from console.anthropic.com.
-                                self.key_input_dialog.open(selected.id.clone(), selected.title.clone());
+                                self.key_input_dialog
+                                    .open(selected.id.clone(), selected.title.clone());
                             }
                             "anthropic-oauth" => {
                                 // Claude Pro/Max subscription: claude.ai OAuth via
                                 // the browser (loopback capture), spawned by the
                                 // main loop. Note: usage draws from the account's
                                 // extra-usage pool, not subscription quota.
-                                self.device_auth_dialog.open(selected.id.clone(), selected.title.clone());
+                                self.device_auth_dialog
+                                    .open(selected.id.clone(), selected.title.clone());
                                 self.device_auth_pending = Some("anthropic-oauth".to_string());
                             }
                             "custom-openai" => {
-                                let current_url = Settings::load_sync()
-                                    .ok()
-                                    .and_then(|settings| settings.providers.get("custom-openai").and_then(|p| p.api_base.clone()));
-                                self.custom_provider_dialog
-                                    .open(selected.id.clone(), selected.title.clone(), current_url);
+                                let current_url = Settings::load_sync().ok().and_then(|settings| {
+                                    settings
+                                        .providers
+                                        .get("custom-openai")
+                                        .and_then(|p| p.api_base.clone())
+                                });
+                                self.custom_provider_dialog.open(
+                                    selected.id.clone(),
+                                    selected.title.clone(),
+                                    current_url,
+                                );
                             }
                             "github-copilot" => {
                                 // GitHub Copilot: device code flow
-                                self.device_auth_dialog.open(selected.id.clone(), selected.title.clone());
+                                self.device_auth_dialog
+                                    .open(selected.id.clone(), selected.title.clone());
                                 self.device_auth_pending = Some("github-copilot".to_string());
                             }
                             "codex" | "openai-codex" => {
                                 // OpenAI Codex: browser OAuth flow (spawned by main loop)
-                                self.device_auth_dialog.open("openai-codex".into(), "OpenAI Codex".into());
+                                self.device_auth_dialog
+                                    .open("openai-codex".into(), "OpenAI Codex".into());
                                 self.device_auth_pending = Some("openai-codex".to_string());
                             }
                             // AWS Bedrock — accept a bearer token via key input dialog
                             "amazon-bedrock" => {
                                 self.key_input_dialog
                                     .open(selected.id.clone(), selected.title.clone());
+                            }
+                            // Custom providers from Settings — may need API key
+                            id if {
+                                let settings = Settings::load_sync().unwrap_or_default();
+                                settings.custom_providers.contains_key(id)
+                            } =>
+                            {
+                                // Check if the custom provider has an API key resolved.
+                                let settings = Settings::load_sync().unwrap_or_default();
+                                let def = settings.custom_providers.get(&selected.id).unwrap();
+                                if def.resolve_api_key().is_some() {
+                                    // Key available — activate directly.
+                                    self.activate_provider(
+                                        selected.id.clone(),
+                                        selected.title.clone(),
+                                        "Switched to",
+                                    );
+                                } else {
+                                    // No key — open key input dialog.
+                                    self.key_input_dialog
+                                        .open(selected.id.clone(), selected.title.clone());
+                                }
                             }
                             // All other providers — open API key input dialog
                             _ => {
@@ -3546,8 +4354,12 @@ impl App {
                         }
                     }
                 }
-                KeyCode::Backspace => { self.connect_dialog.filter_pop(); }
-                KeyCode::Char(c) => { self.connect_dialog.filter_push(c); }
+                KeyCode::Backspace => {
+                    self.connect_dialog.filter_pop();
+                }
+                KeyCode::Char(c) => {
+                    self.connect_dialog.filter_push(c);
+                }
                 _ => {}
             }
             return false;
@@ -3556,15 +4368,33 @@ impl App {
         // Import-config source picker
         if self.import_config_picker.visible {
             match key.code {
-                KeyCode::Esc => { self.import_config_picker.close(); }
-                KeyCode::Home => { self.import_config_picker.move_home(); }
-                KeyCode::End => { self.import_config_picker.move_end(); }
-                KeyCode::Up => { self.import_config_picker.move_up(); }
-                KeyCode::Down => { self.import_config_picker.move_down(); }
-                KeyCode::PageUp => { self.import_config_picker.page_up(); }
-                KeyCode::PageDown => { self.import_config_picker.page_down(); }
-                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => { self.import_config_picker.move_up(); }
-                KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => { self.import_config_picker.move_down(); }
+                KeyCode::Esc => {
+                    self.import_config_picker.close();
+                }
+                KeyCode::Home => {
+                    self.import_config_picker.move_home();
+                }
+                KeyCode::End => {
+                    self.import_config_picker.move_end();
+                }
+                KeyCode::Up => {
+                    self.import_config_picker.move_up();
+                }
+                KeyCode::Down => {
+                    self.import_config_picker.move_down();
+                }
+                KeyCode::PageUp => {
+                    self.import_config_picker.page_up();
+                }
+                KeyCode::PageDown => {
+                    self.import_config_picker.page_down();
+                }
+                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.import_config_picker.move_up();
+                }
+                KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.import_config_picker.move_down();
+                }
                 KeyCode::Enter => {
                     if let Some(selected) = self.import_config_picker.selected().cloned() {
                         self.import_config_picker.close();
@@ -3573,8 +4403,12 @@ impl App {
                         }
                     }
                 }
-                KeyCode::Backspace => { self.import_config_picker.filter_pop(); }
-                KeyCode::Char(c) => { self.import_config_picker.filter_push(c); }
+                KeyCode::Backspace => {
+                    self.import_config_picker.filter_pop();
+                }
+                KeyCode::Char(c) => {
+                    self.import_config_picker.filter_push(c);
+                }
                 _ => {}
             }
             return false;
@@ -3593,15 +4427,33 @@ impl App {
         // Command palette (Ctrl+K)
         if self.command_palette.visible {
             match key.code {
-                KeyCode::Esc => { self.command_palette.close(); }
-                KeyCode::Home => { self.command_palette.move_home(); }
-                KeyCode::End => { self.command_palette.move_end(); }
-                KeyCode::Up => { self.command_palette.move_up(); }
-                KeyCode::Down => { self.command_palette.move_down(); }
-                KeyCode::PageUp => { self.command_palette.page_up(); }
-                KeyCode::PageDown => { self.command_palette.page_down(); }
-                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => { self.command_palette.move_up(); }
-                KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => { self.command_palette.move_down(); }
+                KeyCode::Esc => {
+                    self.command_palette.close();
+                }
+                KeyCode::Home => {
+                    self.command_palette.move_home();
+                }
+                KeyCode::End => {
+                    self.command_palette.move_end();
+                }
+                KeyCode::Up => {
+                    self.command_palette.move_up();
+                }
+                KeyCode::Down => {
+                    self.command_palette.move_down();
+                }
+                KeyCode::PageUp => {
+                    self.command_palette.page_up();
+                }
+                KeyCode::PageDown => {
+                    self.command_palette.page_down();
+                }
+                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.command_palette.move_up();
+                }
+                KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.command_palette.move_down();
+                }
                 KeyCode::Enter => {
                     if let Some(selected) = self.command_palette.selected().cloned() {
                         self.command_palette.close();
@@ -3610,8 +4462,12 @@ impl App {
                         return true; // signal to submit this as input
                     }
                 }
-                KeyCode::Backspace => { self.command_palette.filter_pop(); }
-                KeyCode::Char(c) => { self.command_palette.filter_push(c); }
+                KeyCode::Backspace => {
+                    self.command_palette.filter_pop();
+                }
+                KeyCode::Char(c) => {
+                    self.command_palette.filter_push(c);
+                }
                 _ => {}
             }
             return false;
@@ -3638,13 +4494,48 @@ impl App {
                 KeyCode::Down => self.model_picker.select_next(),
                 KeyCode::Left => self.model_picker.effort_prev(),
                 KeyCode::Right => self.model_picker.effort_next(),
-                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => self.model_picker.select_prev(),
-                KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => self.model_picker.select_next(),
+                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.model_picker.select_prev()
+                }
+                KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.model_picker.select_next()
+                }
+                KeyCode::Tab => self.model_picker.select_next_provider(),
+                KeyCode::BackTab => self.model_picker.select_prev_provider(),
                 KeyCode::Enter => {
+                    // Capture all-providers mode AND the selected entry's
+                    // provider_id BEFORE confirm() — confirm() calls close()
+                    // which resets all_providers_mode to false AND clears the
+                    // filter, changing the grouped list and invalidating
+                    // selected_idx.
+                    let was_all_providers = self.model_picker.all_providers_mode;
+                    let selected_provider_id = if was_all_providers {
+                        self.model_picker
+                            .filtered_models_grouped()
+                            .get(self.model_picker.selected_idx)
+                            .map(|(m, _)| m.provider_id.clone())
+                    } else {
+                        None
+                    };
                     if let Some((model_id, effort)) = self.model_picker.confirm() {
+                        // Default sentinel — clear explicit model override.
+                        if model_id == crate::model_picker::DEFAULT_MODEL_SENTINEL {
+                            self.config.model = None;
+                            let provider = self.config.provider.as_deref().unwrap_or("anthropic");
+                            let best = self.display_default_model_for_provider(provider);
+                            self.model_name = best.clone();
+                            self.cost_tracker.set_model(&best);
+                            self.refresh_context_window_size();
+                            self.context_used_tokens = 0;
+                            self.persist_provider_and_model();
+                            self.status_message = Some(format!("Model: {} (default)", best));
+                            return false;
+                        }
                         // If user picked a model other than the fast-mode model
                         // while fast mode was active, turn fast mode off.
-                        if self.fast_mode && !self.model_picker.is_selected_fast_mode_model(&model_id) {
+                        if self.fast_mode
+                            && !self.model_picker.is_selected_fast_mode_model(&model_id)
+                        {
                             self.fast_mode = false;
                         }
                         if let Some(e) = effort {
@@ -3656,19 +4547,51 @@ impl App {
                         // a routing prefix (`free/…`, `zen/…`, `openrouter/…`)
                         // so re-prefixing would produce nonsense like
                         // `free/free/auto`.
-                        let provider = self.config.provider.as_deref().unwrap_or("anthropic");
-                        let full_model = if provider == "anthropic" || provider == "free" {
-                            model_id.clone()
+                        //
+                        // In all-providers mode the provider is inferred from
+                        // the selected entry's `provider_id` field rather than
+                        // the current config provider.
+                        let full_model = if was_all_providers {
+                            if let Some(ref provider) = selected_provider_id {
+                                if provider == "anthropic" || provider == "free" {
+                                    model_id.clone()
+                                } else {
+                                    format!("{}/{}", provider, model_id)
+                                }
+                            } else {
+                                model_id.clone()
+                            }
                         } else {
-                            format!("{}/{}", provider, model_id)
+                            let provider = self.config.provider.as_deref().unwrap_or("anthropic");
+                            if provider == "anthropic" || provider == "free" {
+                                model_id.clone()
+                            } else {
+                                format!("{}/{}", provider, model_id)
+                            }
                         };
                         self.set_model(full_model.clone());
                         self.persist_provider_and_model();
-                        let effort_hint = effort.map(|e| format!(" [{}]", e.label())).unwrap_or_default();
+                        let effort_hint = effort
+                            .map(|e| format!(" [{}]", e.label()))
+                            .unwrap_or_default();
                         self.status_message = Some(format!("Model: {}{}", full_model, effort_hint));
                     }
                 }
                 KeyCode::Backspace => self.model_picker.pop_filter_char(),
+                KeyCode::Char('f') | KeyCode::Char('*') => {
+                    // Toggle favorite on the currently selected model.
+                    let grouped = self.model_picker.filtered_models_grouped();
+                    if let Some((m, _)) = grouped.get(self.model_picker.selected_idx) {
+                        let provider = self.config.provider.as_deref().unwrap_or("anthropic");
+                        let model_key = if provider == "anthropic" || provider == "free" {
+                            m.id.clone()
+                        } else {
+                            format!("{}/{}", provider, m.id)
+                        };
+                        self.model_picker.toggle_favorite(&model_key);
+                    }
+                }
+                KeyCode::Char('a') => self.model_picker.toggle_show_all_providers(),
                 KeyCode::Char(c) => self.model_picker.push_filter_char(c),
                 _ => {}
             }
@@ -3679,47 +4602,43 @@ impl App {
         if self.session_branching.visible {
             use crate::session_branching::BranchBrowserMode;
             match self.session_branching.mode {
-                BranchBrowserMode::Browse => {
-                    match key.code {
-                        KeyCode::Esc => self.session_branching.cancel(),
-                        KeyCode::Up => self.session_branching.select_prev(),
-                        KeyCode::Down => self.session_branching.select_next(),
-                        KeyCode::Char('n') => self.session_branching.start_create_new(),
-                        KeyCode::Char('d') => self.session_branching.start_delete_confirm(),
-                        KeyCode::Enter => {
-                            if let Some(branch) = self.session_branching.selected_branch() {
-                                self.status_message = Some(format!("Switched to branch: {}", branch.name));
-                                self.session_branching.close();
-                            }
+                BranchBrowserMode::Browse => match key.code {
+                    KeyCode::Esc => self.session_branching.cancel(),
+                    KeyCode::Up => self.session_branching.select_prev(),
+                    KeyCode::Down => self.session_branching.select_next(),
+                    KeyCode::Char('n') => self.session_branching.start_create_new(),
+                    KeyCode::Char('d') => self.session_branching.start_delete_confirm(),
+                    KeyCode::Enter => {
+                        if let Some(branch) = self.session_branching.selected_branch() {
+                            self.status_message =
+                                Some(format!("Switched to branch: {}", branch.name));
+                            self.session_branching.close();
                         }
-                        _ => {}
                     }
-                }
-                BranchBrowserMode::CreateNew => {
-                    match key.code {
-                        KeyCode::Esc => self.session_branching.cancel(),
-                        KeyCode::Enter => {
-                            if let Some((name, at_msg)) = self.session_branching.confirm_create_new() {
-                                self.status_message = Some(format!("Created branch: {} at message {}", name, at_msg));
-                                self.session_branching.close();
-                            }
+                    _ => {}
+                },
+                BranchBrowserMode::CreateNew => match key.code {
+                    KeyCode::Esc => self.session_branching.cancel(),
+                    KeyCode::Enter => {
+                        if let Some((name, at_msg)) = self.session_branching.confirm_create_new() {
+                            self.status_message =
+                                Some(format!("Created branch: {} at message {}", name, at_msg));
+                            self.session_branching.close();
                         }
-                        KeyCode::Backspace => self.session_branching.pop_create_char(),
-                        KeyCode::Char(c) => self.session_branching.push_create_char(c),
-                        _ => {}
                     }
-                }
-                BranchBrowserMode::ConfirmDelete => {
-                    match key.code {
-                        KeyCode::Esc | KeyCode::Char('n') => self.session_branching.cancel(),
-                        KeyCode::Enter | KeyCode::Char('y') => {
-                            if let Some(branch_id) = self.session_branching.confirm_delete() {
-                                self.status_message = Some(format!("Deleted branch: {}", branch_id));
-                            }
+                    KeyCode::Backspace => self.session_branching.pop_create_char(),
+                    KeyCode::Char(c) => self.session_branching.push_create_char(c),
+                    _ => {}
+                },
+                BranchBrowserMode::ConfirmDelete => match key.code {
+                    KeyCode::Esc | KeyCode::Char('n') => self.session_branching.cancel(),
+                    KeyCode::Enter | KeyCode::Char('y') => {
+                        if let Some(branch_id) = self.session_branching.confirm_delete() {
+                            self.status_message = Some(format!("Deleted branch: {}", branch_id));
                         }
-                        _ => {}
                     }
-                }
+                    _ => {}
+                },
             }
             return false;
         }
@@ -3728,38 +4647,32 @@ impl App {
         if self.session_browser.visible {
             use crate::session_browser::SessionBrowserMode;
             match self.session_browser.mode {
-                SessionBrowserMode::Browse => {
-                    match key.code {
-                        KeyCode::Esc => self.session_browser.close(),
-                        KeyCode::Up => self.session_browser.select_prev(),
-                        KeyCode::Down => self.session_browser.select_next(),
-                        KeyCode::Char('r') => self.session_browser.start_rename(),
-                        _ => {}
-                    }
-                }
-                SessionBrowserMode::Rename => {
-                    match key.code {
-                        KeyCode::Esc => self.session_browser.cancel(),
-                        KeyCode::Enter => {
-                            if let Some((_id, name)) = self.session_browser.confirm_rename() {
-                                self.session_title = Some(name.clone());
-                                self.status_message = Some(format!("Renamed to: {}", name));
-                            }
+                SessionBrowserMode::Browse => match key.code {
+                    KeyCode::Esc => self.session_browser.close(),
+                    KeyCode::Up => self.session_browser.select_prev(),
+                    KeyCode::Down => self.session_browser.select_next(),
+                    KeyCode::Char('r') => self.session_browser.start_rename(),
+                    _ => {}
+                },
+                SessionBrowserMode::Rename => match key.code {
+                    KeyCode::Esc => self.session_browser.cancel(),
+                    KeyCode::Enter => {
+                        if let Some((_id, name)) = self.session_browser.confirm_rename() {
+                            self.session_title = Some(name.clone());
+                            self.status_message = Some(format!("Renamed to: {}", name));
                         }
-                        KeyCode::Backspace => self.session_browser.pop_rename_char(),
-                        KeyCode::Char(c) => self.session_browser.push_rename_char(c),
-                        _ => {}
                     }
-                }
-                SessionBrowserMode::Confirm => {
-                    match key.code {
-                        KeyCode::Esc | KeyCode::Char('n') => self.session_browser.cancel(),
-                        KeyCode::Enter | KeyCode::Char('y') => {
-                            self.session_browser.close();
-                        }
-                        _ => {}
+                    KeyCode::Backspace => self.session_browser.pop_rename_char(),
+                    KeyCode::Char(c) => self.session_browser.push_rename_char(c),
+                    _ => {}
+                },
+                SessionBrowserMode::Confirm => match key.code {
+                    KeyCode::Esc | KeyCode::Char('n') => self.session_browser.cancel(),
+                    KeyCode::Enter | KeyCode::Char('y') => {
+                        self.session_browser.close();
                     }
-                }
+                    _ => {}
+                },
             }
             return false;
         }
@@ -3771,7 +4684,9 @@ impl App {
                 KeyCode::Up => self.tasks_overlay.select_prev(),
                 KeyCode::Down => self.tasks_overlay.select_next(),
                 KeyCode::Enter => {
-                    if let Some((task_id, new_status)) = self.tasks_overlay.cycle_and_persist_status() {
+                    if let Some((task_id, new_status)) =
+                        self.tasks_overlay.cycle_and_persist_status()
+                    {
                         self.status_message = Some(format!("Task {} → {}", task_id, new_status));
                     }
                 }
@@ -3828,7 +4743,9 @@ impl App {
 
         // MCP approval dialog
         if self.mcp_approval.visible {
-            if let Some(choice) = crate::dialogs::handle_mcp_approval_key(&mut self.mcp_approval, key) {
+            if let Some(choice) =
+                crate::dialogs::handle_mcp_approval_key(&mut self.mcp_approval, key)
+            {
                 self.handle_mcp_approval_decision(choice);
             }
             return false;
@@ -4090,8 +5007,132 @@ impl App {
             self.keybindings.cancel_chord();
         }
 
+        // ---- Keyboard selection mode -------------------------------
+        if self.kb_select_mode {
+            match key.code {
+                KeyCode::Esc => {
+                    self.kb_select_mode = false;
+                    self.clear_selection();
+                    self.status_message = Some("Selection cancelled.".to_string());
+                    return false;
+                }
+                // Copy selection and exit
+                KeyCode::Char('y') | KeyCode::Char('Y') => {
+                    let text = self.selection_text.borrow().clone();
+                    if !text.is_empty() {
+                        let copied = crate::image_paste::write_clipboard_text(&text);
+                        if copied {
+                            self.push_notification(
+                                NotificationKind::Info,
+                                "Copied to clipboard".to_string(),
+                                Some(2),
+                            );
+                        }
+                    }
+                    self.kb_select_mode = false;
+                    self.clear_selection();
+                    return false;
+                }
+                // Ctrl+C also copies in selection mode
+                KeyCode::Char(c)
+                    if (c == 'c' || c == 'C') && key.modifiers.contains(KeyModifiers::CONTROL) =>
+                {
+                    let text = self.selection_text.borrow().clone();
+                    if !text.is_empty() {
+                        let copied = crate::image_paste::write_clipboard_text(&text);
+                        if copied {
+                            self.push_notification(
+                                NotificationKind::Info,
+                                "Copied to clipboard".to_string(),
+                                Some(2),
+                            );
+                        }
+                    }
+                    self.kb_select_mode = false;
+                    self.clear_selection();
+                    return false;
+                }
+                // Movement: extend selection
+                KeyCode::Up => {
+                    if self.kb_cursor_row > self.last_selectable_area.get().y {
+                        self.kb_cursor_row -= 1;
+                        // Scroll up if cursor goes above visible area
+                        let area = self.last_selectable_area.get();
+                        if self.kb_cursor_row < area.y {
+                            let step = self.scroll_step();
+                            self.scroll_offset = self.scroll_offset.saturating_add(step);
+                        }
+                    }
+                    self.update_kb_selection();
+                    return false;
+                }
+                KeyCode::Down => {
+                    let area = self.last_selectable_area.get();
+                    let max_row = area.y + area.height.saturating_sub(1);
+                    if self.kb_cursor_row < max_row {
+                        self.kb_cursor_row += 1;
+                        // Scroll down if cursor goes below visible area
+                        if self.kb_cursor_row >= area.y + area.height {
+                            let step = self.scroll_step();
+                            let new_off = self.scroll_offset.saturating_sub(step);
+                            self.scroll_offset = new_off;
+                            if new_off == 0 {
+                                self.auto_scroll = true;
+                            }
+                        }
+                    }
+                    self.update_kb_selection();
+                    return false;
+                }
+                KeyCode::Home => {
+                    let area = self.last_selectable_area.get();
+                    self.kb_cursor_row = area.y;
+                    // Scroll to top
+                    self.scroll_offset = self
+                        .total_message_lines
+                        .get()
+                        .saturating_sub(area.height as usize);
+                    self.auto_scroll = false;
+                    self.update_kb_selection();
+                    return false;
+                }
+                KeyCode::End => {
+                    let area = self.last_selectable_area.get();
+                    self.kb_cursor_row = area.y + area.height.saturating_sub(1);
+                    // Scroll to bottom
+                    self.scroll_offset = 0;
+                    self.auto_scroll = true;
+                    self.update_kb_selection();
+                    return false;
+                }
+                KeyCode::PageUp => {
+                    let area = self.last_selectable_area.get();
+                    let step = area.height;
+                    self.kb_cursor_row = self.kb_cursor_row.saturating_sub(step).max(area.y);
+                    self.scroll_offset = self.scroll_offset.saturating_add(step as usize);
+                    self.update_kb_selection();
+                    return false;
+                }
+                KeyCode::PageDown => {
+                    let area = self.last_selectable_area.get();
+                    let max_row = area.y + area.height.saturating_sub(1);
+                    let step = area.height;
+                    self.kb_cursor_row = (self.kb_cursor_row + step).min(max_row);
+                    let new_off = self.scroll_offset.saturating_sub(step as usize);
+                    self.scroll_offset = new_off;
+                    if new_off == 0 {
+                        self.auto_scroll = true;
+                    }
+                    self.update_kb_selection();
+                    return false;
+                }
+                _ => return false, // Swallow all other keys in selection mode
+            }
+        }
+
         // Clear any active text selection on key press (except Ctrl+C which copies it).
-        let is_copy = key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL);
+        let is_copy =
+            key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL);
         if !is_copy && self.selection_anchor.is_some() {
             self.selection_anchor = None;
             self.selection_focus = None;
@@ -4181,7 +5222,9 @@ impl App {
                     | crate::prompt_input::VimMode::VisualBlock
             )
         {
-            use crate::image_paste::{read_clipboard_image, read_clipboard_text, read_primary_text};
+            use crate::image_paste::{
+                read_clipboard_image, read_clipboard_text, read_primary_text,
+            };
             if let Some(img) = read_clipboard_image() {
                 let label = img.label.clone();
                 let dims = img.dimensions;
@@ -4206,10 +5249,7 @@ impl App {
         }
 
         // ---- Enter while PTT recording: stop capture instead of submitting ----
-        if key.code == KeyCode::Enter
-            && self.voice_recording
-            && self.voice_recorder.is_some()
-        {
+        if key.code == KeyCode::Enter && self.voice_recording && self.voice_recorder.is_some() {
             self.handle_voice_ptt_stop();
             return false;
         }
@@ -4227,8 +5267,9 @@ impl App {
                 KeyCode::PageUp | KeyCode::PageDown => {
                     // Let these fall through to the normal scroll handling below.
                 }
-                KeyCode::Char(_) if !key.modifiers.contains(KeyModifiers::CONTROL)
-                    && !key.modifiers.contains(KeyModifiers::ALT) =>
+                KeyCode::Char(_)
+                    if !key.modifiers.contains(KeyModifiers::CONTROL)
+                        && !key.modifiers.contains(KeyModifiers::ALT) =>
                 {
                     // Printable char: switch focus to Input and process normally.
                     self.focus = FocusTarget::Input;
@@ -4252,7 +5293,9 @@ impl App {
             // ---- Quit / cancel ----------------------------------------
             // Accept both 'c' and 'C' so Shift+Ctrl+C also triggers copy
             // (issue #149 follow-up).
-            KeyCode::Char(c) if (c == 'c' || c == 'C') && key.modifiers.contains(KeyModifiers::CONTROL) => {
+            KeyCode::Char(c)
+                if (c == 'c' || c == 'C') && key.modifiers.contains(KeyModifiers::CONTROL) =>
+            {
                 // If text is selected, copy it to clipboard instead of quitting.
                 let sel_text = self.selection_text.borrow().clone();
                 if self.selection_anchor.is_some() && !sel_text.is_empty() {
@@ -4262,7 +5305,11 @@ impl App {
                     self.selection_focus = None;
                     *self.selection_text.borrow_mut() = String::new();
                     if copied {
-                        self.push_notification(NotificationKind::Info, "Copied to clipboard".to_string(), Some(2));
+                        self.push_notification(
+                            NotificationKind::Info,
+                            "Copied to clipboard".to_string(),
+                            Some(2),
+                        );
                     }
                 } else if self.is_streaming {
                     // Cancel streaming.
@@ -4386,6 +5433,25 @@ impl App {
             KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::ALT) => {
                 self.prompt_input.delete_word_at_cursor();
                 self.refresh_prompt_input();
+            }
+
+            // ---- Enter keyboard selection mode ------------------------
+            KeyCode::Char('v')
+                if !key.modifiers.contains(KeyModifiers::CONTROL)
+                    && !key.modifiers.contains(KeyModifiers::ALT)
+                    && self.prompt_input.is_empty() =>
+            {
+                self.kb_select_mode = true;
+                let area = self.last_selectable_area.get();
+                // Start cursor at the bottom of the visible area
+                self.kb_cursor_row = area.y + area.height.saturating_sub(1);
+                // Set anchor at current cursor, focus at same point (empty selection)
+                let col = area.x;
+                self.selection_anchor = Some((col, self.kb_cursor_row));
+                self.selection_focus = Some((col, self.kb_cursor_row));
+                self.status_message =
+                    Some("Selection mode: Arrows select, y/Ctrl+C copy, Esc cancel".to_string());
+                return false;
             }
 
             // ---- Text entry (allowed while streaming so users can queue
@@ -4535,7 +5601,10 @@ impl App {
             // when the cursor is already on the first/last visual row
             // (issue #149 follow-up).
             KeyCode::Up => {
-                if !self.prompt_input.suggestions.is_empty() && (self.prompt_input.text.starts_with('/') || self.prompt_input.has_active_file_ref()) {
+                if !self.prompt_input.suggestions.is_empty()
+                    && (self.prompt_input.text.starts_with('/')
+                        || self.prompt_input.has_active_file_ref())
+                {
                     self.prompt_input.suggestion_prev();
                 } else {
                     let area = self.last_input_area.get();
@@ -4549,7 +5618,10 @@ impl App {
                 self.refresh_prompt_input();
             }
             KeyCode::Down => {
-                if !self.prompt_input.suggestions.is_empty() && (self.prompt_input.text.starts_with('/') || self.prompt_input.has_active_file_ref()) {
+                if !self.prompt_input.suggestions.is_empty()
+                    && (self.prompt_input.text.starts_with('/')
+                        || self.prompt_input.has_active_file_ref())
+                {
                     self.prompt_input.suggestion_next();
                 } else {
                     let area = self.last_input_area.get();
@@ -4580,12 +5652,12 @@ impl App {
 
             // ---- Toggle last thinking block (t key) -------------------
             // (Removed: shadowed by KeyCode::Char(c) prompt input handler.)
-
             _ => {}
         }
 
         // Reset exit confirmation sequence if user presses any key other than Ctrl+C or Ctrl+D.
-        let is_exit_key = key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char(c) if c == 'c' || c == 'd' || c == 'C' || c == 'D');
+        let is_exit_key = key.modifiers.contains(KeyModifiers::CONTROL)
+            && matches!(key.code, KeyCode::Char(c) if c == 'c' || c == 'd' || c == 'C' || c == 'D');
         if !is_exit_key {
             self.last_exit_key_warning = None;
             self.exit_key_sequence_start = None;
@@ -4662,10 +5734,12 @@ impl App {
                 self.pending_mcp_reconnect = true;
                 self.status_message = Some("Reconnecting MCP runtime...".to_string());
             }
-            KeyCode::Char(c) if key.modifiers.is_empty()
-                && self.mcp_view.active_pane != crate::mcp_view::McpViewPane::ServerList => {
-                    self.mcp_view.push_search_char(c);
-                }
+            KeyCode::Char(c)
+                if key.modifiers.is_empty()
+                    && self.mcp_view.active_pane != crate::mcp_view::McpViewPane::ServerList =>
+            {
+                self.mcp_view.push_search_char(c);
+            }
             _ => {}
         }
         false
@@ -4732,10 +5806,9 @@ impl App {
             }
             KeyCode::PageUp => self.diff_viewer.scroll_detail_up(),
             KeyCode::PageDown => self.diff_viewer.scroll_detail_down(),
-            KeyCode::Char(' ')
-                if self.diff_viewer.active_pane == DiffPane::FileList => {
-                    self.diff_viewer.toggle_file_collapse();
-                }
+            KeyCode::Char(' ') if self.diff_viewer.active_pane == DiffPane::FileList => {
+                self.diff_viewer.toggle_file_collapse();
+            }
             _ => {}
         }
     }
@@ -4936,7 +6009,11 @@ impl App {
         }
 
         // Start new sequence (or show message for wrong key)
-        self.push_notification(NotificationKind::Info, exit_message(key_char).to_string(), Some(2));
+        self.push_notification(
+            NotificationKind::Info,
+            exit_message(key_char).to_string(),
+            Some(2),
+        );
         self.last_exit_key_warning = Some(std::time::Instant::now());
         self.exit_key_sequence_start = Some(key_char);
     }
@@ -4959,7 +6036,9 @@ impl App {
                         self.refresh_prompt_input();
                     }
 
-                    let elapsed = self.last_exit_key_warning.map(|t| t.elapsed().as_secs_f64());
+                    let elapsed = self
+                        .last_exit_key_warning
+                        .map(|t| t.elapsed().as_secs_f64());
                     let is_valid = elapsed.map(|e| e <= 2.0).unwrap_or(false);
 
                     if self.last_exit_key_warning.is_some() && is_valid {
@@ -4969,7 +6048,11 @@ impl App {
                         self.exit_key_sequence_start = None;
                     } else {
                         // First press or timeout expired: show exit confirmation.
-                        self.push_notification(NotificationKind::Info, "Press Ctrl+C again to exit".to_string(), Some(2));
+                        self.push_notification(
+                            NotificationKind::Info,
+                            "Press Ctrl+C again to exit".to_string(),
+                            Some(2),
+                        );
                         self.last_exit_key_warning = Some(std::time::Instant::now());
                         self.exit_key_sequence_start = Some('c');
                     }
@@ -5012,7 +6095,8 @@ impl App {
             "historyPrev" => {
                 // Suggestions (slash commands or file refs) take priority over cursor/history.
                 if !self.prompt_input.suggestions.is_empty()
-                    && (self.prompt_input.text.starts_with('/') || self.prompt_input.has_active_file_ref())
+                    && (self.prompt_input.text.starts_with('/')
+                        || self.prompt_input.has_active_file_ref())
                 {
                     self.prompt_input.suggestion_prev();
                     self.refresh_prompt_input();
@@ -5030,7 +6114,8 @@ impl App {
             "historyNext" => {
                 // Suggestions (slash commands or file refs) take priority over cursor/history.
                 if !self.prompt_input.suggestions.is_empty()
-                    && (self.prompt_input.text.starts_with('/') || self.prompt_input.has_active_file_ref())
+                    && (self.prompt_input.text.starts_with('/')
+                        || self.prompt_input.has_active_file_ref())
                 {
                     self.prompt_input.suggestion_next();
                     self.refresh_prompt_input();
@@ -5272,7 +6357,7 @@ impl App {
                         self.refresh_prompt_input();
                     } else if self.prompt_input.is_empty() {
                         self.cycle_agent_mode();
-                    self.rustle_look_down();
+                        self.rustle_look_down();
                     }
                 }
                 false
@@ -5440,7 +6525,8 @@ impl App {
             (Some(last_time), Some(last_pos)) => {
                 let elapsed = now.duration_since(last_time);
                 let distance = ((current_pos.0 as i32 - last_pos.0 as i32).abs()
-                    + (current_pos.1 as i32 - last_pos.1 as i32).abs()) as u16;
+                    + (current_pos.1 as i32 - last_pos.1 as i32).abs())
+                    as u16;
                 elapsed.as_millis() < 500 && distance <= 5
             }
             _ => false,
@@ -5477,7 +6563,10 @@ impl App {
         while end + 1 < chars.len() && is_word(chars[end + 1]) {
             end += 1;
         }
-        Some((selectable_area.x + start as u16, selectable_area.x + end as u16))
+        Some((
+            selectable_area.x + start as u16,
+            selectable_area.x + end as u16,
+        ))
     }
 
     /// Find paragraph boundaries (run of non-blank rows) around `row` and
@@ -5502,7 +6591,11 @@ impl App {
         let mut start = row;
         while start > selectable_area.y {
             let prev = start - 1;
-            if cache.get(&prev).map(|s| s.trim().is_empty()).unwrap_or(true) {
+            if cache
+                .get(&prev)
+                .map(|s| s.trim().is_empty())
+                .unwrap_or(true)
+            {
                 break;
             }
             start = prev;
@@ -5510,7 +6603,11 @@ impl App {
         let mut end = row;
         while end < max_row {
             let next = end + 1;
-            if cache.get(&next).map(|s| s.trim().is_empty()).unwrap_or(true) {
+            if cache
+                .get(&next)
+                .map(|s| s.trim().is_empty())
+                .unwrap_or(true)
+            {
                 break;
             }
             end = next;
@@ -5527,7 +6624,10 @@ impl App {
     fn find_line_boundaries(&self, row: u16) -> Option<(u16, u16)> {
         let selectable_area = self.last_selectable_area.get();
         let line_start = selectable_area.y;
-        let line_end = selectable_area.y.saturating_add(selectable_area.height).saturating_sub(1);
+        let line_end = selectable_area
+            .y
+            .saturating_add(selectable_area.height)
+            .saturating_sub(1);
 
         if row >= line_start && row <= line_end {
             Some((row, row))
@@ -5550,7 +6650,28 @@ impl App {
     fn clear_selection(&mut self) {
         self.selection_anchor = None;
         self.selection_focus = None;
+        self.kb_select_mode = false;
         *self.selection_text.borrow_mut() = String::new();
+    }
+
+    /// Update the selection from keyboard cursor position.
+    fn update_kb_selection(&mut self) {
+        if !self.kb_select_mode {
+            return;
+        }
+        let area = self.last_selectable_area.get();
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        // Anchor stays at original position, focus follows cursor.
+        // The render code in render.rs already handles extracting text between
+        // anchor and focus in row-major order.
+        let col = area.x;
+        self.selection_focus = Some((col, self.kb_cursor_row));
+        // If anchor is None (shouldn't happen), set it.
+        if self.selection_anchor.is_none() {
+            self.selection_anchor = Some((col, self.kb_cursor_row));
+        }
     }
 
     /// Show context menu at the given position.
@@ -5645,9 +6766,12 @@ impl App {
             ContextMenuItem::Fork => {
                 if let ContextMenuKind::Message { message_index } = kind {
                     let branch_point = message_index + 1;
-                    self.prompt_input.replace_text(format!("/fork {}", branch_point));
-                    self.status_message =
-                        Some(format!("Fork at message {} - press Enter to confirm", branch_point));
+                    self.prompt_input
+                        .replace_text(format!("/fork {}", branch_point));
+                    self.status_message = Some(format!(
+                        "Fork at message {} - press Enter to confirm",
+                        branch_point
+                    ));
                 }
             }
         }
@@ -5671,8 +6795,8 @@ impl App {
             return false;
         }
 
-        if let Some(text) = crate::image_paste::read_primary_text()
-            .or_else(crate::image_paste::read_clipboard_text)
+        if let Some(text) =
+            crate::image_paste::read_primary_text().or_else(crate::image_paste::read_clipboard_text)
         {
             self.focus = FocusTarget::Input;
             self.clear_selection();
@@ -5693,8 +6817,8 @@ impl App {
     /// Otherwise the text goes through the normal `prompt_input.paste()` path
     /// which applies the multi-line summary placeholder for large pastes.
     pub fn handle_paste_data(&mut self, data: String) {
-        use crate::prompt_input::detect_pasted_path;
         use crate::image_paste::PastedImage;
+        use crate::prompt_input::detect_pasted_path;
 
         if let Some(path) = detect_pasted_path(&data) {
             let ext = path
@@ -5711,7 +6835,11 @@ impl App {
                     .and_then(|n| n.to_str())
                     .unwrap_or("image")
                     .to_string();
-                let img = PastedImage { path, label: label.clone(), dimensions: None };
+                let img = PastedImage {
+                    path,
+                    label: label.clone(),
+                    dimensions: None,
+                };
                 self.prompt_input.add_image(img);
                 self.push_notification(
                     crate::notifications::NotificationKind::Info,
@@ -5749,8 +6877,7 @@ impl App {
     /// queued composition, and a raw-key paste flood must be captured there
     /// too instead of submitting on every pasted newline.
     pub fn paste_burst_allowed(&self) -> bool {
-        !self.any_modal_open()
-            && self.prompt_input.vim_mode == crate::prompt_input::VimMode::Insert
+        !self.any_modal_open() && self.prompt_input.vim_mode == crate::prompt_input::VimMode::Insert
     }
 
     /// Drain any immediately-available key events from the crossterm event
@@ -5771,10 +6898,7 @@ impl App {
     /// single keystroke.  If a non-character key is encountered while
     /// draining, it is stored in `self.pending_key` and will be replayed at
     /// the top of the next event-loop iteration.
-    pub fn try_detect_paste_burst(
-        &mut self,
-        first: char,
-    ) -> Option<String> {
+    pub fn try_detect_paste_burst(&mut self, first: char) -> Option<String> {
         use crossterm::event::{Event, KeyCode, KeyEventKind};
 
         // Minimum number of chars (including `first`) to classify as a paste.
@@ -5806,7 +6930,8 @@ impl App {
                         // map it back to a newline or Unix pastes lose their
                         // line breaks (they'd insert a literal 'j').
                         KeyCode::Char('j')
-                            if k.modifiers.contains(crossterm::event::KeyModifiers::CONTROL) =>
+                            if k.modifiers
+                                .contains(crossterm::event::KeyModifiers::CONTROL) =>
                         {
                             buf.push('\n')
                         }
@@ -5889,7 +7014,8 @@ impl App {
         }
         let target_row = scroll + (row - text_start_y) as usize;
         let target_col = col.saturating_sub(rect.x + 2) as usize;
-        self.prompt_input.set_cursor_at_visual(target_row, target_col, width);
+        self.prompt_input
+            .set_cursor_at_visual(target_row, target_col, width);
         // Clicking a [Pasted text #N ...] placeholder opens the read-only
         // viewer so the body can be read without splicing it into the
         // prompt; Alt+E remains the in-place expansion for editing.
@@ -5964,15 +7090,29 @@ impl App {
         if matches!(mouse_event.kind, MouseEventKind::Moved) {
             if let Some(menu) = self.context_menu_state.as_mut() {
                 let items = Self::context_menu_items(menu.kind);
-                let item_labels: Vec<&str> = items.iter().map(|i| match i {
-                    ContextMenuItem::Copy => "Copy",
-                    ContextMenuItem::Fork => "Fork new chat",
-                }).collect();
-                let menu_width = (item_labels.iter().map(|l| l.len()).max().unwrap_or(4) + 4) as u16;
+                let item_labels: Vec<&str> = items
+                    .iter()
+                    .map(|i| match i {
+                        ContextMenuItem::Copy => "Copy",
+                        ContextMenuItem::Fork => "Fork new chat",
+                    })
+                    .collect();
+                let menu_width =
+                    (item_labels.iter().map(|l| l.len()).max().unwrap_or(4) + 4) as u16;
                 let menu_height = items.len() as u16 + 2;
                 let screen = self.last_msg_area.get();
-                let menu_x = menu.x.min(screen.x.saturating_add(screen.width).saturating_sub(menu_width + 1));
-                let menu_y = menu.y.min(screen.y.saturating_add(screen.height).saturating_sub(menu_height + 1));
+                let menu_x = menu.x.min(
+                    screen
+                        .x
+                        .saturating_add(screen.width)
+                        .saturating_sub(menu_width + 1),
+                );
+                let menu_y = menu.y.min(
+                    screen
+                        .y
+                        .saturating_add(screen.height)
+                        .saturating_sub(menu_height + 1),
+                );
                 let inner_y = menu_y + 1;
                 let col = mouse_event.column;
                 let row = mouse_event.row;
@@ -6009,11 +7149,14 @@ impl App {
                 MouseEventKind::Down(MouseButton::Left) => {
                     // DialogSelect dialogs — check if click is inside for item selection
                     let in_dialog = if self.connect_dialog.visible {
-                        self.connect_dialog.contains(mouse_event.column, mouse_event.row)
+                        self.connect_dialog
+                            .contains(mouse_event.column, mouse_event.row)
                     } else if self.import_config_picker.visible {
-                        self.import_config_picker.contains(mouse_event.column, mouse_event.row)
+                        self.import_config_picker
+                            .contains(mouse_event.column, mouse_event.row)
                     } else if self.command_palette.visible {
-                        self.command_palette.contains(mouse_event.column, mouse_event.row)
+                        self.command_palette
+                            .contains(mouse_event.column, mouse_event.row)
                     } else {
                         // Other dialogs (model_picker, settings, export, etc.) —
                         // treat any click as "inside" to prevent accidental dismiss.
@@ -6026,7 +7169,8 @@ impl App {
                         if self.connect_dialog.visible {
                             self.connect_dialog.handle_mouse_click(mouse_event.row);
                         } else if self.import_config_picker.visible {
-                            self.import_config_picker.handle_mouse_click(mouse_event.row);
+                            self.import_config_picker
+                                .handle_mouse_click(mouse_event.row);
                         } else if self.command_palette.visible {
                             self.command_palette.handle_mouse_click(mouse_event.row);
                         }
@@ -6039,14 +7183,22 @@ impl App {
                 }
                 MouseEventKind::ScrollUp => {
                     // Scroll through dialog items
-                    if self.connect_dialog.visible { self.connect_dialog.move_up(); }
-                    else if self.import_config_picker.visible { self.import_config_picker.move_up(); }
-                    else if self.command_palette.visible { self.command_palette.move_up(); }
+                    if self.connect_dialog.visible {
+                        self.connect_dialog.move_up();
+                    } else if self.import_config_picker.visible {
+                        self.import_config_picker.move_up();
+                    } else if self.command_palette.visible {
+                        self.command_palette.move_up();
+                    }
                 }
                 MouseEventKind::ScrollDown => {
-                    if self.connect_dialog.visible { self.connect_dialog.move_down(); }
-                    else if self.import_config_picker.visible { self.import_config_picker.move_down(); }
-                    else if self.command_palette.visible { self.command_palette.move_down(); }
+                    if self.connect_dialog.visible {
+                        self.connect_dialog.move_down();
+                    } else if self.import_config_picker.visible {
+                        self.import_config_picker.move_down();
+                    } else if self.command_palette.visible {
+                        self.command_palette.move_down();
+                    }
                 }
                 _ => {}
             }
@@ -6112,16 +7264,30 @@ impl App {
                 // Must replicate the same position clamping as the renderer.
                 if let Some(menu) = self.context_menu_state {
                     let items = Self::context_menu_items(menu.kind);
-                    let item_labels: Vec<&str> = items.iter().map(|i| match i {
-                        ContextMenuItem::Copy => "Copy",
-                        ContextMenuItem::Fork => "Fork new chat",
-                    }).collect();
-                    let menu_width = (item_labels.iter().map(|l| l.len()).max().unwrap_or(4) + 4) as u16;
+                    let item_labels: Vec<&str> = items
+                        .iter()
+                        .map(|i| match i {
+                            ContextMenuItem::Copy => "Copy",
+                            ContextMenuItem::Fork => "Fork new chat",
+                        })
+                        .collect();
+                    let menu_width =
+                        (item_labels.iter().map(|l| l.len()).max().unwrap_or(4) + 4) as u16;
                     let menu_height = items.len() as u16 + 2; // +2 for border
-                    // Clamp to screen bounds (same as render_context_menu)
+                                                              // Clamp to screen bounds (same as render_context_menu)
                     let screen = self.last_msg_area.get();
-                    let menu_x = menu.x.min(screen.x.saturating_add(screen.width).saturating_sub(menu_width + 1));
-                    let menu_y = menu.y.min(screen.y.saturating_add(screen.height).saturating_sub(menu_height + 1));
+                    let menu_x = menu.x.min(
+                        screen
+                            .x
+                            .saturating_add(screen.width)
+                            .saturating_sub(menu_width + 1),
+                    );
+                    let menu_y = menu.y.min(
+                        screen
+                            .y
+                            .saturating_add(screen.height)
+                            .saturating_sub(menu_height + 1),
+                    );
                     let col = mouse_event.column;
                     let row = mouse_event.row;
                     // Inner area starts 1 past the border
@@ -6133,7 +7299,8 @@ impl App {
                     {
                         let clicked_index = (row - inner_y) as usize;
                         if clicked_index < items.len() {
-                            self.context_menu_state.as_mut().unwrap().selected_index = clicked_index;
+                            self.context_menu_state.as_mut().unwrap().selected_index =
+                                clicked_index;
                             self.execute_context_menu_item();
                             return;
                         }
@@ -6146,17 +7313,26 @@ impl App {
                 let input_area = self.last_input_area.get();
                 let selectable_area = self.last_selectable_area.get();
 
-                let in_input = input_area.width > 0 && input_area.height > 0
+                // When an error modal is showing, the selectable area covers
+                // the entire terminal — the modal text is selectable for copy.
+                let error_modal_active = self.notifications.current_is_error();
+
+                let in_input = input_area.width > 0
+                    && input_area.height > 0
                     && mouse_event.row >= input_area.y
                     && mouse_event.row < input_area.y.saturating_add(input_area.height)
                     && mouse_event.column >= input_area.x
                     && mouse_event.column < input_area.x.saturating_add(input_area.width);
 
-                let in_selectable = selectable_area.width > 0 && selectable_area.height > 0
-                    && mouse_event.row >= selectable_area.y
-                    && mouse_event.row < selectable_area.y.saturating_add(selectable_area.height)
-                    && mouse_event.column >= selectable_area.x
-                    && mouse_event.column < selectable_area.x.saturating_add(selectable_area.width);
+                let in_selectable = error_modal_active
+                    || (selectable_area.width > 0
+                        && selectable_area.height > 0
+                        && mouse_event.row >= selectable_area.y
+                        && mouse_event.row
+                            < selectable_area.y.saturating_add(selectable_area.height)
+                        && mouse_event.column >= selectable_area.x
+                        && mouse_event.column
+                            < selectable_area.x.saturating_add(selectable_area.width));
 
                 // Check for click on a thinking block header (takes priority over text selection).
                 if let Some(&hash) = self.thinking_row_map.borrow().get(&mouse_event.row) {
@@ -6169,11 +7345,13 @@ impl App {
                     return;
                 }
 
-                if in_input {
+                if in_input && !error_modal_active {
                     self.focus = FocusTarget::Input;
                     self.clear_selection();
                     self.handle_prompt_click(mouse_event.column, mouse_event.row);
-                } else if selectable_area.width == 0 || selectable_area.height == 0 {
+                } else if !error_modal_active
+                    && (selectable_area.width == 0 || selectable_area.height == 0)
+                {
                     self.click_count = 0;
                 } else if in_selectable {
                     self.focus = FocusTarget::Transcript;
@@ -6206,7 +7384,9 @@ impl App {
                             self.click_count = 0; // Reset for next click sequence
                         } else {
                             // Double-click: select word
-                            if let Some((start, end)) = self.find_word_boundaries(current_pos.0, current_pos.1) {
+                            if let Some((start, end)) =
+                                self.find_word_boundaries(current_pos.0, current_pos.1)
+                            {
                                 self.selection_anchor = Some((start, current_pos.1));
                                 self.selection_focus = Some((end, current_pos.1));
                             }
@@ -6235,12 +7415,18 @@ impl App {
                 if self.selection_anchor.is_some() {
                     let selectable_area = self.last_selectable_area.get();
                     if selectable_area.width > 0 && selectable_area.height > 0 {
-                        let clamped_col = mouse_event.column
-                            .max(selectable_area.x)
-                            .min(selectable_area.x.saturating_add(selectable_area.width).saturating_sub(1));
-                        let clamped_row = mouse_event.row
-                            .max(selectable_area.y)
-                            .min(selectable_area.y.saturating_add(selectable_area.height).saturating_sub(1));
+                        let clamped_col = mouse_event.column.max(selectable_area.x).min(
+                            selectable_area
+                                .x
+                                .saturating_add(selectable_area.width)
+                                .saturating_sub(1),
+                        );
+                        let clamped_row = mouse_event.row.max(selectable_area.y).min(
+                            selectable_area
+                                .y
+                                .saturating_add(selectable_area.height)
+                                .saturating_sub(1),
+                        );
                         self.selection_focus = Some((clamped_col, clamped_row));
                         self.click_count = 0; // Reset on drag to prevent further double-clicks
                     }
@@ -6312,6 +7498,11 @@ impl App {
                         self.stall_start = None;
                         match delta {
                             claurst_api::streaming::ContentDelta::TextDelta { text } => {
+                                let now = std::time::Instant::now();
+                                if self.stream_first_token.is_none() {
+                                    self.stream_first_token = Some(now);
+                                }
+                                self.stream_last_token = Some(now);
                                 self.streaming_text.push_str(&text);
                                 self.invalidate_transcript();
                             }
@@ -6339,7 +7530,11 @@ impl App {
                 }
             }
 
-            QueryEvent::ToolStart { tool_name, tool_id, input_json } => {
+            QueryEvent::ToolStart {
+                tool_name,
+                tool_id,
+                input_json,
+            } => {
                 if !self.is_streaming && self.spinner_verb.is_none() {
                     let seed = self.frame_count as usize ^ (self.messages.len() * 17);
                     self.spinner_verb = Some(sample_spinner_verb(seed).to_string());
@@ -6347,9 +7542,7 @@ impl App {
                 self.is_streaming = true;
                 self.status_message = Some(format!("Running {}…", tool_name));
                 let turn_index = self.current_user_turn_index();
-                if let Some(existing) =
-                    self.tool_use_blocks.iter_mut().find(|b| b.id == tool_id)
-                {
+                if let Some(existing) = self.tool_use_blocks.iter_mut().find(|b| b.id == tool_id) {
                     existing.turn_index = turn_index;
                     existing.status = ToolStatus::Running;
                     existing.output_preview = None;
@@ -6381,9 +7574,7 @@ impl App {
                 if remaining > 0 {
                     preview.push_str(&format!("\n\u{2026} {} more lines", remaining));
                 }
-                if let Some(block) =
-                    self.tool_use_blocks.iter_mut().find(|b| b.id == tool_id)
-                {
+                if let Some(block) = self.tool_use_blocks.iter_mut().find(|b| b.id == tool_id) {
                     block.status = if is_error {
                         ToolStatus::Error
                     } else {
@@ -6400,30 +7591,85 @@ impl App {
                 self.refresh_turn_diff_from_history();
             }
 
-            QueryEvent::TurnComplete { turn, stop_reason, usage, .. } => {
+            QueryEvent::TurnComplete {
+                turn,
+                stop_reason,
+                usage,
+                ..
+            } => {
                 debug!(turn, stop_reason, "Turn complete");
                 self.is_streaming = false;
                 self.spinner_verb = None;
 
                 // Update context window usage from the usage info.
                 if let Some(ref u) = usage {
-                    let turn_tokens = u.input_tokens + u.output_tokens
-                        + u.cache_creation_input_tokens + u.cache_read_input_tokens;
+                    let turn_tokens = u.input_tokens
+                        + u.output_tokens
+                        + u.cache_creation_input_tokens
+                        + u.cache_read_input_tokens;
                     self.context_used_tokens = self.context_used_tokens.saturating_add(turn_tokens);
                 }
                 // Record elapsed time and pick a completion verb
                 let seed = self.frame_count as usize ^ (self.messages.len() * 7);
-                let elapsed = self.turn_start.take()
+                // Track tokens per second for the status indicator (before take()).
+                // Prefer real usage; fall back to a rough char-based estimate
+                // (~4 chars/token) for providers that never report usage.
+                let reported_output = usage.as_ref().map(|u| u.output_tokens).unwrap_or(0);
+                let output_tokens = if reported_output > 0 {
+                    reported_output
+                } else {
+                    (self.streaming_text.len() / 4).max(if self.streaming_text.is_empty() {
+                        0
+                    } else {
+                        1
+                    }) as u64
+                };
+                // Active streaming throughput: time between first and last
+                // token arrival, excluding TTFT and post-stream idle.
+                if output_tokens > 0 {
+                    if let (Some(first), Some(last)) =
+                        (self.stream_first_token, self.stream_last_token)
+                    {
+                        let active_secs = last.duration_since(first).as_secs_f64();
+                        if active_secs > 0.0 {
+                            let rate = output_tokens as f64 / active_secs;
+                            self.recent_token_rates.push(rate);
+                            if self.recent_token_rates.len() > 5 {
+                                self.recent_token_rates.remove(0);
+                            }
+                        }
+                    } else if let Some(start) = self.turn_start {
+                        // Fallback for turns with no streamed text deltas
+                        // (e.g. non-streaming / cached): use submit-to-complete.
+                        let elapsed_secs = start.elapsed().as_secs_f64();
+                        if elapsed_secs > 0.0 {
+                            let rate = output_tokens as f64 / elapsed_secs;
+                            self.recent_token_rates.push(rate);
+                            if self.recent_token_rates.len() > 5 {
+                                self.recent_token_rates.remove(0);
+                            }
+                        }
+                    }
+                }
+                let elapsed = self
+                    .turn_start
+                    .take()
                     .map(|start| format_elapsed_ms(start.elapsed().as_millis()));
-                self.last_turn_elapsed = Some(
-                    elapsed.unwrap_or_else(|| "0s".to_string())
-                );
+                self.last_turn_elapsed = Some(elapsed.unwrap_or_else(|| "0s".to_string()));
                 self.last_turn_verb = Some(sample_completion_verb(seed));
+                self.stream_first_token = None;
+                self.stream_last_token = None;
                 self.flush_streamed_assistant_message();
-                self.tool_use_blocks.retain(|b| b.status != ToolStatus::Running);
-                self.complete_current_turn_snapshot(stop_reason.contains("abort") || stop_reason.contains("cancel"));
+                self.tool_use_blocks
+                    .retain(|b| b.status != ToolStatus::Running);
+                self.complete_current_turn_snapshot(
+                    stop_reason.contains("abort") || stop_reason.contains("cancel"),
+                );
                 self.invalidate_transcript();
                 self.refresh_turn_diff_from_history();
+
+                // Auto-poke: check for incomplete todos and queue continuation.
+                self.check_auto_poke();
             }
 
             QueryEvent::Status(msg) => {
@@ -6435,6 +7681,8 @@ impl App {
                 self.spinner_verb = None;
                 self.streaming_text.clear();
                 self.streaming_thinking.clear();
+                self.stream_first_token = None;
+                self.stream_last_token = None;
                 self.invalidate_transcript();
                 let err_msg = format!("Error: {}", msg);
                 self.push_assistant_message(err_msg.clone());
@@ -6454,7 +7702,10 @@ impl App {
                         self.token_warning_threshold_shown = 80;
                         self.push_notification(
                             NotificationKind::Warning,
-                            format!("Context window {:.0}% full. Consider /compact.", pct_used * 100.0),
+                            format!(
+                                "Context window {:.0}% full. Consider /compact.",
+                                pct_used * 100.0
+                            ),
                             Some(30),
                         );
                     }
@@ -6462,7 +7713,10 @@ impl App {
                         self.token_warning_threshold_shown = 95;
                         self.push_notification(
                             NotificationKind::Error,
-                            format!("Context window {:.0}% full! Run /compact now.", pct_used * 100.0),
+                            format!(
+                                "Context window {:.0}% full! Run /compact now.",
+                                pct_used * 100.0
+                            ),
                             None,
                         );
                     }
@@ -6473,6 +7727,63 @@ impl App {
 
         // Update token count from tracker.
         self.token_count = self.cost_tracker.total_tokens() as u32;
+    }
+
+    // -------------------------------------------------------------------
+    // Auto-poke
+    // -------------------------------------------------------------------
+
+    /// Check whether auto-poke should fire after a model turn.
+    /// If the model stopped with incomplete todos, queue a synthetic
+    /// continuation message via the existing `queued_messages` mechanism.
+    fn check_auto_poke(&mut self) {
+        // Don't poke if the turn was aborted/cancelled.
+        if !self.last_turn_elapsed.is_some() && self.tool_use_blocks.is_empty() {
+            // Likely a fresh state — still allow poke.
+        }
+
+        // Don't poke if auto-poke is disabled (check settings).
+        let settings = claurst_core::Settings::load_sync().unwrap_or_default();
+        if !settings.auto_poke_enabled {
+            return;
+        }
+
+        // Check poke budget.
+        if self.auto_poke_count >= claurst_tools::todo_write::MAX_AUTO_POKES {
+            self.status_message = Some(format!(
+                "Auto-poke stopped: budget of {} reached.",
+                claurst_tools::todo_write::MAX_AUTO_POKES
+            ));
+            return;
+        }
+
+        // Count incomplete todos.
+        let incomplete = claurst_tools::todo_write::count_incomplete_todos(&self.session_id);
+        if incomplete == 0 {
+            return; // All done — no poke needed.
+        }
+
+        // No-progress detection: hash the todo state.
+        let current_hash = claurst_tools::todo_write::todo_state_hash(&self.session_id);
+        if current_hash == self.last_todo_hash {
+            self.no_progress_turns += 1;
+        } else {
+            self.no_progress_turns = 0;
+            self.last_todo_hash = current_hash;
+        }
+
+        if self.no_progress_turns >= claurst_tools::todo_write::NO_PROGRESS_THRESHOLD {
+            self.status_message = Some("Auto-poke stopped: no progress for 3 turns.".to_string());
+            return;
+        }
+
+        // Queue the auto-poke message via the existing queued_messages
+        // infrastructure so the main loop submits it on the next iteration.
+        let poke_msg = claurst_tools::todo_write::build_auto_poke_message(incomplete);
+        self.auto_poke_count += 1;
+        self.status_message = Some(format!("Auto-poking... ({} incomplete todos)", incomplete));
+        self.queued_messages.push_back(poke_msg);
+        self.pending_auto_submit = true;
     }
 
     // -------------------------------------------------------------------
@@ -6513,8 +7824,7 @@ impl App {
                     let entries: Vec<crate::session_browser::SessionEntry> = sessions
                         .into_iter()
                         .map(|s| {
-                            let age = chrono::Utc::now()
-                                .signed_duration_since(s.updated_at);
+                            let age = chrono::Utc::now().signed_duration_since(s.updated_at);
                             let last_updated = if age.num_minutes() < 1 {
                                 "just now".to_string()
                             } else if age.num_hours() < 1 {
@@ -6596,8 +7906,7 @@ impl App {
                         }
                         VoiceEvent::RecordingStopped => {
                             self.voice_recording = false;
-                            self.status_message =
-                                Some("Transcribing\u{2026}".to_string());
+                            self.status_message = Some("Transcribing\u{2026}".to_string());
                         }
                         VoiceEvent::TranscriptReady(text) => {
                             if !text.is_empty() {
@@ -6610,9 +7919,8 @@ impl App {
                                 }
                                 self.prompt_input.paste(&text);
                                 self.refresh_prompt_input();
-                                self.status_message = Some(
-                                    format!("Transcribed: {}", &text[..text.len().min(60)])
-                                );
+                                self.status_message =
+                                    Some(format!("Transcribed: {}", &text[..text.len().min(60)]));
                             }
                             // Clear the channel once we have the result.
                             self.voice_event_rx = None;
@@ -6654,8 +7962,7 @@ impl App {
             let pending = self.pending_key.take();
 
             // Poll for events with a short timeout so we can redraw for animation
-            let got_event = pending.is_some()
-                || event::poll(std::time::Duration::from_millis(50))?;
+            let got_event = pending.is_some() || event::poll(std::time::Duration::from_millis(50))?;
 
             if got_event {
                 let event = if let Some(k) = pending {
@@ -6714,22 +8021,37 @@ impl App {
                         if self.should_exit {
                             return Ok(None);
                         }
-                        if should_submit {
+                        // Intercept instant slash commands even while streaming.
+                        // These are settings/info commands that don’t need the model.
+                        if should_submit
+                            || (self.is_streaming
+                                && crate::input::is_slash_command(&self.prompt_input.text))
+                        {
                             // Dismiss any active error modal when the user sends a message
                             self.dismiss_error_notifications();
+                            // Check for bang command (! prefix) — execute directly, no model.
+                            if crate::input::is_bang_command(&self.prompt_input.text) {
+                                let command = self.prompt_input.text[1..].trim().to_string();
+                                self.clear_prompt();
+                                if !command.is_empty() {
+                                    self.execute_bang_command(command);
+                                }
+                                continue;
+                            }
                             // Check if this is a slash command that should open a UI screen
                             if crate::input::is_slash_command(&self.prompt_input.text) {
                                 let slash_input = self.prompt_input.text.clone();
-                                let (cmd, args) =
-                                        crate::input::parse_slash_command(&slash_input);
+                                let (cmd, args) = crate::input::parse_slash_command(&slash_input);
                                 if self.intercept_slash_command_with_args(cmd, args) {
                                     self.clear_prompt();
                                     continue;
                                 }
                             }
-                            let input = self.take_input();
-                            if !input.is_empty() {
-                                return Ok(Some(input));
+                            if should_submit {
+                                let input = self.take_input();
+                                if !input.is_empty() {
+                                    return Ok(Some(input));
+                                }
                             }
                         }
                     }
@@ -6764,9 +8086,9 @@ impl App {
             let content = msg.get_all_text().to_lowercase();
 
             // Check if message contains error keywords
-            let has_error = ERROR_KEYWORDS.iter().any(|keyword| {
-                content.contains(keyword)
-            });
+            let has_error = ERROR_KEYWORDS
+                .iter()
+                .any(|keyword| content.contains(keyword));
 
             if has_error && i > (self.messages.len().saturating_sub(self.scroll_offset / 2)) {
                 // Found an error message, scroll to it
@@ -6792,9 +8114,9 @@ impl App {
             let content = msg.get_all_text().to_lowercase();
 
             // Check if message contains error keywords
-            let has_error = ERROR_KEYWORDS.iter().any(|keyword| {
-                content.contains(keyword)
-            });
+            let has_error = ERROR_KEYWORDS
+                .iter()
+                .any(|keyword| content.contains(keyword));
 
             if has_error && i < (self.messages.len().saturating_sub(self.scroll_offset / 2)) {
                 // Found an error message, scroll to it
@@ -6815,17 +8137,13 @@ fn open_file_externally(path: &std::path::Path) -> Result<(), Box<dyn std::error
     // Try to open with the system's default application
     #[cfg(target_os = "macos")]
     {
-        std::process::Command::new("open")
-            .arg(path)
-            .spawn()?;
+        std::process::Command::new("open").arg(path).spawn()?;
         Ok(())
     }
 
     #[cfg(target_os = "linux")]
     {
-        std::process::Command::new("xdg-open")
-            .arg(path)
-            .spawn()?;
+        std::process::Command::new("xdg-open").arg(path).spawn()?;
         Ok(())
     }
 
@@ -6842,10 +8160,7 @@ fn open_file_externally(path: &std::path::Path) -> Result<(), Box<dyn std::error
     {
         // Fallback for other systems: try common editors in order
         for editor in &["nano", "vi", "vim", "emacs"] {
-            match std::process::Command::new(editor)
-                .arg(path)
-                .spawn()
-            {
+            match std::process::Command::new(editor).arg(path).spawn() {
                 Ok(_) => return Ok(()),
                 Err(_) => continue,
             }
@@ -6887,10 +8202,7 @@ mod tests {
 
     #[test]
     fn recent_session_label_falls_back_to_first_prompt_line() {
-        let label = recent_session_label(
-            None,
-            Some("  fix the bug\nand more details".to_string()),
-        );
+        let label = recent_session_label(None, Some("  fix the bug\nand more details".to_string()));
         assert_eq!(label, "fix the bug");
     }
 
@@ -6937,7 +8249,10 @@ mod tests {
         assert_eq!(app.scroll_offset, 0);
         app.last_max_scroll.set(50);
         app.handle_mouse_event(scroll_up_event());
-        assert!(app.scroll_offset > 0, "scroll should advance when capture is on");
+        assert!(
+            app.scroll_offset > 0,
+            "scroll should advance when capture is on"
+        );
         assert!(app.scroll_offset <= 50, "scroll stays within max_scroll");
     }
 
@@ -6948,7 +8263,12 @@ mod tests {
         let mut app = make_app();
         // Bottom pane as rendered: 1 status row (height > 2), then the top
         // separator at y=21, text rows from y=22. Prefix "❯ " is 2 cells.
-        app.last_input_area.set(ratatui::layout::Rect { x: 0, y: 20, width: 80, height: 8 });
+        app.last_input_area.set(ratatui::layout::Rect {
+            x: 0,
+            y: 20,
+            width: 80,
+            height: 8,
+        });
         for c in "hi ".chars() {
             app.prompt_input.insert_char(c);
         }
@@ -6973,7 +8293,12 @@ mod tests {
     #[test]
     fn paste_viewer_alt_e_expands_into_prompt() {
         let mut app = make_app();
-        app.last_input_area.set(ratatui::layout::Rect { x: 0, y: 20, width: 80, height: 8 });
+        app.last_input_area.set(ratatui::layout::Rect {
+            x: 0,
+            y: 20,
+            width: 80,
+            height: 8,
+        });
         for c in "hi ".chars() {
             app.prompt_input.insert_char(c);
         }
@@ -6994,7 +8319,12 @@ mod tests {
     #[test]
     fn prompt_click_off_placeholder_moves_cursor_only() {
         let mut app = make_app();
-        app.last_input_area.set(ratatui::layout::Rect { x: 0, y: 20, width: 80, height: 8 });
+        app.last_input_area.set(ratatui::layout::Rect {
+            x: 0,
+            y: 20,
+            width: 80,
+            height: 8,
+        });
         for c in "hello ".chars() {
             app.prompt_input.insert_char(c);
         }
@@ -7049,7 +8379,10 @@ mod tests {
         for _ in 0..20 {
             app.scroll_up_by(10);
         }
-        assert_eq!(app.scroll_offset, 0, "no scroll room means no offset growth");
+        assert_eq!(
+            app.scroll_offset, 0,
+            "no scroll room means no offset growth"
+        );
     }
 
     #[test]
@@ -7060,7 +8393,10 @@ mod tests {
         app.config.mouse_capture = Some(false);
         assert!(!app.config.mouse_capture_enabled());
         app.handle_mouse_event(scroll_up_event());
-        assert_eq!(app.scroll_offset, 0, "scroll must not move when capture is off");
+        assert_eq!(
+            app.scroll_offset, 0,
+            "scroll must not move when capture is off"
+        );
     }
 
     // ---- normalize_char_with_shift tests ----
@@ -7121,7 +8457,10 @@ mod tests {
         // CTRL or ALT without SHIFT should not shift the character
         assert_eq!(normalize_char_with_shift('a', KeyModifiers::CONTROL), 'a');
         assert_eq!(normalize_char_with_shift('1', KeyModifiers::ALT), '1');
-        assert_eq!(normalize_char_with_shift('a', KeyModifiers::CONTROL | KeyModifiers::ALT), 'a');
+        assert_eq!(
+            normalize_char_with_shift('a', KeyModifiers::CONTROL | KeyModifiers::ALT),
+            'a'
+        );
     }
 
     #[test]
@@ -7207,7 +8546,10 @@ mod tests {
 
         let should_submit = app.handle_key_event(press_key(KeyCode::Enter, KeyModifiers::NONE));
 
-        assert!(should_submit, "Enter should submit/run the highlighted command");
+        assert!(
+            should_submit,
+            "Enter should submit/run the highlighted command"
+        );
         assert_eq!(app.prompt_input.text, "/help");
         assert!(
             app.prompt_input.suggestions.is_empty(),
@@ -7279,7 +8621,10 @@ mod tests {
         }
         let submitted = app.handle_key_event(press_key(KeyCode::Char('j'), KeyModifiers::CONTROL));
         assert!(!submitted, "Ctrl+J must not submit");
-        assert_eq!(app.prompt_input.text, "hi\n", "Ctrl+J should insert a newline, not 'j'");
+        assert_eq!(
+            app.prompt_input.text, "hi\n",
+            "Ctrl+J should insert a newline, not 'j'"
+        );
     }
 
     #[test]
@@ -7291,7 +8636,10 @@ mod tests {
         }
         let submitted = app.handle_key_event(press_key(KeyCode::Enter, KeyModifiers::NONE));
         assert!(submitted, "bare Enter should submit");
-        assert_eq!(app.prompt_input.text, "hi", "bare Enter must not insert a newline");
+        assert_eq!(
+            app.prompt_input.text, "hi",
+            "bare Enter must not insert a newline"
+        );
         assert!(!app.prompt_input.text.contains('\n'));
     }
 
@@ -7669,20 +9017,14 @@ mod tests {
     #[test]
     fn test_key_event_to_keystroke_maps_ctrl_cyrillic_to_latin() {
         // Ctrl+С (Cyrillic) on a non-Latin layout must resolve to the Latin "c".
-        let ks = key_event_to_keystroke(&press_key(
-            KeyCode::Char('с'),
-            KeyModifiers::CONTROL,
-        ))
-        .expect("keystroke");
+        let ks = key_event_to_keystroke(&press_key(KeyCode::Char('с'), KeyModifiers::CONTROL))
+            .expect("keystroke");
         assert_eq!(ks.key, "c");
         assert!(ks.ctrl);
 
         // Ctrl+О (Cyrillic, the physical J key) → "j" so Ctrl+J newline works.
-        let ks = key_event_to_keystroke(&press_key(
-            KeyCode::Char('о'),
-            KeyModifiers::CONTROL,
-        ))
-        .expect("keystroke");
+        let ks = key_event_to_keystroke(&press_key(KeyCode::Char('о'), KeyModifiers::CONTROL))
+            .expect("keystroke");
         assert_eq!(ks.key, "j");
     }
 
@@ -7699,10 +9041,8 @@ mod tests {
     #[test]
     fn test_normalize_layout_shortcut_key_rewrites_pure_ctrl() {
         // Pure Ctrl + Cyrillic → Latin letter at the same physical position.
-        let out = normalize_layout_shortcut_key(press_key(
-            KeyCode::Char('с'),
-            KeyModifiers::CONTROL,
-        ));
+        let out =
+            normalize_layout_shortcut_key(press_key(KeyCode::Char('с'), KeyModifiers::CONTROL));
         assert_eq!(out.code, KeyCode::Char('c'));
         assert!(out.modifiers.contains(KeyModifiers::CONTROL));
     }
@@ -7728,7 +9068,8 @@ mod tests {
     #[test]
     fn test_normalize_layout_shortcut_key_passes_ascii_through() {
         // ASCII Ctrl combos (English layout) are unchanged — no regression.
-        let out = normalize_layout_shortcut_key(press_key(KeyCode::Char('c'), KeyModifiers::CONTROL));
+        let out =
+            normalize_layout_shortcut_key(press_key(KeyCode::Char('c'), KeyModifiers::CONTROL));
         assert_eq!(out.code, KeyCode::Char('c'));
     }
 
@@ -7803,5 +9144,19 @@ mod tests {
         assert!(!app.should_exit);
         app.handle_key_event(press_key(KeyCode::Char('c'), KeyModifiers::CONTROL));
         assert!(app.should_exit);
+    }
+
+    #[test]
+    fn kb_select_mode_starts_and_cancels() {
+        let mut app = make_app();
+        app.kb_select_mode = true;
+        app.selection_anchor = Some((0, 5));
+        app.selection_focus = Some((0, 5));
+        app.kb_cursor_row = 5;
+        // Simulate Esc by testing state directly via clear_selection.
+        app.clear_selection();
+        assert!(!app.kb_select_mode);
+        assert!(app.selection_anchor.is_none());
+        assert!(app.selection_focus.is_none());
     }
 }

--- a/src-rust/crates/tui/src/input.rs
+++ b/src-rust/crates/tui/src/input.rs
@@ -5,6 +5,13 @@ pub fn is_slash_command(input: &str) -> bool {
     input.starts_with('/') && !input.starts_with("//")
 }
 
+/// Check if the input is a bang command (! prefix).
+/// A single `!` is a bang command only when followed by at least one
+/// non-whitespace character; `!!` (double bang) is NOT a bang command.
+pub fn is_bang_command(input: &str) -> bool {
+    input.starts_with('!') && !input.starts_with("!!") && input.len() > 1
+}
+
 /// Parse a slash command into `(command_name, args)`.
 /// Returns `("", "")` if the input is not a slash command.
 pub fn parse_slash_command(input: &str) -> (&str, &str) {
@@ -54,5 +61,21 @@ mod tests {
         let (cmd, args) = parse_slash_command("hello world");
         assert_eq!(cmd, "");
         assert_eq!(args, "");
+    }
+
+    #[test]
+    fn is_bang_command_true() {
+        assert!(is_bang_command("!ls"));
+        assert!(is_bang_command("! git status"));
+        assert!(is_bang_command("!echo hello"));
+    }
+
+    #[test]
+    fn is_bang_command_false() {
+        assert!(!is_bang_command("ls"));
+        assert!(!is_bang_command("/help"));
+        assert!(!is_bang_command("!! multi-line"));
+        assert!(!is_bang_command("hello"));
+        assert!(!is_bang_command(""));
     }
 }

--- a/src-rust/crates/tui/src/messages/mod.rs
+++ b/src-rust/crates/tui/src/messages/mod.rs
@@ -7,10 +7,10 @@
 
 use std::collections::HashMap;
 
-use claurst_core::types::{ContentBlock, Message, Role, ToolResultContent};
 use crate::app::TurnMetadata;
 use crate::kitty_image::render_image;
 use crate::transcript_turn::reasoning_heading;
+use claurst_core::types::{ContentBlock, Message, Role, ToolResultContent};
 use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
@@ -22,8 +22,7 @@ pub use markdown::render_markdown;
 
 mod markdown_enhanced;
 pub use markdown_enhanced::{
-    detect_table, render_table, parse_inline_formatting,
-    Table, TableAlignment,
+    detect_table, parse_inline_formatting, render_table, Table, TableAlignment,
 };
 
 /// Context passed to all renderers.
@@ -44,6 +43,8 @@ pub struct RenderContext<'a> {
     pub tool_names: &'a HashMap<String, String>,
     /// Set of thinking block content hashes that are expanded per-block.
     pub expanded_thinking: &'a std::collections::HashSet<u64>,
+    /// When true, tool-use blocks show only the tool type, not the content.
+    pub hide_tool_content: bool,
 }
 
 /// Shared empty collections so `RenderContext::default()` can hand out
@@ -61,6 +62,7 @@ impl Default for RenderContext<'static> {
             show_thinking: false,
             tool_names: &EMPTY_TOOL_NAMES,
             expanded_thinking: &EMPTY_EXPANDED_THINKING,
+            hide_tool_content: false,
         }
     }
 }
@@ -211,7 +213,12 @@ fn render_file_chip(label: String) -> Line<'static> {
     render_attachment_chip_colored("file", label, Color::Rgb(51, 102, 170), Color::White)
 }
 
-fn render_attachment_chip_colored(kind: &str, label: String, badge_bg: Color, badge_fg: Color) -> Line<'static> {
+fn render_attachment_chip_colored(
+    kind: &str,
+    label: String,
+    badge_bg: Color,
+    badge_fg: Color,
+) -> Line<'static> {
     Line::from(vec![
         Span::styled(
             format!(" {} ", kind),
@@ -233,7 +240,10 @@ fn user_metadata_line(_meta: Option<&TurnMetadata>) -> Option<Line<'static>> {
     None
 }
 
-pub fn render_transcript_assistant_meta(meta: Option<&TurnMetadata>, accent: Color) -> Option<Line<'static>> {
+pub fn render_transcript_assistant_meta(
+    meta: Option<&TurnMetadata>,
+    accent: Color,
+) -> Option<Line<'static>> {
     let meta = meta?;
 
     // Only show interrupted status — mode, model, and duration are already
@@ -245,14 +255,9 @@ pub fn render_transcript_assistant_meta(meta: Option<&TurnMetadata>, accent: Col
     let spans = vec![
         Span::styled(
             "   \u{25a3} ",
-            Style::default()
-                .fg(accent)
-                .add_modifier(Modifier::BOLD),
+            Style::default().fg(accent).add_modifier(Modifier::BOLD),
         ),
-        Span::styled(
-            "interrupted",
-            Style::default().fg(TRANSCRIPT_MUTED),
-        ),
+        Span::styled("interrupted", Style::default().fg(TRANSCRIPT_MUTED)),
     ];
 
     Some(Line::from(spans))
@@ -277,10 +282,7 @@ enum TextSegment {
 /// as chips. Replaces `@long/absolute/path/file.rs` with just `@file.rs` so the
 /// text stays readable ("Delete @file.rs" still makes sense) without showing the
 /// full path noise.
-fn normalize_at_tokens(
-    text: &str,
-    injected: &std::collections::HashSet<String>,
-) -> String {
+fn normalize_at_tokens(text: &str, injected: &std::collections::HashSet<String>) -> String {
     let mut result = String::with_capacity(text.len());
     for word in text.split_inclusive(|c: char| c.is_whitespace()) {
         let trimmed = word.trim_end_matches(|c: char| c.is_whitespace());
@@ -289,7 +291,10 @@ fn normalize_at_tokens(
         if trimmed.starts_with('@') && trimmed.len() > 1 {
             let mut path_part = trimmed[1..].to_string();
             // Strip trailing punctuation (same logic as parse_at_refs)
-            while !path_part.is_empty() && path_part.ends_with(|c: char| c.is_ascii_punctuation()) && !path_part.ends_with('/') {
+            while !path_part.is_empty()
+                && path_part.ends_with(|c: char| c.is_ascii_punctuation())
+                && !path_part.ends_with('/')
+            {
                 path_part.pop();
             }
             let punct_suffix = &trimmed[1 + path_part.len()..];
@@ -301,7 +306,10 @@ fn normalize_at_tokens(
 
             let matches = injected.iter().any(|p| {
                 p == &path_part
-                    || std::path::Path::new(p).file_name().map(|n| n.to_string_lossy().as_ref() == path_part.as_str()).unwrap_or(false)
+                    || std::path::Path::new(p)
+                        .file_name()
+                        .map(|n| n.to_string_lossy().as_ref() == path_part.as_str())
+                        .unwrap_or(false)
                     || p.ends_with(&format!("/{}", path_part))
             });
 
@@ -338,7 +346,11 @@ fn extract_file_segments(text: &str) -> Vec<TextSegment> {
             if let Some(close_pos) = after_open_tag.find(CLOSE) {
                 let consumed = start + close_pos + CLOSE.len();
                 // skip one trailing newline if present
-                let consumed = if remaining[consumed..].starts_with('\n') { consumed + 1 } else { consumed };
+                let consumed = if remaining[consumed..].starts_with('\n') {
+                    consumed + 1
+                } else {
+                    consumed
+                };
                 result.push(TextSegment::FileBlock(path));
                 remaining = &remaining[consumed..];
             } else {
@@ -363,6 +375,7 @@ pub fn render_transcript_user_message(
     msg: &Message,
     meta: Option<&TurnMetadata>,
     width: u16,
+    hide_tool_content: bool,
 ) -> Vec<Line<'static>> {
     // Goal-event messages injected by the /goal machinery render as a compact
     // event block, not as a user input bubble. The same applies to the user's
@@ -384,18 +397,27 @@ pub fn render_transcript_user_message(
 
     // Collect the absolute paths of every injected file so we can strip the
     // corresponding @token references from the user's original text block.
-    let injected_paths: std::collections::HashSet<String> = msg.content_blocks()
+    let injected_paths: std::collections::HashSet<String> = msg
+        .content_blocks()
         .iter()
         .filter_map(|b| {
             if let ContentBlock::Text { text } = b {
-                if text.contains("<file path=\"") { Some(text) } else { None }
+                if text.contains("<file path=\"") {
+                    Some(text)
+                } else {
+                    None
+                }
             } else {
                 None
             }
         })
         .flat_map(|text| {
             extract_file_segments(text).into_iter().filter_map(|s| {
-                if let TextSegment::FileBlock(p) = s { Some(p) } else { None }
+                if let TextSegment::FileBlock(p) = s {
+                    Some(p)
+                } else {
+                    None
+                }
             })
         })
         .collect();
@@ -404,10 +426,13 @@ pub fn render_transcript_user_message(
         if buffer.is_empty() {
             return;
         }
-        target.extend(render_user_text_with_ctx(buffer, &RenderContext {
-            width: inner_width,
-            ..RenderContext::default()
-        }));
+        target.extend(render_user_text_with_ctx(
+            buffer,
+            &RenderContext {
+                width: inner_width,
+                ..RenderContext::default()
+            },
+        ));
         buffer.clear();
     };
 
@@ -461,7 +486,12 @@ pub fn render_transcript_user_message(
                     .unwrap_or_else(|| "pasted image".to_string());
                 lines.push(render_attachment_chip("img", label));
             }
-            ContentBlock::Document { title, context, source, .. } => {
+            ContentBlock::Document {
+                title,
+                context,
+                source,
+                ..
+            } => {
                 flush_text(&mut pending_text, &mut lines);
                 let label = title
                     .or(context)
@@ -482,36 +512,61 @@ pub fn render_transcript_user_message(
                 flush_text(&mut pending_text, &mut lines);
                 lines.extend(render_user_memory_input(&key, &value));
             }
-            ContentBlock::SystemAPIError { message, retry_secs } => {
+            ContentBlock::SystemAPIError {
+                message,
+                retry_secs,
+            } => {
                 flush_text(&mut pending_text, &mut lines);
                 lines.extend(render_system_api_error(&message, retry_secs));
             }
-            ContentBlock::CollapsedReadSearch { tool_name, paths, n_hidden } => {
+            ContentBlock::CollapsedReadSearch {
+                tool_name,
+                paths,
+                n_hidden,
+            } => {
                 flush_text(&mut pending_text, &mut lines);
                 let path_refs: Vec<&str> = paths.iter().map(|path| path.as_str()).collect();
-                lines.extend(render_collapsed_read_search(&tool_name, &path_refs, n_hidden));
+                lines.extend(render_collapsed_read_search(
+                    &tool_name, &path_refs, n_hidden,
+                ));
             }
-            ContentBlock::TaskAssignment { id, subject, description } => {
+            ContentBlock::TaskAssignment {
+                id,
+                subject,
+                description,
+            } => {
                 flush_text(&mut pending_text, &mut lines);
                 lines.extend(render_task_assignment(&id, &subject, &description));
             }
             ContentBlock::ToolUse { name, input, .. } => {
                 flush_text(&mut pending_text, &mut lines);
-                lines.extend(render_tool_use_inner(&name, &input));
+                lines.extend(render_tool_use_inner(&name, &input, hide_tool_content));
             }
-            ContentBlock::ToolResult { tool_use_id: _, content, is_error } => {
+            ContentBlock::ToolResult {
+                tool_use_id: _,
+                content,
+                is_error,
+            } => {
                 flush_text(&mut pending_text, &mut lines);
-                let text = tool_result_text(&content);
-                let rendered = if is_error.unwrap_or(false) {
-                    render_tool_result_error(&text)
+                if hide_tool_content {
+                    lines.extend(render_tool_result_hidden());
                 } else {
-                    render_tool_result_success(&text, false)
-                };
-                lines.extend(rendered);
+                    let text = tool_result_text(&content);
+                    let rendered = if is_error.unwrap_or(false) {
+                        render_tool_result_error(&text)
+                    } else {
+                        render_tool_result_success(&text, false)
+                    };
+                    lines.extend(rendered);
+                }
             }
             ContentBlock::Thinking { thinking, .. } => {
                 flush_text(&mut pending_text, &mut lines);
-                lines.extend(render_transcript_reasoning_block(&thinking, false, inner_width));
+                lines.extend(render_transcript_reasoning_block(
+                    &thinking,
+                    false,
+                    inner_width,
+                ));
             }
             ContentBlock::RedactedThinking { .. } => {
                 flush_text(&mut pending_text, &mut lines);
@@ -596,15 +651,16 @@ pub fn render_transcript_assistant_message_tagged(
     let mut out: Vec<(Line<'static>, Option<u64>)> = Vec::new();
     let mut pending_text = String::new();
 
-    let flush_text = |buffer: &mut String, target: &mut Vec<(Line<'static>, Option<u64>)>, width: u16| {
-        if buffer.is_empty() {
-            return;
-        }
-        for line in render_transcript_live_text(buffer, width) {
-            target.push((line, None));
-        }
-        buffer.clear();
-    };
+    let flush_text =
+        |buffer: &mut String, target: &mut Vec<(Line<'static>, Option<u64>)>, width: u16| {
+            if buffer.is_empty() {
+                return;
+            }
+            for line in render_transcript_live_text(buffer, width) {
+                target.push((line, None));
+            }
+            buffer.clear();
+        };
 
     for block in msg.content_blocks() {
         match block {
@@ -645,7 +701,7 @@ pub fn render_transcript_assistant_message_tagged(
             ContentBlock::ToolUse { name, input, .. } => {
                 flush_text(&mut pending_text, &mut out, ctx.width);
                 for line in indent_lines(
-                    render_tool_use_inner(&name, &input),
+                    render_tool_use_inner(&name, &input, ctx.hide_tool_content),
                     "   ",
                     Style::default(),
                     TRANSCRIPT_TEXT,
@@ -653,15 +709,23 @@ pub fn render_transcript_assistant_message_tagged(
                     out.push((line, None));
                 }
             }
-            ContentBlock::ToolResult { tool_use_id, content, is_error } => {
+            ContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                is_error,
+            } => {
                 flush_text(&mut pending_text, &mut out, ctx.width);
-                let text = tool_result_text(&content);
-                let tool_name = ctx.tool_names.get(&tool_use_id).map(|name| name.as_str());
-                let rendered = if is_error.unwrap_or(false) {
-                    render_tool_result_error(&text)
+                let rendered = if ctx.hide_tool_content {
+                    render_tool_result_hidden()
+                } else if is_error.unwrap_or(false) {
+                    render_tool_result_error(&tool_result_text(&content))
                 } else {
+                    let text = tool_result_text(&content);
+                    let tool_name = ctx.tool_names.get(&tool_use_id).map(|name| name.as_str());
                     match tool_name {
-                        Some("Bash") | Some("PowerShell") => render_bash_output_block(&text, TOOL_RESULT_MAX_LINES),
+                        Some("Bash") | Some("PowerShell") => {
+                            render_bash_output_block(&text, TOOL_RESULT_MAX_LINES)
+                        }
                         Some("Read") => render_file_read_result(&text),
                         Some("Edit") => render_file_op_result(false),
                         Some("Write") => render_file_op_result(true),
@@ -689,7 +753,12 @@ pub fn render_transcript_assistant_message_tagged(
                     out.push((line, None));
                 }
             }
-            ContentBlock::Document { title, context, source, .. } => {
+            ContentBlock::Document {
+                title,
+                context,
+                source,
+                ..
+            } => {
                 flush_text(&mut pending_text, &mut out, ctx.width);
                 let label = title
                     .or(context)
@@ -738,7 +807,10 @@ pub fn render_transcript_assistant_message_tagged(
                     out.push((line, None));
                 }
             }
-            ContentBlock::SystemAPIError { message, retry_secs } => {
+            ContentBlock::SystemAPIError {
+                message,
+                retry_secs,
+            } => {
                 flush_text(&mut pending_text, &mut out, ctx.width);
                 for line in indent_lines(
                     render_system_api_error(&message, retry_secs),
@@ -749,7 +821,11 @@ pub fn render_transcript_assistant_message_tagged(
                     out.push((line, None));
                 }
             }
-            ContentBlock::CollapsedReadSearch { tool_name, paths, n_hidden } => {
+            ContentBlock::CollapsedReadSearch {
+                tool_name,
+                paths,
+                n_hidden,
+            } => {
                 flush_text(&mut pending_text, &mut out, ctx.width);
                 let path_refs: Vec<&str> = paths.iter().map(|path| path.as_str()).collect();
                 for line in indent_lines(
@@ -761,7 +837,11 @@ pub fn render_transcript_assistant_message_tagged(
                     out.push((line, None));
                 }
             }
-            ContentBlock::TaskAssignment { id, subject, description } => {
+            ContentBlock::TaskAssignment {
+                id,
+                subject,
+                description,
+            } => {
                 flush_text(&mut pending_text, &mut out, ctx.width);
                 for line in indent_lines(
                     render_task_assignment(&id, &subject, &description),
@@ -812,7 +892,9 @@ pub fn render_transcript_assistant_message(
                     h.finish()
                 };
                 let expanded = ctx.show_thinking || ctx.expanded_thinking.contains(&thinking_hash);
-                lines.extend(render_transcript_reasoning_block(&thinking, expanded, ctx.width));
+                lines.extend(render_transcript_reasoning_block(
+                    &thinking, expanded, ctx.width,
+                ));
             }
             ContentBlock::RedactedThinking { .. } => {
                 flush_text(&mut pending_text, &mut lines);
@@ -826,21 +908,29 @@ pub fn render_transcript_assistant_message(
             ContentBlock::ToolUse { name, input, .. } => {
                 flush_text(&mut pending_text, &mut lines);
                 lines.extend(indent_lines(
-                    render_tool_use_inner(&name, &input),
+                    render_tool_use_inner(&name, &input, ctx.hide_tool_content),
                     "   ",
                     Style::default(),
                     TRANSCRIPT_TEXT,
                 ));
             }
-            ContentBlock::ToolResult { tool_use_id, content, is_error } => {
+            ContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                is_error,
+            } => {
                 flush_text(&mut pending_text, &mut lines);
-                let text = tool_result_text(&content);
-                let tool_name = ctx.tool_names.get(&tool_use_id).map(|name| name.as_str());
-                let rendered = if is_error.unwrap_or(false) {
-                    render_tool_result_error(&text)
+                let rendered = if ctx.hide_tool_content {
+                    render_tool_result_hidden()
+                } else if is_error.unwrap_or(false) {
+                    render_tool_result_error(&tool_result_text(&content))
                 } else {
+                    let text = tool_result_text(&content);
+                    let tool_name = ctx.tool_names.get(&tool_use_id).map(|name| name.as_str());
                     match tool_name {
-                        Some("Bash") | Some("PowerShell") => render_bash_output_block(&text, TOOL_RESULT_MAX_LINES),
+                        Some("Bash") | Some("PowerShell") => {
+                            render_bash_output_block(&text, TOOL_RESULT_MAX_LINES)
+                        }
                         Some("Read") => render_file_read_result(&text),
                         Some("Edit") => render_file_op_result(false),
                         Some("Write") => render_file_op_result(true),
@@ -869,7 +959,12 @@ pub fn render_transcript_assistant_message(
                     TRANSCRIPT_TEXT,
                 ));
             }
-            ContentBlock::Document { title, context, source, .. } => {
+            ContentBlock::Document {
+                title,
+                context,
+                source,
+                ..
+            } => {
                 flush_text(&mut pending_text, &mut lines);
                 let label = title
                     .or(context)
@@ -910,7 +1005,10 @@ pub fn render_transcript_assistant_message(
                     TRANSCRIPT_TEXT,
                 ));
             }
-            ContentBlock::SystemAPIError { message, retry_secs } => {
+            ContentBlock::SystemAPIError {
+                message,
+                retry_secs,
+            } => {
                 flush_text(&mut pending_text, &mut lines);
                 lines.extend(indent_lines(
                     render_system_api_error(&message, retry_secs),
@@ -919,7 +1017,11 @@ pub fn render_transcript_assistant_message(
                     TRANSCRIPT_TEXT,
                 ));
             }
-            ContentBlock::CollapsedReadSearch { tool_name, paths, n_hidden } => {
+            ContentBlock::CollapsedReadSearch {
+                tool_name,
+                paths,
+                n_hidden,
+            } => {
                 flush_text(&mut pending_text, &mut lines);
                 let path_refs: Vec<&str> = paths.iter().map(|path| path.as_str()).collect();
                 lines.extend(indent_lines(
@@ -929,7 +1031,11 @@ pub fn render_transcript_assistant_message(
                     TRANSCRIPT_TEXT,
                 ));
             }
-            ContentBlock::TaskAssignment { id, subject, description } => {
+            ContentBlock::TaskAssignment {
+                id,
+                subject,
+                description,
+            } => {
                 flush_text(&mut pending_text, &mut lines);
                 lines.extend(indent_lines(
                     render_task_assignment(&id, &subject, &description),
@@ -982,7 +1088,11 @@ pub fn extract_tool_summary(tool_name: &str, input: &serde_json::Value) -> Strin
         "websearch" => truncate(str_field(input, "query"), 60),
         "task" | "agent" => {
             let task = str_field(input, "task");
-            let task = if task.is_empty() { str_field(input, "description") } else { task };
+            let task = if task.is_empty() {
+                str_field(input, "description")
+            } else {
+                task
+            };
             truncate(task.lines().next().unwrap_or(""), 60)
         }
         _ => {
@@ -1011,12 +1121,27 @@ pub fn subagent_title(input: &serde_json::Value) -> String {
 
 /// Render a compact tool-use block that matches the newer transcript language.
 pub fn render_tool_use(tool_name: &str, input_json: &str) -> Vec<Line<'static>> {
-    let input: serde_json::Value =
-        serde_json::from_str(input_json).unwrap_or(serde_json::Value::Null);
-    render_tool_use_inner(tool_name, &input)
+    render_tool_use_with_detail(tool_name, input_json, false)
 }
 
-fn render_tool_use_inner(tool_name: &str, input: &serde_json::Value) -> Vec<Line<'static>> {
+/// Render a tool-use block. When `hide_content` is true, only the tool
+/// type title (e.g. "Running command") is shown -- no summary or command
+/// lines.
+pub fn render_tool_use_with_detail(
+    tool_name: &str,
+    input_json: &str,
+    hide_content: bool,
+) -> Vec<Line<'static>> {
+    let input: serde_json::Value =
+        serde_json::from_str(input_json).unwrap_or(serde_json::Value::Null);
+    render_tool_use_inner(tool_name, &input, hide_content)
+}
+
+fn render_tool_use_inner(
+    tool_name: &str,
+    input: &serde_json::Value,
+    hide_content: bool,
+) -> Vec<Line<'static>> {
     let summary = extract_tool_summary(tool_name, input);
     let mut lines = Vec::new();
     let title = match tool_name.to_ascii_lowercase().as_str() {
@@ -1028,23 +1153,27 @@ fn render_tool_use_inner(tool_name: &str, input: &serde_json::Value) -> Vec<Line
         "grep" => "Searching code",
         "webfetch" => "Fetching page",
         "websearch" => "Searching web",
-        "task" | "agent" => return {
-            let mut task_lines = Vec::new();
-            task_lines.push(Line::from(vec![
-                Span::styled("  ~ ".to_string(), Style::default().fg(CLAUDE_ORANGE)),
-                Span::styled(
-                    subagent_title(input),
-                    Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
-                ),
-            ]));
-            if !summary.is_empty() {
+        "task" | "agent" => {
+            return {
+                let mut task_lines = Vec::new();
                 task_lines.push(Line::from(vec![
-                    Span::raw("    "),
-                    Span::styled(summary, Style::default().fg(TRANSCRIPT_MUTED)),
+                    Span::styled("  ~ ".to_string(), Style::default().fg(CLAUDE_ORANGE)),
+                    Span::styled(
+                        subagent_title(input),
+                        Style::default()
+                            .fg(Color::White)
+                            .add_modifier(Modifier::BOLD),
+                    ),
                 ]));
+                if !hide_content && !summary.is_empty() {
+                    task_lines.push(Line::from(vec![
+                        Span::raw("    "),
+                        Span::styled(summary, Style::default().fg(TRANSCRIPT_MUTED)),
+                    ]));
+                }
+                task_lines
             }
-            task_lines
-        },
+        }
         _ => tool_name,
     };
 
@@ -1052,17 +1181,25 @@ fn render_tool_use_inner(tool_name: &str, input: &serde_json::Value) -> Vec<Line
         Span::styled("  ~ ".to_string(), Style::default().fg(CLAUDE_ORANGE)),
         Span::styled(
             title.to_string(),
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         ),
     ]));
-    if !summary.is_empty() {
+    if !hide_content && !summary.is_empty() {
         lines.push(Line::from(vec![
             Span::raw("    "),
             Span::styled(summary, Style::default().fg(TRANSCRIPT_MUTED)),
         ]));
     }
 
-    if matches!(tool_name.to_ascii_lowercase().as_str(), "bash" | "powershell") {
+    // Always show the `$ command` line for bash/powershell, even when
+    // hide_tool_content is on — the user wants the command visible, only
+    // tool *results* should be hidden.
+    if matches!(
+        tool_name.to_ascii_lowercase().as_str(),
+        "bash" | "powershell"
+    ) {
         let command = input.get("command").and_then(|v| v.as_str()).unwrap_or("");
         for (i, cmd_line) in command.lines().enumerate() {
             if i >= 2 {
@@ -1077,11 +1214,15 @@ fn render_tool_use_inner(tool_name: &str, input: &serde_json::Value) -> Vec<Line
             lines.push(Line::from(vec![
                 Span::styled(
                     "    $ ".to_string(),
-                    Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::Green)
+                        .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled(
                     display,
-                    Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::White)
+                        .add_modifier(Modifier::BOLD),
                 ),
             ]));
         }
@@ -1134,7 +1275,9 @@ pub fn render_tool_result_success(output: &str, truncated: bool) -> Vec<Line<'st
         let remaining = total_lines - TOOL_RESULT_MAX_LINES;
         lines.push(Line::from(vec![Span::styled(
             format!("  ... {} more lines", remaining),
-            Style::default().fg(Color::DarkGray).add_modifier(Modifier::DIM),
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::DIM),
         )]));
     }
     if truncated {
@@ -1150,10 +1293,12 @@ pub fn render_tool_result_success(output: &str, truncated: bool) -> Vec<Line<'st
 pub fn render_tool_result_error(error: &str) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
     // Use orange instead of red for color-blind accessibility
-    let error_color = Color::Rgb(255, 140, 0);  // Orange
+    let error_color = Color::Rgb(255, 140, 0); // Orange
     lines.push(Line::from(vec![Span::styled(
         "  Error",
-        Style::default().fg(error_color).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(error_color)
+            .add_modifier(Modifier::BOLD),
     )]));
     for line in error.lines().take(10) {
         lines.push(Line::from(vec![
@@ -1168,6 +1313,18 @@ pub fn render_tool_result_error(error: &str) -> Vec<Line<'static>> {
 pub fn render_tool_result_cancelled(tool_name: &str) -> Vec<Line<'static>> {
     vec![Line::from(vec![Span::styled(
         format!("  \u{2717} {} \u{2014} cancelled", tool_name),
+        Style::default()
+            .fg(Color::DarkGray)
+            .add_modifier(Modifier::DIM),
+    )])]
+}
+
+/// Render a compact placeholder for a tool result when `hide_tool_content`
+/// is enabled. Shows only a dim "Result hidden" line — the command itself
+/// (from the preceding ToolUse block) remains visible.
+pub fn render_tool_result_hidden() -> Vec<Line<'static>> {
+    vec![Line::from(vec![Span::styled(
+        "  Result hidden",
         Style::default()
             .fg(Color::DarkGray)
             .add_modifier(Modifier::DIM),
@@ -1191,7 +1348,11 @@ pub fn render_tool_result_rejected(tool_name: &str, reason: &str) -> Vec<Line<'s
 }
 
 /// Render an attachment message (skill listing, agent listing, MCP instructions, hook results, etc.)
-pub fn render_attachment_message(kind_label: &str, content: &str, width: u16) -> Vec<Line<'static>> {
+pub fn render_attachment_message(
+    kind_label: &str,
+    content: &str,
+    width: u16,
+) -> Vec<Line<'static>> {
     // Reserve space for the "  [label] " prefix and a small margin.
     let prefix_len = kind_label.len() + 6; // "  [label] "
     let preview_max = (width as usize).saturating_sub(prefix_len).clamp(20, 120);
@@ -1204,20 +1365,17 @@ pub fn render_attachment_message(kind_label: &str, content: &str, width: u16) ->
     vec![Line::from(vec![
         Span::styled(
             format!("  [{kind_label}] "),
-            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(preview, Style::default().fg(Color::White)),
     ])]
 }
 
 /// Render an advisor status line.
-pub fn render_advisor_message(
-    is_loading: bool,
-    model_name: Option<&str>,
-) -> Vec<Line<'static>> {
-    let model_suffix = model_name
-        .map(|m| format!(" ({})", m))
-        .unwrap_or_default();
+pub fn render_advisor_message(is_loading: bool, model_name: Option<&str>) -> Vec<Line<'static>> {
+    let model_suffix = model_name.map(|m| format!(" ({})", m)).unwrap_or_default();
     if is_loading {
         vec![Line::from(vec![Span::styled(
             format!("  \u{25cc} Advising\u{2026}{}", model_suffix),
@@ -1228,7 +1386,9 @@ pub fn render_advisor_message(
     } else {
         vec![Line::from(vec![Span::styled(
             format!("  \u{2713} Advisor reviewed{}", model_suffix),
-            Style::default().fg(Color::DarkGray).add_modifier(Modifier::DIM),
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::DIM),
         )])]
     }
 }
@@ -1281,11 +1441,15 @@ pub fn render_bash_input_line(command: &str) -> Vec<Line<'static>> {
     vec![Line::from(vec![
         Span::styled(
             "  $ ".to_string(),
-            Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             command.to_string(),
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         ),
     ])]
 }
@@ -1318,14 +1482,13 @@ pub fn render_plan_steps(steps: &[String]) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
     lines.push(Line::from(vec![Span::styled(
         "  Plan:".to_string(),
-        Style::default().fg(CLAUDE_ORANGE).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(CLAUDE_ORANGE)
+            .add_modifier(Modifier::BOLD),
     )]));
     for (i, step) in steps.iter().enumerate() {
         lines.push(Line::from(vec![
-            Span::styled(
-                format!("  {}. ", i + 1),
-                Style::default().fg(CLAUDE_ORANGE),
-            ),
+            Span::styled(format!("  {}. ", i + 1), Style::default().fg(CLAUDE_ORANGE)),
             Span::styled(step.clone(), Style::default().fg(Color::White)),
         ]));
     }
@@ -1337,7 +1500,9 @@ pub fn render_plan_approval_prompt() -> Vec<Line<'static>> {
     vec![Line::from(vec![
         Span::styled(
             "  Approve this plan? ".to_string(),
-            Style::default().fg(CLAUDE_ORANGE).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(CLAUDE_ORANGE)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             "[y] yes  [n] no  [e] edit".to_string(),
@@ -1350,7 +1515,9 @@ pub fn render_plan_approval_prompt() -> Vec<Line<'static>> {
 pub fn render_compact_boundary() -> Vec<Line<'static>> {
     vec![Line::from(vec![Span::styled(
         "----------- context compacted -----------",
-        Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC),
+        Style::default()
+            .fg(Color::DarkGray)
+            .add_modifier(Modifier::ITALIC),
     )])]
 }
 
@@ -1359,7 +1526,9 @@ pub fn render_summary_message(text: &str) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
     lines.push(Line::from(vec![Span::styled(
         "Summary",
-        Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
     )]));
     for line in text.lines() {
         lines.push(Line::from(vec![
@@ -1373,7 +1542,11 @@ pub fn render_summary_message(text: &str) -> Vec<Line<'static>> {
 /// Render an unseen divider.
 pub fn render_unseen_divider(count: usize) -> Vec<Line<'static>> {
     vec![Line::from(vec![Span::styled(
-        format!("---- {} new message{} ----", count, if count == 1 { "" } else { "s" }),
+        format!(
+            "---- {} new message{} ----",
+            count,
+            if count == 1 { "" } else { "s" }
+        ),
         Style::default().fg(Color::Yellow),
     )])]
 }
@@ -1399,11 +1572,15 @@ pub fn render_thinking_block(text: &str, expanded: bool) -> Vec<Line<'static>> {
     lines.push(Line::from(vec![
         Span::styled(
             "Thinking: ",
-            Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC),
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::ITALIC),
         ),
         Span::styled(
             heading,
-            Style::default().fg(Color::Gray).add_modifier(Modifier::ITALIC),
+            Style::default()
+                .fg(Color::Gray)
+                .add_modifier(Modifier::ITALIC),
         ),
     ]));
     if expanded {
@@ -1423,11 +1600,16 @@ pub fn render_rate_limit_banner(retry_after_secs: u64) -> Vec<Line<'static>> {
 }
 
 /// Render a rate-limit warning banner with optional upgrade hint.
-pub fn render_rate_limit_with_hint(retry_after_secs: u64, show_upgrade_hint: bool) -> Vec<Line<'static>> {
+pub fn render_rate_limit_with_hint(
+    retry_after_secs: u64,
+    show_upgrade_hint: bool,
+) -> Vec<Line<'static>> {
     let mut lines = vec![
         Line::from(vec![Span::styled(
             "Rate limit exceeded",
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
         )]),
         Line::from(vec![Span::styled(
             format!("  Retrying in {}s...", retry_after_secs),
@@ -1499,11 +1681,7 @@ fn prefix_message_lines(
                 .add_modifier(Modifier::BOLD),
             Style::default().fg(Color::White),
         ),
-        Role::Assistant => (
-            "",
-            Style::default(),
-            Style::default().fg(Color::White),
-        ),
+        Role::Assistant => ("", Style::default(), Style::default().fg(Color::White)),
     };
 
     if !prefix.is_empty() {
@@ -1579,7 +1757,9 @@ fn render_attachment_line(kind: &str, label: String) -> Vec<Line<'static>> {
     vec![Line::from(vec![
         Span::styled(
             format!("  {} ", kind),
-            Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(label, Style::default().fg(Color::DarkGray)),
     ])]
@@ -1627,20 +1807,28 @@ pub fn render_message(msg: &Message, ctx: &RenderContext) -> Vec<Line<'static>> 
                     ctx.width,
                 ));
             }
-            ContentBlock::ToolUse { id, name, input, .. } => {
+            ContentBlock::ToolUse {
+                id, name, input, ..
+            } => {
                 flush_text(&mut lines, &msg.role, &mut pending_text, ctx);
-                let rendered = render_tool_use_inner(&name, &input);
+                let rendered = render_tool_use_inner(&name, &input, ctx.hide_tool_content);
                 // Silence unused-variable warning on id — kept for symmetry with ToolResult lookup.
                 let _ = &id;
                 lines.extend(prefix_message_lines(rendered, &msg.role, ctx.width));
             }
-            ContentBlock::ToolResult { tool_use_id, content, is_error } => {
+            ContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                is_error,
+            } => {
                 flush_text(&mut lines, &msg.role, &mut pending_text, ctx);
-                let text = tool_result_text(&content);
-                let tool_name = ctx.tool_names.get(&tool_use_id).map(|s| s.as_str());
-                let rendered = if is_error.unwrap_or(false) {
-                    render_tool_result_error(&text)
+                let rendered = if ctx.hide_tool_content {
+                    render_tool_result_hidden()
+                } else if is_error.unwrap_or(false) {
+                    render_tool_result_error(&tool_result_text(&content))
                 } else {
+                    let text = tool_result_text(&content);
+                    let tool_name = ctx.tool_names.get(&tool_use_id).map(|s| s.as_str());
                     match tool_name {
                         Some("Bash") | Some("PowerShell") => {
                             render_bash_output_block(&text, TOOL_RESULT_MAX_LINES)
@@ -1669,7 +1857,12 @@ pub fn render_message(msg: &Message, ctx: &RenderContext) -> Vec<Line<'static>> 
                     ));
                 }
             }
-            ContentBlock::Document { title, context, source, .. } => {
+            ContentBlock::Document {
+                title,
+                context,
+                source,
+                ..
+            } => {
                 flush_text(&mut lines, &msg.role, &mut pending_text, ctx);
                 let label = title
                     .or(context)
@@ -1694,16 +1887,29 @@ pub fn render_message(msg: &Message, ctx: &RenderContext) -> Vec<Line<'static>> 
                 flush_text(&mut lines, &msg.role, &mut pending_text, ctx);
                 lines.extend(render_user_memory_input(&key, &value));
             }
-            ContentBlock::SystemAPIError { message, retry_secs } => {
+            ContentBlock::SystemAPIError {
+                message,
+                retry_secs,
+            } => {
                 flush_text(&mut lines, &msg.role, &mut pending_text, ctx);
                 lines.extend(render_system_api_error(&message, retry_secs));
             }
-            ContentBlock::CollapsedReadSearch { tool_name, paths, n_hidden } => {
+            ContentBlock::CollapsedReadSearch {
+                tool_name,
+                paths,
+                n_hidden,
+            } => {
                 flush_text(&mut lines, &msg.role, &mut pending_text, ctx);
                 let path_refs: Vec<&str> = paths.iter().map(|s| s.as_str()).collect();
-                lines.extend(render_collapsed_read_search(&tool_name, &path_refs, n_hidden));
+                lines.extend(render_collapsed_read_search(
+                    &tool_name, &path_refs, n_hidden,
+                ));
             }
-            ContentBlock::TaskAssignment { id, subject, description } => {
+            ContentBlock::TaskAssignment {
+                id,
+                subject,
+                description,
+            } => {
                 flush_text(&mut lines, &msg.role, &mut pending_text, ctx);
                 lines.extend(render_task_assignment(&id, &subject, &description));
             }
@@ -1767,11 +1973,15 @@ pub fn render_user_command(name: &str, args: &str) -> Vec<Line<'static>> {
     vec![Line::from(vec![
         Span::styled(
             "\u{25b8} ",
-            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             name.to_string(),
-            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(" ".to_string(), Style::default()),
         Span::styled(args.to_string(), Style::default().fg(Color::White)),
@@ -1817,7 +2027,9 @@ fn extract_goal_objective_from_args(args: &str) -> Option<String> {
     // doesn't include the budget flag.
     let rest = if let Some(after_flag) = trimmed.strip_prefix("--tokens") {
         let after_flag = after_flag.trim_start();
-        after_flag.split_once(char::is_whitespace).map(|x| x.1)
+        after_flag
+            .split_once(char::is_whitespace)
+            .map(|x| x.1)
             .unwrap_or("")
             .trim()
     } else {
@@ -1843,6 +2055,16 @@ fn extract_goal_objective_from_args(args: &str) -> Option<String> {
 /// Render the yellow `GOAL ACTIVE / Objective: …` badge that replaces the
 /// `/goal <objective>` user-input line in the transcript.
 fn render_goal_active_block(objective: &str) -> Vec<Line<'static>> {
+    // Truncate to a single line: take the first line of the objective,
+    // and cap its visible width so it fits on one terminal line.
+    let first_line = objective.lines().next().unwrap_or(objective);
+    const MAX_GOAL_LINE_CHARS: usize = 120;
+    let truncated = if first_line.chars().count() > MAX_GOAL_LINE_CHARS {
+        let trimmed: String = first_line.chars().take(MAX_GOAL_LINE_CHARS - 1).collect();
+        format!("{}...", trimmed)
+    } else {
+        first_line.to_string()
+    };
     vec![
         Line::from(vec![Span::styled(
             "  GOAL ACTIVE".to_string(),
@@ -1857,7 +2079,7 @@ fn render_goal_active_block(objective: &str) -> Vec<Line<'static>> {
                     .fg(GOAL_ACCENT)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::styled(objective.to_string(), Style::default().fg(GOAL_BODY)),
+            Span::styled(truncated, Style::default().fg(GOAL_BODY)),
         ]),
     ]
 }
@@ -1890,7 +2112,9 @@ pub fn render_user_local_command_output(
     let mut lines = Vec::new();
     lines.push(Line::from(vec![Span::styled(
         format!("  !{}", command),
-        Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(Color::DarkGray)
+            .add_modifier(Modifier::BOLD),
     )]));
     let total = output.lines().count();
     for line in output.lines().take(max_lines) {
@@ -1915,7 +2139,9 @@ pub fn render_resource_update(server: &str, uri: &str, reason: &str) -> Vec<Line
         Span::styled("\u{21bb} ", Style::default().fg(Color::Cyan)),
         Span::styled(
             format!("{}: ", server),
-            Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(uri.to_string(), Style::default().fg(Color::White)),
         Span::styled(
@@ -1935,13 +2161,12 @@ pub fn render_collapsed_read_search(
 ) -> Vec<Line<'static>> {
     let paths_str = paths.join(", ");
     let mut spans = vec![
-        Span::styled(
-            "\u{25b8} ",
-            Style::default().fg(Color::Yellow),
-        ),
+        Span::styled("\u{25b8} ", Style::default().fg(Color::Yellow)),
         Span::styled(
             format!("{} ", tool_name),
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(paths_str, Style::default().fg(Color::White)),
     ];
@@ -1966,7 +2191,9 @@ pub fn render_task_assignment(id: &str, subject: &str, desc: &str) -> Vec<Line<'
         Span::styled("  ~ ", Style::default().fg(CLAUDE_ORANGE)),
         Span::styled(
             title.to_string(),
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             format!(" · task #{}", id),
@@ -1976,10 +2203,7 @@ pub fn render_task_assignment(id: &str, subject: &str, desc: &str) -> Vec<Line<'
     for line in desc.lines().take(5) {
         lines.push(Line::from(vec![
             Span::raw("    "),
-            Span::styled(
-                line.to_string(),
-                Style::default().fg(TRANSCRIPT_MUTED),
-            ),
+            Span::styled(line.to_string(), Style::default().fg(TRANSCRIPT_MUTED)),
         ]));
     }
     lines
@@ -1994,11 +2218,15 @@ pub fn render_grouped_tool_use(names: &[&str], expanded: bool) -> Vec<Line<'stat
     let header = Line::from(vec![
         Span::styled(
             "\u{25b8} ",
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             format!("{} tool call{}", n, if n == 1 { "" } else { "s" }),
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             format!("  {}", preview),
@@ -2027,7 +2255,7 @@ pub fn render_grouped_tool_use(names: &[&str], expanded: bool) -> Vec<Line<'stat
 pub fn is_goal_event_message(text: &str) -> bool {
     text.starts_with("[Goal started]")
         || text.starts_with("[Goal continuation \u{2014}")  // em dash
-        || text.starts_with("[Goal continuation -")         // fallback
+        || text.starts_with("[Goal continuation -") // fallback
 }
 
 /// Extract the turn number from a "[Goal continuation — turn N]" header.
@@ -2035,7 +2263,9 @@ fn extract_goal_turn(text: &str) -> Option<u32> {
     // Find the first [...] bracket, search inside for "turn <N>"
     let open = text.find('[')?;
     let close = text.find(']')?;
-    if close <= open { return None; }
+    if close <= open {
+        return None;
+    }
     let segment = &text[open..close];
     let tag = "turn ";
     let idx = segment.rfind(tag)? + tag.len();
@@ -2054,12 +2284,14 @@ pub fn render_goal_event(text: &str, _width: u16) -> Vec<Line<'static>> {
         let turn = extract_goal_turn(text).unwrap_or(0);
         return vec![Line::from(vec![
             Span::styled(
-                "  \u{21ba} ".to_string(),  // ↺
+                "  \u{21ba} ".to_string(), // ↺
                 Style::default().fg(GOAL_MUTED),
             ),
             Span::styled(
-                format!("goal \u{00b7} turn {}", turn),  // ·
-                Style::default().fg(GOAL_MUTED).add_modifier(Modifier::ITALIC),
+                format!("goal \u{00b7} turn {}", turn), // ·
+                Style::default()
+                    .fg(GOAL_MUTED)
+                    .add_modifier(Modifier::ITALIC),
             ),
         ])];
     }
@@ -2073,7 +2305,10 @@ mod tests {
     use super::*;
 
     fn line_text(line: &Line<'_>) -> String {
-        line.spans.iter().map(|s| s.content.to_string()).collect::<String>()
+        line.spans
+            .iter()
+            .map(|s| s.content.to_string())
+            .collect::<String>()
     }
 
     #[test]
@@ -2171,7 +2406,8 @@ mod tests {
 
     #[test]
     fn test_render_attachment_message() {
-        let result = render_attachment_message("skill_listing", "5 tools available: Bash, Read", 80);
+        let result =
+            render_attachment_message("skill_listing", "5 tools available: Bash, Read", 80);
         assert!(!result.is_empty());
         let text = line_text(&result[0]);
         assert!(text.contains("skill_listing"));
@@ -2184,7 +2420,10 @@ mod tests {
         let result = render_attachment_message("kind", &long, 80);
         assert!(!result.is_empty());
         let text = line_text(&result[0]);
-        assert!(text.contains('\u{2026}') || text.len() < long.len(), "expected truncation");
+        assert!(
+            text.contains('\u{2026}') || text.len() < long.len(),
+            "expected truncation"
+        );
     }
 
     #[test]
@@ -2217,7 +2456,11 @@ mod tests {
     fn test_render_shutdown_message() {
         let result = render_shutdown_message("max turns reached");
         assert!(!result.is_empty());
-        let combined = result.iter().map(|l| line_text(l)).collect::<Vec<_>>().join("\n");
+        let combined = result
+            .iter()
+            .map(|l| line_text(l))
+            .collect::<Vec<_>>()
+            .join("\n");
         assert!(combined.contains("Session ended"));
         assert!(combined.contains("max turns reached"));
     }
@@ -2233,7 +2476,10 @@ mod tests {
 
     #[test]
     fn test_render_bash_output_block() {
-        let output = (0..50).map(|i| format!("line {}", i)).collect::<Vec<_>>().join("\n");
+        let output = (0..50)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
         let result = render_bash_output_block(&output, 10);
         assert!(!result.is_empty());
         // 10 content lines + 1 overflow indicator
@@ -2254,7 +2500,11 @@ mod tests {
         let steps = vec!["First step".to_string(), "Second step".to_string()];
         let result = render_plan_steps(&steps);
         assert!(!result.is_empty());
-        let combined = result.iter().map(|l| line_text(l)).collect::<Vec<_>>().join("\n");
+        let combined = result
+            .iter()
+            .map(|l| line_text(l))
+            .collect::<Vec<_>>()
+            .join("\n");
         assert!(combined.contains("Plan:"));
         assert!(combined.contains("1."));
         assert!(combined.contains("First step"));
@@ -2275,7 +2525,10 @@ mod tests {
 
     #[test]
     fn test_render_tool_result_success_uses_30_lines() {
-        let output = (0..50).map(|i| format!("line {}", i)).collect::<Vec<_>>().join("\n");
+        let output = (0..50)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
         let result = render_tool_result_success(&output, false);
         // 30 content lines + 1 overflow indicator = 31 (no separate header line)
         assert_eq!(result.len(), 31);
@@ -2297,9 +2550,18 @@ mod tests {
             .map(|l| line_text(&l))
             .collect::<Vec<_>>()
             .join("\n");
-        assert!(rendered.contains("ls -la"), "command should appear in output");
-        assert!(rendered.contains("Running command"), "updated tool title should appear");
-        assert!(!rendered.contains("ctrl+o"), "legacy expansion hint should be removed");
+        assert!(
+            rendered.contains("ls -la"),
+            "command should appear in output"
+        );
+        assert!(
+            rendered.contains("Running command"),
+            "updated tool title should appear"
+        );
+        assert!(
+            !rendered.contains("ctrl+o"),
+            "legacy expansion hint should be removed"
+        );
     }
 
     #[test]
@@ -2315,9 +2577,18 @@ mod tests {
             .map(|l| line_text(&l))
             .collect::<Vec<_>>()
             .join("\n");
-        assert!(rendered.contains("Reading file"), "tool title should appear");
-        assert!(rendered.contains("foo.txt"), "file path summary should appear");
-        assert!(!rendered.contains("ctrl+o"), "legacy expansion hint should be removed");
+        assert!(
+            rendered.contains("Reading file"),
+            "tool title should appear"
+        );
+        assert!(
+            rendered.contains("foo.txt"),
+            "file path summary should appear"
+        );
+        assert!(
+            !rendered.contains("ctrl+o"),
+            "legacy expansion hint should be removed"
+        );
     }
 
     #[test]
@@ -2344,7 +2615,10 @@ mod tests {
     fn bash_tool_result_renders_as_bash_output_with_tool_names_context() {
         let mut tool_names = HashMap::new();
         tool_names.insert("tu-bash-1".to_string(), "Bash".to_string());
-        let ctx = RenderContext { tool_names: &tool_names, ..Default::default() };
+        let ctx = RenderContext {
+            tool_names: &tool_names,
+            ..Default::default()
+        };
 
         let msg = Message::user_blocks(vec![ContentBlock::ToolResult {
             tool_use_id: "tu-bash-1".to_string(),
@@ -2358,7 +2632,10 @@ mod tests {
             .join("\n");
         assert!(rendered.contains("hello world"), "output should appear");
         // bash_output_block does NOT prefix with "Result" (that's render_tool_result_success)
-        assert!(!rendered.contains("Result"), "bash output should NOT show generic 'Result' header");
+        assert!(
+            !rendered.contains("Result"),
+            "bash output should NOT show generic 'Result' header"
+        );
     }
 
     #[test]
@@ -2374,7 +2651,10 @@ mod tests {
             .map(|l| line_text(&l))
             .collect::<Vec<_>>()
             .join("\n");
-        assert!(rendered.contains("file content here"), "content should appear");
+        assert!(
+            rendered.contains("file content here"),
+            "content should appear"
+        );
     }
 
     // ── New function tests ────────────────────────────────────────────────────
@@ -2383,7 +2663,11 @@ mod tests {
     fn test_render_system_api_error_short_message() {
         let result = render_system_api_error("Connection refused", None);
         assert!(!result.is_empty());
-        let combined = result.iter().map(|l| line_text(l)).collect::<Vec<_>>().join("\n");
+        let combined = result
+            .iter()
+            .map(|l| line_text(l))
+            .collect::<Vec<_>>()
+            .join("\n");
         assert!(combined.contains("API Error"));
         assert!(combined.contains("Connection refused"));
         // No retry line
@@ -2393,7 +2677,11 @@ mod tests {
     #[test]
     fn test_render_system_api_error_with_retry() {
         let result = render_system_api_error("Timeout", Some(30));
-        let combined = result.iter().map(|l| line_text(l)).collect::<Vec<_>>().join("\n");
+        let combined = result
+            .iter()
+            .map(|l| line_text(l))
+            .collect::<Vec<_>>()
+            .join("\n");
         assert!(combined.contains("API Error"));
         assert!(combined.contains("Timeout"));
         assert!(combined.contains("Retrying in 30s"));
@@ -2401,10 +2689,20 @@ mod tests {
 
     #[test]
     fn test_render_system_api_error_long_message_shows_expand_hint() {
-        let msg = (0..10).map(|i| format!("line {}", i)).collect::<Vec<_>>().join("\n");
+        let msg = (0..10)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
         let result = render_system_api_error(&msg, None);
-        let combined = result.iter().map(|l| line_text(l)).collect::<Vec<_>>().join("\n");
-        assert!(combined.contains("[expand]"), "should show [expand] hint when more than 5 lines");
+        let combined = result
+            .iter()
+            .map(|l| line_text(l))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            combined.contains("[expand]"),
+            "should show [expand] hint when more than 5 lines"
+        );
         assert!(combined.contains("5 more lines"));
     }
 
@@ -2424,7 +2722,10 @@ mod tests {
         let header = line_text(&result[0]);
         let body = line_text(&result[1]);
         assert!(header.contains("GOAL ACTIVE"));
-        assert!(!header.contains('\u{25b8}'), "should not show ▸ user-command prefix");
+        assert!(
+            !header.contains('\u{25b8}'),
+            "should not show ▸ user-command prefix"
+        );
         assert!(body.contains("Objective:"));
         assert!(body.contains("Migrate to React"));
     }
@@ -2434,7 +2735,10 @@ mod tests {
         for sub in ["status", "pause", "resume", "clear", "complete"] {
             let result = render_user_command("goal", sub);
             let text = line_text(&result[0]);
-            assert!(text.contains('\u{25b8}'), "/goal {sub} should keep ▸ prefix");
+            assert!(
+                text.contains('\u{25b8}'),
+                "/goal {sub} should keep ▸ prefix"
+            );
             assert!(text.contains(sub));
         }
     }
@@ -2444,7 +2748,10 @@ mod tests {
         let result = render_user_command("goal", "--tokens 250K Migrate to React");
         let body = line_text(&result[1]);
         assert!(body.contains("Migrate to React"));
-        assert!(!body.contains("--tokens"), "flag should not appear in displayed objective");
+        assert!(
+            !body.contains("--tokens"),
+            "flag should not appear in displayed objective"
+        );
         assert!(!body.contains("250K"));
     }
 
@@ -2499,7 +2806,10 @@ mod tests {
 
     #[test]
     fn test_render_user_local_command_output_with_overflow() {
-        let output = (0..20).map(|i| format!("out {}", i)).collect::<Vec<_>>().join("\n");
+        let output = (0..20)
+            .map(|i| format!("out {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
         let result = render_user_local_command_output("ls", &output, 5);
         // 1 header + 5 body + 1 overflow = 7
         assert_eq!(result.len(), 7);
@@ -2539,7 +2849,10 @@ mod tests {
         assert!(text.contains('\u{25b8}'), "should have ▸ prefix");
         assert!(text.contains("Read"));
         assert!(text.contains("src/lib.rs"));
-        assert!(!text.contains("more"), "should not show 'more' when n_hidden is 0");
+        assert!(
+            !text.contains("more"),
+            "should not show 'more' when n_hidden is 0"
+        );
     }
 
     #[test]
@@ -2553,9 +2866,17 @@ mod tests {
 
     #[test]
     fn test_render_task_assignment() {
-        let result = render_task_assignment("42", "Implement feature X", "Add the new widget system\nWith multi-line support");
+        let result = render_task_assignment(
+            "42",
+            "Implement feature X",
+            "Add the new widget system\nWith multi-line support",
+        );
         assert!(!result.is_empty());
-        let combined = result.iter().map(|l| line_text(l)).collect::<Vec<_>>().join("\n");
+        let combined = result
+            .iter()
+            .map(|l| line_text(l))
+            .collect::<Vec<_>>()
+            .join("\n");
         assert!(combined.contains("Implement feature X"));
         assert!(combined.contains("task #42"));
         assert!(combined.contains("Add the new widget system"));
@@ -2563,12 +2884,22 @@ mod tests {
 
     #[test]
     fn test_render_task_assignment_truncates_desc_at_5_lines() {
-        let desc = (0..10).map(|i| format!("desc line {}", i)).collect::<Vec<_>>().join("\n");
+        let desc = (0..10)
+            .map(|i| format!("desc line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
         let result = render_task_assignment("1", "Subject", &desc);
-        let combined = result.iter().map(|l| line_text(l)).collect::<Vec<_>>().join("\n");
+        let combined = result
+            .iter()
+            .map(|l| line_text(l))
+            .collect::<Vec<_>>()
+            .join("\n");
         // Only first 5 desc lines should appear
         assert!(combined.contains("desc line 4"));
-        assert!(!combined.contains("desc line 5"), "should truncate desc at 5 lines");
+        assert!(
+            !combined.contains("desc line 5"),
+            "should truncate desc at 5 lines"
+        );
     }
 
     #[test]
@@ -2587,18 +2918,29 @@ mod tests {
         let result = render_grouped_tool_use(&names, true);
         // 1 header + 2 tool lines
         assert_eq!(result.len(), 3);
-        let combined = result.iter().map(|l| line_text(l)).collect::<Vec<_>>().join("\n");
+        let combined = result
+            .iter()
+            .map(|l| line_text(l))
+            .collect::<Vec<_>>()
+            .join("\n");
         assert!(combined.contains("2 tool calls"));
         assert!(combined.contains("Bash"));
         assert!(combined.contains("Read"));
-        assert!(combined.contains('\u{2022}'), "expanded lines should have • prefix");
+        assert!(
+            combined.contains('\u{2022}'),
+            "expanded lines should have • prefix"
+        );
     }
 
     #[test]
     fn test_render_rate_limit_with_hint_false() {
         let result = render_rate_limit_with_hint(60, false);
         assert_eq!(result.len(), 2, "without hint should have 2 lines");
-        let combined = result.iter().map(|l| line_text(l)).collect::<Vec<_>>().join("\n");
+        let combined = result
+            .iter()
+            .map(|l| line_text(l))
+            .collect::<Vec<_>>()
+            .join("\n");
         assert!(combined.contains("Rate limit exceeded"));
         assert!(combined.contains("Retrying in 60s"));
         assert!(!combined.contains("upgrade"));
@@ -2671,5 +3013,49 @@ mod tests {
         // Mixed multibyte content around both cut points must also be safe.
         let mixed = "😀é✅ん".repeat(3_000);
         let _ = truncate_user_prompt_text(&mixed); // no panic == pass
+    }
+
+    #[test]
+    fn test_goal_active_truncates_to_one_line() {
+        let objective = "First line of goal\nSecond line that should not appear";
+        let lines = render_goal_active_block(objective);
+        assert_eq!(lines.len(), 2);
+        let objective_text = line_text(&lines[1]);
+        assert!(objective_text.contains("First line of goal"));
+        assert!(!objective_text.contains("Second line"));
+    }
+
+    #[test]
+    fn test_goal_active_truncates_long_line() {
+        let long = "A".repeat(200);
+        let lines = render_goal_active_block(&long);
+        let objective_text = line_text(&lines[1]);
+        assert!(objective_text.ends_with("..."));
+        assert!(objective_text.chars().count() <= 150);
+    }
+
+    #[test]
+    fn test_render_tool_use_hide_content() {
+        let input = serde_json::json!({ "command": "ls -la", "description": "list files" });
+        let lines_full = render_tool_use_inner("bash", &input, false);
+        let lines_hidden = render_tool_use_inner("bash", &input, true);
+        assert!(!lines_full.is_empty());
+        assert!(!lines_hidden.is_empty());
+        // When hidden, summary line is suppressed but $ command still shows.
+        // So: title line + $ command line = 2 lines (vs 3 when full: title + summary + $ command).
+        assert!(lines_full.len() > lines_hidden.len());
+        assert_eq!(lines_hidden.len(), 2);
+        let title = line_text(&lines_hidden[0]);
+        assert!(title.contains("Running command"));
+        let cmd = line_text(&lines_hidden[1]);
+        assert!(cmd.contains("$ ls -la"));
+    }
+
+    #[test]
+    fn test_render_tool_result_hidden() {
+        let lines = render_tool_result_hidden();
+        assert_eq!(lines.len(), 1);
+        let text = line_text(&lines[0]);
+        assert!(text.contains("Result hidden"));
     }
 }

--- a/src-rust/crates/tui/src/model_picker.rs
+++ b/src-rust/crates/tui/src/model_picker.rs
@@ -24,6 +24,10 @@ use crate::overlays::{centered_rect, modal_search_line, CLAURST_PANEL_BG};
 /// support reasoning honour it.
 pub use claurst_core::effort::EffortLevel;
 
+/// Sentinel model id for the "Default" picker entry. When the user selects
+/// this, the app clears the explicit model override so the provider's best
+/// model is used.
+pub const DEFAULT_MODEL_SENTINEL: &str = "__default__";
 
 // ---------------------------------------------------------------------------
 // Model capability helpers — driven by the opencode variants() ladder
@@ -221,6 +225,8 @@ pub struct ModelEntry {
     pub description: String,
     /// Whether this is the currently active model.
     pub is_current: bool,
+    /// Provider ID this model belongs to (for all-providers mode).
+    pub provider_id: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -228,12 +234,13 @@ pub struct ModelEntry {
 // ---------------------------------------------------------------------------
 
 /// Helper to build a `ModelEntry` with `is_current = false`.
-fn model_entry(id: &str, name: &str, desc: &str) -> ModelEntry {
+fn model_entry(id: &str, name: &str, desc: &str, provider_id: &str) -> ModelEntry {
     ModelEntry {
         id: id.to_string(),
         display_name: name.to_string(),
         description: desc.to_string(),
         is_current: false,
+        provider_id: provider_id.to_string(),
     }
 }
 
@@ -254,7 +261,7 @@ pub fn models_for_provider_from_registry(
     // directly.  `free/auto` is the default routing entry; the rest pin a
     // specific upstream model for users who care.
     if provider_id == "free" {
-        return free_provider_models();
+        return free_provider_models(provider_id);
     }
     // Codex (ChatGPT-authenticated OpenAI) is not in the models.dev catalog —
     // serve the curated CODEX_MODELS list so the picker isn't empty.  Accept
@@ -262,7 +269,7 @@ pub fn models_for_provider_from_registry(
     // ("openai-codex"); without the alias a fresh Codex login lands on the
     // empty-registry fallback and the picker shows no models.
     if is_codex_provider(provider_id) {
-        return codex_provider_models(registry);
+        return codex_provider_models(registry, provider_id);
     }
 
     let mut entries = registry.list_visible_by_provider(provider_id);
@@ -280,6 +287,7 @@ pub fn models_for_provider_from_registry(
             "default",
             "Default model",
             "no catalog entry for this provider",
+            provider_id,
         )];
     }
 
@@ -307,6 +315,7 @@ pub fn models_for_provider_from_registry(
                 display_name: e.info.name.clone(),
                 description: cost_str,
                 is_current: false,
+                provider_id: provider_id.to_string(),
             }
         })
         .collect()
@@ -377,10 +386,23 @@ pub fn default_model_for_provider(
 /// event loop either replaces or merges the projection according to
 /// [`provider_has_authoritative_live_models`].
 pub fn provider_uses_catalog_projection(provider_id: &str) -> bool {
-    matches!(
+    if matches!(
         provider_id,
         "openai" | "google" | "azure" | "amazon-bedrock" | "cohere" | "minimax"
-    )
+    ) {
+        return true;
+    }
+    // Custom providers have a curated model list in settings — no live
+    // endpoint to fetch from, so skip the background fetch.
+    if let Ok(settings) = claurst_core::Settings::load_sync() {
+        if settings.custom_providers.contains_key(provider_id) {
+            return true;
+        }
+    }
+if provider_id == "ollama" || provider_id == "lmstudio" || provider_id == "lm-studio" {
+        return true;
+    }
+    false
 }
 
 /// Whether live discovery is the complete set of models usable through a local
@@ -417,7 +439,7 @@ fn is_codex_provider(provider_id: &str) -> bool {
 /// catalog yields nothing (e.g. an empty/old snapshot).
 ///
 /// [`codex_model_allowed`]: claurst_core::codex_oauth::codex_model_allowed
-fn codex_provider_models(registry: &claurst_api::ModelRegistry) -> Vec<ModelEntry> {
+fn codex_provider_models(registry: &claurst_api::ModelRegistry, provider_id: &str) -> Vec<ModelEntry> {
     use claurst_core::codex_oauth::{codex_limit_override, codex_model_allowed};
 
     let mut entries: Vec<&claurst_api::ModelEntry> = registry
@@ -427,7 +449,7 @@ fn codex_provider_models(registry: &claurst_api::ModelRegistry) -> Vec<ModelEntr
         .collect();
 
     if entries.is_empty() {
-        return codex_fallback_models();
+        return codex_fallback_models(provider_id);
     }
 
     // Newest release first, then by id for stability — matches the picker's
@@ -455,13 +477,14 @@ fn codex_provider_models(registry: &claurst_api::ModelRegistry) -> Vec<ModelEntr
                     format_context_window(ctx)
                 ),
                 is_current: false,
+                provider_id: provider_id.to_string(),
             }
         })
         .collect()
 }
 
 /// Static fallback used when the models.dev `openai` catalog is unavailable.
-fn codex_fallback_models() -> Vec<ModelEntry> {
+fn codex_fallback_models(provider_id: &str) -> Vec<ModelEntry> {
     use claurst_core::codex_oauth::codex_limit_override;
     claurst_core::codex_oauth::CODEX_MODELS
         .iter()
@@ -477,6 +500,7 @@ fn codex_fallback_models() -> Vec<ModelEntry> {
                     format_context_window(ctx)
                 ),
                 is_current: false,
+                provider_id: provider_id.to_string(),
             }
         })
         .collect()
@@ -485,12 +509,13 @@ fn codex_fallback_models() -> Vec<ModelEntry> {
 /// Curated free-mode model list used by `models_for_provider_from_registry`.
 /// Always shows `free/auto` first; one pin entry per catalog upstream so the
 /// user can target a specific provider when they need to.
-fn free_provider_models() -> Vec<ModelEntry> {
+fn free_provider_models(provider_id: &str) -> Vec<ModelEntry> {
     let mut entries = vec![ModelEntry {
         id: "free/auto".to_string(),
         display_name: "Auto (round-robin across configured providers)".to_string(),
         description: "stacks every free-tier key you've added · $0.00 per M".to_string(),
         is_current: false,
+        provider_id: provider_id.to_string(),
     }];
 
     for upstream in claurst_api::FREE_CATALOG {
@@ -499,6 +524,7 @@ fn free_provider_models() -> Vec<ModelEntry> {
             display_name: format!("{} \u{2014} {}", upstream.title, upstream.default_model),
             description: format!("{} · $0.00 per M", upstream.note),
             is_current: false,
+            provider_id: provider_id.to_string(),
         });
     }
 
@@ -523,6 +549,25 @@ pub struct ModelPickerState {
     pub models_loaded: bool,
     /// `true` while the background fetch is in flight.
     pub loading_models: bool,
+    /// Favorited model keys ("provider/model" format), loaded from Settings.
+    pub favorites: Vec<String>,
+    /// Synthetic "Default" entry prepended to the model list.
+    default_entry: ModelEntry,
+    /// When true, the picker shows models from all connected providers
+    /// grouped by provider name.
+    pub all_providers_mode: bool,
+    /// Provider ID → display name map, populated from the model registry
+    /// when the all-providers picker opens. Used for group headers so
+    /// built-in providers (nvidia, deepinfra, etc.) show their real name
+    /// instead of "Other".
+    pub provider_names: std::collections::HashMap<String, String>,
+    /// When true, show ALL providers (including unconfigured) in the picker.
+    /// Default false — only connected providers shown.
+    pub show_all_providers: bool,
+    /// Set of connected provider IDs. When `show_all_providers` is false,
+    /// only models whose provider_id is in this set are shown (plus the
+    /// default entry). Populated by `open_model_picker_all_providers`.
+    pub connected_provider_ids: std::collections::HashSet<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -551,6 +596,18 @@ impl ModelPickerState {
             fast_mode_model: None,
             models_loaded: false,
             loading_models: false,
+            favorites: Vec::new(),
+            default_entry: ModelEntry {
+                id: DEFAULT_MODEL_SENTINEL.to_string(),
+                display_name: "Default".to_string(),
+                description: "Provider's recommended model (auto-selects best)".to_string(),
+                is_current: false,
+                provider_id: String::new(),
+            },
+            all_providers_mode: false,
+            provider_names: std::collections::HashMap::new(),
+            show_all_providers: false,
+            connected_provider_ids: std::collections::HashSet::new(),
         }
     }
 
@@ -568,6 +625,48 @@ impl ModelPickerState {
         self.open_with_title("Select model", current_model, effort, fast_mode);
     }
 
+    /// Open in all-providers mode — shows models from all connected
+    /// providers grouped by provider name.
+    pub fn open_all_providers(&mut self, current_model: &str, effort: EffortLevel, fast_mode: bool) {
+        self.all_providers_mode = true;
+        self.open_with_title("Select model (all providers)", current_model, effort, fast_mode);
+    }
+
+    /// Get the display name for a provider ID (for all-providers mode).
+    pub fn provider_group_name(provider_id: &str) -> String {
+        // Custom providers: use the user-configured display name from settings.
+        if let Ok(settings) = claurst_core::Settings::load_sync() {
+            if let Some(def) = settings.custom_providers.get(provider_id) {
+                return def.name.clone();
+            }
+        }
+        match provider_id {
+            "anthropic" => "Anthropic".to_string(),
+            "openai" => "OpenAI".to_string(),
+            "google" => "Google".to_string(),
+            "groq" => "Groq".to_string(),
+            "openrouter" => "OpenRouter".to_string(),
+            "deepseek" => "DeepSeek".to_string(),
+            "ollama" => "Ollama".to_string(),
+            "lmstudio" => "LM Studio".to_string(),
+            "llamacpp" | "llama-cpp" | "llama-server" => "llama.cpp".to_string(),
+            "github-copilot" => "GitHub Copilot".to_string(),
+            "codex" | "openai-codex" => "OpenAI Codex".to_string(),
+            "cohere" => "Cohere".to_string(),
+            "xai" => "xAI".to_string(),
+            "free" => "Free Mode".to_string(),
+            "cerebras" => "Cerebras".to_string(),
+            "sambanova" => "SambaNova".to_string(),
+            "together-ai" | "togetherai" => "Together AI".to_string(),
+            "mistral" => "Mistral".to_string(),
+            "perplexity" => "Perplexity".to_string(),
+            "azure" => "Azure OpenAI".to_string(),
+            "amazon-bedrock" => "AWS Bedrock".to_string(),
+            "custom-openai" => "Custom OpenAI".to_string(),
+            _ => "Other".to_string(),
+        }
+    }
+
     pub fn open_with_title(
         &mut self,
         title: impl Into<String>,
@@ -576,15 +675,24 @@ impl ModelPickerState {
         fast_mode: bool,
     ) {
         for m in &mut self.models {
-            m.is_current = m.id == current_model;
+            m.is_current = m.id == current_model
+                || current_model == format!("{}/{}", m.provider_id, m.id);
         }
-        self.selected_idx = self
-            .models
-            .iter()
-            .position(|m| m.is_current)
-            .unwrap_or(0);
+        // Mark default entry as current when no explicit model is set.
+        self.default_entry.is_current = current_model.is_empty()
+            || current_model == DEFAULT_MODEL_SENTINEL;
         self.title = title.into();
+        // Clear the filter BEFORE computing selected_idx so a stale filter
+        // can't hide the current model and leave the cursor on row 0.
         self.filter.clear();
+        // Compute selected_idx from the grouped list (default entry at 0,
+        // favorites first, then non-favorites) — not the raw models vec —
+        // so the cursor highlights the correct row.
+        self.selected_idx = self
+            .filtered_models_grouped()
+            .iter()
+            .position(|(m, _)| m.is_current)
+            .unwrap_or(0);
         self.effort_level = effort;
         self.fast_mode = fast_mode;
         self.fast_mode_model = fast_mode.then_some(current_model.to_string());
@@ -595,6 +703,10 @@ impl ModelPickerState {
     pub fn close(&mut self) {
         self.visible = false;
         self.filter.clear();
+        self.all_providers_mode = false;
+        self.provider_names.clear();
+        self.show_all_providers = false;
+        self.connected_provider_ids.clear();
     }
 
     pub fn is_selected_fast_mode_model(&self, model_id: &str) -> bool {
@@ -603,7 +715,7 @@ impl ModelPickerState {
 
     /// Move selection up one row (wraps to last if at top).
     pub fn select_prev(&mut self) {
-        let count = self.filtered_models().len();
+        let count = self.filtered_models_grouped().len();
         if count == 0 { return; }
         if self.selected_idx == 0 {
             self.selected_idx = count - 1;
@@ -614,9 +726,90 @@ impl ModelPickerState {
 
     /// Move selection down one row (wraps to first if at bottom).
     pub fn select_next(&mut self) {
-        let count = self.filtered_models().len();
+        let count = self.filtered_models_grouped().len();
         if count == 0 { return; }
         self.selected_idx = (self.selected_idx + 1) % count;
+    }
+
+    /// Jump to the first model of the next provider group (all-providers mode).
+    /// Wraps around to the default entry (index 0) after the last provider.
+    pub fn select_next_provider(&mut self) {
+        let grouped = self.filtered_models_grouped();
+        if grouped.is_empty() {
+            return;
+        }
+        let current_provider = grouped
+            .get(self.selected_idx)
+            .map(|(m, _)| m.provider_id.as_str())
+            .unwrap_or("");
+        // Find the first entry after the current position with a different
+        // non-empty provider_id. Skip the default entry (empty provider_id).
+        for i in (self.selected_idx + 1)..grouped.len() {
+            let pid = grouped[i].0.provider_id.as_str();
+            if !pid.is_empty() && pid != current_provider {
+                self.selected_idx = i;
+                return;
+            }
+        }
+        // Wrap around: find the first entry with a non-empty provider_id
+        // from the beginning (skips default entry at index 0).
+        for i in 0..self.selected_idx {
+            let pid = grouped[i].0.provider_id.as_str();
+            if !pid.is_empty() && pid != current_provider {
+                self.selected_idx = i;
+                return;
+            }
+        }
+        // No other provider found — stay put.
+    }
+
+    /// Jump to the first model of the previous provider group (all-providers mode).
+    /// Wraps around to the last provider's first model after index 0.
+    pub fn select_prev_provider(&mut self) {
+        let grouped = self.filtered_models_grouped();
+        if grouped.is_empty() {
+            return;
+        }
+        let current_provider = grouped
+            .get(self.selected_idx)
+            .map(|(m, _)| m.provider_id.as_str())
+            .unwrap_or("");
+        // Walk backwards to find the first entry of the previous provider.
+        // We need to find the boundary: the first entry whose provider_id
+        // differs from current AND is non-empty, then from that point find
+        // the FIRST entry of that provider group.
+        let mut prev_provider = None;
+        if self.selected_idx > 0 {
+            for i in (0..self.selected_idx).rev() {
+                let pid = grouped[i].0.provider_id.as_str();
+                if !pid.is_empty() && pid != current_provider {
+                    prev_provider = Some(pid);
+                    // Now find the first entry of this provider group.
+                    for j in 0..=i {
+                        if grouped[j].0.provider_id == pid {
+                            self.selected_idx = j;
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+        // Wrap around: find the last provider group's first entry.
+        if prev_provider.is_none() {
+            // Find the last distinct provider group.
+            let mut last_provider = "";
+            let mut last_provider_first_idx = 0;
+            for (i, (m, _)) in grouped.iter().enumerate() {
+                let pid = m.provider_id.as_str();
+                if !pid.is_empty() && pid != last_provider {
+                    last_provider = pid;
+                    last_provider_first_idx = i;
+                }
+            }
+            if !last_provider.is_empty() && last_provider != current_provider {
+                self.selected_idx = last_provider_first_idx;
+            }
+        }
     }
 
     pub fn select_first(&mut self) {
@@ -624,17 +817,27 @@ impl ModelPickerState {
     }
 
     pub fn select_last(&mut self) {
-        let count = self.filtered_models().len();
+        let count = self.filtered_models_grouped().len();
         self.selected_idx = count.saturating_sub(1);
+    }
+
+    /// Toggle showing all providers vs only connected ones.
+    pub fn toggle_show_all_providers(&mut self) {
+        self.show_all_providers = !self.show_all_providers;
+        // Reset selection to stay in bounds.
+        let count = self.filtered_models_grouped().len();
+        if count > 0 && self.selected_idx >= count {
+            self.selected_idx = count - 1;
+        }
     }
 
     /// The reasoning-effort ladder of the currently highlighted model (ascending,
     /// no ultracode). Empty when nothing is highlighted or the model is
     /// non-reasoning.
     fn selected_ladder(&self) -> Vec<EffortLevel> {
-        let filtered = self.filtered_models();
+        let filtered = self.filtered_models_grouped();
         match filtered.get(self.selected_idx) {
-            Some(m) => picker_variant_ladder(&m.id),
+            Some((m, _)) => picker_variant_ladder(&m.id),
             None => Vec::new(),
         }
     }
@@ -671,7 +874,7 @@ impl ModelPickerState {
     /// Returns the selected model; the caller is responsible for persisting it
     /// in the correct provider-aware format.
     pub fn confirm(&mut self) -> Option<(String, Option<EffortLevel>)> {
-        let filtered = self.filtered_models();
+        let filtered = self.filtered_models_grouped();
         let custom = self.filter.trim();
         if filtered.is_empty() {
             if custom.is_empty() {
@@ -681,8 +884,12 @@ impl ModelPickerState {
             self.close();
             return Some((id, None));
         }
-        let entry = filtered.get(self.selected_idx)?;
+        let (entry, _is_fav) = filtered.get(self.selected_idx)?;
         let id = entry.id.clone();
+        if id == DEFAULT_MODEL_SENTINEL {
+            self.close();
+            return Some((id, None));
+        }
         let ladder = picker_variant_ladder(&id);
         let effort = if ladder.len() > 1 {
             Some(clamp_to_ladder(&ladder, self.effort_level))
@@ -723,6 +930,133 @@ impl ModelPickerState {
             .collect()
     }
 
+    /// Load favorites from Settings into the picker state.
+    pub fn load_favorites(&mut self) {
+        if let Ok(settings) = claurst_core::Settings::load_sync() {
+            self.favorites = settings.favorite_models;
+        }
+    }
+
+    /// Toggle favorite status on a model key. Saves to Settings immediately.
+    pub fn toggle_favorite(&mut self, model_key: &str) {
+        if self.favorites.contains(&model_key.to_string()) {
+            self.favorites.retain(|f| f != model_key);
+        } else {
+            self.favorites.push(model_key.to_string());
+        }
+        // Persist to settings.
+        if let Ok(mut settings) = claurst_core::Settings::load_sync() {
+            settings.favorite_models = self.favorites.clone();
+            let _ = settings.save_sync();
+        }
+    }
+
+    /// Check if a model key is favorited.
+    pub fn is_favorite(&self, model_key: &str) -> bool {
+        self.favorites.contains(&model_key.to_string())
+    }
+
+    /// Get the list of valid favorites — those present in the picker's
+    /// current model list. Stale favorites (model removed from catalog)
+    /// are silently excluded from display but NOT removed from settings.
+    pub fn valid_favorites(&self) -> Vec<String> {
+        let model_ids: std::collections::HashSet<&str> =
+            self.models.iter().map(|m| m.id.as_str()).collect();
+        self.favorites
+            .iter()
+            .filter(|f| {
+                // Favorites are in "provider/model" format. The picker's
+                // models list has bare model ids (no provider prefix) since
+                // the picker is scoped to one provider. So we match on the
+                // model portion after the slash.
+                if let Some((_, model)) = f.split_once('/') {
+                    model_ids.contains(model)
+                } else {
+                    model_ids.contains(f.as_str())
+                }
+            })
+            .cloned()
+            .collect()
+    }
+
+    /// Returns model entries for display: favorites first (marked with ★),
+    /// then all other models. Applies the current filter to both sections.
+    pub fn filtered_models_grouped(&self) -> Vec<(&ModelEntry, bool)> {
+        let valid_favs = self.valid_favorites();
+        let fav_model_ids: std::collections::HashSet<String> = valid_favs
+            .iter()
+            .map(|f| f.split_once('/').map(|(_, m)| m.to_string()).unwrap_or(f.clone()))
+            .collect();
+
+        // Connected-providers filter: when show_all_providers is false AND
+        // we're in all-providers mode, only show models whose provider_id is
+        // in the connected set. The default entry (empty provider_id) always
+        // passes.
+        let connected_filter = |m: &&ModelEntry| -> bool {
+            if m.provider_id.is_empty() {
+                return true;
+            }
+            if self.show_all_providers || !self.all_providers_mode {
+                return true;
+            }
+            self.connected_provider_ids.contains(&m.provider_id)
+        };
+
+        if self.filter.is_empty() {
+            // No filter: favorites section, then all models
+            let mut result = Vec::new();
+            // Default entry always at top.
+            result.push((&self.default_entry, false));
+            // Favorites first
+            for m in &self.models {
+                if fav_model_ids.contains(&m.id) && connected_filter(&m) {
+                    result.push((m, true));
+                }
+            }
+            // Then non-favorites
+            for m in &self.models {
+                if !fav_model_ids.contains(&m.id) && connected_filter(&m) {
+                    result.push((m, false));
+                }
+            }
+            result
+        } else {
+            let needle = self.filter.to_lowercase();
+            let mut result = Vec::new();
+            // Default entry — always show if filter matches or is empty.
+            if self.filter.is_empty()
+                || "default".contains(&needle)
+                || self.default_entry.display_name.to_lowercase().contains(&needle)
+                || self.default_entry.description.to_lowercase().contains(&needle)
+            {
+                result.push((&self.default_entry, false));
+            }
+            // Favorites matching filter
+            for m in &self.models {
+                if fav_model_ids.contains(&m.id)
+                    && (m.id.to_lowercase().contains(&needle)
+                        || m.display_name.to_lowercase().contains(&needle)
+                        || m.description.to_lowercase().contains(&needle))
+                    && connected_filter(&m)
+                {
+                    result.push((m, true));
+                }
+            }
+            // Non-favorites matching filter
+            for m in &self.models {
+                if !fav_model_ids.contains(&m.id)
+                    && (m.id.to_lowercase().contains(&needle)
+                        || m.display_name.to_lowercase().contains(&needle)
+                        || m.description.to_lowercase().contains(&needle))
+                    && connected_filter(&m)
+                {
+                    result.push((m, false));
+                }
+            }
+            result
+        }
+    }
+
     /// Replace the model list with dynamically loaded entries.
     ///
     /// Called by the app event loop when the background fetch completes.
@@ -731,8 +1065,8 @@ impl ModelPickerState {
         self.models = entries;
         self.loading_models = false;
         self.models_loaded = true;
-        // Keep selected_idx in bounds.
-        let count = self.filtered_models().len();
+        // Keep selected_idx in bounds (grouped view includes default entry).
+        let count = self.filtered_models_grouped().len();
         if count > 0 && self.selected_idx >= count {
             self.selected_idx = count - 1;
         }
@@ -769,8 +1103,8 @@ impl ModelPickerState {
         }
         self.loading_models = false;
         self.models_loaded = true;
-        // Keep selected_idx in bounds.
-        let count = self.filtered_models().len();
+        // Keep selected_idx in bounds (grouped view includes default entry).
+        let count = self.filtered_models_grouped().len();
         if count > 0 && self.selected_idx >= count {
             self.selected_idx = count - 1;
         }
@@ -820,8 +1154,8 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
     // ── Dialog size ──
     let width = 65u16.min(area.width.saturating_sub(6));
     let max_height = (area.height as f32 * 0.75) as u16;
-    let filtered = state.filtered_models();
-    let content_h = (filtered.len() as u16 + 6).min(max_height).max(8);
+    let grouped = state.filtered_models_grouped();
+    let content_h = (grouped.len() as u16 + 6).min(max_height).max(8);
     let dialog_area = centered_rect(width, content_h, area);
 
     // ── Fill dialog bg (no border) ──
@@ -909,7 +1243,7 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
         lines.push(Line::from(""));
     }
 
-    if filtered.is_empty() {
+    if grouped.is_empty() {
         lines.push(Line::from(vec![Span::styled(" No results found", Style::default().fg(dim))]));
         if !state.filter.trim().is_empty() {
             lines.push(Line::from(vec![Span::styled(
@@ -918,7 +1252,24 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
             )]));
         }
     } else {
-        for (i, model) in filtered.iter().enumerate() {
+        let mut last_provider: Option<&str> = None;
+        for (i, (model, is_fav)) in grouped.iter().enumerate() {
+            // Provider group header in all-providers mode — skip for the
+            // synthetic default entry (empty provider_id).
+            if state.all_providers_mode
+                && model.id != DEFAULT_MODEL_SENTINEL
+                && last_provider != Some(&model.provider_id) {
+                last_provider = Some(&model.provider_id);
+                let group_name = state
+                    .provider_names
+                    .get(&model.provider_id)
+                    .cloned()
+                    .unwrap_or_else(|| ModelPickerState::provider_group_name(&model.provider_id));
+                lines.push(Line::from(vec![Span::styled(
+                    format!(" {} ", group_name),
+                    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                )]));
+            }
             let is_selected = i == state.selected_idx;
             let supports_effort = model_supports_effort(&model.id);
 
@@ -934,12 +1285,18 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
 
             let mut spans: Vec<Span<'static>> = Vec::new();
 
-            // Current model indicator
-            if model.is_current {
+            // Default entry gets a star (★); active model gets a green dot (●).
+            if model.id == DEFAULT_MODEL_SENTINEL {
+                spans.push(Span::styled(" \u{2605} ", Style::default().fg(Color::Cyan).bg(bg)));
+            } else if model.is_current {
                 spans.push(Span::styled(" \u{25cf} ", Style::default().fg(Color::Green).bg(bg)));
             } else {
                 spans.push(Span::styled("   ", Style::default().bg(bg)));
             }
+
+            // Favorite indicator — heart (♥) when favorited.
+            let heart = if *is_fav { "\u{2665} " } else { "  " };
+            spans.push(Span::styled(heart.to_string(), Style::default().fg(Color::Yellow).bg(bg)));
 
             spans.push(Span::styled(model.display_name.clone(), Style::default().fg(fg).bg(bg)));
 
@@ -990,11 +1347,37 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
 
     para.render(body_area, buf);
 
-    let mut footer_spans = vec![
-        Span::styled(" enter", Style::default().fg(dim)),
-        Span::styled(" select", Style::default().fg(dim)),
-    ];
-    if let Some(model) = filtered.get(state.selected_idx) {
+    let mut footer_spans = vec![];
+    // Show "enter set default" when the default sentinel is selected,
+    // otherwise "enter select".
+    let is_on_default = grouped
+        .get(state.selected_idx)
+        .map(|(m, _)| m.id == DEFAULT_MODEL_SENTINEL)
+        .unwrap_or(false);
+    if is_on_default {
+        footer_spans.push(Span::styled(" enter", Style::default().fg(dim)));
+        footer_spans.push(Span::styled(" set default", Style::default().fg(dim)));
+    } else {
+        footer_spans.push(Span::styled(" enter", Style::default().fg(dim)));
+        footer_spans.push(Span::styled(" select", Style::default().fg(dim)));
+    }
+    // Favorite toggle shortcut.
+    footer_spans.push(Span::raw("  "));
+    footer_spans.push(Span::styled("f", Style::default().fg(dim)));
+    footer_spans.push(Span::styled(" favorite", Style::default().fg(dim)));
+    // Tab to jump between provider groups.
+    footer_spans.push(Span::raw("  "));
+    footer_spans.push(Span::styled("Tab", Style::default().fg(dim)));
+    footer_spans.push(Span::styled(" providers", Style::default().fg(dim)));
+    // Show-all toggle shortcut.
+    footer_spans.push(Span::raw("  "));
+    footer_spans.push(Span::styled("a", Style::default().fg(dim)));
+    if state.show_all_providers {
+        footer_spans.push(Span::styled(" connected", Style::default().fg(dim)));
+    } else {
+        footer_spans.push(Span::styled(" all", Style::default().fg(dim)));
+    }
+    if let Some((model, _)) = grouped.get(state.selected_idx) {
         if model_supports_effort(&model.id) {
             footer_spans.push(Span::raw("  "));
             footer_spans.push(Span::styled("\u{2190}/\u{2192}", Style::default().fg(dim)));
@@ -1026,18 +1409,21 @@ mod tests {
                 display_name: "Claude Opus 4.6".to_string(),
                 description: "200K context".to_string(),
                 is_current: false,
+                provider_id: "anthropic".to_string(),
             },
             ModelEntry {
                 id: "claude-sonnet-4-6".to_string(),
                 display_name: "Claude Sonnet 4.6".to_string(),
                 description: "200K context".to_string(),
                 is_current: false,
+                provider_id: "anthropic".to_string(),
             },
             ModelEntry {
                 id: "claude-haiku-4-5".to_string(),
                 display_name: "Claude Haiku 4.5".to_string(),
                 description: "200K context".to_string(),
                 is_current: false,
+                provider_id: "anthropic".to_string(),
             },
         ]
     }
@@ -1137,7 +1523,7 @@ mod tests {
     #[test]
     fn select_next_wraps() {
         let mut p = make_picker_with_current("claude-opus-4-6");
-        let total = p.filtered_models().len();
+        let total = p.filtered_models_grouped().len();
         p.selected_idx = total - 1;
         p.select_next();
         assert_eq!(p.selected_idx, 0);
@@ -1149,7 +1535,7 @@ mod tests {
         let mut p = make_picker_with_current("claude-opus-4-6");
         p.selected_idx = 0;
         p.select_prev();
-        let total = p.filtered_models().len();
+        let total = p.filtered_models_grouped().len();
         assert_eq!(p.selected_idx, total - 1);
     }
 
@@ -1182,10 +1568,10 @@ mod tests {
     #[test]
     fn confirm_returns_id_and_closes() {
         let mut p = make_picker_with_current("claude-opus-4-6");
-        p.selected_idx = 0;
-        let first_id = p.filtered_models()[0].id.clone();
+        p.selected_idx = 1; // skip Default sentinel at index 0
+        let first_model_id = p.filtered_models()[0].id.clone();
         let result = p.confirm();
-        assert_eq!(result.map(|(id, _)| id), Some(first_id));
+        assert_eq!(result.map(|(id, _)| id), Some(first_model_id));
         assert!(!p.visible, "picker should be closed after confirm");
     }
 
@@ -1478,6 +1864,7 @@ mod tests {
                 display_name: "LIVE OVERWRITE".to_string(),
                 description: "live desc".to_string(),
                 is_current: false,
+                provider_id: "anthropic".to_string(),
             },
             // A brand-new live id absent from the catalog — must be appended.
             ModelEntry {
@@ -1485,6 +1872,7 @@ mod tests {
                 display_name: "GPT-5.5 (live)".to_string(),
                 description: "live only".to_string(),
                 is_current: false,
+                provider_id: "anthropic".to_string(),
             },
         ];
         p.merge_models(live);
@@ -1530,12 +1918,14 @@ mod tests {
             "default",
             "Default model",
             "no catalog entry for this provider",
+            "anthropic",
         )]);
         p.merge_models(vec![ModelEntry {
             id: "llama3.3".to_string(),
             display_name: "Llama 3.3".to_string(),
             description: "local".to_string(),
             is_current: false,
+            provider_id: "anthropic".to_string(),
         }]);
         assert!(
             !p.models.iter().any(|m| m.id == "default"),
@@ -1581,5 +1971,530 @@ mod tests {
         }
         assert!(!provider_has_authoritative_live_models("github-copilot"));
         assert!(!provider_has_authoritative_live_models("openrouter"));
+    }
+
+    #[test]
+    fn valid_favorites_filters_stale_entries() {
+        let mut state = ModelPickerState::new();
+        state.models = vec![
+            ModelEntry { id: "model-a".to_string(), display_name: "A".to_string(), description: "".to_string(), is_current: false, provider_id: String::new() },
+            ModelEntry { id: "model-b".to_string(), display_name: "B".to_string(), description: "".to_string(), is_current: false, provider_id: String::new() },
+        ];
+        state.favorites = vec![
+            "provider/model-a".to_string(),  // valid
+            "provider/model-c".to_string(),  // stale (not in models list)
+            "model-b".to_string(),           // valid (no provider prefix)
+        ];
+        let valid = state.valid_favorites();
+        assert_eq!(valid.len(), 2);
+        assert!(valid.contains(&"provider/model-a".to_string()));
+        assert!(valid.contains(&"model-b".to_string()));
+    }
+
+    #[test]
+    fn filtered_models_grouped_puts_favorites_first() {
+        let mut state = ModelPickerState::new();
+        state.models = vec![
+            ModelEntry { id: "regular".to_string(), display_name: "Regular".to_string(), description: "".to_string(), is_current: false, provider_id: String::new() },
+            ModelEntry { id: "pinned".to_string(), display_name: "Pinned".to_string(), description: "".to_string(), is_current: false, provider_id: String::new() },
+            ModelEntry { id: "other".to_string(), display_name: "Other".to_string(), description: "".to_string(), is_current: false, provider_id: String::new() },
+        ];
+        state.favorites = vec!["provider/pinned".to_string()];
+        let grouped = state.filtered_models_grouped();
+        assert_eq!(grouped.len(), 4);
+        // Default sentinel at top.
+        assert_eq!(grouped[0].0.id, DEFAULT_MODEL_SENTINEL);
+        // Favorite must come next.
+        assert_eq!(grouped[1].0.id, "pinned");
+        assert!(grouped[1].1);
+        // Rest are non-favorites, preserve source order.
+        assert_eq!(grouped[2].0.id, "regular");
+        assert!(!grouped[2].1);
+        assert_eq!(grouped[3].0.id, "other");
+        assert!(!grouped[3].1);
+    }
+
+    #[test]
+    fn filtered_models_grouped_respects_filter() {
+        let mut state = ModelPickerState::new();
+        state.models = vec![
+            ModelEntry { id: "pinned-a".to_string(), display_name: "Pinned A".to_string(), description: "".to_string(), is_current: false, provider_id: String::new() },
+            ModelEntry { id: "pinned-b".to_string(), display_name: "Other B".to_string(), description: "".to_string(), is_current: false, provider_id: String::new() },
+        ];
+        state.favorites = vec![
+            "provider/pinned-a".to_string(),
+            "provider/pinned-b".to_string(),
+        ];
+        for c in "pinned a".chars() {
+            state.push_filter_char(c);
+        }
+        let grouped = state.filtered_models_grouped();
+        // Only the favorite matching the filter appears, on top.
+        assert_eq!(grouped.len(), 1);
+        assert_eq!(grouped[0].0.id, "pinned-a");
+        assert!(grouped[0].1);
+    }
+
+    #[test]
+    fn is_favorite_roundtrips_without_persist() {
+        let mut state = ModelPickerState::new();
+        state.favorites = vec!["anthropic/claude-sonnet-4-6".to_string()];
+        assert!(state.is_favorite("anthropic/claude-sonnet-4-6"));
+        assert!(!state.is_favorite("openai/gpt-4o"));
+    }
+
+    #[test]
+    fn default_entry_appears_at_top() {
+        let mut picker = ModelPickerState::new();
+        picker.set_models(vec![
+            ModelEntry {
+                id: "model-a".to_string(),
+                display_name: "Model A".to_string(),
+                description: "desc".to_string(),
+                is_current: false,
+                provider_id: String::new(),
+            },
+            ModelEntry {
+                id: "model-b".to_string(),
+                display_name: "Model B".to_string(),
+                description: "desc".to_string(),
+                is_current: false,
+                provider_id: String::new(),
+            },
+        ]);
+        picker.open("model-a");
+        let grouped = picker.filtered_models_grouped();
+        assert_eq!(grouped.len(), 3);
+        assert_eq!(grouped[0].0.id, DEFAULT_MODEL_SENTINEL);
+        assert_eq!(grouped[1].0.id, "model-a");
+    }
+
+    #[test]
+    fn default_entry_is_current_when_no_model() {
+        let mut picker = ModelPickerState::new();
+        picker.set_models(vec![
+            ModelEntry {
+                id: "model-a".to_string(),
+                display_name: "Model A".to_string(),
+                description: "desc".to_string(),
+                is_current: false,
+                provider_id: String::new(),
+            },
+        ]);
+        picker.open_with_title("Test", "", EffortLevel::Medium, false);
+        assert!(picker.default_entry.is_current);
+    }
+
+    #[test]
+    fn confirm_returns_default_sentinel() {
+        let mut picker = ModelPickerState::new();
+        picker.set_models(vec![
+            ModelEntry {
+                id: "model-a".to_string(),
+                display_name: "Model A".to_string(),
+                description: "desc".to_string(),
+                is_current: false,
+                provider_id: String::new(),
+            },
+        ]);
+        picker.open("model-a");
+        picker.selected_idx = 0; // Default entry
+        let result = picker.confirm();
+        assert_eq!(result.unwrap().0, DEFAULT_MODEL_SENTINEL);
+    }
+
+    // --- selected_idx preselection from grouped order (Bug 1 + Bug 2) ---
+
+    #[test]
+    fn open_with_title_preselects_current_in_grouped_order() {
+        let mut p = make_picker();
+        // Set the model at raw index 1 (claude-sonnet-4-6) as current.
+        // Grouped order: [default, opus, sonnet, haiku] (no favorites).
+        // The grouped index of sonnet should be 2 (default=0, opus=1, sonnet=2).
+        p.open_with_title("Test", "claude-sonnet-4-6", EffortLevel::Medium, false);
+        let grouped = p.filtered_models_grouped();
+        let expected_idx = grouped
+            .iter()
+            .position(|(m, _)| m.id == "claude-sonnet-4-6")
+            .unwrap();
+        assert_eq!(
+            p.selected_idx, expected_idx,
+            "selected_idx must match grouped position, not raw models position"
+        );
+        // Sanity: grouped includes default entry at 0.
+        assert_eq!(grouped[0].0.id, DEFAULT_MODEL_SENTINEL);
+        assert!(p.models.iter().find(|m| m.id == "claude-sonnet-4-6").unwrap().is_current);
+    }
+
+    #[test]
+    fn open_with_title_preselects_default_entry_when_no_model() {
+        let mut p = make_picker();
+        p.open_with_title("Test", "", EffortLevel::Medium, false);
+        assert!(p.default_entry.is_current);
+        assert_eq!(p.selected_idx, 0);
+    }
+
+    #[test]
+    fn open_with_title_preselects_with_provider_prefixed_current() {
+        let models = vec![
+            ModelEntry {
+                id: "revolut-ca/glm-5-2".to_string(),
+                display_name: "GLM 5.2".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "together-ai-coding".to_string(),
+            },
+            ModelEntry {
+                id: "some-other-model".to_string(),
+                display_name: "Other".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "together-ai-coding".to_string(),
+            },
+        ];
+        let mut p = ModelPickerState::new();
+        p.set_models(models);
+        p.open_with_title(
+            "Test",
+            "together-ai-coding/revolut-ca/glm-5-2",
+            EffortLevel::Medium,
+            false,
+        );
+        let glm = p
+            .models
+            .iter()
+            .find(|m| m.id == "revolut-ca/glm-5-2")
+            .unwrap();
+        assert!(glm.is_current, "provider-prefixed current must set is_current");
+        // Other model must NOT be current.
+        assert!(!p
+            .models
+            .iter()
+            .find(|m| m.id == "some-other-model")
+            .unwrap()
+            .is_current);
+        let grouped = p.filtered_models_grouped();
+        let expected_idx = grouped
+            .iter()
+            .position(|(m, _)| m.id == "revolut-ca/glm-5-2")
+            .unwrap();
+        assert_eq!(p.selected_idx, expected_idx);
+    }
+
+    #[test]
+    fn open_with_title_preselects_correct_row_with_favorites() {
+        // Build a picker where a NON-current model is a favorite.
+        // sample_models: [opus, sonnet, haiku] (all anthropic).
+        // Favorite: anthropic/claude-sonnet-4-6
+        // Current:  claude-opus-4-6
+        // Grouped order: [default, sonnet(fav), opus, haiku]
+        // So opus is at grouped index 2, not raw index 0.
+        let mut p = make_picker();
+        p.favorites = vec!["anthropic/claude-sonnet-4-6".to_string()];
+        p.open_with_title("Test", "claude-opus-4-6", EffortLevel::Medium, false);
+        let grouped = p.filtered_models_grouped();
+        // Verify grouped order: default, sonnet (favorite), opus, haiku.
+        assert_eq!(grouped.len(), 4);
+        assert_eq!(grouped[0].0.id, DEFAULT_MODEL_SENTINEL);
+        assert_eq!(grouped[1].0.id, "claude-sonnet-4-6");
+        assert!(grouped[1].1, "sonnet should be favorite");
+        assert_eq!(grouped[2].0.id, "claude-opus-4-6");
+        assert!(!grouped[2].1, "opus should not be favorite");
+        assert_eq!(grouped[3].0.id, "claude-haiku-4-5");
+        // selected_idx must point to opus in grouped order (index 2).
+        assert_eq!(
+            p.selected_idx, 2,
+            "selected_idx must be the grouped position of the current model, not the raw index"
+        );
+    }
+
+    #[test]
+    fn open_all_providers_preselects_provider_prefixed_model() {
+        let models = vec![
+            ModelEntry {
+                id: "revolut-ca/glm-5-2".to_string(),
+                display_name: "GLM 5.2".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "together-ai-coding".to_string(),
+            },
+            ModelEntry {
+                id: "another-model".to_string(),
+                display_name: "Another".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "together-ai-coding".to_string(),
+            },
+        ];
+        let mut p = ModelPickerState::new();
+        p.set_models(models);
+        p.connected_provider_ids =
+            ["together-ai-coding".to_string()].into_iter().collect();
+        p.open_all_providers(
+            "together-ai-coding/revolut-ca/glm-5-2",
+            EffortLevel::Medium,
+            false,
+        );
+        assert!(p.all_providers_mode);
+        let glm = p
+            .models
+            .iter()
+            .find(|m| m.id == "revolut-ca/glm-5-2")
+            .unwrap();
+        assert!(glm.is_current, "all-providers mode must match provider-prefixed current");
+        let grouped = p.filtered_models_grouped();
+        let expected_idx = grouped
+            .iter()
+            .position(|(m, _)| m.id == "revolut-ca/glm-5-2")
+            .unwrap();
+        assert_eq!(p.selected_idx, expected_idx);
+    }
+
+    #[test]
+    fn default_entry_does_not_get_group_header() {
+        let entry = ModelEntry {
+            id: DEFAULT_MODEL_SENTINEL.to_string(),
+            display_name: "Default".to_string(),
+            description: "".to_string(),
+            is_current: false,
+            provider_id: String::new(),
+        };
+        // The render condition checks model.id != DEFAULT_MODEL_SENTINEL
+        // before pushing a group header. The default entry must NOT pass.
+        assert!(entry.id == DEFAULT_MODEL_SENTINEL);
+    }
+
+    #[test]
+    fn selected_provider_id_captured_before_close() {
+        // When a filter is active and the user navigates + confirms,
+        // the provider_id must be captured BEFORE close() clears the filter.
+        let mut picker = ModelPickerState::new();
+        picker.all_providers_mode = true;
+        picker.connected_provider_ids =
+["together-ai-coding".to_string(), "ollama".to_string()]
+                .into_iter()
+                .collect();
+        picker.set_models(vec![
+            ModelEntry {
+                id: "glm-5-2".to_string(),
+                display_name: "GLM 5.2".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "together-ai-coding".to_string(),
+            },
+            ModelEntry {
+                id: "opus-4-8".to_string(),
+                display_name: "Opus 4.8".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "ollama".to_string(),
+            },
+        ]);
+        // Type filter "glm" so only the glm model shows (default entry is
+        // filtered out because "glm" does not match "default").
+        for c in "glm".chars() {
+            picker.push_filter_char(c);
+        }
+        // glm is the only filtered result → grouped index 0.
+        picker.selected_idx = 0;
+        // Capture provider BEFORE confirm (as the fixed Enter handler does).
+        let captured_provider = picker
+            .filtered_models_grouped()
+            .get(picker.selected_idx)
+            .map(|(m, _)| m.provider_id.clone());
+        // Now confirm — this closes and clears the filter.
+        let confirmed_id = picker.confirm();
+        // After close, the filter is cleared — unfiltered list is different.
+        // But we captured the provider BEFORE close.
+        assert_eq!(confirmed_id, Some(("glm-5-2".to_string(), None)));
+        assert_eq!(captured_provider, Some("together-ai-coding".to_string()));
+        // If we had re-read AFTER close, selected_idx=0 would point to the
+        // default entry (provider_id="") in the unfiltered list — the bug.
+        assert_ne!(
+            picker
+                .filtered_models_grouped()
+                .get(0)
+                .map(|(m, _)| m.provider_id.clone()),
+            Some("together-ai-coding".to_string())
+        );
+    }
+
+    // --- Tab / BackTab provider-group navigation (all-providers mode) ---
+
+    /// Two providers with two models each — the basic multi-provider fixture.
+    fn two_provider_models() -> Vec<ModelEntry> {
+        vec![
+            ModelEntry {
+                id: "model-a1".to_string(),
+                display_name: "Model A1".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "provider-a".to_string(),
+            },
+            ModelEntry {
+                id: "model-a2".to_string(),
+                display_name: "Model A2".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "provider-a".to_string(),
+            },
+            ModelEntry {
+                id: "model-b1".to_string(),
+                display_name: "Model B1".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "provider-b".to_string(),
+            },
+            ModelEntry {
+                id: "model-b2".to_string(),
+                display_name: "Model B2".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "provider-b".to_string(),
+            },
+        ]
+    }
+
+    #[test]
+    fn select_next_provider_jumps_to_next_group() {
+        let mut p = ModelPickerState::new();
+        p.set_models(two_provider_models());
+        p.connected_provider_ids =
+            ["provider-a".to_string(), "provider-b".to_string()]
+                .into_iter()
+                .collect();
+        p.open_all_providers("model-a1", EffortLevel::Medium, false);
+        // Default entry at index 0, then provider-a models, then provider-b.
+        let grouped = p.filtered_models_grouped();
+        let a1_idx = grouped.iter().position(|(m, _)| m.id == "model-a1").unwrap();
+        let b1_idx = grouped.iter().position(|(m, _)| m.id == "model-b1").unwrap();
+        p.selected_idx = a1_idx;
+        p.select_next_provider();
+        assert_eq!(
+            p.selected_idx, b1_idx,
+            "Tab from provider A should jump to provider B's first model"
+        );
+    }
+
+    #[test]
+    fn select_prev_provider_jumps_to_previous_group() {
+        let mut p = ModelPickerState::new();
+        p.set_models(two_provider_models());
+        p.connected_provider_ids =
+            ["provider-a".to_string(), "provider-b".to_string()]
+                .into_iter()
+                .collect();
+        p.open_all_providers("model-b1", EffortLevel::Medium, false);
+        let grouped = p.filtered_models_grouped();
+        let a1_idx = grouped.iter().position(|(m, _)| m.id == "model-a1").unwrap();
+        let b1_idx = grouped.iter().position(|(m, _)| m.id == "model-b1").unwrap();
+        p.selected_idx = b1_idx;
+        p.select_prev_provider();
+        assert_eq!(
+            p.selected_idx, a1_idx,
+            "BackTab from provider B should jump to provider A's first model"
+        );
+    }
+
+    #[test]
+    fn select_next_provider_wraps_around() {
+        let mut p = ModelPickerState::new();
+        p.set_models(two_provider_models());
+        p.connected_provider_ids =
+            ["provider-a".to_string(), "provider-b".to_string()]
+                .into_iter()
+                .collect();
+        p.open_all_providers("model-b2", EffortLevel::Medium, false);
+        let grouped = p.filtered_models_grouped();
+        let b2_idx = grouped.iter().position(|(m, _)| m.id == "model-b2").unwrap();
+        let a1_idx = grouped.iter().position(|(m, _)| m.id == "model-a1").unwrap();
+        p.selected_idx = b2_idx;
+        p.select_next_provider();
+        assert_eq!(
+            p.selected_idx, a1_idx,
+            "Tab from last provider should wrap to first provider's first model"
+        );
+    }
+
+    #[test]
+    fn select_next_provider_skips_default_entry() {
+        let mut p = ModelPickerState::new();
+        p.set_models(two_provider_models());
+        p.connected_provider_ids =
+            ["provider-a".to_string(), "provider-b".to_string()]
+                .into_iter()
+                .collect();
+        p.open_all_providers("", EffortLevel::Medium, false);
+        // No current model → default entry (index 0) is selected.
+        {
+            let grouped = p.filtered_models_grouped();
+            assert_eq!(p.selected_idx, 0, "default entry should be at index 0");
+            assert_eq!(grouped[0].0.id, DEFAULT_MODEL_SENTINEL);
+            assert_eq!(grouped[0].0.provider_id, "");
+        }
+        p.select_next_provider();
+        // Tab must skip the default entry and land on the first real
+        // provider's first model — never back on the default entry.
+        assert_ne!(
+            p.selected_idx, 0,
+            "Tab must never select the default entry"
+        );
+        let selected_pid = p.filtered_models_grouped()[p.selected_idx].0.provider_id.clone();
+        assert!(
+            !selected_pid.is_empty(),
+            "Tab must land on a real provider, not the default entry"
+        );
+    }
+
+    #[test]
+    fn connected_filter_hides_unconnected_providers() {
+        let mut state = ModelPickerState::new();
+        state.all_providers_mode = true;
+        state.connected_provider_ids =
+            ["provider-a".to_string()].into_iter().collect();
+        state.set_models(vec![
+            ModelEntry { id: "model-a1".to_string(), display_name: "A1".to_string(), description: "".to_string(), is_current: false, provider_id: "provider-a".to_string() },
+            ModelEntry { id: "model-a2".to_string(), display_name: "A2".to_string(), description: "".to_string(), is_current: false, provider_id: "provider-a".to_string() },
+            ModelEntry { id: "model-b1".to_string(), display_name: "B1".to_string(), description: "".to_string(), is_current: false, provider_id: "provider-b".to_string() },
+            ModelEntry { id: "model-b2".to_string(), display_name: "B2".to_string(), description: "".to_string(), is_current: false, provider_id: "provider-b".to_string() },
+        ]);
+        let grouped = state.filtered_models_grouped();
+        // Default entry + 2 provider-a models. Provider-b filtered out.
+        assert_eq!(grouped.len(), 3);
+        assert_eq!(grouped[0].0.id, DEFAULT_MODEL_SENTINEL);
+        let provider_ids: std::collections::HashSet<&str> =
+            grouped.iter().map(|(m, _)| m.provider_id.as_str()).collect();
+        assert!(!provider_ids.contains("provider-b"));
+        assert!(provider_ids.contains("provider-a"));
+    }
+
+    #[test]
+    fn show_all_providers_shows_everyone() {
+        let mut state = ModelPickerState::new();
+        state.all_providers_mode = true;
+        state.show_all_providers = true;
+        state.connected_provider_ids =
+            ["provider-a".to_string()].into_iter().collect();
+        state.set_models(vec![
+            ModelEntry { id: "model-a1".to_string(), display_name: "A1".to_string(), description: "".to_string(), is_current: false, provider_id: "provider-a".to_string() },
+            ModelEntry { id: "model-b1".to_string(), display_name: "B1".to_string(), description: "".to_string(), is_current: false, provider_id: "provider-b".to_string() },
+        ]);
+        let grouped = state.filtered_models_grouped();
+        // Default entry + 1 from provider-a + 1 from provider-b.
+        assert_eq!(grouped.len(), 3);
+        let provider_ids: std::collections::HashSet<&str> =
+            grouped.iter().map(|(m, _)| m.provider_id.as_str()).collect();
+        assert!(provider_ids.contains("provider-a"));
+        assert!(provider_ids.contains("provider-b"));
+    }
+
+    #[test]
+    fn toggle_show_all_providers_flips_state() {
+        let mut state = ModelPickerState::new();
+        assert!(!state.show_all_providers);
+        state.toggle_show_all_providers();
+        assert!(state.show_all_providers);
+        state.toggle_show_all_providers();
+        assert!(!state.show_all_providers);
     }
 }

--- a/src-rust/crates/tui/src/overlays.rs
+++ b/src-rust/crates/tui/src/overlays.rs
@@ -159,7 +159,9 @@ pub fn modal_title_line(title: &str, right_hint: &str) -> Line<'static> {
     Line::from(vec![
         Span::styled(
             format!(" {}", title),
-            Style::default().fg(CLAURST_TEXT).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(CLAURST_TEXT)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             format!("  {}", right_hint),
@@ -180,15 +182,22 @@ pub fn render_modal_title_frame(frame: &mut Frame, area: Rect, title: &str, righ
     let line = Line::from(vec![
         Span::styled(
             format!(" {}", title),
-            Style::default().fg(CLAURST_TEXT).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(CLAURST_TEXT)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(" ".repeat(padding), Style::default().fg(CLAURST_TEXT)),
-        Span::styled(
-            right_hint.to_string(),
-            Style::default().fg(CLAURST_MUTED),
-        ),
+        Span::styled(right_hint.to_string(), Style::default().fg(CLAURST_MUTED)),
     ]);
-    frame.render_widget(Paragraph::new(line), Rect { x: area.x, y: area.y, width: area.width, height: 1 });
+    frame.render_widget(
+        Paragraph::new(line),
+        Rect {
+            x: area.x,
+            y: area.y,
+            width: area.width,
+            height: 1,
+        },
+    );
 }
 
 pub fn render_modal_title_buf(buf: &mut Buffer, area: Rect, title: &str, right_hint: &str) {
@@ -203,13 +212,12 @@ pub fn render_modal_title_buf(buf: &mut Buffer, area: Rect, title: &str, right_h
     let line = Line::from(vec![
         Span::styled(
             format!(" {}", title),
-            Style::default().fg(CLAURST_TEXT).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(CLAURST_TEXT)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(" ".repeat(padding), Style::default().fg(CLAURST_TEXT)),
-        Span::styled(
-            right_hint.to_string(),
-            Style::default().fg(CLAURST_MUTED),
-        ),
+        Span::styled(right_hint.to_string(), Style::default().fg(CLAURST_MUTED)),
     ]);
     Paragraph::new(line).render(
         Rect {
@@ -297,9 +305,8 @@ impl HelpOverlay {
     pub fn populate_from_commands(&mut self, entries: Vec<HelpEntry>) {
         self.commands = entries;
         // Sort stable by category, then name for consistent display.
-        self.commands.sort_by(|a, b| {
-            a.category.cmp(&b.category).then(a.name.cmp(&b.name))
-        });
+        self.commands
+            .sort_by(|a, b| a.category.cmp(&b.category).then(a.name.cmp(&b.name)));
     }
 
     pub fn toggle(&mut self) {
@@ -340,9 +347,9 @@ impl HelpOverlay {
 
 /// Render the help overlay into the frame.
 pub fn render_help_overlay(frame: &mut Frame, overlay: &HelpOverlay, area: Rect) {
+    use claurst_core::constants::APP_VERSION;
     use ratatui::layout::{Constraint, Direction, Layout};
     use ratatui::widgets::Wrap;
-    use claurst_core::constants::APP_VERSION;
 
     if !overlay.visible {
         return;
@@ -367,7 +374,11 @@ pub fn render_help_overlay(frame: &mut Frame, overlay: &HelpOverlay, area: Rect)
 
     let col_chunks = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(42), Constraint::Length(1), Constraint::Min(1)])
+        .constraints([
+            Constraint::Percentage(42),
+            Constraint::Length(1),
+            Constraint::Min(1),
+        ])
         .split(content_area);
 
     // ─── Left column: keyboard shortcuts by category ───────────────────────
@@ -375,19 +386,23 @@ pub fn render_help_overlay(frame: &mut Frame, overlay: &HelpOverlay, area: Rect)
 
     left_lines.push(Line::from(Span::styled(
         " Keyboard Shortcuts",
-        Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(CLAURST_ACCENT)
+            .add_modifier(Modifier::BOLD),
     )));
     left_lines.push(Line::from(""));
 
     // Navigation category
     left_lines.push(Line::from(Span::styled(
         " Navigation",
-        Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(CLAURST_ACCENT)
+            .add_modifier(Modifier::BOLD),
     )));
     for (key, desc) in &[
-        ("PageUp / PgDn",   "Scroll messages"),
-        ("j / k",           "Scroll one line"),
-        ("Home / End",      "Top / bottom"),
+        ("PageUp / PgDn", "Scroll messages"),
+        ("j / k", "Scroll one line"),
+        ("Home / End", "Top / bottom"),
     ] {
         left_lines.push(kb_line(key, desc));
     }
@@ -396,14 +411,16 @@ pub fn render_help_overlay(frame: &mut Frame, overlay: &HelpOverlay, area: Rect)
     // Input category
     left_lines.push(Line::from(Span::styled(
         " Input",
-        Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(CLAURST_ACCENT)
+            .add_modifier(Modifier::BOLD),
     )));
     for (key, desc) in &[
-        ("Enter",           "Submit message"),
-        ("Up / Down",       "Input history"),
-        ("Ctrl+R",          "Search history"),
-        ("Alt+E",           "Expand pasted text"),
-        ("Esc",             "Cancel / close"),
+        ("Enter", "Submit message"),
+        ("Up / Down", "Input history"),
+        ("Ctrl+R", "Search history"),
+        ("Alt+E", "Expand pasted text"),
+        ("Esc", "Cancel / close"),
     ] {
         left_lines.push(kb_line(key, desc));
     }
@@ -412,16 +429,18 @@ pub fn render_help_overlay(frame: &mut Frame, overlay: &HelpOverlay, area: Rect)
     // App category
     left_lines.push(Line::from(Span::styled(
         " App",
-        Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(CLAURST_ACCENT)
+            .add_modifier(Modifier::BOLD),
     )));
     for (key, desc) in &[
-        ("F1 / ?",          "Toggle help"),
-        ("Ctrl+Shift+A",    "Model picker"),
-        ("Ctrl+K",          "Command palette"),
-        ("Ctrl+C",          "Cancel / quit"),
-        ("Ctrl+D",          "Quit (empty input)"),
-        ("Ctrl+L",          "Clear screen"),
-        ("t",               "Expand/collapse thinking"),
+        ("F1 / ?", "Toggle help"),
+        ("Ctrl+Shift+A", "Model picker"),
+        ("Ctrl+K", "Command palette"),
+        ("Ctrl+C", "Cancel / quit"),
+        ("Ctrl+D", "Quit (empty input)"),
+        ("Ctrl+L", "Clear screen"),
+        ("t", "Expand/collapse thinking"),
     ] {
         left_lines.push(kb_line(key, desc));
     }
@@ -456,7 +475,9 @@ pub fn render_help_overlay(frame: &mut Frame, overlay: &HelpOverlay, area: Rect)
 
     right_lines.push(Line::from(Span::styled(
         " Slash Commands",
-        Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(CLAURST_ACCENT)
+            .add_modifier(Modifier::BOLD),
     )));
     right_lines.push(Line::from(""));
 
@@ -469,7 +490,9 @@ pub fn render_help_overlay(frame: &mut Frame, overlay: &HelpOverlay, area: Rect)
             }
             right_lines.push(Line::from(Span::styled(
                 format!(" {}", entry.category),
-                Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(CLAURST_ACCENT)
+                    .add_modifier(Modifier::BOLD),
             )));
         }
         let aliases_text = if entry.aliases.is_empty() {
@@ -481,11 +504,16 @@ pub fn render_help_overlay(frame: &mut Frame, overlay: &HelpOverlay, area: Rect)
             Span::raw("  "),
             Span::styled(
                 format!("/{:<14}", entry.name),
-                Style::default().fg(CLAURST_TEXT).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(CLAURST_TEXT)
+                    .add_modifier(Modifier::BOLD),
             ),
             Span::styled(aliases_text, Style::default().fg(CLAURST_MUTED)),
             Span::raw("  "),
-            Span::styled(entry.description.clone(), Style::default().fg(CLAURST_MUTED)),
+            Span::styled(
+                entry.description.clone(),
+                Style::default().fg(CLAURST_MUTED),
+            ),
         ]));
     }
 
@@ -509,17 +537,15 @@ pub fn render_help_overlay(frame: &mut Frame, overlay: &HelpOverlay, area: Rect)
         col_chunks[2],
     );
 
-    let version_line = Line::from(vec![
-        Span::styled(
-            format!(
-                " v{}  ·  type to filter  ·  ↑↓ scroll commands  ·  esc close",
-                APP_VERSION
-            ),
-            Style::default()
-                .fg(CLAURST_MUTED)
-                .add_modifier(Modifier::ITALIC),
+    let version_line = Line::from(vec![Span::styled(
+        format!(
+            " v{}  ·  type to filter  ·  ↑↓ scroll commands  ·  esc close",
+            APP_VERSION
         ),
-    ]);
+        Style::default()
+            .fg(CLAURST_MUTED)
+            .add_modifier(Modifier::ITALIC),
+    )]);
     frame.render_widget(Paragraph::new(version_line), layout.footer_area);
 }
 
@@ -554,12 +580,20 @@ pub struct HistoryEntry {
 impl HistoryEntry {
     /// Create a new entry stamped with the current time.
     pub fn new(text: String) -> Self {
-        Self { text, timestamp: Some(current_unix_secs()), pinned: false }
+        Self {
+            text,
+            timestamp: Some(current_unix_secs()),
+            pinned: false,
+        }
     }
 
     /// Create a legacy entry without a timestamp.
     pub fn legacy(text: String) -> Self {
-        Self { text, timestamp: None, pinned: false }
+        Self {
+            text,
+            timestamp: None,
+            pinned: false,
+        }
     }
 
     /// Human-readable relative time: "just now", "2m ago", "3h ago", "2d ago", etc.
@@ -598,8 +632,7 @@ pub fn load_pinned_texts() -> std::collections::HashSet<String> {
         Ok(c) => c,
         Err(_) => return std::collections::HashSet::new(),
     };
-    serde_json::from_str::<std::collections::HashSet<String>>(&content)
-        .unwrap_or_default()
+    serde_json::from_str::<std::collections::HashSet<String>>(&content).unwrap_or_default()
 }
 
 /// Persist `pinned_texts` to `~/.claurst/history_pins.json`.
@@ -796,9 +829,13 @@ impl HistorySearchOverlay {
     /// Persists the updated pin set to `~/.claurst/history_pins.json` and
     /// recomputes the match list so the entry moves to/from the pinned section.
     pub fn toggle_pin(&mut self) {
-        let Some(m) = self.matches.get(self.selected_idx) else { return };
+        let Some(m) = self.matches.get(self.selected_idx) else {
+            return;
+        };
         let snap_idx = m.snapshot_idx;
-        let Some(entry) = self.snapshot.get_mut(snap_idx) else { return };
+        let Some(entry) = self.snapshot.get_mut(snap_idx) else {
+            return;
+        };
         entry.pinned = !entry.pinned;
 
         // Rebuild the persisted pin set from the full snapshot.
@@ -849,7 +886,10 @@ impl HistorySearchOverlay {
             match (b_pinned, a_pinned) {
                 (true, false) => std::cmp::Ordering::Greater,
                 (false, true) => std::cmp::Ordering::Less,
-                _ => b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal),
+                _ => b
+                    .score
+                    .partial_cmp(&a.score)
+                    .unwrap_or(std::cmp::Ordering::Equal),
             }
         });
 
@@ -963,7 +1003,9 @@ pub fn render_history_search_overlay(
         Span::raw("  Search: "),
         Span::styled(
             overlay.query.clone(),
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled("\u{2588}", Style::default().fg(Color::White)),
         Span::raw("  "),
@@ -993,17 +1035,12 @@ pub fn render_history_search_overlay(
             let is_selected = real_i == overlay.selected_idx;
 
             // Resolve snapshot entry (for text, timestamp, pinned state).
-            let snap_entry: Option<&HistoryEntry> =
-                overlay.snapshot.get(match_entry.snapshot_idx);
+            let snap_entry: Option<&HistoryEntry> = overlay.snapshot.get(match_entry.snapshot_idx);
 
             // Resolve entry text: prefer snapshot, fall back to passed-in history.
             let entry_text: &str = snap_entry
                 .map(|e| e.text.as_str())
-                .or_else(|| {
-                    history
-                        .get(match_entry.snapshot_idx)
-                        .map(String::as_str)
-                })
+                .or_else(|| history.get(match_entry.snapshot_idx).map(String::as_str))
                 .unwrap_or("");
 
             let is_pinned = snap_entry.is_some_and(|e| e.pinned);
@@ -1012,7 +1049,11 @@ pub fn render_history_search_overlay(
             let time_suffix: String = snap_entry
                 .map(|e| {
                     let t = e.relative_time();
-                    if t.is_empty() { t } else { format!(" · {}", t) }
+                    if t.is_empty() {
+                        t
+                    } else {
+                        format!(" · {}", t)
+                    }
                 })
                 .unwrap_or_default();
 
@@ -1021,8 +1062,8 @@ pub fn render_history_search_overlay(
             let pin_prefix_width: usize = if is_pinned { 2 } else { 0 };
             let prefix_width: usize = 4 + pin_prefix_width; // "    " or "  ► " + optional "★ "
             let time_width = UnicodeWidthStr::width(time_suffix.as_str());
-            let max_text_chars = (dialog_width as usize)
-                .saturating_sub(prefix_width + time_width + 2);
+            let max_text_chars =
+                (dialog_width as usize).saturating_sub(prefix_width + time_width + 2);
 
             let (prefix, base_style) = if is_selected {
                 (
@@ -1049,7 +1090,7 @@ pub fn render_history_search_overlay(
             // Pin star badge (shown for all pinned entries)
             if is_pinned {
                 row_spans.push(Span::styled(
-                    "\u{2605} ",  // ★
+                    "\u{2605} ", // ★
                     Style::default()
                         .fg(Color::Yellow)
                         .add_modifier(Modifier::BOLD),
@@ -1101,8 +1142,7 @@ fn build_highlighted_spans<'a>(
     let chars: Vec<(usize, char)> = text.char_indices().collect();
 
     // Convert highlight byte-positions to a set of byte offsets for O(1) lookup
-    let hl_set: std::collections::HashSet<usize> =
-        highlight_positions.iter().copied().collect();
+    let hl_set: std::collections::HashSet<usize> = highlight_positions.iter().copied().collect();
 
     let mut spans: Vec<Span<'a>> = Vec::new();
     let mut current_text = String::new();
@@ -1140,7 +1180,10 @@ fn build_highlighted_spans<'a>(
         spans.push(Span::styled(current_text, style));
     }
     if truncated {
-        spans.push(Span::styled("…".to_string(), Style::default().fg(Color::DarkGray)));
+        spans.push(Span::styled(
+            "…".to_string(),
+            Style::default().fg(Color::DarkGray),
+        ));
     }
     spans
 }
@@ -1320,7 +1363,9 @@ pub fn render_message_selector(frame: &mut Frame, overlay: &MessageSelectorOverl
 
     lines.push(Line::from(vec![Span::styled(
         "  Select a message to rewind to:",
-        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
     )]));
     lines.push(Line::from(""));
 
@@ -1364,11 +1409,13 @@ pub fn render_message_selector(frame: &mut Frame, overlay: &MessageSelectorOverl
                 Span::styled(format!("{:>3}. ", msg.idx), idx_style),
                 Span::styled(
                     format!("{:<10}", msg.role),
-                    Style::default().fg(role_color).add_modifier(if is_selected {
-                        Modifier::BOLD
-                    } else {
-                        Modifier::empty()
-                    }),
+                    Style::default()
+                        .fg(role_color)
+                        .add_modifier(if is_selected {
+                            Modifier::BOLD
+                        } else {
+                            Modifier::empty()
+                        }),
                 ),
                 Span::styled(
                     preview,
@@ -1378,10 +1425,7 @@ pub fn render_message_selector(frame: &mut Frame, overlay: &MessageSelectorOverl
                         Style::default().fg(Color::DarkGray)
                     },
                 ),
-                Span::styled(
-                    tool_tag.to_string(),
-                    Style::default().fg(Color::Yellow),
-                ),
+                Span::styled(tool_tag.to_string(), Style::default().fg(Color::Yellow)),
             ]));
         }
     }
@@ -1522,7 +1566,9 @@ fn render_rewind_confirm(frame: &mut Frame, message_idx: usize, area: Rect) {
         Line::from(vec![
             Span::styled(
                 "  [y] ",
-                Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
             ),
             Span::raw("Yes, rewind"),
             Span::raw("    "),
@@ -1595,7 +1641,9 @@ impl GlobalSearchState {
         self.selected = 0;
     }
 
-    pub fn close(&mut self) { self.visible = false; }
+    pub fn close(&mut self) {
+        self.visible = false;
+    }
 
     pub fn select_prev(&mut self) {
         let count = self.results.len();
@@ -1637,8 +1685,10 @@ impl GlobalSearchState {
         let output = std::process::Command::new("rg")
             .args([
                 "--json",
-                "--max-count", "10",
-                "--max-filesize", "1M",
+                "--max-count",
+                "10",
+                "--max-filesize",
+                "1M",
                 &self.query,
                 ".",
             ])
@@ -1656,7 +1706,11 @@ impl GlobalSearchState {
                         let data = &val["data"];
                         let file = data["path"]["text"].as_str().unwrap_or("").to_string();
                         let line_no = data["line_number"].as_u64().unwrap_or(0) as u32;
-                        let text = data["lines"]["text"].as_str().unwrap_or("").trim_end_matches('\n').to_string();
+                        let text = data["lines"]["text"]
+                            .as_str()
+                            .unwrap_or("")
+                            .trim_end_matches('\n')
+                            .to_string();
                         let col = data["submatches"][0]["start"].as_u64().unwrap_or(0) as u32;
                         self.results.push(SearchResult {
                             file,
@@ -1667,7 +1721,9 @@ impl GlobalSearchState {
                             context_after: Vec::new(),
                         });
                         self.total_matches += 1;
-                        if self.results.len() >= 500 { break; }
+                        if self.results.len() >= 500 {
+                            break;
+                        }
                     }
                 }
             }
@@ -1676,12 +1732,18 @@ impl GlobalSearchState {
 
     /// Return the selected result as a `file:line` string for prompt injection.
     pub fn selected_ref(&self) -> Option<String> {
-        self.results.get(self.selected).map(|r| format!("{}:{}", r.file, r.line))
+        self.results
+            .get(self.selected)
+            .map(|r| format!("{}:{}", r.file, r.line))
     }
 }
 
 /// Render the global search dialog overlay.
-pub fn render_global_search(state: &GlobalSearchState, area: ratatui::layout::Rect, buf: &mut ratatui::buffer::Buffer) {
+pub fn render_global_search(
+    state: &GlobalSearchState,
+    area: ratatui::layout::Rect,
+    buf: &mut ratatui::buffer::Buffer,
+) {
     use ratatui::{
         layout::Rect,
         style::{Color, Modifier, Style},
@@ -1690,13 +1752,20 @@ pub fn render_global_search(state: &GlobalSearchState, area: ratatui::layout::Re
     };
     use std::path::Path;
 
-    if !state.visible { return; }
+    if !state.visible {
+        return;
+    }
 
     let w = (area.width * 4 / 5).max(40).min(area.width);
     let h = (area.height * 3 / 4).max(10).min(area.height);
     let x = area.x + (area.width - w) / 2;
     let y = area.y + (area.height - h) / 4;
-    let dialog = Rect { x, y, width: w, height: h };
+    let dialog = Rect {
+        x,
+        y,
+        width: w,
+        height: h,
+    };
 
     Clear.render(dialog, buf);
     Block::default()
@@ -1719,7 +1788,12 @@ pub fn render_global_search(state: &GlobalSearchState, area: ratatui::layout::Re
         Span::styled("\u{2588}", Style::default().fg(Color::Cyan)),
     ]);
     Paragraph::new(query_line).render(
-        Rect { x: inner.x, y: inner.y, width: inner.width, height: 1 },
+        Rect {
+            x: inner.x,
+            y: inner.y,
+            width: inner.width,
+            height: 1,
+        },
         buf,
     );
 
@@ -1729,7 +1803,12 @@ pub fn render_global_search(state: &GlobalSearchState, area: ratatui::layout::Re
         Style::default().fg(Color::DarkGray),
     ));
     Paragraph::new(sep).render(
-        Rect { x: inner.x, y: inner.y + 1, width: inner.width, height: 1 },
+        Rect {
+            x: inner.x,
+            y: inner.y + 1,
+            width: inner.width,
+            height: 1,
+        },
         buf,
     );
 
@@ -1783,17 +1862,22 @@ pub fn render_global_search(state: &GlobalSearchState, area: ratatui::layout::Re
 
     let max_visible = results_area.height as usize;
     // Scroll so the selected result is visible — find which display row it's in
-    let selected_display_row = rows.iter().position(|r| {
-        if let DisplayRow::Result { result_idx } = r {
-            *result_idx == state.selected
-        } else {
-            false
-        }
-    }).unwrap_or(0);
+    let selected_display_row = rows
+        .iter()
+        .position(|r| {
+            if let DisplayRow::Result { result_idx } = r {
+                *result_idx == state.selected
+            } else {
+                false
+            }
+        })
+        .unwrap_or(0);
     let start = selected_display_row.saturating_sub(max_visible / 2);
 
     for (i, row) in rows[start..].iter().enumerate() {
-        if i >= max_visible { break; }
+        if i >= max_visible {
+            break;
+        }
         let row_y = results_area.y + i as u16;
 
         match row {
@@ -1803,14 +1887,24 @@ pub fn render_global_search(state: &GlobalSearchState, area: ratatui::layout::Re
                 let label_part = format!(" {} ", label);
                 let dashes_right = (results_area.width as usize)
                     .saturating_sub(4 + label_part.len() + count_str.len());
-                let header_line = Line::from(vec![
-                    Span::styled(
-                        format!("\u{2500}\u{2500}\u{2500}{}{}{}", label_part, count_str, "\u{2500}".repeat(dashes_right)),
-                        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                let header_line = Line::from(vec![Span::styled(
+                    format!(
+                        "\u{2500}\u{2500}\u{2500}{}{}{}",
+                        label_part,
+                        count_str,
+                        "\u{2500}".repeat(dashes_right)
                     ),
-                ]);
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                )]);
                 Paragraph::new(header_line).render(
-                    Rect { x: results_area.x, y: row_y, width: results_area.width, height: 1 },
+                    Rect {
+                        x: results_area.x,
+                        y: row_y,
+                        width: results_area.width,
+                        height: 1,
+                    },
                     buf,
                 );
             }
@@ -1819,7 +1913,9 @@ pub fn render_global_search(state: &GlobalSearchState, area: ratatui::layout::Re
                 let selected = *result_idx == state.selected;
                 let prefix = if selected { "> " } else { "  " };
                 let style = if selected {
-                    Style::default().add_modifier(Modifier::BOLD).fg(Color::White)
+                    Style::default()
+                        .add_modifier(Modifier::BOLD)
+                        .fg(Color::White)
                 } else {
                     Style::default().fg(Color::Gray)
                 };
@@ -1838,7 +1934,10 @@ pub fn render_global_search(state: &GlobalSearchState, area: ratatui::layout::Re
                         let after: String = text_trimmed[end..].chars().take(30).collect();
                         vec![
                             Span::styled(before, style),
-                            Span::styled(matched, style.bg(Color::Rgb(60, 50, 0)).fg(Color::Yellow)),
+                            Span::styled(
+                                matched,
+                                style.bg(Color::Rgb(60, 50, 0)).fg(Color::Yellow),
+                            ),
                             Span::styled(after, style),
                         ]
                     } else {
@@ -1852,15 +1951,17 @@ pub fn render_global_search(state: &GlobalSearchState, area: ratatui::layout::Re
 
                 let mut spans = vec![
                     Span::styled(prefix.to_string(), style),
-                    Span::styled(
-                        format!("{:>4}  ", result.line),
-                        style.fg(Color::DarkGray),
-                    ),
+                    Span::styled(format!("{:>4}  ", result.line), style.fg(Color::DarkGray)),
                 ];
                 spans.extend(text_spans);
 
                 Paragraph::new(Line::from(spans)).render(
-                    Rect { x: results_area.x, y: row_y, width: results_area.width, height: 1 },
+                    Rect {
+                        x: results_area.x,
+                        y: row_y,
+                        width: results_area.width,
+                        height: 1,
+                    },
                     buf,
                 );
             }
@@ -1873,14 +1974,33 @@ pub fn render_global_search(state: &GlobalSearchState, area: ratatui::layout::Re
     } else if state.results.is_empty() && !state.query.is_empty() {
         "No matches".to_string()
     } else if state.total_matches > 0 {
-        format!("{} matches in {} files", state.total_matches,
-            state.results.iter().map(|r| &r.file).collect::<std::collections::HashSet<_>>().len())
+        format!(
+            "{} matches in {} files",
+            state.total_matches,
+            state
+                .results
+                .iter()
+                .map(|r| &r.file)
+                .collect::<std::collections::HashSet<_>>()
+                .len()
+        )
     } else {
         "Type to search".to_string()
     };
     let status_y = inner.y + inner.height.saturating_sub(1);
-    Paragraph::new(Line::from(vec![Span::styled(status, Style::default().fg(Color::DarkGray))]))
-        .render(Rect { x: inner.x, y: status_y, width: inner.width, height: 1 }, buf);
+    Paragraph::new(Line::from(vec![Span::styled(
+        status,
+        Style::default().fg(Color::DarkGray),
+    )]))
+    .render(
+        Rect {
+            x: inner.x,
+            y: status_y,
+            width: inner.width,
+            height: 1,
+        },
+        buf,
+    );
 }
 
 // ============================================================================
@@ -1918,8 +2038,8 @@ mod tests {
     #[test]
     fn help_overlay_filter() {
         let mut h = HelpOverlay::new();
-        h.push_filter_char('h', );
-        h.push_filter_char('e', );
+        h.push_filter_char('h');
+        h.push_filter_char('e');
         assert_eq!(h.filter, "he");
         h.pop_filter_char();
         assert_eq!(h.filter, "h");
@@ -1939,7 +2059,11 @@ mod tests {
     #[test]
     fn history_search_update_matches() {
         // All three entries contain 'g', so all three match.
-        let history = vec!["git commit".to_string(), "cargo build".to_string(), "git push".to_string()];
+        let history = vec![
+            "git commit".to_string(),
+            "cargo build".to_string(),
+            "git push".to_string(),
+        ];
         let mut hs = HistorySearchOverlay::open(&history);
         hs.push_char('g', &history);
         assert_eq!(hs.matches.len(), 3);
@@ -2020,10 +2144,7 @@ mod tests {
     fn subseq_score_sorts_correctly_in_overlay() {
         // "git commit" and "get items together" both match query "git".
         // "git commit" is a substring match → higher score → appears first.
-        let history = vec![
-            "get items together".to_string(),
-            "git commit".to_string(),
-        ];
+        let history = vec!["get items together".to_string(), "git commit".to_string()];
         let mut hs = HistorySearchOverlay::open(&history);
         hs.push_char('g', &history);
         hs.push_char('i', &history);
@@ -2101,8 +2222,18 @@ mod tests {
     #[test]
     fn message_selector_open_selects_last() {
         let msgs = vec![
-            SelectorMessage { idx: 0, role: "user".to_string(), preview: "hi".to_string(), has_tool_use: false },
-            SelectorMessage { idx: 1, role: "assistant".to_string(), preview: "hello".to_string(), has_tool_use: false },
+            SelectorMessage {
+                idx: 0,
+                role: "user".to_string(),
+                preview: "hi".to_string(),
+                has_tool_use: false,
+            },
+            SelectorMessage {
+                idx: 1,
+                role: "assistant".to_string(),
+                preview: "hello".to_string(),
+                has_tool_use: false,
+            },
         ];
         let sel = MessageSelectorOverlay::open(msgs);
         assert_eq!(sel.selected_idx, 1);
@@ -2111,9 +2242,24 @@ mod tests {
     #[test]
     fn message_selector_navigate() {
         let msgs = vec![
-            SelectorMessage { idx: 0, role: "user".to_string(), preview: "a".to_string(), has_tool_use: false },
-            SelectorMessage { idx: 1, role: "assistant".to_string(), preview: "b".to_string(), has_tool_use: false },
-            SelectorMessage { idx: 2, role: "user".to_string(), preview: "c".to_string(), has_tool_use: false },
+            SelectorMessage {
+                idx: 0,
+                role: "user".to_string(),
+                preview: "a".to_string(),
+                has_tool_use: false,
+            },
+            SelectorMessage {
+                idx: 1,
+                role: "assistant".to_string(),
+                preview: "b".to_string(),
+                has_tool_use: false,
+            },
+            SelectorMessage {
+                idx: 2,
+                role: "user".to_string(),
+                preview: "c".to_string(),
+                has_tool_use: false,
+            },
         ];
         let mut sel = MessageSelectorOverlay::open(msgs);
         // starts at last
@@ -2130,21 +2276,30 @@ mod tests {
 
     #[test]
     fn rewind_flow_confirm_advances_step() {
-        let msgs = vec![
-            SelectorMessage { idx: 0, role: "user".to_string(), preview: "hi".to_string(), has_tool_use: false },
-        ];
+        let msgs = vec![SelectorMessage {
+            idx: 0,
+            role: "user".to_string(),
+            preview: "hi".to_string(),
+            has_tool_use: false,
+        }];
         let mut flow = RewindFlowOverlay::new();
         flow.open(msgs);
         let idx = flow.confirm_selection().unwrap();
         assert_eq!(idx, 0);
-        assert!(matches!(flow.step, RewindStep::Confirming { message_idx: 0 }));
+        assert!(matches!(
+            flow.step,
+            RewindStep::Confirming { message_idx: 0 }
+        ));
     }
 
     #[test]
     fn rewind_flow_accept_closes() {
-        let msgs = vec![
-            SelectorMessage { idx: 3, role: "user".to_string(), preview: "test".to_string(), has_tool_use: false },
-        ];
+        let msgs = vec![SelectorMessage {
+            idx: 3,
+            role: "user".to_string(),
+            preview: "test".to_string(),
+            has_tool_use: false,
+        }];
         let mut flow = RewindFlowOverlay::new();
         flow.open(msgs);
         flow.confirm_selection();
@@ -2155,9 +2310,12 @@ mod tests {
 
     #[test]
     fn rewind_flow_reject_returns_to_selector() {
-        let msgs = vec![
-            SelectorMessage { idx: 0, role: "user".to_string(), preview: "x".to_string(), has_tool_use: false },
-        ];
+        let msgs = vec![SelectorMessage {
+            idx: 0,
+            role: "user".to_string(),
+            preview: "x".to_string(),
+            has_tool_use: false,
+        }];
         let mut flow = RewindFlowOverlay::new();
         flow.open(msgs);
         flow.confirm_selection();
@@ -2186,10 +2344,10 @@ mod tests {
         // İ (U+0130) -> "i̇" (2 chars); K (U+212A) -> "k"; ẞ (U+1E9E) -> "ß".
         // Indexing the original with the lowercased copy's offsets panics.
         let cases = [
-            ("\u{0130}", "i"),          // İ
-            ("\u{212A}", "k"),          // K (Kelvin sign)
-            ("\u{1E9E}", "\u{00df}"),   // ẞ matched by ß
-            ("abc\u{0130}def", "i"),    // match in the middle
+            ("\u{0130}", "i"),        // İ
+            ("\u{212A}", "k"),        // K (Kelvin sign)
+            ("\u{1E9E}", "\u{00df}"), // ẞ matched by ß
+            ("abc\u{0130}def", "i"),  // match in the middle
         ];
         for (hay, needle_lc) in cases {
             let (start, end) = case_insensitive_find(hay, needle_lc)
@@ -2223,7 +2381,12 @@ mod tests {
             total_matches: 1,
             searching: false,
         };
-        let area = Rect { x: 0, y: 0, width: 60, height: 20 };
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 60,
+            height: 20,
+        };
         let mut buf = Buffer::empty(area);
         render_global_search(&state, area, &mut buf); // no panic == pass
     }

--- a/src-rust/crates/tui/src/render.rs
+++ b/src-rust/crates/tui/src/render.rs
@@ -2085,6 +2085,59 @@ fn render_tool_block_lines(lines: &mut Vec<Line<'static>>, block: &crate::app::T
     }
 }
 
+/// Extract the confidence score used by the TodoWrite checklist.
+fn todo_confidence(todo: &serde_json::Value) -> Option<u8> {
+    let value = if todo.get("status").and_then(|status| status.as_str()) == Some("completed") {
+        todo.get("completion_confidence")
+            .filter(|value| !value.is_null())
+            .or_else(|| todo.get("confidence"))
+    } else {
+        todo.get("confidence")
+    }?;
+
+    match value {
+        serde_json::Value::Number(number) => number
+            .as_f64()
+            .filter(|score| score.is_finite() && score.fract() == 0.0)
+            .filter(|score| (0.0..=100.0).contains(score))
+            .map(|score| score as u8),
+        serde_json::Value::String(raw) => raw
+            .trim()
+            .parse::<f64>()
+            .ok()
+            .filter(|score| score.is_finite() && score.fract() == 0.0)
+            .filter(|score| (0.0..=100.0).contains(score))
+            .map(|score| score as u8),
+        _ => None,
+    }
+}
+
+fn aggregate_todo_confidence(todos: &[serde_json::Value]) -> Option<u8> {
+    let mut weighted_sum = 0u32;
+    let mut total_weight = 0u32;
+    for todo in todos {
+        let Some(score) = todo_confidence(todo) else {
+            continue;
+        };
+        let weight = match todo.get("priority").and_then(|priority| priority.as_str()) {
+            Some("high") => 3,
+            Some("medium") => 2,
+            _ => 1,
+        };
+        weighted_sum += u32::from(score) * weight;
+        total_weight += weight;
+    }
+    (total_weight > 0).then_some(((weighted_sum + total_weight / 2) / total_weight) as u8)
+}
+
+fn confidence_color(score: u8) -> Color {
+    match score {
+        80..=100 => Color::Rgb(120, 200, 120),
+        50..=79 => Color::Rgb(220, 190, 100),
+        _ => Color::Rgb(220, 120, 100),
+    }
+}
+
 /// Render a TodoWrite call as a checklist. Returns `false` (so the caller can
 /// fall back to the generic block) when the input carries no `todos` array.
 fn render_todo_block(
@@ -2121,6 +2174,12 @@ fn render_todo_block(
             format!("  {}/{} done", done, total),
             Style::default().fg(Color::DarkGray),
         ));
+        if let Some(confidence) = aggregate_todo_confidence(todos) {
+            header.push(Span::styled(
+                format!(" · confidence {}%", confidence),
+                Style::default().fg(confidence_color(confidence)),
+            ));
+        }
     }
     lines.push(Line::from(header));
 
@@ -2154,9 +2213,19 @@ fn render_todo_block(
                 Style::default().fg(Color::Rgb(170, 170, 170)),
             ),
         };
+        let confidence = todo_confidence(t);
         lines.push(Line::from(vec![
             Span::styled(format!("     {} ", glyph), Style::default().fg(glyph_color)),
             Span::styled(content.to_string(), text_style),
+            Span::styled(
+                confidence
+                    .map(|score| format!(" [{}%]", score))
+                    .unwrap_or_default(),
+                confidence
+                    .map(confidence_color)
+                    .map(|color| Style::default().fg(color))
+                    .unwrap_or_default(),
+            ),
         ]));
     }
     if total > MAX_ITEMS {
@@ -3481,9 +3550,9 @@ mod tool_block_tests {
             "TodoWrite",
             ToolStatus::Done,
             r#"{"todos":[
-                {"content":"Locate files","status":"completed"},
-                {"content":"Build importer","status":"in_progress"},
-                {"content":"Wire adapter","status":"pending"}
+                {"content":"Locate files","status":"completed","completion_confidence":90},
+                {"content":"Build importer","status":"in_progress","confidence":70},
+                {"content":"Wire adapter","status":"pending","confidence":50}
             ]}"#,
             Some("Todo list updated (3 total)"),
         );
@@ -3492,10 +3561,11 @@ mod tool_block_tests {
         // Header shows count, not the raw "Todo list updated (...)".
         assert!(joined.contains("Todos"), "{joined:?}");
         assert!(joined.contains("1/3 done"), "{joined:?}");
+        assert!(joined.contains("confidence 70%"), "{joined:?}");
         // Each status has its ASCII checkbox + content.
-        assert!(joined.contains("[x] Locate files"), "done marker: {joined:?}");
-        assert!(joined.contains("[>] Build importer"), "in-progress marker: {joined:?}");
-        assert!(joined.contains("[ ] Wire adapter"), "pending marker: {joined:?}");
+        assert!(joined.contains("[x] Locate files [90%]"), "done marker: {joined:?}");
+        assert!(joined.contains("[>] Build importer [70%]"), "in-progress marker: {joined:?}");
+        assert!(joined.contains("[ ] Wire adapter [50%]"), "pending marker: {joined:?}");
         // The raw result-preview string must NOT leak into the checklist view.
         assert!(!joined.contains("Todo list updated"), "preview suppressed: {joined:?}");
     }

--- a/src-rust/crates/tui/src/render.rs
+++ b/src-rust/crates/tui/src/render.rs
@@ -3,54 +3,55 @@
 use std::cell::RefCell;
 
 use crate::agents_view::render_agents_menu;
+use crate::app::{
+    App, ContextMenuKind, DisplayMessage, SystemAnnotation, SystemMessageStyle, ToolStatus,
+};
+use crate::ask_user_dialog::render_ask_user_dialog;
+use crate::bypass_permissions_dialog::render_bypass_permissions_dialog;
 use crate::context_viz::render_context_viz;
-use crate::export_dialog::render_export_dialog;
-use crate::app::{App, ContextMenuKind, SystemAnnotation, SystemMessageStyle, ToolStatus};
-use crate::rustle::rustle_lines;
-use crate::diff_viewer::render_diff_dialog;
-use crate::model_picker::render_model_picker;
-use crate::session_browser::render_session_browser;
-use crate::session_branching::render_session_branching;
-use crate::tasks_overlay::render_tasks_overlay;
-use crate::dialogs::{render_mcp_approval_dialog, render_permission_dialog};
-use crate::feedback_survey::render_feedback_survey;
-use crate::overage_upsell::render_overage_upsell;
-use crate::voice_mode_notice::render_voice_mode_notice;
+use crate::custom_provider_dialog::render_custom_provider_dialog;
 use crate::desktop_upsell_startup::render_desktop_upsell_startup;
-use crate::memory_update_notification::render_memory_update_notification;
+use crate::device_auth_dialog::render_device_auth_dialog;
+use crate::dialog_select::render_dialog_select;
+use crate::dialogs::{render_mcp_approval_dialog, render_permission_dialog};
+use crate::diff_viewer::render_diff_dialog;
+use crate::elicitation_dialog::render_elicitation_dialog;
+use crate::export_dialog::render_export_dialog;
+use crate::feedback_survey::render_feedback_survey;
+use crate::figures;
+use crate::file_injection_dialog::render_file_injection_dialog;
+use crate::hooks_config_menu::render_hooks_config_menu;
 use crate::import_config_dialog::render_import_config_dialog;
 use crate::invalid_config_dialog::render_invalid_config_dialog;
-use crate::bypass_permissions_dialog::render_bypass_permissions_dialog;
-use crate::file_injection_dialog::render_file_injection_dialog;
-use crate::ask_user_dialog::render_ask_user_dialog;
-use crate::onboarding_dialog::render_onboarding_dialog;
-use crate::dialog_select::render_dialog_select;
 use crate::key_input_dialog::render_key_input_dialog;
-use crate::custom_provider_dialog::render_custom_provider_dialog;
-use crate::device_auth_dialog::render_device_auth_dialog;
-use crate::elicitation_dialog::render_elicitation_dialog;
-use crate::figures;
-use crate::hooks_config_menu::render_hooks_config_menu;
 use crate::mcp_view::render_mcp_view;
 use crate::memory_file_selector::render_memory_file_selector;
+use crate::memory_update_notification::render_memory_update_notification;
 use crate::messages::{
-    render_transcript_assistant_message_tagged,
+    render_thinking_live_content, render_transcript_assistant_message_tagged,
     render_transcript_assistant_meta, render_transcript_live_text, render_transcript_user_message,
-    render_thinking_live_content,
     RenderContext,
 };
+use crate::model_picker::render_model_picker;
 use crate::notifications::{render_notification_banner, Notification, NotificationKind};
+use crate::onboarding_dialog::render_onboarding_dialog;
+use crate::overage_upsell::render_overage_upsell;
 use crate::overlays::{
     render_global_search, render_help_overlay, render_history_search_overlay, render_rewind_flow,
     CLAURST_ACCENT,
 };
 use crate::plugin_views::render_plugin_hints;
-use crate::prompt_input::{InputMode, TypeaheadSource, VimMode, input_height, render_prompt_input};
+use crate::prompt_input::{input_height, render_prompt_input, InputMode, TypeaheadSource, VimMode};
+use crate::rustle::rustle_lines;
+use crate::session_branching::render_session_branching;
+use crate::session_browser::render_session_browser;
 use crate::settings_screen::render_settings_screen;
 use crate::stats_dialog::render_stats_dialog;
+use crate::tasks_overlay::render_tasks_overlay;
 use crate::theme_screen::render_theme_screen;
 use crate::transcript_turn::{build_transcript_turns, TranscriptTurn};
 use crate::virtual_list::{VirtualItem, VirtualList};
+use crate::voice_mode_notice::render_voice_mode_notice;
 use claurst_core::constants::APP_VERSION;
 use claurst_core::types::Role;
 use ratatui::buffer::Buffer;
@@ -65,11 +66,15 @@ use unicode_width::UnicodeWidthStr;
 // characters mirrored (forward + reverse) for a smooth pulse effect.
 // Windows uses '*' instead of '✳'/'✽' for better font coverage.
 #[cfg(target_os = "windows")]
-const SPINNER: &[char] = &['\u{00b7}', '\u{2722}', '*', '\u{2736}', '\u{273b}', '\u{273d}',
-                            '\u{273d}', '\u{273b}', '\u{2736}', '*', '\u{2722}', '\u{00b7}'];
+const SPINNER: &[char] = &[
+    '\u{00b7}', '\u{2722}', '*', '\u{2736}', '\u{273b}', '\u{273d}', '\u{273d}', '\u{273b}',
+    '\u{2736}', '*', '\u{2722}', '\u{00b7}',
+];
 #[cfg(not(target_os = "windows"))]
-const SPINNER: &[char] = &['\u{00b7}', '\u{2722}', '\u{2733}', '\u{2736}', '\u{273b}', '\u{273d}',
-                            '\u{273d}', '\u{273b}', '\u{2736}', '\u{2733}', '\u{2722}', '\u{00b7}'];
+const SPINNER: &[char] = &[
+    '\u{00b7}', '\u{2722}', '\u{2733}', '\u{2736}', '\u{273b}', '\u{273d}', '\u{273d}', '\u{273b}',
+    '\u{2736}', '\u{2733}', '\u{2722}', '\u{00b7}',
+];
 const CLAUDE_ORANGE: Color = Color::Rgb(233, 30, 99);
 const WELCOME_BOX_HEIGHT: u16 = 9;
 const STATUS_THINKING: &str = "thinking";
@@ -99,7 +104,14 @@ fn is_modal_open(app: &App) -> bool {
 // -----------------------------------------------------------------------
 
 /// Render an error modal dialog with wrapped content.
-fn render_error_modal(frame: &mut Frame, area: Rect, notification: &Notification, _scroll_offset: usize, footer_area: Rect, is_welcome_screen: bool) {
+fn render_error_modal(
+    frame: &mut Frame,
+    area: Rect,
+    notification: &Notification,
+    _scroll_offset: usize,
+    footer_area: Rect,
+    is_welcome_screen: bool,
+) {
     // When the footer anchor is inside the welcome box (y < WELCOME_BOX_HEIGHT), or explicitly on
     // the welcome screen, center the modal so it doesn't awkwardly overlap the welcome box.
     let anchored_in_welcome_box = footer_area.width > 0 && footer_area.y < WELCOME_BOX_HEIGHT;
@@ -113,7 +125,8 @@ fn render_error_modal(frame: &mut Frame, area: Rect, notification: &Notification
             height: modal_height,
         }
     } else if footer_area.width > 0 {
-        let desired_height = (area.height / 3).max(8)
+        let desired_height = (area.height / 3)
+            .max(8)
             .min(area.height.saturating_sub(footer_area.y));
         Rect {
             x: footer_area.x,
@@ -147,8 +160,8 @@ fn render_error_modal(frame: &mut Frame, area: Rect, notification: &Notification
         height: 1,
     };
     let header_style = Style::default().bg(Color::Rgb(60, 15, 15)).fg(Color::Red);
-    let header_para = Paragraph::new("  ⚠ Error  ")
-        .style(header_style.add_modifier(Modifier::BOLD));
+    let header_para =
+        Paragraph::new("  ⚠ Error  ").style(header_style.add_modifier(Modifier::BOLD));
     frame.render_widget(header_para, header_bg_area);
 
     let sep_area = Rect {
@@ -317,7 +330,9 @@ fn startup_notice_lines(app: &App, width: u16) -> Vec<Line<'static>> {
         lines.push(Line::from(vec![
             Span::styled(
                 format!(" {} ", crate::figures::REFERENCE_MARK),
-                Style::default().fg(CLAUDE_ORANGE).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(CLAUDE_ORANGE)
+                    .add_modifier(Modifier::BOLD),
             ),
             Span::styled(
                 truncate_end(summary, max_width),
@@ -329,7 +344,11 @@ fn startup_notice_lines(app: &App, width: u16) -> Vec<Line<'static>> {
     match &app.bridge_state {
         crate::bridge_state::BridgeConnectionState::Connected { peer_count, .. } => {
             let label = if *peer_count > 0 {
-                format!("Remote session active \u{00b7} {} peer{}", peer_count, if *peer_count == 1 { "" } else { "s" })
+                format!(
+                    "Remote session active \u{00b7} {} peer{}",
+                    peer_count,
+                    if *peer_count == 1 { "" } else { "s" }
+                )
             } else {
                 "Remote session active".to_string()
             };
@@ -543,8 +562,7 @@ pub fn render_app(frame: &mut Frame, app: &App) {
         size,
     );
 
-    let prompt_focused =
-        app.permission_request.is_none() && !app.history_search_overlay.visible;
+    let prompt_focused = app.permission_request.is_none() && !app.history_search_overlay.visible;
     // Suggestions popup tracks whether the prompt accepts input, not whether
     // it is the focused widget. Text entry is allowed during streaming so the
     // user can queue the next message, so the typeahead popup must follow
@@ -577,6 +595,12 @@ pub fn render_app(frame: &mut Frame, app: &App) {
     } else {
         0
     };
+    // Queued prompts indicator: one line per queued message (max 3).
+    let queued_height: u16 = if app.is_streaming && !app.queued_messages.is_empty() {
+        app.queued_messages.len().min(3) as u16
+    } else {
+        0
+    };
     // The prompt body width is the terminal width minus the prompt prefix
     // ("> ") and the right-margin padding used inside `render_prompt_input`.
     // Keep this in sync with prefix_width=2 + right_pad=2 there.
@@ -596,6 +620,7 @@ pub fn render_app(frame: &mut Frame, app: &App) {
             Constraint::Min(1),
             Constraint::Length(separator_height),
             Constraint::Length(status_height),
+            Constraint::Length(queued_height),
             Constraint::Length(prompt_height),
             Constraint::Length(suggestions_height),
             Constraint::Length(1),
@@ -607,6 +632,9 @@ pub fn render_app(frame: &mut Frame, app: &App) {
     if status_height > 0 {
         render_status_row(frame, app, chunks[2]);
     }
+    if queued_height > 0 {
+        render_queued_prompts(frame, app, chunks[3]);
+    }
     // The `/effort` selector replaces the prompt box while open: render it into
     // the input area (full width) and SKIP the prompt input. The prompt returns
     // when the picker closes on confirm/cancel.
@@ -614,17 +642,17 @@ pub fn render_app(frame: &mut Frame, app: &App) {
         crate::effort_picker::render_effort_picker(
             frame,
             &app.effort_picker,
-            chunks[3],
+            chunks[4],
             app.frame_count,
         );
     } else {
-        render_input(frame, app, chunks[3], prompt_focused);
+        render_input(frame, app, chunks[4], prompt_focused);
     }
-    app.last_input_area.set(chunks[3]);
+    app.last_input_area.set(chunks[4]);
     if suggestions_height > 0 {
-        render_prompt_suggestions(frame, app, chunks[4]);
+        render_prompt_suggestions(frame, app, chunks[5]);
     }
-    render_footer(frame, app, chunks[5]);
+    render_footer(frame, app, chunks[6]);
 
     // Overlays (rendered on top in Z-order)
 
@@ -715,7 +743,12 @@ pub fn render_app(frame: &mut Frame, app: &App) {
     if app.overage_upsell.visible {
         let banner_h = app.overage_upsell.height();
         if size.height > banner_h + 4 {
-            let banner_area = Rect { x: size.x, y: size.y, width: size.width, height: banner_h };
+            let banner_area = Rect {
+                x: size.x,
+                y: size.y,
+                width: size.width,
+                height: banner_h,
+            };
             render_overage_upsell(&app.overage_upsell, banner_area, frame.buffer_mut());
         }
     }
@@ -724,7 +757,12 @@ pub fn render_app(frame: &mut Frame, app: &App) {
     if app.voice_mode_notice.visible {
         let notice_h = app.voice_mode_notice.height();
         if size.height > notice_h + 4 {
-            let notice_area = Rect { x: size.x, y: size.y, width: size.width, height: notice_h };
+            let notice_area = Rect {
+                x: size.x,
+                y: size.y,
+                width: size.width,
+                height: notice_h,
+            };
             render_voice_mode_notice(&app.voice_mode_notice, notice_area, frame.buffer_mut());
         }
     }
@@ -735,7 +773,12 @@ pub fn render_app(frame: &mut Frame, app: &App) {
         if size.height > notif_h + 4 {
             // Place at the bottom of the screen, just above the prompt bar area
             let notif_y = size.y + size.height.saturating_sub(notif_h + 4);
-            let notif_area = Rect { x: size.x, y: notif_y, width: size.width, height: notif_h };
+            let notif_area = Rect {
+                x: size.x,
+                y: notif_y,
+                width: size.width,
+                height: notif_h,
+            };
             render_memory_update_notification(
                 &app.memory_update_notification,
                 notif_area,
@@ -862,6 +905,15 @@ pub fn render_app(frame: &mut Frame, app: &App) {
         render_mcp_approval_dialog(&app.mcp_approval, size, frame.buffer_mut());
     }
 
+    // When error modal is showing, selectable area = full terminal
+    if app.notifications.current_is_error() {
+        app.last_selectable_area.set(size);
+    }
+
+    // ---- Text selection highlight (applied before modal overlay) ----------
+    apply_selection_highlight(frame, app);
+    cache_selectable_row_text(frame, app);
+
     // Always show error modals on top of everything (highest priority)
     if let Some(notif) = app.notifications.current() {
         if notif.kind == NotificationKind::Error {
@@ -869,7 +921,15 @@ pub fn render_app(frame: &mut Frame, app: &App) {
                 && app.streaming_text.is_empty()
                 && app.streaming_thinking.is_empty()
                 && app.tool_use_blocks.is_empty();
-            render_error_modal(frame, size, notif, app.error_modal_scroll_offset, app.footer_right_column_area.get(), is_welcome_screen);
+            render_error_modal(
+                frame,
+                size,
+                notif,
+                app.error_modal_scroll_offset,
+                app.footer_right_column_area.get(),
+                is_welcome_screen,
+            );
+            render_context_menu(frame, app);
             return; // Don't render other overlays/notifications when error modal is showing
         }
     }
@@ -881,9 +941,6 @@ pub fn render_app(frame: &mut Frame, app: &App) {
         render_notification_banner(frame, &app.notifications, size);
     }
 
-    // ---- Text selection highlight (topmost post-pass) ---------------------
-    apply_selection_highlight(frame, app);
-    cache_selectable_row_text(frame, app);
     render_context_menu(frame, app);
 }
 
@@ -978,12 +1035,20 @@ fn apply_selection_highlight(frame: &mut Frame, app: &App) {
     let mut text = String::new();
     let last_row = end.1.min(max_row);
     for row in start.1..=last_row {
-        let col_from = if row == start.1 { start.0 } else { selectable_area.x };
+        let col_from = if row == start.1 {
+            start.0
+        } else {
+            selectable_area.x
+        };
         let col_to = if row == end.1 { end.0 } else { max_col };
         for col in col_from..=col_to {
             if let Some(cell) = buf.cell_mut((col, row)) {
                 let sym = cell.symbol().to_owned();
-                text.push_str(if sym.is_empty() || sym == "\0" { " " } else { &sym });
+                text.push_str(if sym.is_empty() || sym == "\0" {
+                    " "
+                } else {
+                    &sym
+                });
                 // Highlight: white background, black foreground
                 let new_style = Style::default()
                     .fg(Color::Black)
@@ -993,11 +1058,15 @@ fn apply_selection_highlight(frame: &mut Frame, app: &App) {
         }
         if row < last_row {
             // Trim trailing spaces from line before newline
-            while text.ends_with(' ') { text.pop(); }
+            while text.ends_with(' ') {
+                text.pop();
+            }
             text.push('\n');
         }
     }
-    while text.ends_with(|c: char| c.is_whitespace()) { text.pop(); }
+    while text.ends_with(|c: char| c.is_whitespace()) {
+        text.pop();
+    }
     *app.selection_text.borrow_mut() = text;
 }
 
@@ -1058,20 +1127,31 @@ fn render_context_menu(frame: &mut Frame, app: &App) {
             let is_selected = idx == menu.selected_index;
 
             let fg_color = if *enabled {
-                if is_selected { Color::Black } else { Color::White }
+                if is_selected {
+                    Color::Black
+                } else {
+                    Color::White
+                }
             } else {
                 Color::DarkGray
             };
 
             let bg_color = if is_selected {
-                if *enabled { CLAURST_ACCENT } else { Color::Rgb(24, 24, 30) }
+                if *enabled {
+                    CLAURST_ACCENT
+                } else {
+                    Color::Rgb(24, 24, 30)
+                }
             } else {
                 Color::Rgb(24, 24, 30)
             };
 
             let style = Style::default().fg(fg_color).bg(bg_color);
-            let padded_label =
-                format!(" {:<width$} ", label, width = menu_width.saturating_sub(2) as usize);
+            let padded_label = format!(
+                " {:<width$} ",
+                label,
+                width = menu_width.saturating_sub(2) as usize
+            );
 
             if let Some(cell) = frame.buffer_mut().cell_mut((inner.x, y)) {
                 cell.set_symbol(&padded_label[0..1.min(padded_label.len())]);
@@ -1082,7 +1162,10 @@ fn render_context_menu(frame: &mut Frame, app: &App) {
                 if col_offset >= inner.width as usize {
                     break;
                 }
-                if let Some(cell) = frame.buffer_mut().cell_mut((inner.x + col_offset as u16, y)) {
+                if let Some(cell) = frame
+                    .buffer_mut()
+                    .cell_mut((inner.x + col_offset as u16, y))
+                {
                     cell.set_symbol(&ch.to_string());
                     cell.set_style(style);
                 }
@@ -1126,7 +1209,8 @@ fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
     let transcript_empty = app.messages.is_empty()
         && app.streaming_text.is_empty()
         && app.streaming_thinking.is_empty()
-        && app.tool_use_blocks.is_empty();
+        && app.tool_use_blocks.is_empty()
+        && app.display_messages.is_empty();
 
     if transcript_empty {
         app.last_msg_area.set(Rect::default());
@@ -1162,23 +1246,31 @@ fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
     // Highlight search matches in transcript when global search is active
     let lines = if app.global_search.visible && !app.global_search.query.is_empty() {
         let query_lc = app.global_search.query.to_lowercase();
-        lines.into_iter().map(|mut item| {
-            if item.search_text.to_lowercase().contains(query_lc.as_str()) {
-                // Re-render the line with yellow highlight on matching spans
-                let highlighted_spans: Vec<Span<'static>> = item.line.spans.into_iter().map(|span| {
-                    if span.content.to_lowercase().contains(query_lc.as_str()) {
-                        Span::styled(
-                            span.content,
-                            span.style.bg(Color::Rgb(60, 50, 0)).fg(Color::Yellow),
-                        )
-                    } else {
-                        span
-                    }
-                }).collect();
-                item.line = ratatui::text::Line::from(highlighted_spans);
-            }
-            item
-        }).collect()
+        lines
+            .into_iter()
+            .map(|mut item| {
+                if item.search_text.to_lowercase().contains(query_lc.as_str()) {
+                    // Re-render the line with yellow highlight on matching spans
+                    let highlighted_spans: Vec<Span<'static>> = item
+                        .line
+                        .spans
+                        .into_iter()
+                        .map(|span| {
+                            if span.content.to_lowercase().contains(query_lc.as_str()) {
+                                Span::styled(
+                                    span.content,
+                                    span.style.bg(Color::Rgb(60, 50, 0)).fg(Color::Yellow),
+                                )
+                            } else {
+                                span
+                            }
+                        })
+                        .collect();
+                    item.line = ratatui::text::Line::from(highlighted_spans);
+                }
+                item
+            })
+            .collect()
     } else {
         lines
     };
@@ -1187,7 +1279,7 @@ fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
     // When auto_scroll is on we always show the tail; otherwise we respect
     // the user's scroll_offset.
     let content_height = lines.len() as u16;
-    let visible_height = msg_area.height;  // no borders, full height available
+    let visible_height = msg_area.height; // no borders, full height available
     let max_scroll = content_height.saturating_sub(visible_height) as usize;
     // Publish the max meaningful scroll offset so the next scroll event can
     // clamp `scroll_offset` against it (the content height is only known here,
@@ -1205,8 +1297,15 @@ fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
 
     let mut visible_rows: std::collections::HashMap<u16, usize> = std::collections::HashMap::new();
     let mut thinking_rows: std::collections::HashMap<u16, u64> = std::collections::HashMap::new();
-    for (idx, item) in lines.iter().enumerate().skip(scroll).take(msg_area.height as usize) {
-        let screen_row = msg_area.y.saturating_add((idx.saturating_sub(scroll)) as u16);
+    for (idx, item) in lines
+        .iter()
+        .enumerate()
+        .skip(scroll)
+        .take(msg_area.height as usize)
+    {
+        let screen_row = msg_area
+            .y
+            .saturating_add((idx.saturating_sub(scroll)) as u16);
         if let Some(message_index) = item.message_index {
             visible_rows.insert(screen_row, message_index);
         }
@@ -1262,7 +1361,11 @@ fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
         let indicator = format!(
             " \u{2193} {} new message{} ",
             app.new_messages_while_scrolled,
-            if app.new_messages_while_scrolled == 1 { "" } else { "s" }
+            if app.new_messages_while_scrolled == 1 {
+                ""
+            } else {
+                "s"
+            }
         );
         let ind_len = indicator.len() as u16;
         let ind_x = msg_area
@@ -1325,7 +1428,11 @@ fn push_blank_item(items: &mut Vec<RenderedLineItem>) {
     push_rendered_items(items, vec![Line::from("")], None, false);
 }
 
-fn render_live_thinking_lines(turn: &TranscriptTurn<'_>, frame_count: u64, width: u16) -> Vec<Line<'static>> {
+fn render_live_thinking_lines(
+    turn: &TranscriptTurn<'_>,
+    frame_count: u64,
+    width: u16,
+) -> Vec<Line<'static>> {
     let mut header_spans = vec![Span::raw("  ▼ ")];
     header_spans.extend(shimmer_spans("Thinking", frame_count));
     if let Some(heading) = turn.reasoning_heading() {
@@ -1353,7 +1460,12 @@ fn append_turn_items(
     let width = ctx.width;
     push_rendered_items(
         items,
-        render_transcript_user_message(turn.user_message, turn.metadata, width),
+        render_transcript_user_message(
+            turn.user_message,
+            turn.metadata,
+            width,
+            ctx.hide_tool_content,
+        ),
         Some(turn.user_index),
         true,
     );
@@ -1375,7 +1487,10 @@ fn append_turn_items(
         let mut lines = Vec::new();
         render_tool_block_lines(&mut lines, block, frame_count);
         if !lines.is_empty() {
-            sections.push((SectionContent::Plain(lines), Some(turn.primary_message_index())));
+            sections.push((
+                SectionContent::Plain(lines),
+                Some(turn.primary_message_index()),
+            ));
         }
     }
 
@@ -1392,7 +1507,10 @@ fn append_turn_items(
     if turn.active
         && turn.live_text.is_none()
         && turn.live_thinking.is_none()
-        && turn.tool_blocks.iter().all(|b| b.status != ToolStatus::Running)
+        && turn
+            .tool_blocks
+            .iter()
+            .all(|b| b.status != ToolStatus::Running)
     {
         let mut spans = vec![Span::raw("  ")];
         spans.extend(shimmer_spans("Thinking", frame_count));
@@ -1405,14 +1523,20 @@ fn append_turn_items(
     if let Some(text) = turn.live_text {
         let lines = render_transcript_live_text(text, width);
         if !lines.is_empty() {
-            sections.push((SectionContent::Plain(lines), Some(turn.primary_message_index())));
+            sections.push((
+                SectionContent::Plain(lines),
+                Some(turn.primary_message_index()),
+            ));
         }
     }
 
     if !turn.active {
         if let Some(meta_line) = render_transcript_assistant_meta(turn.metadata, accent) {
             if turn.has_visible_assistant_content() {
-                sections.push((SectionContent::Plain(vec![meta_line]), Some(turn.primary_message_index())));
+                sections.push((
+                    SectionContent::Plain(vec![meta_line]),
+                    Some(turn.primary_message_index()),
+                ));
             }
         }
     }
@@ -1422,8 +1546,12 @@ fn append_turn_items(
         let total_sections = sections.len();
         for (index, (content, message_index)) in sections.into_iter().enumerate() {
             match content {
-                SectionContent::Plain(lines) => push_rendered_items(items, lines, message_index, false),
-                SectionContent::Tagged(tagged) => push_rendered_items_tagged(items, tagged, message_index),
+                SectionContent::Plain(lines) => {
+                    push_rendered_items(items, lines, message_index, false)
+                }
+                SectionContent::Tagged(tagged) => {
+                    push_rendered_items_tagged(items, tagged, message_index)
+                }
             }
             if index + 1 < total_sections {
                 push_blank_item(items);
@@ -1461,7 +1589,11 @@ fn build_message_items_range(
 ) {
     let mut index = start;
     while index < end {
-        for ann in app.system_annotations.iter().filter(|ann| ann.after_index == index) {
+        for ann in app
+            .system_annotations
+            .iter()
+            .filter(|ann| ann.after_index == index)
+        {
             let mut lines = Vec::new();
             render_system_annotation_lines(&mut lines, ann, width as usize);
             push_rendered_items(items, lines, None, false);
@@ -1483,7 +1615,11 @@ fn build_message_items_range(
     }
 
     if emit_end_annotations {
-        for ann in app.system_annotations.iter().filter(|ann| ann.after_index == end) {
+        for ann in app
+            .system_annotations
+            .iter()
+            .filter(|ann| ann.after_index == end)
+        {
             let mut lines = Vec::new();
             render_system_annotation_lines(&mut lines, ann, width as usize);
             push_rendered_items(items, lines, None, false);
@@ -1504,6 +1640,7 @@ fn build_all_items(app: &App, width: u16) -> Vec<RenderedLineItem> {
         show_thinking: false,
         tool_names: &tool_names,
         expanded_thinking: &app.thinking_expanded,
+        hide_tool_content: app.config.hide_tool_content,
     };
     let turns = build_transcript_turns(app);
     let mut turn_map = std::collections::HashMap::new();
@@ -1528,13 +1665,61 @@ fn build_all_items(app: &App, width: u16) -> Vec<RenderedLineItem> {
         }
     }
 
+    // Append display-only bang command output (never sent to the model).
+    let bang_lines = render_bang_display_lines(app);
+    if !bang_lines.is_empty() {
+        push_rendered_items(&mut items, bang_lines, None, false);
+    }
+
     items
 }
 
+/// Render display-only `!` bang command entries (command, output, error).
+/// These are appended at the end of the transcript and never sent to the model.
+fn render_bang_display_lines(app: &App) -> Vec<Line<'static>> {
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let mut found = false;
+    for msg in &app.display_messages {
+        match msg {
+            DisplayMessage::BangCommand { command } => {
+                found = true;
+                if !lines.is_empty() {
+                    lines.push(Line::from(""));
+                }
+                lines.push(Line::styled(
+                    format!("$ {}", command),
+                    Style::default()
+                        .fg(Color::DarkGray)
+                        .add_modifier(Modifier::BOLD),
+                ));
+            }
+            DisplayMessage::BangOutput { text, exit_code } => {
+                found = true;
+                let color = if exit_code.unwrap_or(0) != 0 {
+                    Color::Red
+                } else {
+                    Color::Gray
+                };
+                for line in text.lines() {
+                    lines.push(Line::styled(line.to_string(), Style::default().fg(color)));
+                }
+            }
+            DisplayMessage::BangError { text } => {
+                found = true;
+                lines.push(Line::styled(text.clone(), Style::default().fg(Color::Red)));
+            }
+            _ => {}
+        }
+    }
+    if found {
+        lines.push(Line::from(""));
+    }
+    lines
+}
+
 fn render_message_items(app: &App, width: u16) -> Vec<RenderedLineItem> {
-    let streaming = app.is_streaming
-        || !app.streaming_text.is_empty()
-        || !app.streaming_thinking.is_empty();
+    let streaming =
+        app.is_streaming || !app.streaming_text.is_empty() || !app.streaming_thinking.is_empty();
     let has_running_tool_blocks = app
         .tool_use_blocks
         .iter()
@@ -1595,6 +1780,7 @@ fn render_streaming_items(app: &App, width: u16) -> Vec<RenderedLineItem> {
         show_thinking: false,
         tool_names: &tool_names,
         expanded_thinking: &app.thinking_expanded,
+        hide_tool_content: app.config.hide_tool_content,
     };
     let turns = build_transcript_turns(app);
 
@@ -1639,7 +1825,16 @@ fn render_streaming_items(app: &App, width: u16) -> Vec<RenderedLineItem> {
     } else {
         record_prefix_cache_miss();
         let mut prefix = Vec::new();
-        build_message_items_range(app, width, &ctx, &turn_map, 0, split_idx, false, &mut prefix);
+        build_message_items_range(
+            app,
+            width,
+            &ctx,
+            &turn_map,
+            0,
+            split_idx,
+            false,
+            &mut prefix,
+        );
         COMPLETED_MSG_CACHE.with(|cache| {
             *cache.borrow_mut() = Some(CompletedMsgCache {
                 key: prefix_key,
@@ -1657,7 +1852,9 @@ fn render_streaming_items(app: &App, width: u16) -> Vec<RenderedLineItem> {
     items.extend(prefix);
 
     // Live tail: the actively-streaming turn, rebuilt fresh every frame.
-    build_message_items_range(app, width, &ctx, &turn_map, split_idx, total, true, &mut items);
+    build_message_items_range(
+        app, width, &ctx, &turn_map, split_idx, total, true, &mut items,
+    );
     items
 }
 
@@ -1665,7 +1862,6 @@ fn render_streaming_items(app: &App, width: u16) -> Vec<RenderedLineItem> {
 
 /// Render the two-column orange round-bordered welcome box (matches TS LogoV2).
 fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
-
     // --- Box dimensions ---
     // The box should be at most the full area width, and a fixed height.
     let box_width = area.width;
@@ -1673,13 +1869,26 @@ fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
     if area.height < box_height || box_width < 30 {
         // Too small: fall back to a single line
         let line = Line::from(vec![
-            Span::styled("Claurst ", Style::default().fg(CLAUDE_ORANGE).add_modifier(Modifier::BOLD)),
-            Span::styled(format!("v{}", APP_VERSION), Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                "Claurst ",
+                Style::default()
+                    .fg(CLAUDE_ORANGE)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!("v{}", APP_VERSION),
+                Style::default().fg(Color::DarkGray),
+            ),
         ]);
         frame.render_widget(Paragraph::new(vec![line]), area);
         return;
     }
-    let box_area = Rect { x: area.x, y: area.y, width: box_width, height: box_height };
+    let box_area = Rect {
+        x: area.x,
+        y: area.y,
+        width: box_width,
+        height: box_height,
+    };
 
     // Outer border with title "Claurst vX.Y"
     let accent = app.accent_color;
@@ -1688,8 +1897,14 @@ fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(accent))
         .title(Line::from(vec![
-            Span::styled(" Claurst ", Style::default().fg(accent).add_modifier(Modifier::BOLD)),
-            Span::styled(format!("v{} ", APP_VERSION), Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                " Claurst ",
+                Style::default().fg(accent).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!("v{} ", APP_VERSION),
+                Style::default().fg(Color::DarkGray),
+            ),
         ]));
     frame.render_widget(outer_block, box_area);
 
@@ -1703,7 +1918,9 @@ fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
 
     // Split inner into left | divider(1) | right
     // Left width: ~28 chars or half the inner width, whichever is smaller
-    let left_w = (inner.width / 2).clamp(22, 32).min(inner.width.saturating_sub(3));
+    let left_w = (inner.width / 2)
+        .clamp(22, 32)
+        .min(inner.width.saturating_sub(3));
     let right_w = inner.width.saturating_sub(left_w + 1);
     let h_chunks = Layout::default()
         .direction(Direction::Horizontal)
@@ -1737,7 +1954,9 @@ fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
     let mut left_lines: Vec<Line> = Vec::new();
     left_lines.push(Line::from(Span::styled(
         welcome_msg,
-        Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(Color::White)
+            .add_modifier(Modifier::BOLD),
     )));
     left_lines.push(Line::from(""));
     // Center mascot in left column
@@ -1748,7 +1967,10 @@ fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
         spans.extend(cl.spans.iter().cloned());
         left_lines.push(Line::from(spans));
     }
-    frame.render_widget(Paragraph::new(left_lines).wrap(Wrap { trim: false }), h_chunks[0]);
+    frame.render_widget(
+        Paragraph::new(left_lines).wrap(Wrap { trim: false }),
+        h_chunks[0],
+    );
 
     // --- Right column ---
     let tip_text = claurst_core::tips::select_tip(0)
@@ -1762,7 +1984,11 @@ fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
     )));
     // Word-wrap the tip text into the right column width
     let right_w_usize = right_w.saturating_sub(1) as usize;
-    for chunk in tip_text.chars().collect::<Vec<_>>().chunks(right_w_usize.max(1)) {
+    for chunk in tip_text
+        .chars()
+        .collect::<Vec<_>>()
+        .chunks(right_w_usize.max(1))
+    {
         right_lines.push(Line::from(chunk.iter().collect::<String>()));
     }
     right_lines.push(Line::from(""));
@@ -1772,7 +1998,10 @@ fn render_welcome_box(frame: &mut Frame, app: &App, area: Rect) {
     )));
     right_lines.extend(recent_activity_lines(&app.recent_sessions, right_w_usize));
 
-    frame.render_widget(Paragraph::new(right_lines).wrap(Wrap { trim: false }), h_chunks[2]);
+    frame.render_widget(
+        Paragraph::new(right_lines).wrap(Wrap { trim: false }),
+        h_chunks[2],
+    );
 }
 
 /// Build the compact welcome banner shown at the very top of the transcript.
@@ -1851,7 +2080,10 @@ fn welcome_banner_lines(app: &App, width: u16) -> Vec<Line<'static>> {
     };
 
     let bottom = Line::from(Span::styled(
-        format!("\u{2570}{}\u{256f}", "\u{2500}".repeat(box_w.saturating_sub(2))),
+        format!(
+            "\u{2570}{}\u{256f}",
+            "\u{2500}".repeat(box_w.saturating_sub(2))
+        ),
         Style::default().fg(accent),
     ));
 
@@ -1859,7 +2091,9 @@ fn welcome_banner_lines(app: &App, width: u16) -> Vec<Line<'static>> {
         top,
         content_row(
             greeting,
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         ),
         content_row(
             "/help for commands  \u{00b7}  ? for shortcuts".to_string(),
@@ -1876,7 +2110,9 @@ fn welcome_banner_lines(app: &App, width: u16) -> Vec<Line<'static>> {
 
 /// Build a tool_use_id → tool_name lookup from all messages in the transcript.
 /// This allows ToolResult blocks to dispatch to tool-specific renderers.
-fn build_tool_names(messages: &[claurst_core::types::Message]) -> std::collections::HashMap<String, String> {
+fn build_tool_names(
+    messages: &[claurst_core::types::Message],
+) -> std::collections::HashMap<String, String> {
     let mut map = std::collections::HashMap::new();
     for msg in messages {
         for block in msg.content_blocks() {
@@ -1917,6 +2153,7 @@ fn render_system_annotation_lines(
         SystemMessageStyle::Info => (Color::DarkGray, Color::DarkGray),
         SystemMessageStyle::Warning => (Color::Yellow, Color::Yellow),
         SystemMessageStyle::Compact => unreachable!(),
+        SystemMessageStyle::TodoCard => (Color::Cyan, Color::Cyan),
     };
 
     // Centred, padded rule: "â”€â”€â”€ text â”€â”€â”€"
@@ -1936,10 +2173,7 @@ fn render_system_annotation_lines(
             format!("\u{2500} {} \u{2500}", text),
             Style::default().fg(text_color).add_modifier(Modifier::DIM),
         ),
-        Span::styled(
-            "\u{2500}".repeat(right),
-            Style::default().fg(border_color),
-        ),
+        Span::styled("\u{2500}".repeat(right), Style::default().fg(border_color)),
     ]));
     lines.push(Line::from(""));
 }
@@ -2001,7 +2235,11 @@ fn tool_running_label(normalized: &str, fallback: &str) -> String {
     .to_string()
 }
 
-fn render_tool_block_lines(lines: &mut Vec<Line<'static>>, block: &crate::app::ToolUseBlock, frame_count: u64) {
+fn render_tool_block_lines(
+    lines: &mut Vec<Line<'static>>,
+    block: &crate::app::ToolUseBlock,
+    frame_count: u64,
+) {
     let input_val: serde_json::Value =
         serde_json::from_str(&block.input_json).unwrap_or(serde_json::Value::Null);
     let normalized = block.name.to_ascii_lowercase();
@@ -2023,7 +2261,10 @@ fn render_tool_block_lines(lines: &mut Vec<Line<'static>>, block: &crate::app::T
     // Primary argument shown on the header line (icon + arg), opencode-style.
     let mut summary = crate::messages::extract_tool_summary(&block.name, &input_val);
     let running_label = if normalized == "task" || normalized == "agent" {
-        if let Some(description) = input_val.get("description").and_then(|value| value.as_str()) {
+        if let Some(description) = input_val
+            .get("description")
+            .and_then(|value| value.as_str())
+        {
             summary = description.to_string();
         }
         crate::messages::subagent_title(&input_val)
@@ -2039,7 +2280,10 @@ fn render_tool_block_lines(lines: &mut Vec<Line<'static>>, block: &crate::app::T
         summary = shorten_home_path(&summary);
     }
 
-    let mut header_spans = vec![Span::styled(format!("   {} ", icon), Style::default().fg(accent))];
+    let mut header_spans = vec![Span::styled(
+        format!("   {} ", icon),
+        Style::default().fg(accent),
+    )];
     if running {
         header_spans.extend(shimmer_spans(&running_label, frame_count));
     } else {
@@ -2052,7 +2296,11 @@ fn render_tool_block_lines(lines: &mut Vec<Line<'static>>, block: &crate::app::T
         header_spans.push(Span::styled(
             primary,
             Style::default()
-                .fg(if block.status == ToolStatus::Error { accent } else { Color::White })
+                .fg(if block.status == ToolStatus::Error {
+                    accent
+                } else {
+                    Color::White
+                })
                 .add_modifier(Modifier::BOLD),
         ));
     }
@@ -2085,59 +2333,6 @@ fn render_tool_block_lines(lines: &mut Vec<Line<'static>>, block: &crate::app::T
     }
 }
 
-/// Extract the confidence score used by the TodoWrite checklist.
-fn todo_confidence(todo: &serde_json::Value) -> Option<u8> {
-    let value = if todo.get("status").and_then(|status| status.as_str()) == Some("completed") {
-        todo.get("completion_confidence")
-            .filter(|value| !value.is_null())
-            .or_else(|| todo.get("confidence"))
-    } else {
-        todo.get("confidence")
-    }?;
-
-    match value {
-        serde_json::Value::Number(number) => number
-            .as_f64()
-            .filter(|score| score.is_finite() && score.fract() == 0.0)
-            .filter(|score| (0.0..=100.0).contains(score))
-            .map(|score| score as u8),
-        serde_json::Value::String(raw) => raw
-            .trim()
-            .parse::<f64>()
-            .ok()
-            .filter(|score| score.is_finite() && score.fract() == 0.0)
-            .filter(|score| (0.0..=100.0).contains(score))
-            .map(|score| score as u8),
-        _ => None,
-    }
-}
-
-fn aggregate_todo_confidence(todos: &[serde_json::Value]) -> Option<u8> {
-    let mut weighted_sum = 0u32;
-    let mut total_weight = 0u32;
-    for todo in todos {
-        let Some(score) = todo_confidence(todo) else {
-            continue;
-        };
-        let weight = match todo.get("priority").and_then(|priority| priority.as_str()) {
-            Some("high") => 3,
-            Some("medium") => 2,
-            _ => 1,
-        };
-        weighted_sum += u32::from(score) * weight;
-        total_weight += weight;
-    }
-    (total_weight > 0).then_some(((weighted_sum + total_weight / 2) / total_weight) as u8)
-}
-
-fn confidence_color(score: u8) -> Color {
-    match score {
-        80..=100 => Color::Rgb(120, 200, 120),
-        50..=79 => Color::Rgb(220, 190, 100),
-        _ => Color::Rgb(220, 120, 100),
-    }
-}
-
 /// Render a TodoWrite call as a checklist. Returns `false` (so the caller can
 /// fall back to the generic block) when the input carries no `todos` array.
 fn render_todo_block(
@@ -2156,30 +2351,31 @@ fn render_todo_block(
     }
 
     fn status_of(t: &serde_json::Value) -> &str {
-        t.get("status").and_then(|s| s.as_str()).unwrap_or("pending")
+        t.get("status")
+            .and_then(|s| s.as_str())
+            .unwrap_or("pending")
     }
     let done = todos.iter().filter(|t| status_of(t) == "completed").count();
     let total = todos.len();
 
     // Header: ☰ Todos   <done>/<total>
-    let mut header = vec![Span::styled(format!("   {} ", icon), Style::default().fg(accent))];
+    let mut header = vec![Span::styled(
+        format!("   {} ", icon),
+        Style::default().fg(accent),
+    )];
     if running {
         header.extend(shimmer_spans("Updating todos", frame_count));
     } else {
         header.push(Span::styled(
             "Todos".to_string(),
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         ));
         header.push(Span::styled(
             format!("  {}/{} done", done, total),
             Style::default().fg(Color::DarkGray),
         ));
-        if let Some(confidence) = aggregate_todo_confidence(todos) {
-            header.push(Span::styled(
-                format!(" · confidence {}%", confidence),
-                Style::default().fg(confidence_color(confidence)),
-            ));
-        }
     }
     lines.push(Line::from(header));
 
@@ -2200,7 +2396,9 @@ fn render_todo_block(
             "completed" => (
                 "[x]",
                 Color::Rgb(120, 200, 120),
-                Style::default().fg(Color::DarkGray).add_modifier(Modifier::DIM),
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::DIM),
             ),
             "in_progress" => (
                 "[>]",
@@ -2213,19 +2411,9 @@ fn render_todo_block(
                 Style::default().fg(Color::Rgb(170, 170, 170)),
             ),
         };
-        let confidence = todo_confidence(t);
         lines.push(Line::from(vec![
             Span::styled(format!("     {} ", glyph), Style::default().fg(glyph_color)),
             Span::styled(content.to_string(), text_style),
-            Span::styled(
-                confidence
-                    .map(|score| format!(" [{}%]", score))
-                    .unwrap_or_default(),
-                confidence
-                    .map(confidence_color)
-                    .map(|color| Style::default().fg(color))
-                    .unwrap_or_default(),
-            ),
         ]));
     }
     if total > MAX_ITEMS {
@@ -2233,7 +2421,9 @@ fn render_todo_block(
             Span::raw("     "),
             Span::styled(
                 format!("... {} more", total - MAX_ITEMS),
-                Style::default().fg(Color::DarkGray).add_modifier(Modifier::DIM),
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::DIM),
             ),
         ]));
     }
@@ -2243,6 +2433,37 @@ fn render_todo_block(
 // -----------------------------------------------------------------------
 // Input pane
 // -----------------------------------------------------------------------
+
+/// Render queued prompts that will be sent after the current turn finishes.
+/// Each queued message gets one line: `>> {truncated text}`.
+fn render_queued_prompts(frame: &mut Frame, app: &App, area: Rect) {
+    let max_lines = area.height as usize;
+    let width = area.width as usize;
+    let prefix = ">> ";
+    let prefix_len = prefix.len();
+    let max_text = width.saturating_sub(prefix_len + 1);
+
+    let lines: Vec<Line> = app
+        .queued_messages
+        .iter()
+        .take(max_lines)
+        .map(|msg| {
+            let text = if msg.chars().count() > max_text {
+                let trimmed: String = msg.chars().take(max_text.saturating_sub(3)).collect();
+                format!("{}...", trimmed)
+            } else {
+                msg.clone()
+            };
+            Line::from(vec![
+                Span::styled(prefix, Style::default().fg(Color::DarkGray)),
+                Span::styled(text, Style::default().fg(Color::DarkGray)),
+            ])
+        })
+        .collect();
+
+    let paragraph = Paragraph::new(lines);
+    frame.render_widget(paragraph, area);
+}
 
 fn render_input(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
     // Split: 1-row model/mode status line + remaining rows for the prompt input.
@@ -2269,15 +2490,19 @@ fn render_input(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
         let dim = Color::Rgb(110, 110, 124);
         let chunks = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints([Constraint::Min(1), Constraint::Length(status_area.width.min(50))])
+            .constraints([
+                Constraint::Min(1),
+                Constraint::Length(status_area.width.min(50)),
+            ])
             .split(status_area);
 
         let left_line = if app.has_credentials {
-            let (provider, model_short) = if let Some((provider, model)) = app.model_name.split_once('/') {
-                (provider.to_string(), model.to_string())
-            } else {
-                ("local".to_string(), app.model_name.clone())
-            };
+            let (provider, model_short) =
+                if let Some((provider, model)) = app.model_name.split_once('/') {
+                    (provider.to_string(), model.to_string())
+                } else {
+                    ("local".to_string(), app.model_name.clone())
+                };
             let mut spans = vec![
                 Span::styled(
                     format!(" {} ", agent_mode.to_uppercase()),
@@ -2289,7 +2514,9 @@ fn render_input(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
                 Span::raw(" "),
                 Span::styled(
                     model_short,
-                    Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::White)
+                        .add_modifier(Modifier::BOLD),
                 ),
             ];
             spans.push(Span::styled(
@@ -2321,15 +2548,14 @@ fn render_input(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
         // also suppressed once the prompt has text, so the hint doesn't compete
         // with what the user is typing (matches the footer contract).
         let right_hint = if app.has_credentials && app.prompt_input.text.is_empty() {
-            Line::from(vec![
-                Span::styled("? shortcuts", Style::default().fg(dim)),
-            ])
+            Line::from(vec![Span::styled("? shortcuts", Style::default().fg(dim))])
         } else if app.prompt_input.has_expandable_paste_ref() {
             // A [Pasted text #N ...] placeholder is in the buffer — tell the
             // user how to view the full pasted body before submitting.
-            Line::from(vec![
-                Span::styled("click to view paste · alt+e expands", Style::default().fg(dim)),
-            ])
+            Line::from(vec![Span::styled(
+                "click to view paste · alt+e expands",
+                Style::default().fg(dim),
+            )])
         } else {
             Line::from(Vec::<Span>::new())
         };
@@ -2399,14 +2625,19 @@ fn render_status_row(frame: &mut Frame, app: &App, area: Rect) {
 
     let spans = if app.voice_recording {
         vec![Span::styled(
-            format!("{} Recording... press Alt+V to transcribe", figures::black_circle()),
+            format!(
+                "{} Recording... press Alt+V to transcribe",
+                figures::black_circle()
+            ),
             Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
         )]
     } else if app.is_streaming {
         // Pick a label: use the status message if it has real content,
         // otherwise show a default "Thinking" shimmer so the user always
         // sees that the model is working.
-        let raw_label = app.status_message.as_deref()
+        let raw_label = app
+            .status_message
+            .as_deref()
             .filter(|s| {
                 let t = s.trim();
                 !t.is_empty()
@@ -2418,21 +2649,30 @@ fn render_status_row(frame: &mut Frame, app: &App, area: Rect) {
 
         let mut s = vec![Span::styled(
             spinner_char(app.frame_count).to_string(),
-            Style::default().fg(spinner_color(app)).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(spinner_color(app))
+                .add_modifier(Modifier::BOLD),
         )];
         let label = format!("{}…", raw_label.trim_end_matches('…'));
 
         s.push(Span::raw(" "));
         s.extend(shimmer_spans(&label, app.frame_count));
         s
-    } else if let (Some(verb), Some(elapsed)) = (app.last_turn_verb, app.last_turn_elapsed.as_deref()) {
+    } else if let (Some(verb), Some(elapsed)) =
+        (app.last_turn_verb, app.last_turn_elapsed.as_deref())
+    {
         // "✽ Worked for 2m 5s" — mirrors TS TeammateSpinnerLine idle state
         vec![Span::styled(
             format!("{} {} for {}", figures::TEARDROP_ASTERISK, verb, elapsed),
-            Style::default().fg(Color::DarkGray).add_modifier(Modifier::DIM),
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::DIM),
         )]
     } else if let Some(status) = app.status_message.as_deref() {
-        vec![Span::styled(status.to_string(), Style::default().fg(Color::DarkGray))]
+        vec![Span::styled(
+            status.to_string(),
+            Style::default().fg(Color::DarkGray),
+        )]
     } else {
         Vec::new()
     };
@@ -2442,8 +2682,7 @@ fn render_status_row(frame: &mut Frame, app: &App, area: Rect) {
     }
 
     frame.render_widget(
-        Paragraph::new(Line::from(spans))
-            .wrap(ratatui::widgets::Wrap { trim: false }),
+        Paragraph::new(Line::from(spans)).wrap(ratatui::widgets::Wrap { trim: false }),
         area,
     );
 }
@@ -2480,7 +2719,10 @@ fn shimmer_spans(text: &str, frame_count: u64) -> Vec<Span<'static>> {
             && glimmer_center < len as isize;
 
         if is_bright != run_bright && !run.is_empty() {
-            spans.push(Span::styled(run.clone(), if run_bright { bright } else { base }));
+            spans.push(Span::styled(
+                run.clone(),
+                if run_bright { bright } else { base },
+            ));
             run.clear();
         }
         run_bright = is_bright;
@@ -2523,7 +2765,9 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
         if let Some(ref badge) = app.agent_type_badge {
             spans.push(Span::styled(
                 format!("\u{2699} {}", badge),
-                Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
             ));
         }
 
@@ -2566,10 +2810,7 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
             } else {
                 format!("\u{27f3} {} tasks", app.background_task_count)
             };
-            spans.push(Span::styled(
-                label,
-                Style::default().fg(Color::Yellow),
-            ));
+            spans.push(Span::styled(label, Style::default().fg(Color::Yellow)));
         } else if let Some(ref task_status) = app.background_task_status {
             if !spans.is_empty() {
                 spans.push(Span::raw("  "));
@@ -2587,13 +2828,43 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
                 spans.push(Span::raw("  "));
             }
             let (label, style) = match app.prompt_input.vim_mode {
-                VimMode::Insert      => ("-- INSERT --",       Style::default().fg(Color::DarkGray)),
-                VimMode::Normal      => ("-- NORMAL --",       Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
-                VimMode::Visual      => ("-- VISUAL --",       Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD)),
-                VimMode::VisualLine  => ("-- VISUAL LINE --",  Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD)),
-                VimMode::VisualBlock => ("-- VISUAL BLOCK --", Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD)),
-                VimMode::Command     => ("-- COMMAND --",      Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
-                VimMode::Search      => ("-- SEARCH --",       Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+                VimMode::Insert => ("-- INSERT --", Style::default().fg(Color::DarkGray)),
+                VimMode::Normal => (
+                    "-- NORMAL --",
+                    Style::default()
+                        .fg(Color::Green)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                VimMode::Visual => (
+                    "-- VISUAL --",
+                    Style::default()
+                        .fg(Color::Magenta)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                VimMode::VisualLine => (
+                    "-- VISUAL LINE --",
+                    Style::default()
+                        .fg(Color::Magenta)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                VimMode::VisualBlock => (
+                    "-- VISUAL BLOCK --",
+                    Style::default()
+                        .fg(Color::Magenta)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                VimMode::Command => (
+                    "-- COMMAND --",
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                VimMode::Search => (
+                    "-- SEARCH --",
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                ),
             };
             spans.push(Span::styled(label, style));
         }
@@ -2605,7 +2876,9 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
             }
             spans.push(Span::styled(
                 "[BASH]",
-                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
             ));
         }
 
@@ -2615,25 +2888,28 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
             use claurst_core::config::PermissionMode;
             match &app.config.permission_mode {
                 PermissionMode::BypassPermissions => {
-                    if !spans.is_empty() { spans.push(Span::raw("  ")); }
+                    if !spans.is_empty() {
+                        spans.push(Span::raw("  "));
+                    }
                     spans.push(Span::styled(
                         "\u{23f5}\u{23f5} bypass",
                         Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
                     ));
                 }
                 PermissionMode::AcceptEdits => {
-                    if !spans.is_empty() { spans.push(Span::raw("  ")); }
+                    if !spans.is_empty() {
+                        spans.push(Span::raw("  "));
+                    }
                     spans.push(Span::styled(
                         "accept-edits",
                         Style::default().fg(Color::Yellow),
                     ));
                 }
                 PermissionMode::Plan => {
-                    if !spans.is_empty() { spans.push(Span::raw("  ")); }
-                    spans.push(Span::styled(
-                        "plan",
-                        Style::default().fg(Color::Blue),
-                    ));
+                    if !spans.is_empty() {
+                        spans.push(Span::raw("  "));
+                    }
+                    spans.push(Span::styled("plan", Style::default().fg(Color::Blue)));
                 }
                 PermissionMode::Default => {}
             }
@@ -2660,7 +2936,8 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
         //    When an update is available and context is below 85%, show the update notification
         //    instead to keep the status bar uncluttered.
         if app.context_window_size > 0 {
-            let used_pct = (app.context_used_tokens as f64 / app.context_window_size as f64 * 100.0) as u64;
+            let used_pct =
+                (app.context_used_tokens as f64 / app.context_window_size as f64 * 100.0) as u64;
             let left_pct = 100u64.saturating_sub(used_pct);
 
             if !parts.is_empty() {
@@ -2684,7 +2961,9 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
                 // Update available and context is fine — show update nudge in bottom-right.
                 parts.push(Span::styled(
                     format!("⬆ v{} available  Run: /update", version),
-                    Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
                 ));
             } else if used_pct >= 70 {
                 // 70–84%: mild warning.
@@ -2714,10 +2993,7 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
             } else {
                 format!("${:.2}", app.cost_usd)
             };
-            parts.push(Span::styled(
-                cost_str,
-                Style::default().fg(Color::DarkGray),
-            ));
+            parts.push(Span::styled(cost_str, Style::default().fg(Color::DarkGray)));
         }
 
         // 3b. Token budget (feature-gated)
@@ -2746,13 +3022,65 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
             ));
         }
 
+        // Tokens per second average (from last 5 turns).
+        if !app.recent_token_rates.is_empty() {
+            if !parts.is_empty() {
+                parts.push(Span::raw("  "));
+            }
+            let avg_tps =
+                app.recent_token_rates.iter().sum::<f64>() / app.recent_token_rates.len() as f64;
+            parts.push(Span::styled(
+                format!("{:.0} tok/s", avg_tps),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+
+        // Todo progress (done/total).
+        let todos = claurst_tools::todo_write::load_todos(&app.session_id);
+        if !todos.is_empty() {
+            if !parts.is_empty() {
+                parts.push(Span::raw("  "));
+            }
+            let total = todos.len();
+            let completed = todos
+                .iter()
+                .filter(|t| t.get("status").and_then(|s| s.as_str()) == Some("completed"))
+                .count();
+            parts.push(Span::styled(
+                format!("\u{2713}{}/{}", completed, total),
+                Style::default().fg(if completed == total {
+                    Color::Green
+                } else {
+                    Color::Yellow
+                }),
+            ));
+        }
+
+        // Skills + MCP count indicator.
+        if app.skill_count > 0 || app.mcp_server_count > 0 {
+            if !parts.is_empty() {
+                parts.push(Span::raw("  "));
+            }
+            parts.push(Span::styled(
+                format!(
+                    "{} skills \u{00b7} {} mcp",
+                    app.skill_count, app.mcp_server_count
+                ),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+
         // 4. Rate limits
         if let Some(pct) = app.rate_limit_5h_pct {
             if pct > 0.0 {
                 if !parts.is_empty() {
                     parts.push(Span::raw("  "));
                 }
-                let color = if pct >= 90.0 { Color::Red } else { Color::Yellow };
+                let color = if pct >= 90.0 {
+                    Color::Red
+                } else {
+                    Color::Yellow
+                };
                 parts.push(Span::styled(
                     format!("5h:{:.0}%", pct),
                     Style::default().fg(color),
@@ -2764,7 +3092,11 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
                 if !parts.is_empty() {
                     parts.push(Span::raw("  "));
                 }
-                let color = if pct >= 90.0 { Color::Red } else { Color::Yellow };
+                let color = if pct >= 90.0 {
+                    Color::Red
+                } else {
+                    Color::Yellow
+                };
                 parts.push(Span::styled(
                     format!("7d:{:.0}%", pct),
                     Style::default().fg(color),
@@ -2781,7 +3113,9 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
             }
             parts.push(Span::styled(
                 format!("[goal: {}]", badge),
-                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
             ));
         }
 
@@ -2930,12 +3264,16 @@ fn render_prompt_suggestions(frame: &mut Frame, app: &App, area: Rect) {
     for (row, suggestion) in suggestions[start..end].iter().enumerate() {
         let is_selected = start + row == selected;
         let accent_style = if is_selected {
-            Style::default().fg(CLAUDE_ORANGE).add_modifier(Modifier::BOLD)
+            Style::default()
+                .fg(CLAUDE_ORANGE)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(Color::DarkGray)
         };
         let label_style = if is_selected {
-            Style::default().fg(CLAUDE_ORANGE).add_modifier(Modifier::BOLD)
+            Style::default()
+                .fg(CLAUDE_ORANGE)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(Color::White)
         };
@@ -2944,7 +3282,10 @@ fn render_prompt_suggestions(frame: &mut Frame, app: &App, area: Rect) {
         } else {
             Style::default().fg(Color::DarkGray)
         };
-        let mut spans = vec![Span::styled(if is_selected { "\u{203a} " } else { "  " }, accent_style)];
+        let mut spans = vec![Span::styled(
+            if is_selected { "\u{203a} " } else { "  " },
+            accent_style,
+        )];
         match suggestion.source {
             TypeaheadSource::SlashCommand => {
                 let display_name = truncate_text(&suggestion.text, label_width);
@@ -2952,7 +3293,10 @@ fn render_prompt_suggestions(frame: &mut Frame, app: &App, area: Rect) {
                     format!("{display_name:<width$}", width = label_width),
                     label_style,
                 ));
-                spans.push(Span::styled(" [cmd] ", Style::default().fg(Color::DarkGray)));
+                spans.push(Span::styled(
+                    " [cmd] ",
+                    Style::default().fg(Color::DarkGray),
+                ));
                 if !suggestion.description.is_empty() {
                     spans.push(Span::styled(
                         truncate_text(
@@ -2970,7 +3314,10 @@ fn render_prompt_suggestions(frame: &mut Frame, app: &App, area: Rect) {
                     label_style,
                 ));
                 if !suggestion.description.is_empty() {
-                    spans.push(Span::styled(" \u{2014} ", Style::default().fg(Color::DarkGray)));
+                    spans.push(Span::styled(
+                        " \u{2014} ",
+                        Style::default().fg(Color::DarkGray),
+                    ));
                     spans.push(Span::styled(
                         truncate_text(&suggestion.description, area.width as usize / 2),
                         detail_style,
@@ -2983,7 +3330,10 @@ fn render_prompt_suggestions(frame: &mut Frame, app: &App, area: Rect) {
                     format!("{display_name:<width$}", width = label_width),
                     label_style,
                 ));
-                spans.push(Span::styled(" [history] ", Style::default().fg(Color::DarkGray)));
+                spans.push(Span::styled(
+                    " [history] ",
+                    Style::default().fg(Color::DarkGray),
+                ));
                 if !suggestion.description.is_empty() {
                     spans.push(Span::styled(
                         truncate_text(&suggestion.description, area.width as usize / 2),
@@ -3088,8 +3438,8 @@ fn render_legacy_history_search(
 ) {
     let dialog_width = 60u16.min(area.width.saturating_sub(4));
     let visible_matches = 8usize;
-    let dialog_height =
-        (4 + visible_matches.min(hs.matches.len().max(1)) as u16).min(area.height.saturating_sub(4));
+    let dialog_height = (4 + visible_matches.min(hs.matches.len().max(1)) as u16)
+        .min(area.height.saturating_sub(4));
     let dialog_area = crate::overlays::centered_rect(dialog_width, dialog_height, area);
 
     frame.render_widget(Clear, dialog_area);
@@ -3099,7 +3449,9 @@ fn render_legacy_history_search(
         Span::raw("  Search: "),
         Span::styled(
             hs.query.clone(),
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled("\u{2588}", Style::default().fg(Color::White)),
     ]));
@@ -3168,8 +3520,8 @@ pub struct StatusLineData {
     pub tokens_used: u64,
     pub tokens_total: u64,
     pub cost_cents: f64,
-    pub compact_warning_pct: Option<f64>,  // None = no warning; Some(pct) = show warning
-    pub vim_mode: Option<String>,           // None = no vim mode; Some("NORMAL") etc.
+    pub compact_warning_pct: Option<f64>, // None = no warning; Some(pct) = show warning
+    pub vim_mode: Option<String>,         // None = no vim mode; Some("NORMAL") etc.
     pub bridge_connected: bool,
     pub session_id: Option<String>,
     pub worktree: Option<String>,
@@ -3180,7 +3532,11 @@ pub struct StatusLineData {
     pub goal_badge: Option<String>,
 }
 
-pub fn render_full_status_line(data: &StatusLineData, area: Rect, buf: &mut ratatui::buffer::Buffer) {
+pub fn render_full_status_line(
+    data: &StatusLineData,
+    area: Rect,
+    buf: &mut ratatui::buffer::Buffer,
+) {
     use ratatui::{
         style::{Color, Modifier, Style},
         text::{Line, Span},
@@ -3201,7 +3557,13 @@ pub fn render_full_status_line(data: &StatusLineData, area: Rect, buf: &mut rata
     // Context window
     if data.tokens_total > 0 {
         let pct = data.tokens_used as f64 / data.tokens_total as f64;
-        let ctx_color = if pct >= 0.95 { Color::Red } else if pct >= 0.80 { Color::Yellow } else { Color::Green };
+        let ctx_color = if pct >= 0.95 {
+            Color::Red
+        } else if pct >= 0.80 {
+            Color::Yellow
+        } else {
+            Color::Green
+        };
         let used_k = data.tokens_used / 1000;
         let total_k = data.tokens_total / 1000;
         spans.push(Span::styled(
@@ -3223,7 +3585,11 @@ pub fn render_full_status_line(data: &StatusLineData, area: Rect, buf: &mut rata
     // Compact warning
     if let Some(pct) = data.compact_warning_pct {
         if pct >= 0.80 {
-            let color = if pct >= 0.95 { Color::Red } else { Color::Yellow };
+            let color = if pct >= 0.95 {
+                Color::Red
+            } else {
+                Color::Yellow
+            };
             spans.push(Span::styled(
                 format!("âš  ctx {:.0}% ", pct * 100.0),
                 Style::default().fg(color).add_modifier(Modifier::BOLD),
@@ -3259,17 +3625,16 @@ pub fn render_full_status_line(data: &StatusLineData, area: Rect, buf: &mut rata
     if let Some(goal) = &data.goal_badge {
         spans.push(Span::styled(
             format!("[goal: {}]", goal),
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
         ));
         spans.push(Span::styled(" ", Style::default()));
     }
 
     // Bridge connected
     if data.bridge_connected {
-        spans.push(Span::styled(
-            "ðŸ”— ",
-            Style::default().fg(Color::Green),
-        ));
+        spans.push(Span::styled("ðŸ”— ", Style::default().fg(Color::Green)));
     }
 
     // Session ID
@@ -3294,7 +3659,6 @@ pub fn render_full_status_line(data: &StatusLineData, area: Rect, buf: &mut rata
         .style(Style::default().bg(Color::Black))
         .render(area, buf);
 }
-
 
 // ---------------------------------------------------------------------------
 // Multi-agent UI components
@@ -3323,15 +3687,10 @@ pub fn render_agent_progress_line(
     let mut spans = vec![
         Span::styled(
             format!("[agent-{}]", agent_id),
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::DIM),
+            Style::default().fg(Color::Cyan).add_modifier(Modifier::DIM),
         ),
         Span::raw(" "),
-        Span::styled(
-            status.to_string(),
-            Style::default().fg(status_color),
-        ),
+        Span::styled(status.to_string(), Style::default().fg(status_color)),
     ];
 
     if let Some(tool) = current_tool {
@@ -3374,12 +3733,13 @@ pub fn render_coordinator_status_lines(
                 .fg(Color::Cyan)
                 .add_modifier(Modifier::BOLD),
         ),
+        Span::styled(" · ".to_string(), Style::default().fg(Color::DarkGray)),
         Span::styled(
-            " · ".to_string(),
-            Style::default().fg(Color::DarkGray),
-        ),
-        Span::styled(
-            format!("{} agent{}", agent_count, if agent_count == 1 { "" } else { "s" }),
+            format!(
+                "{} agent{}",
+                agent_count,
+                if agent_count == 1 { "" } else { "s" }
+            ),
             Style::default().fg(Color::White),
         ),
         Span::styled(
@@ -3416,10 +3776,7 @@ pub fn render_coordinator_status_lines(
 /// # Arguments
 /// * `teammate_id`  — teammate identifier string
 /// * `session_info` — optional session info snippet to append
-pub fn render_teammate_header(
-    teammate_id: &str,
-    session_info: Option<&str>,
-) -> Line<'static> {
+pub fn render_teammate_header(teammate_id: &str, session_info: Option<&str>) -> Line<'static> {
     let mut spans = vec![
         Span::styled(
             "┤ teammate: ".to_string(),
@@ -3431,10 +3788,7 @@ pub fn render_teammate_header(
                 .fg(Color::Magenta)
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::styled(
-            " ├".to_string(),
-            Style::default().fg(Color::Magenta),
-        ),
+        Span::styled(" ├".to_string(), Style::default().fg(Color::Magenta)),
     ];
 
     if let Some(info) = session_info {
@@ -3489,7 +3843,18 @@ mod tool_block_tests {
         assert_eq!(tool_icon("todowrite"), ":");
         assert_eq!(tool_icon("something-unknown"), "~");
         // All markers must be single-byte ASCII (guaranteed one terminal cell).
-        for t in ["bash", "read", "write", "glob", "grep", "webfetch", "websearch", "todo", "task", "x"] {
+        for t in [
+            "bash",
+            "read",
+            "write",
+            "glob",
+            "grep",
+            "webfetch",
+            "websearch",
+            "todo",
+            "task",
+            "x",
+        ] {
             let icon = tool_icon(t);
             assert_eq!(icon.len(), 1, "{t} icon {icon:?} must be 1 ASCII byte");
             assert!(icon.is_ascii(), "{t} icon {icon:?} must be ASCII");
@@ -3519,11 +3884,23 @@ mod tool_block_tests {
         );
         let lines = render(&b);
         // Header: "$ python3 - <<'PY'"
-        assert!(lines[0].contains('$'), "header should be icon-led: {:?}", lines[0]);
-        assert!(lines[0].contains("python3 - <<'PY'"), "header shows command: {:?}", lines[0]);
+        assert!(
+            lines[0].contains('$'),
+            "header should be icon-led: {:?}",
+            lines[0]
+        );
+        assert!(
+            lines[0].contains("python3 - <<'PY'"),
+            "header shows command: {:?}",
+            lines[0]
+        );
         // The command must appear exactly once (no summary + $-line duplication).
         let joined = lines.join("\n");
-        assert_eq!(joined.matches("python3 - <<'PY'").count(), 1, "no dup: {joined:?}");
+        assert_eq!(
+            joined.matches("python3 - <<'PY'").count(),
+            1,
+            "no dup: {joined:?}"
+        );
         // Output preview still shown.
         assert!(joined.contains("218183"));
     }
@@ -3550,9 +3927,9 @@ mod tool_block_tests {
             "TodoWrite",
             ToolStatus::Done,
             r#"{"todos":[
-                {"content":"Locate files","status":"completed","completion_confidence":90},
-                {"content":"Build importer","status":"in_progress","confidence":70},
-                {"content":"Wire adapter","status":"pending","confidence":50}
+                {"content":"Locate files","status":"completed"},
+                {"content":"Build importer","status":"in_progress"},
+                {"content":"Wire adapter","status":"pending"}
             ]}"#,
             Some("Todo list updated (3 total)"),
         );
@@ -3561,13 +3938,24 @@ mod tool_block_tests {
         // Header shows count, not the raw "Todo list updated (...)".
         assert!(joined.contains("Todos"), "{joined:?}");
         assert!(joined.contains("1/3 done"), "{joined:?}");
-        assert!(joined.contains("confidence 70%"), "{joined:?}");
         // Each status has its ASCII checkbox + content.
-        assert!(joined.contains("[x] Locate files [90%]"), "done marker: {joined:?}");
-        assert!(joined.contains("[>] Build importer [70%]"), "in-progress marker: {joined:?}");
-        assert!(joined.contains("[ ] Wire adapter [50%]"), "pending marker: {joined:?}");
+        assert!(
+            joined.contains("[x] Locate files"),
+            "done marker: {joined:?}"
+        );
+        assert!(
+            joined.contains("[>] Build importer"),
+            "in-progress marker: {joined:?}"
+        );
+        assert!(
+            joined.contains("[ ] Wire adapter"),
+            "pending marker: {joined:?}"
+        );
         // The raw result-preview string must NOT leak into the checklist view.
-        assert!(!joined.contains("Todo list updated"), "preview suppressed: {joined:?}");
+        assert!(
+            !joined.contains("Todo list updated"),
+            "preview suppressed: {joined:?}"
+        );
     }
 
     #[test]
@@ -3639,7 +4027,8 @@ mod stream_cache_tests {
         let mut app = test_app();
         // Turn 0 is fully committed; turn 1 is the live/streaming turn.
         app.messages.push(Message::user("user one prompt"));
-        app.messages.push(Message::assistant("assistant one committed reply"));
+        app.messages
+            .push(Message::assistant("assistant one committed reply"));
         app.messages.push(Message::user("user two prompt"));
         app.is_streaming = true;
         app.streaming_text = "streaming tail alpha".to_string();
@@ -3648,7 +4037,11 @@ mod stream_cache_tests {
 
         // First render: prefix is built fresh (a miss).
         let render1 = render_message_items(&app, WIDTH);
-        assert_eq!(prefix_cache_counts(), (0, 1), "first render builds the prefix");
+        assert_eq!(
+            prefix_cache_counts(),
+            (0, 1),
+            "first render builds the prefix"
+        );
 
         // A streaming delta arrives: only the live text grows. Real code bumps
         // transcript_version on every delta — assert that does NOT evict the
@@ -3691,7 +4084,10 @@ mod stream_cache_tests {
         let text2 = joined_text(&render2);
         assert!(text1.contains("streaming tail alpha"));
         assert!(!text1.contains("streaming tail alpha beta"));
-        assert!(text2.contains("streaming tail alpha beta"), "tail rebuilt with the delta");
+        assert!(
+            text2.contains("streaming tail alpha beta"),
+            "tail rebuilt with the delta"
+        );
     }
 
     /// Streaming render (cached prefix + rebuilt tail) is byte-identical to a
@@ -3701,9 +4097,12 @@ mod stream_cache_tests {
     fn streaming_render_matches_full_rebuild() {
         let mut app = test_app();
         app.messages.push(Message::user("first user question"));
-        app.messages.push(Message::assistant("first assistant answer with **markdown**"));
+        app.messages.push(Message::assistant(
+            "first assistant answer with **markdown**",
+        ));
         app.messages.push(Message::user("second user question"));
-        app.messages.push(Message::assistant("second assistant answer"));
+        app.messages
+            .push(Message::assistant("second assistant answer"));
         app.messages.push(Message::user("third user question"));
         app.is_streaming = true;
         app.streaming_thinking = "pondering the third answer".to_string();
@@ -3741,7 +4140,8 @@ mod stream_cache_tests {
     fn transcript_swap_does_not_ghost_stale_prefix() {
         let mut app = test_app();
         app.messages.push(Message::user("session A user"));
-        app.messages.push(Message::assistant("session A assistant reply"));
+        app.messages
+            .push(Message::assistant("session A assistant reply"));
         app.messages.push(Message::user("session A live turn"));
         app.is_streaming = true;
         app.streaming_text = "A tail".to_string();
@@ -3763,7 +4163,10 @@ mod stream_cache_tests {
 
         let render_b = render_message_items(&app, WIDTH);
         let text_b = joined_text(&render_b);
-        assert!(text_b.contains("session B assistant reply"), "shows swapped content");
+        assert!(
+            text_b.contains("session B assistant reply"),
+            "shows swapped content"
+        );
         assert!(
             !text_b.contains("session A"),
             "no stale session-A content ghosts through: {text_b:?}"
@@ -3936,13 +4339,17 @@ mod recent_activity_tests {
         assert!(out.contains("Wire up onboarding"), "second title: {out:?}");
         assert!(out.contains("3d ago"), "second time: {out:?}");
         // The placeholder must NOT appear when there is real activity.
-        assert!(!out.contains("No recent activity"), "no placeholder: {out:?}");
+        assert!(
+            !out.contains("No recent activity"),
+            "no placeholder: {out:?}"
+        );
     }
 
     #[test]
     fn caps_at_five_entries() {
-        let sessions: Vec<RecentSession> =
-            (0..8).map(|i| recent(&format!("session {i}"), 60)).collect();
+        let sessions: Vec<RecentSession> = (0..8)
+            .map(|i| recent(&format!("session {i}"), 60))
+            .collect();
         assert_eq!(recent_activity_lines(&sessions, 40).len(), 5);
     }
 
@@ -3977,7 +4384,10 @@ mod recent_activity_tests {
             .iter()
             .map(|c| c.symbol().chars().next().unwrap_or(' '))
             .collect();
-        assert!(screen.contains("Recent activity"), "header rendered: present");
+        assert!(
+            screen.contains("Recent activity"),
+            "header rendered: present"
+        );
         assert!(screen.contains("Sortable label"), "session label rendered");
     }
 }

--- a/src-rust/crates/tui/src/settings_screen.rs
+++ b/src-rust/crates/tui/src/settings_screen.rs
@@ -4,12 +4,12 @@
 // in a single scrollable list with live search filtering.
 // Changes are persisted via Settings::save_sync() or settings.json writes.
 
-use claurst_core::config::{Config, Settings};
-use claurst_core::output_styles::{builtin_styles, find_style};
 use crate::overlays::{
     centered_rect, modal_search_line, render_dark_overlay, render_dialog_bg, CLAURST_ACCENT,
     CLAURST_MUTED, CLAURST_PANEL_BG,
 };
+use claurst_core::config::{Config, Settings};
+use claurst_core::output_styles::{builtin_styles, find_style};
 use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -118,7 +118,12 @@ impl SettingsScreen {
         self.auto_compact = self.settings_snapshot.auto_compact;
         self.notifications = self.settings_snapshot.notifications;
         self.show_turn_duration = self.settings_snapshot.show_turn_duration;
-        self.output_style = self.settings_snapshot.config.output_style.clone().unwrap_or_else(|| "default".to_string());
+        self.output_style = self
+            .settings_snapshot
+            .config
+            .output_style
+            .clone()
+            .unwrap_or_else(|| "default".to_string());
         self.reduce_motion = self.settings_snapshot.reduce_motion;
         self.terminal_progress_bar = self.settings_snapshot.terminal_progress_bar;
         self.verbose = self.settings_snapshot.config.verbose;
@@ -136,9 +141,20 @@ impl SettingsScreen {
         };
         self.disable_claude_mds = self.settings_snapshot.config.disable_claude_mds;
         self.file_injection_enabled = self.settings_snapshot.config.file_injection_enabled;
-        self.file_autocomplete_limit = self.settings_snapshot.config.file_autocomplete_limit.to_string();
-        self.file_autocomplete_show_hidden_files = self.settings_snapshot.config.file_autocomplete_show_hidden_files;
-        self.file_injection_max_size = self.settings_snapshot.config.file_injection_max_size.to_string();
+        self.file_autocomplete_limit = self
+            .settings_snapshot
+            .config
+            .file_autocomplete_limit
+            .to_string();
+        self.file_autocomplete_show_hidden_files = self
+            .settings_snapshot
+            .config
+            .file_autocomplete_show_hidden_files;
+        self.file_injection_max_size = self
+            .settings_snapshot
+            .config
+            .file_injection_max_size
+            .to_string();
     }
 
     pub fn open(&mut self) {
@@ -406,7 +422,12 @@ fn all_entries(screen: &SettingsScreen) -> Vec<SettingsEntry> {
             label: "Show hidden files",
             description: "Include hidden files (.) in @ autocomplete.",
             kind: SettingKind::Bool,
-            value: if screen.file_autocomplete_show_hidden_files { "true" } else { "false" }.to_string(),
+            value: if screen.file_autocomplete_show_hidden_files {
+                "true"
+            } else {
+                "false"
+            }
+            .to_string(),
         });
         entries.push(SettingsEntry {
             key: "fileInjectionMaxSize",
@@ -432,8 +453,12 @@ pub fn render_settings_screen(frame: &mut Frame, screen: &SettingsScreen, area: 
     render_dark_overlay(frame, area);
 
     // 80% width, 90% height, centred
-    let w = (area.width * 4 / 5).max(60).min(area.width.saturating_sub(2));
-    let h = (area.height * 9 / 10).max(20).min(area.height.saturating_sub(2));
+    let w = (area.width * 4 / 5)
+        .max(60)
+        .min(area.width.saturating_sub(2));
+    let h = (area.height * 9 / 10)
+        .max(20)
+        .min(area.height.saturating_sub(2));
     let popup = centered_rect(w, h, area);
     render_dialog_bg(frame, popup);
 
@@ -470,26 +495,51 @@ pub fn render_settings_screen(frame: &mut Frame, screen: &SettingsScreen, area: 
 
     // Header
     let title = Line::from(vec![
-        Span::styled(" Settings", Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            " Settings",
+            Style::default()
+                .fg(CLAURST_ACCENT)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::styled(" — Claurst", Style::default().fg(CLAURST_MUTED)),
         Span::styled(
-            format!("{:>width$}", "Esc close", width = inner.width.saturating_sub(19) as usize),
+            format!(
+                "{:>width$}",
+                "Esc close",
+                width = inner.width.saturating_sub(19) as usize
+            ),
             Style::default().fg(CLAURST_MUTED),
         ),
     ]);
-    frame.render_widget(Paragraph::new(title).style(Style::default().bg(CLAURST_PANEL_BG)), header_area);
+    frame.render_widget(
+        Paragraph::new(title).style(Style::default().bg(CLAURST_PANEL_BG)),
+        header_area,
+    );
 
     // Search
-    let search_line = modal_search_line(&screen.search_query, "Type to search settings...", Color::DarkGray, CLAURST_ACCENT);
-    frame.render_widget(Paragraph::new(search_line).style(Style::default().bg(CLAURST_PANEL_BG)), search_area);
+    let search_line = modal_search_line(
+        &screen.search_query,
+        "Type to search settings...",
+        Color::DarkGray,
+        CLAURST_ACCENT,
+    );
+    frame.render_widget(
+        Paragraph::new(search_line).style(Style::default().bg(CLAURST_PANEL_BG)),
+        search_area,
+    );
 
     // Content
     render_settings_list(frame, screen, content_area);
 
     // Description of selected entry
     let all = all_entries(screen);
-    let filtered: Vec<_> = all.iter()
-        .filter(|e| e.label.to_lowercase().contains(&screen.search_query.to_lowercase()))
+    let filtered: Vec<_> = all
+        .iter()
+        .filter(|e| {
+            e.label
+                .to_lowercase()
+                .contains(&screen.search_query.to_lowercase())
+        })
         .collect();
 
     let desc_text = if let Some(entry) = filtered.get(screen.selected_idx) {
@@ -498,9 +548,16 @@ pub fn render_settings_screen(frame: &mut Frame, screen: &SettingsScreen, area: 
             let mut lines = vec![entry.description.to_string(), String::new()];
 
             let all_styles = builtin_styles();
-            let current_style_name = if screen.output_style.is_empty() { "default" } else { &screen.output_style };
+            let current_style_name = if screen.output_style.is_empty() {
+                "default"
+            } else {
+                &screen.output_style
+            };
             if let Some(current_style) = find_style(&all_styles, current_style_name) {
-                lines.push(format!("Current: {} — {}", current_style.label, current_style.description));
+                lines.push(format!(
+                    "Current: {} — {}",
+                    current_style.label, current_style.description
+                ));
                 lines.push(String::new());
             }
 
@@ -524,18 +581,43 @@ pub fn render_settings_screen(frame: &mut Frame, screen: &SettingsScreen, area: 
     // Footer
     let footer = if screen.edit_field.is_some() {
         Line::from(vec![
-            Span::styled(" Enter ", Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                " Enter ",
+                Style::default()
+                    .fg(CLAURST_ACCENT)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::raw("save  "),
-            Span::styled(" Esc ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                " Esc ",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::raw("cancel"),
         ])
     } else {
         Line::from(vec![
-            Span::styled(" ↑↓ ", Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                " ↑↓ ",
+                Style::default()
+                    .fg(CLAURST_ACCENT)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::raw("navigate  "),
-            Span::styled(" Enter ", Style::default().fg(CLAURST_ACCENT).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                " Enter ",
+                Style::default()
+                    .fg(CLAURST_ACCENT)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::raw("toggle/edit  "),
-            Span::styled(" Esc ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                " Esc ",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::raw("close"),
         ])
     };
@@ -551,11 +633,16 @@ fn render_settings_list(frame: &mut Frame, screen: &SettingsScreen, area: Rect) 
     // Filter entries by search query
     let filtered: Vec<_> = all
         .iter()
-        .filter(|e| e.label.to_lowercase().contains(&screen.search_query.to_lowercase()))
+        .filter(|e| {
+            e.label
+                .to_lowercase()
+                .contains(&screen.search_query.to_lowercase())
+        })
         .collect();
 
     if filtered.is_empty() {
-        let para = Paragraph::new("No settings match your search.").style(Style::default().fg(Color::DarkGray));
+        let para = Paragraph::new("No settings match your search.")
+            .style(Style::default().fg(Color::DarkGray));
         frame.render_widget(para, area);
         return;
     }
@@ -572,7 +659,7 @@ fn render_settings_list(frame: &mut Frame, screen: &SettingsScreen, area: Rect) 
 
         // Show edit value if currently editing this field, otherwise show the entry value
         let value_str = if screen.edit_field.as_deref() == Some(entry.key) && is_selected {
-            format!("{}_ ", screen.edit_value)  // Add cursor indicator
+            format!("{}_ ", screen.edit_value) // Add cursor indicator
         } else {
             entry.value.clone()
         };
@@ -669,7 +756,11 @@ pub fn handle_settings_key(
             let all = all_entries(screen);
             let filtered: Vec<_> = all
                 .iter()
-                .filter(|e| e.label.to_lowercase().contains(&screen.search_query.to_lowercase()))
+                .filter(|e| {
+                    e.label
+                        .to_lowercase()
+                        .contains(&screen.search_query.to_lowercase())
+                })
                 .collect();
             screen.select_next(filtered.len());
             update_scroll_offset_for_selection(screen);
@@ -695,7 +786,11 @@ fn toggle_or_cycle_current(screen: &mut SettingsScreen) {
     let all = all_entries(screen);
     let filtered: Vec<_> = all
         .iter()
-        .filter(|e| e.label.to_lowercase().contains(&screen.search_query.to_lowercase()))
+        .filter(|e| {
+            e.label
+                .to_lowercase()
+                .contains(&screen.search_query.to_lowercase())
+        })
         .collect();
 
     if let Some(entry) = filtered.get(screen.selected_idx) {
@@ -762,7 +857,8 @@ fn toggle_or_cycle_current(screen: &mut SettingsScreen) {
                     }
                     "auto_commits" => {
                         screen.auto_commits = new_value;
-                        screen.settings_snapshot.config.auto_commits = if new_value { Some(true) } else { None };
+                        screen.settings_snapshot.config.auto_commits =
+                            if new_value { Some(true) } else { None };
                         let _ = screen.settings_snapshot.save_sync();
                     }
                     "disable_claude_mds" => {
@@ -777,7 +873,10 @@ fn toggle_or_cycle_current(screen: &mut SettingsScreen) {
                     }
                     "fileAutocompleteShowHiddenFiles" => {
                         screen.file_autocomplete_show_hidden_files = new_value;
-                        screen.settings_snapshot.config.file_autocomplete_show_hidden_files = new_value;
+                        screen
+                            .settings_snapshot
+                            .config
+                            .file_autocomplete_show_hidden_files = new_value;
                         let _ = screen.settings_snapshot.save_sync();
                     }
                     _ => {}
@@ -836,8 +935,16 @@ mod tests {
         let screen = SettingsScreen::new();
         let entries = all_entries(&screen);
         // Base settings are always present, plus 0-3 conditional file injection settings
-        assert!(entries.len() >= 16, "Should have at least 16 editable settings, got {}", entries.len());
-        assert!(entries.len() <= 20, "Should have at most 20 editable settings, got {}", entries.len());
+        assert!(
+            entries.len() >= 16,
+            "Should have at least 16 editable settings, got {}",
+            entries.len()
+        );
+        assert!(
+            entries.len() <= 22,
+            "Should have at most 22 editable settings, got {}",
+            entries.len()
+        );
     }
 
     #[test]
@@ -848,7 +955,11 @@ mod tests {
             .iter()
             .filter(|e| e.label.to_lowercase().contains("token"))
             .collect();
-        assert_eq!(filtered.len(), 1, "Should find exactly 1 entry matching 'token'");
+        assert_eq!(
+            filtered.len(),
+            1,
+            "Should find exactly 1 entry matching 'token'"
+        );
         assert_eq!(filtered[0].label, "Max Tokens");
     }
 


### PR DESCRIPTION
## Summary

Fixes the `hide_tool_content` setting so that tool commands (`$ command`, `<> file paths`) are always shown, but tool result content is hidden with a "Result hidden" placeholder.

## Changes

- `render_tool_use_inner()` in `messages/mod.rs`: Removed `!hide_content` guard from bash `$ command` block so the command always renders
- Added `render_tool_result_hidden()` function returning a dim "Result hidden" placeholder
- Applied `hide_tool_content` guard to all four `ContentBlock::ToolResult` rendering paths
- Updated test `test_render_tool_use_hide_content` and added test `test_render_tool_result_hidden`

## Testing

- `cargo check --workspace` clean
- `cargo fmt --all` clean
- `cargo test --package claurst-tui` — all 5 tool rendering tests pass
