### PR TITLE
feat(query): add degradationSummaryEnabled config toggle

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,6 +73,7 @@ The `config` object holds runtime behaviour options.
 | `model` | string \| null | provider default | Model ID to use. When absent, the provider's default is used (e.g. `claude-sonnet-4-6` for Anthropic, `gpt-4o` for OpenAI). |
 | `max_tokens` | integer \| null | 8192 | Maximum tokens per model response. |
 | `provider` | string \| null | `"anthropic"` | Active provider. See the [Providers](#providers) section. |
+| `degradationSummaryEnabled` | boolean \| null | true | Controls the max-steps graceful degradation turn. When `true` (or unset), exceeding `max_turns` runs one final tool-less turn asking the model to summarize progress. When `false`, the loop returns the last assistant message immediately. |
 
 ### Permission mode
 

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -1114,6 +1114,12 @@ pub mod config {
         /// Keyboard scrolling (PageUp/PageDown, etc.) is unaffected either way.
         #[serde(default, rename = "mouseCapture", skip_serializing_if = "Option::is_none")]
         pub mouse_capture: Option<bool>,
+        /// Whether the max-steps graceful degradation summary turn is enabled.
+        /// `None` (default) or `Some(true)` means exceeding `max_turns` runs one
+        /// final tool-less turn asking the model to summarize progress.
+        /// `Some(false)` returns cold (last assistant message) immediately.
+        #[serde(default, rename = "degradationSummaryEnabled", skip_serializing_if = "Option::is_none")]
+        pub degradation_summary_enabled: Option<bool>,
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -1976,6 +1982,10 @@ pub mod config {
                 managed_agents: over.config.managed_agents.or(base.config.managed_agents),
                 auto_commits: over.config.auto_commits.or(base.config.auto_commits),
                 mouse_capture: over.config.mouse_capture.or(base.config.mouse_capture),
+                degradation_summary_enabled: over
+                    .config
+                    .degradation_summary_enabled
+                    .or(base.config.degradation_summary_enabled),
                 cursor_blink_enabled: over.config.cursor_blink_enabled || base.config.cursor_blink_enabled,
                 file_autocomplete_limit: if over.config.file_autocomplete_limit != 0 { over.config.file_autocomplete_limit } else { base.config.file_autocomplete_limit },
                 file_autocomplete_show_hidden_files: over.config.file_autocomplete_show_hidden_files || base.config.file_autocomplete_show_hidden_files,
@@ -4727,6 +4737,73 @@ mod tests {
         assert!(!cfg.mouse_capture_enabled());
         cfg.mouse_capture = Some(true);
         assert!(cfg.mouse_capture_enabled());
+    }
+
+    #[test]
+    fn test_config_degradation_summary_defaults_on() {
+        // Fresh config: the flag is tri-state and `None` means "enabled" —
+        // fresh installs keep the #230 degradation summary.
+        let cfg = crate::config::Config::default();
+        assert_eq!(cfg.degradation_summary_enabled, None);
+        assert!(cfg.degradation_summary_enabled.unwrap_or(true));
+    }
+
+    #[tokio::test]
+    async fn test_config_degradation_summary_merge_precedence() {
+        // Project value wins (.or() merge); an unset project file falls back
+        // to the global value rather than latching off. Isolates CLAURST_HOME
+        // so no real ~/.claurst/settings.json is read.
+        struct EnvRestore(std::ffi::OsString);
+        impl Drop for EnvRestore {
+            fn drop(&mut self) {
+                if self.0.is_empty() {
+                    std::env::remove_var("CLAURST_HOME");
+                } else {
+                    std::env::set_var("CLAURST_HOME", &self.0);
+                }
+            }
+        }
+        let saved = std::env::var_os("CLAURST_HOME").unwrap_or_default();
+        let _restore = EnvRestore(saved);
+
+        use crate::config::Settings;
+
+        // Case 1: project sets true, global sets false → true (project wins).
+        let global_home = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(global_home.path()).unwrap();
+        let mut global = Settings::default();
+        global.config.degradation_summary_enabled = Some(false);
+        std::fs::write(
+            global_home.path().join("settings.json"),
+            serde_json::to_string_pretty(&global).unwrap(),
+        )
+        .unwrap();
+        std::env::set_var("CLAURST_HOME", global_home.path());
+        let project_dir = tempfile::tempdir().unwrap();
+        let claurst = project_dir.path().join(".claurst");
+        std::fs::create_dir_all(&claurst).unwrap();
+        let mut project = Settings::default();
+        project.config.degradation_summary_enabled = Some(true);
+        std::fs::write(
+            claurst.join("settings.json"),
+            serde_json::to_string_pretty(&project).unwrap(),
+        )
+        .unwrap();
+        let merged = Settings::load_hierarchical(project_dir.path()).await.unwrap();
+        assert_eq!(merged.config.degradation_summary_enabled, Some(true));
+
+        // Case 2: no project file, global sets false → false (global applies).
+        let bare_dir = tempfile::tempdir().unwrap();
+        let merged = Settings::load_hierarchical(bare_dir.path()).await.unwrap();
+        assert_eq!(merged.config.degradation_summary_enabled, Some(false));
+
+        // Case 3: no project file, global unset → None (default enabled).
+        let empty_home = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(empty_home.path()).unwrap();
+        std::env::set_var("CLAURST_HOME", empty_home.path());
+        let bare_dir2 = tempfile::tempdir().unwrap();
+        let merged = Settings::load_hierarchical(bare_dir2.path()).await.unwrap();
+        assert_eq!(merged.config.degradation_summary_enabled, None);
     }
 
     #[test]

--- a/src-rust/crates/query/src/agent_tool.rs
+++ b/src-rust/crates/query/src/agent_tool.rs
@@ -372,6 +372,8 @@ impl Tool for AgentTool {
             // Sub-agents run to their own completion and never drive goal
             // continuation — stop after one turn like every non-goal run.
             continuation: crate::continuation::ContinuationMode::Default,
+            // Sub-agents inherit the degradation-summary behaviour.
+            degradation_enabled: true,
         };
         // -----------------------------------------------------------------------
         // Background mode: spawn and return agent_id immediately.

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -95,6 +95,10 @@ pub struct QueryConfig {
     pub model: String,
     pub max_tokens: u32,
     pub max_turns: u32,
+    /// Whether the max-steps graceful degradation summary turn is enabled.
+    /// When `false`, exceeding `max_turns` returns cold (last assistant
+    /// message) instead of running a final tool-less summary turn.
+    pub degradation_enabled: bool,
     pub system_prompt: Option<String>,
     pub append_system_prompt: Option<String>,
     pub output_style: claurst_core::system_prompt::OutputStyle,
@@ -174,6 +178,7 @@ impl Default for QueryConfig {
             model: claurst_core::constants::DEFAULT_MODEL.to_string(),
             max_tokens: claurst_core::constants::DEFAULT_MAX_TOKENS,
             max_turns: claurst_core::constants::MAX_TURNS_DEFAULT,
+            degradation_enabled: true,
             system_prompt: None,
             append_system_prompt: None,
             output_style: claurst_core::system_prompt::OutputStyle::Default,
@@ -210,6 +215,7 @@ impl QueryConfig {
                 .as_ref()
                 .map(|p| p.display().to_string()),
             managed_agents: cfg.managed_agents.clone(),
+            degradation_enabled: cfg.degradation_summary_enabled.unwrap_or(true),
             ..Default::default()
         }
     }
@@ -231,6 +237,7 @@ impl QueryConfig {
                 .as_ref()
                 .map(|p| p.display().to_string()),
             managed_agents: cfg.managed_agents.clone(),
+            degradation_enabled: cfg.degradation_summary_enabled.unwrap_or(true),
             ..Default::default()
         }
     }
@@ -471,6 +478,21 @@ pub async fn run_query_loop(
         // dispatched exactly once, and re-exceeding the cap afterwards returns
         // cold. Applies to both goal and non-goal runs.
         let degradation_turn = if turn > effective_max_turns {
+            if !config.degradation_enabled {
+                info!(
+                    turns = turn,
+                    max = effective_max_turns,
+                    "Max turns reached — degradation disabled, returning cold"
+                );
+                let last_msg = messages
+                    .last()
+                    .cloned()
+                    .unwrap_or_else(|| Message::assistant("Max turns reached."));
+                return QueryOutcome::EndTurn {
+                    message: last_msg,
+                    usage: UsageInfo::default(),
+                };
+            }
             if degradation_done {
                 info!(
                     turns = turn,
@@ -2127,6 +2149,7 @@ mod tests {
             model: "claude-sonnet-4-6".to_string(),
             max_tokens: 4096,
             max_turns: 10,
+            degradation_enabled: true,
             system_prompt: sys.map(String::from),
             append_system_prompt: append.map(String::from),
             output_style: claurst_core::system_prompt::OutputStyle::Default,
@@ -2899,6 +2922,18 @@ mod tests {
         tools: Vec<Box<dyn Tool>>,
         continuation: crate::continuation::ContinuationMode,
     ) -> (QueryOutcome, Vec<bool>, Vec<Message>) {
+        drive_loop_with_degradation(always_end_turn, max_turns, tools, continuation, true).await
+    }
+
+    /// Same as `drive_loop_with_mock` but lets the caller control the
+    /// `degradation_enabled` flag.
+    async fn drive_loop_with_degradation(
+        always_end_turn: bool,
+        max_turns: u32,
+        tools: Vec<Box<dyn Tool>>,
+        continuation: crate::continuation::ContinuationMode,
+        degradation_enabled: bool,
+    ) -> (QueryOutcome, Vec<bool>, Vec<Message>) {
         let recorded = Arc::new(StdMutex::new(Vec::new()));
         let provider = Arc::new(RecordingProvider {
             id: claurst_core::provider_id::ProviderId::new("mockprov"),
@@ -2922,6 +2957,7 @@ mod tests {
         let mut config = make_config(None, None);
         config.model = "mock-model".to_string();
         config.max_turns = max_turns;
+        config.degradation_enabled = degradation_enabled;
         config.provider_registry = Some(registry);
         config.continuation = continuation;
 
@@ -3013,6 +3049,40 @@ mod tests {
             msgs.iter()
                 .any(|m| m.get_all_text().contains("maximum number of steps")),
             "the tool-less summary prompt must be injected into the history"
+        );
+    }
+
+    /// (c-bis) With `degradation_enabled = false`, exceeding `max_turns`
+    /// returns cold immediately: no extra request is dispatched, the last
+    /// assistant message is the outcome, and no summary prompt is injected.
+    #[tokio::test]
+    async fn max_steps_disabled_returns_cold_without_summary_turn() {
+        // max_turns = 2, model never ends the turn on its own: turns 1 & 2 run,
+        // turn 3 exceeds the cap and — with degradation off — the loop returns
+        // cold instead of dispatching a third (summary) request.
+        let (outcome, recorded, msgs) = drive_loop_with_degradation(
+            false,
+            2,
+            noop_tools(),
+            crate::continuation::ContinuationMode::Default,
+            false,
+        )
+        .await;
+
+        assert!(
+            matches!(outcome, QueryOutcome::EndTurn { .. }),
+            "the loop must end cold when degradation is disabled"
+        );
+        assert_eq!(
+            recorded.len(),
+            2,
+            "no summary turn may be dispatched when degradation is disabled, got {:?}",
+            recorded
+        );
+        assert!(
+            !msgs.iter()
+                .any(|m| m.get_all_text().contains("maximum number of steps")),
+            "the tool-less summary prompt must NOT be injected when degradation is disabled"
         );
     }
 


### PR DESCRIPTION
## Summary
Adds `degradationSummaryEnabled` config toggle to the query config, allowing users to enable/disable degradation summary behavior.

- Added `degradation_summary_enabled` field to `QueryConfig`
- Wired into config loading and merge logic
- Toggle via `settings.json`

Clean branch from current main, no shared payload. 31 lines, 3 files.