### PR TITLE
feat: add todo confidence indicators

### DIFF
--- a/src-rust/crates/tools/src/todo_write.rs
+++ b/src-rust/crates/tools/src/todo_write.rs
@@ -139,6 +139,33 @@ struct TodoItem {
     #[serde(default)]
     #[allow(dead_code)]
     priority: Option<String>,
+    /// Optional 0-100 estimate of the evidence that this task can be
+    /// completed correctly.
+    #[serde(default, deserialize_with = "deserialize_confidence")]
+    confidence: Option<u8>,
+    /// Optional 0-100 estimate recorded when a task is completed.
+    #[serde(default, deserialize_with = "deserialize_confidence")]
+    completion_confidence: Option<u8>,
+}
+
+fn deserialize_confidence<'de, D>(deserializer: D) -> Result<Option<u8>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Value::deserialize(deserializer)?;
+    let score = match value {
+        Value::Null => return Ok(None),
+        Value::Number(number) => number.as_f64(),
+        Value::String(raw) if raw.trim().is_empty() => return Ok(None),
+        Value::String(raw) => raw.trim().parse::<f64>().ok(),
+        _ => None,
+    };
+    let score = score
+        .filter(|score| {
+            score.is_finite() && score.fract() == 0.0 && (0.0..=100.0).contains(score)
+        })
+        .ok_or_else(|| serde::de::Error::custom("confidence must be an integer from 0 to 100"))?;
+    Ok(Some(score as u8))
 }
 
 // ---------------------------------------------------------------------------
@@ -189,7 +216,8 @@ impl Tool for TodoWriteTool {
     fn description(&self) -> &str {
         "Write and manage a todo/task list. Provide the complete list of todos \
          each time (this replaces the entire list). Use this to track progress \
-         on multi-step tasks."
+         on multi-step tasks. Each item may include a confidence percentage from \
+         0 to 100, plus a completion_confidence percentage when completed."
     }
 
     fn permission_level(&self) -> PermissionLevel {
@@ -211,7 +239,19 @@ impl Tool for TodoWriteTool {
                                 "type": "string",
                                 "enum": ["pending", "in_progress", "completed"]
                             },
-                            "priority": { "type": "string" }
+                            "priority": { "type": "string" },
+                            "confidence": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 100,
+                                "description": "Optional confidence percentage that this task can be completed correctly."
+                            },
+                            "completion_confidence": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 100,
+                                "description": "Optional confidence percentage recorded when this task is completed."
+                            }
                         },
                         "required": ["id", "content", "status"]
                     },
@@ -310,6 +350,12 @@ impl Tool for TodoWriteTool {
                 TodoStatus::Completed => "[x]",
             };
             output.push_str(&format!("{} {} ({})\n", icon, item.content, item.id));
+            if let Some(confidence) = item.confidence {
+                output.push_str(&format!("    confidence: {}%\n", confidence));
+            }
+            if let Some(confidence) = item.completion_confidence {
+                output.push_str(&format!("    completion confidence: {}%\n", confidence));
+            }
         }
 
         // --- 6. Persist to disk ----------------------------------------------
@@ -324,6 +370,12 @@ impl Tool for TodoWriteTool {
                 });
                 if let Some(ref p) = t.priority {
                     obj["priority"] = json!(p);
+                }
+                if let Some(confidence) = t.confidence {
+                    obj["confidence"] = json!(confidence);
+                }
+                if let Some(confidence) = t.completion_confidence {
+                    obj["completion_confidence"] = json!(confidence);
                 }
                 obj
             })
@@ -427,6 +479,46 @@ mod tests {
         // tempdir cleans up automatically.
     }
 
+    #[test]
+    fn test_confidence_accepts_integer_and_numeric_string() {
+        let input: TodoWriteInput = serde_json::from_value(json!({
+            "todos": [
+                {
+                    "id": "1",
+                    "content": "Task one",
+                    "status": "pending",
+                    "confidence": 80
+                },
+                {
+                    "id": "2",
+                    "content": "Task two",
+                    "status": "completed",
+                    "confidence": "70",
+                    "completion_confidence": 95.0
+                }
+            ]
+        }))
+        .expect("valid confidence values should parse");
+
+        assert_eq!(input.todos[0].confidence, Some(80));
+        assert_eq!(input.todos[1].confidence, Some(70));
+        assert_eq!(input.todos[1].completion_confidence, Some(95));
+    }
+
+    #[test]
+    fn test_confidence_rejects_values_outside_percentage_range() {
+        let result = serde_json::from_value::<TodoWriteInput>(json!({
+            "todos": [{
+                "id": "1",
+                "content": "Task",
+                "status": "pending",
+                "confidence": 101
+            }]
+        }));
+
+        assert!(result.is_err());
+    }
+
     // --- Status parsing ------------------------------------------------------
 
     #[test]
@@ -479,5 +571,70 @@ mod tests {
         let err = TodoStatus::from_str_ci("banana").unwrap_err();
         assert!(err.contains("Invalid status"), "error should mention invalid status");
         assert!(err.contains("banana"), "error should echo the bad value");
+    }
+
+    #[tokio::test]
+    async fn test_confidence_displayed_in_output() {
+        use crate::test_support::allow_all_context;
+        use claurst_core::config::Settings;
+        use std::sync::Mutex;
+
+        static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+        let session_id = format!(
+            "test-session-conf-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        );
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        // Set env vars inside the lock, then drop the guard before awaiting.
+        {
+            let _guard = ENV_LOCK.lock().unwrap();
+            std::env::set_var("CLAURST_HOME", temp.path());
+        }
+        let home = Settings::config_dir();
+        std::fs::create_dir_all(home.join("todos")).unwrap();
+
+        let mut ctx = allow_all_context(temp.path().to_path_buf());
+        ctx.session_id = session_id;
+
+        let tool = TodoWriteTool;
+        let input = json!({
+            "todos": [
+                {
+                    "id": "1",
+                    "content": "Write tests",
+                    "status": "in_progress",
+                    "confidence": 80,
+                },
+                {
+                    "id": "2",
+                    "content": "Review PR",
+                    "status": "completed",
+                    "confidence": 70,
+                    "completion_confidence": 95,
+                },
+            ],
+        });
+
+        let result = tool.execute(input, &ctx).await;
+        let output = result.content;
+
+        assert!(
+            output.contains("confidence: 80%"),
+            "output should include confidence: {output}"
+        );
+        assert!(
+            output.contains("completion confidence: 95%"),
+            "output should include completion confidence: {output}"
+        );
+
+        {
+            let _guard = ENV_LOCK.lock().unwrap();
+            std::env::remove_var("CLAURST_HOME");
+        }
     }
 }

--- a/src-rust/crates/tui/src/render.rs
+++ b/src-rust/crates/tui/src/render.rs
@@ -2085,6 +2085,62 @@ fn render_tool_block_lines(lines: &mut Vec<Line<'static>>, block: &crate::app::T
     }
 }
 
+/// Extract the confidence score used by the TodoWrite checklist.
+fn todo_confidence(todo: &serde_json::Value) -> Option<u8> {
+    let value = if todo.get("status").and_then(|status| status.as_str()) == Some("completed") {
+        todo.get("completion_confidence")
+            .filter(|value| !value.is_null())
+            .or_else(|| todo.get("confidence"))
+    } else {
+        todo.get("confidence")
+    }?;
+
+    match value {
+        serde_json::Value::Number(number) => number
+            .as_f64()
+            .filter(|score| score.is_finite() && score.fract() == 0.0)
+            .filter(|score| (0.0..=100.0).contains(score))
+            .map(|score| score as u8),
+        serde_json::Value::String(raw) => raw
+            .trim()
+            .parse::<f64>()
+            .ok()
+            .filter(|score| score.is_finite() && score.fract() == 0.0)
+            .filter(|score| (0.0..=100.0).contains(score))
+            .map(|score| score as u8),
+        _ => None,
+    }
+}
+
+fn aggregate_todo_confidence(todos: &[serde_json::Value]) -> Option<u8> {
+    let mut weighted_sum = 0u32;
+    let mut total_weight = 0u32;
+    for todo in todos {
+        let Some(score) = todo_confidence(todo) else {
+            continue;
+        };
+        let weight = match todo.get("priority").and_then(|priority| priority.as_str()) {
+            Some("high") => 3,
+            Some("medium") => 2,
+            _ => 1,
+        };
+        weighted_sum += u32::from(score) * weight;
+        total_weight += weight;
+    }
+    if total_weight == 0 {
+        return None;
+    }
+    Some(((weighted_sum + total_weight / 2) / total_weight) as u8)
+}
+
+fn confidence_color(score: u8) -> Color {
+    match score {
+        80..=100 => Color::Rgb(120, 200, 120),
+        50..=79 => Color::Rgb(220, 190, 100),
+        _ => Color::Rgb(220, 120, 100),
+    }
+}
+
 /// Render a TodoWrite call as a checklist. Returns `false` (so the caller can
 /// fall back to the generic block) when the input carries no `todos` array.
 fn render_todo_block(
@@ -2121,6 +2177,12 @@ fn render_todo_block(
             format!("  {}/{} done", done, total),
             Style::default().fg(Color::DarkGray),
         ));
+        if let Some(confidence) = aggregate_todo_confidence(todos) {
+            header.push(Span::styled(
+                format!(" · confidence {}%", confidence),
+                Style::default().fg(confidence_color(confidence)),
+            ));
+        }
     }
     lines.push(Line::from(header));
 
@@ -2154,9 +2216,19 @@ fn render_todo_block(
                 Style::default().fg(Color::Rgb(170, 170, 170)),
             ),
         };
+        let confidence = todo_confidence(t);
         lines.push(Line::from(vec![
             Span::styled(format!("     {} ", glyph), Style::default().fg(glyph_color)),
             Span::styled(content.to_string(), text_style),
+            Span::styled(
+                confidence
+                    .map(|score| format!(" [{}%]", score))
+                    .unwrap_or_default(),
+                confidence
+                    .map(confidence_color)
+                    .map(|color| Style::default().fg(color))
+                    .unwrap_or_default(),
+            ),
         ]));
     }
     if total > MAX_ITEMS {
@@ -3481,9 +3553,9 @@ mod tool_block_tests {
             "TodoWrite",
             ToolStatus::Done,
             r#"{"todos":[
-                {"content":"Locate files","status":"completed"},
-                {"content":"Build importer","status":"in_progress"},
-                {"content":"Wire adapter","status":"pending"}
+                {"content":"Locate files","status":"completed","completion_confidence":90},
+                {"content":"Build importer","status":"in_progress","confidence":70},
+                {"content":"Wire adapter","status":"pending","confidence":50}
             ]}"#,
             Some("Todo list updated (3 total)"),
         );
@@ -3492,10 +3564,11 @@ mod tool_block_tests {
         // Header shows count, not the raw "Todo list updated (...)".
         assert!(joined.contains("Todos"), "{joined:?}");
         assert!(joined.contains("1/3 done"), "{joined:?}");
+        assert!(joined.contains("confidence 70%"), "{joined:?}");
         // Each status has its ASCII checkbox + content.
-        assert!(joined.contains("[x] Locate files"), "done marker: {joined:?}");
-        assert!(joined.contains("[>] Build importer"), "in-progress marker: {joined:?}");
-        assert!(joined.contains("[ ] Wire adapter"), "pending marker: {joined:?}");
+        assert!(joined.contains("[x] Locate files [90%]"), "done marker: {joined:?}");
+        assert!(joined.contains("[>] Build importer [70%]"), "in-progress marker: {joined:?}");
+        assert!(joined.contains("[ ] Wire adapter [50%]"), "pending marker: {joined:?}");
         // The raw result-preview string must NOT leak into the checklist view.
         assert!(!joined.contains("Todo list updated"), "preview suppressed: {joined:?}");
     }
@@ -3519,6 +3592,72 @@ mod tool_block_tests {
         terminal
             .draw(|frame| render_legacy_history_search(frame, &hs, &app, frame.area()))
             .unwrap();
+    }
+
+    #[test]
+    fn confidence_color_boundaries() {
+        assert_eq!(confidence_color(0), Color::Rgb(220, 120, 100));
+        assert_eq!(confidence_color(49), Color::Rgb(220, 120, 100));
+        assert_eq!(confidence_color(50), Color::Rgb(220, 190, 100));
+        assert_eq!(confidence_color(79), Color::Rgb(220, 190, 100));
+        assert_eq!(confidence_color(80), Color::Rgb(120, 200, 120));
+        assert_eq!(confidence_color(100), Color::Rgb(120, 200, 120));
+    }
+
+    #[test]
+    fn aggregate_todo_confidence_empty() {
+        assert!(aggregate_todo_confidence(&[]).is_none());
+    }
+
+    #[test]
+    fn aggregate_todo_confidence_all_none() {
+        let todos = serde_json::json!([
+            {"content": "A", "status": "pending"},
+            {"content": "B", "status": "completed"},
+        ]);
+        assert!(aggregate_todo_confidence(todos.as_array().unwrap()).is_none());
+    }
+
+    #[test]
+    fn aggregate_todo_confidence_weighted() {
+        let todos = serde_json::json!([
+            {"content": "High", "status": "in_progress", "confidence": 60, "priority": "high"},
+            {"content": "Low", "status": "pending", "confidence": 80, "priority": "low"},
+        ]);
+        let score = aggregate_todo_confidence(todos.as_array().unwrap()).unwrap();
+        // (60*3 + 80*1) / (3+1) = 260/4 = 65
+        assert_eq!(score, 65);
+    }
+
+    #[test]
+    fn todo_confidence_completed_uses_completion_confidence() {
+        let todo = serde_json::json!({
+            "status": "completed",
+            "confidence": 50,
+            "completion_confidence": 90,
+        });
+        assert_eq!(todo_confidence(&todo), Some(90));
+    }
+
+    #[test]
+    fn todo_confidence_pending_uses_confidence() {
+        let todo = serde_json::json!({
+            "status": "in_progress",
+            "confidence": 70,
+        });
+        assert_eq!(todo_confidence(&todo), Some(70));
+    }
+
+    #[test]
+    fn todo_confidence_string_parsing() {
+        let todo = serde_json::json!({"status": "pending", "confidence": "75"});
+        assert_eq!(todo_confidence(&todo), Some(75));
+    }
+
+    #[test]
+    fn todo_confidence_null_returns_none() {
+        let todo = serde_json::json!({"status": "pending", "confidence": null});
+        assert!(todo_confidence(&todo).is_none());
     }
 }
 


### PR DESCRIPTION
## Summary
- Add optional 0-100 confidence and completion-confidence values to TodoWrite items.
- Persist and display confidence percentages in the TodoWrite output and TUI checklist.
- Add weighted aggregate confidence with color-coded indicators and parsing tests.

## Test plan
- `cargo test -p claurst-tools --lib todo_write`
- `cargo test -p claurst-tui --lib todo_renders_checklist`
- `cargo check --workspace`

Clean branch from current main, no shared payload. 304 lines, 2 files.