### PR TITLE
fix(core,tui): support directory-based skills, tilde paths, and dynamic tui autocomplete

### DIFF
--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -12,8 +12,8 @@
 // parameters; grouping them into structs is a larger refactor out of scope here.
 #![allow(clippy::too_many_arguments)]
 
-mod oauth_flow;
 mod codex_oauth_flow;
+mod oauth_flow;
 mod upgrade;
 
 // ---------------------------------------------------------------------------
@@ -36,6 +36,9 @@ pub const FEEDBACK_CHANNEL: &str = env!("FEEDBACK_CHANNEL");
 pub const ISSUES_EXPLAINER: &str = env!("ISSUES_EXPLAINER");
 
 use anyhow::Context;
+use async_trait::async_trait;
+use clap::{ArgAction, Parser, ValueEnum};
+use claurst_core::types::ToolDefinition;
 use claurst_core::{
     config::{Config, PermissionMode, Settings},
     constants::APP_VERSION,
@@ -43,10 +46,7 @@ use claurst_core::{
     cost::CostTracker,
     permissions::{AutoPermissionHandler, InteractivePermissionHandler, PermissionManager},
 };
-use async_trait::async_trait;
-use claurst_core::types::ToolDefinition;
 use claurst_tools::{PermissionLevel, Tool, ToolContext, ToolResult};
-use clap::{ArgAction, Parser, ValueEnum};
 use parking_lot::Mutex as ParkingMutex;
 use std::{path::PathBuf, sync::Arc};
 use tracing::{debug, info, warn};
@@ -351,8 +351,15 @@ fn resolve_bridge_config(
     bridge_config.is_active().then_some(bridge_config)
 }
 
-fn handle_exit_key(app: &mut claurst_tui::app::App, key: crossterm::event::KeyEvent, cancel: &Option<tokio_util::sync::CancellationToken>) -> bool {
-    if !key.modifiers.contains(crossterm::event::KeyModifiers::CONTROL) {
+fn handle_exit_key(
+    app: &mut claurst_tui::app::App,
+    key: crossterm::event::KeyEvent,
+    cancel: &Option<tokio_util::sync::CancellationToken>,
+) -> bool {
+    if !key
+        .modifiers
+        .contains(crossterm::event::KeyModifiers::CONTROL)
+    {
         return false;
     }
 
@@ -422,7 +429,8 @@ async fn main() -> anyhow::Result<()> {
     if let Some(cmd_name) = raw_args.get(1).map(|s| s.as_str()) {
         // Only intercept if it looks like a subcommand (no leading `-` or `/`)
         if !cmd_name.starts_with('-') && !cmd_name.starts_with('/') {
-            if let Some(named_cmd) = claurst_commands::named_commands::find_named_command(cmd_name) {
+            if let Some(named_cmd) = claurst_commands::named_commands::find_named_command(cmd_name)
+            {
                 // Build a minimal CommandContext (named commands are pre-session)
                 let settings = Settings::load().await.unwrap_or_default();
                 let config = settings.effective_config();
@@ -465,12 +473,20 @@ async fn main() -> anyhow::Result<()> {
 
     // Setup logging
     let log_level = if cli.verbose { "debug" } else { "warn" };
-    let base_filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::new(log_level));
+    let base_filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(log_level));
     let log_filter = base_filter
-        .add_directive("rmcp::service::client=error".parse().expect("valid rmcp directive"))
+        .add_directive(
+            "rmcp::service::client=error"
+                .parse()
+                .expect("valid rmcp directive"),
+        )
         // Suppress error/warn logs from providers and query — errors are already shown as error modals
-        .add_directive("claurst_api::providers::free=off".parse().expect("valid directive"))
+        .add_directive(
+            "claurst_api::providers::free=off"
+                .parse()
+                .expect("valid directive"),
+        )
         .add_directive("claurst_query=off".parse().expect("valid directive"));
     tracing_subscriber::fmt()
         .with_env_filter(log_filter)
@@ -563,7 +579,10 @@ async fn main() -> anyhow::Result<()> {
     }
     if let Some(base) = &cli.api_base {
         // Store in the provider's config entry
-        let provider_id = config.provider.clone().unwrap_or_else(|| "anthropic".to_string());
+        let provider_id = config
+            .provider
+            .clone()
+            .unwrap_or_else(|| "anthropic".to_string());
         config
             .provider_configs
             .entry(provider_id)
@@ -573,8 +592,7 @@ async fn main() -> anyhow::Result<()> {
 
     // --dump-system-prompt fast path
     if cli.dump_system_prompt {
-        let ctx = ContextBuilder::new(cwd.clone())
-            .disable_claude_mds(config.disable_claude_mds);
+        let ctx = ContextBuilder::new(cwd.clone()).disable_claude_mds(config.disable_claude_mds);
         let sys = ctx.build_system_context().await;
         let user = ctx.build_user_context().await;
         println!("{}\n\n{}", sys, user);
@@ -582,8 +600,8 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // Build context
-    let ctx_builder = ContextBuilder::new(cwd.clone())
-        .disable_claude_mds(config.disable_claude_mds);
+    let ctx_builder =
+        ContextBuilder::new(cwd.clone()).disable_claude_mds(config.disable_claude_mds);
     let system_ctx = ctx_builder.build_system_context().await;
     let user_ctx = ctx_builder.build_user_context().await;
 
@@ -668,9 +686,13 @@ async fn main() -> anyhow::Result<()> {
     )));
 
     let permission_handler: Arc<dyn claurst_core::PermissionHandler> = if is_headless {
-        Arc::new(AutoPermissionHandler::with_manager(permission_manager.clone()))
+        Arc::new(AutoPermissionHandler::with_manager(
+            permission_manager.clone(),
+        ))
     } else {
-        Arc::new(InteractivePermissionHandler::with_manager(permission_manager.clone()))
+        Arc::new(InteractivePermissionHandler::with_manager(
+            permission_manager.clone(),
+        ))
     };
     let cost_tracker = CostTracker::new();
     // Use --session-id if provided, otherwise generate a fresh UUID.
@@ -704,7 +726,10 @@ async fn main() -> anyhow::Result<()> {
     };
     let pending_project_mcp = mcp_decision.pending.clone();
     if !pending_project_mcp.is_empty() {
-        let names: Vec<&str> = pending_project_mcp.iter().map(|s| s.name.as_str()).collect();
+        let names: Vec<&str> = pending_project_mcp
+            .iter()
+            .map(|s| s.name.as_str())
+            .collect();
         if is_headless {
             warn!(
                 servers = ?names,
@@ -721,7 +746,9 @@ async fn main() -> anyhow::Result<()> {
     }
     let mcp_manager_arc = connect_mcp_manager_arc(&mcp_decision.allowed).await;
 
-    let pending_permissions = Arc::new(ParkingMutex::new(claurst_tools::PendingPermissionStore::default()));
+    let pending_permissions = Arc::new(ParkingMutex::new(
+        claurst_tools::PendingPermissionStore::default(),
+    ));
 
     let is_non_interactive = cli.print || cli.prompt.is_some();
 
@@ -729,7 +756,11 @@ async fn main() -> anyhow::Result<()> {
     // Only created in interactive mode; None in headless/print mode.
     let (user_question_tx, user_question_rx) =
         tokio::sync::mpsc::unbounded_channel::<claurst_tools::UserQuestionEvent>();
-    let user_question_rx = if is_non_interactive { None } else { Some(user_question_rx) };
+    let user_question_rx = if is_non_interactive {
+        None
+    } else {
+        Some(user_question_rx)
+    };
 
     let tool_ctx = ToolContext {
         working_dir: cwd.clone(),
@@ -746,7 +777,11 @@ async fn main() -> anyhow::Result<()> {
         completion_notifier: None,
         pending_permissions: Some(pending_permissions.clone()),
         permission_manager: Some(permission_manager.clone()),
-        user_question_tx: if is_non_interactive { None } else { Some(user_question_tx) },
+        user_question_tx: if is_non_interactive {
+            None
+        } else {
+            Some(user_question_tx)
+        },
         // Placeholder token; `run_query_loop` rebinds it to the loop's actual
         // cancel token so the parallel tool executor honours Ctrl-C (issue #218).
         cancel_token: tokio_util::sync::CancellationToken::new(),
@@ -806,11 +841,8 @@ async fn main() -> anyhow::Result<()> {
 
         // Register plugin MCP servers into the in-memory config so they are
         // picked up by any subsequent MCP manager construction.
-        let existing_names: std::collections::HashSet<String> = config
-            .mcp_servers
-            .iter()
-            .map(|s| s.name.clone())
-            .collect();
+        let existing_names: std::collections::HashSet<String> =
+            config.mcp_servers.iter().map(|s| s.name.clone()).collect();
         for mcp_server in plugin_registry.all_mcp_servers() {
             if !existing_names.contains(&mcp_server.name) {
                 config.mcp_servers.push(mcp_server);
@@ -824,7 +856,8 @@ async fn main() -> anyhow::Result<()> {
     let model_registry = load_cached_model_registry(&config);
 
     // Build query config
-    let mut query_config = claurst_query::QueryConfig::from_config_with_registry(&config, &model_registry);
+    let mut query_config =
+        claurst_query::QueryConfig::from_config_with_registry(&config, &model_registry);
     query_config.model_registry = Some(model_registry.clone());
     query_config.max_turns = cli.max_turns;
     query_config.system_prompt = Some(system_prompt);
@@ -837,7 +870,10 @@ async fn main() -> anyhow::Result<()> {
         if let Some(level) = claurst_core::effort::EffortLevel::from_str(level_str) {
             query_config.effort_level = Some(level);
         } else {
-            eprintln!("Warning: unknown effort level '{}' — expected low/medium/high/max", level_str);
+            eprintln!(
+                "Warning: unknown effort level '{}' — expected low/medium/high/max",
+                level_str
+            );
         }
     }
     if let Some(usd) = cli.max_budget_usd {
@@ -865,7 +901,10 @@ async fn main() -> anyhow::Result<()> {
             }
             filter_tools_for_agent(tools, &access)
         } else {
-            eprintln!("Warning: unknown agent '{}'. Run /agent to see available agents.", agent_name);
+            eprintln!(
+                "Warning: unknown agent '{}'. Run /agent to see available agents.",
+                agent_name
+            );
             tools
         }
     } else {
@@ -885,15 +924,7 @@ async fn main() -> anyhow::Result<()> {
 
     // --print mode (headless)
     let result = if is_headless {
-        run_headless(
-            &cli,
-            client,
-            tools,
-            tool_ctx,
-            query_config,
-            cost_tracker,
-        )
-        .await
+        run_headless(&cli, client, tools, tool_ctx, query_config, cost_tracker).await
     } else {
         let auth_store = claurst_core::AuthStore::load();
         let has_saved_credentials = !auth_store.credentials.is_empty()
@@ -1026,8 +1057,7 @@ async fn run_models_command(args: &[String]) -> anyhow::Result<()> {
         }
     }
 
-    let mut registry = claurst_api::ModelRegistry::new()
-        .with_cache_path(models_cache_path());
+    let mut registry = claurst_api::ModelRegistry::new().with_cache_path(models_cache_path());
 
     if refresh {
         // Force-refresh by clearing the freshness check first.
@@ -1099,12 +1129,26 @@ async fn run_models_command(args: &[String]) -> anyhow::Result<()> {
         let out_cost = entry.cost_output.unwrap_or(0.0);
 
         let mut flags = Vec::new();
-        if entry.tool_calling { flags.push("tools"); }
-        if entry.reasoning { flags.push("reasoning"); }
-        if entry.vision() { flags.push("vision"); }
-        if entry.audio_input() { flags.push("audio"); }
-        if entry.pdf_input() { flags.push("pdf"); }
-        let flags_str = if flags.is_empty() { String::new() } else { format!(" [{}]", flags.join(",")) };
+        if entry.tool_calling {
+            flags.push("tools");
+        }
+        if entry.reasoning {
+            flags.push("reasoning");
+        }
+        if entry.vision() {
+            flags.push("vision");
+        }
+        if entry.audio_input() {
+            flags.push("audio");
+        }
+        if entry.pdf_input() {
+            flags.push("pdf");
+        }
+        let flags_str = if flags.is_empty() {
+            String::new()
+        } else {
+            format!(" [{}]", flags.join(","))
+        };
 
         if verbose {
             println!(
@@ -1361,8 +1405,10 @@ async fn refresh_provider_runtime_state(
         claurst_api::AnthropicClient::new(client_config.clone())
             .context("Failed to rebuild Anthropic client")?,
     );
-    let provider_registry =
-        Arc::new(claurst_api::ProviderRegistry::from_config(&config, client_config));
+    let provider_registry = Arc::new(claurst_api::ProviderRegistry::from_config(
+        &config,
+        client_config,
+    ));
     let model_registry = load_cached_model_registry(&config);
 
     spawn_models_cache_refresh();
@@ -1406,8 +1452,10 @@ async fn reload_provider_runtime_state(
         claurst_api::AnthropicClient::new(client_config.clone())
             .context("Failed to rebuild Anthropic client")?,
     );
-    let provider_registry =
-        Arc::new(claurst_api::ProviderRegistry::from_config(&config, client_config));
+    let provider_registry = Arc::new(claurst_api::ProviderRegistry::from_config(
+        &config,
+        client_config,
+    ));
     let model_registry = load_cached_model_registry(&config);
 
     Ok(RefreshedProviderRuntime {
@@ -1486,72 +1534,78 @@ async fn run_headless(
     // --input-format stream-json: stdin is newline-delimited JSON, each line is
     //   {"role":"user"|"assistant","content":"..."} (mirrors TS --input-format stream-json).
     // --input-format text (default): read prompt from positional arg or entire stdin as text.
-    let mut messages: Vec<claurst_core::types::Message> = if cli.input_format == CliInputFormat::StreamJson {
-        use tokio::io::{self, AsyncBufReadExt, BufReader};
-        let stdin = io::stdin();
-        let mut reader = BufReader::new(stdin);
-        let mut line = String::new();
-        let mut parsed: Vec<claurst_core::types::Message> = Vec::new();
-        loop {
-            line.clear();
-            let n = reader.read_line(&mut line).await?;
-            if n == 0 {
-                break;
-            }
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-            match serde_json::from_str::<serde_json::Value>(trimmed) {
-                Ok(v) => {
-                    let role = v.get("role").and_then(|r| r.as_str()).unwrap_or("user");
-                    let content = v
-                        .get("content")
-                        .and_then(|c| c.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    if role == "assistant" {
-                        parsed.push(claurst_core::types::Message::assistant(content));
-                    } else {
-                        parsed.push(claurst_core::types::Message::user(content));
+    let mut messages: Vec<claurst_core::types::Message> =
+        if cli.input_format == CliInputFormat::StreamJson {
+            use tokio::io::{self, AsyncBufReadExt, BufReader};
+            let stdin = io::stdin();
+            let mut reader = BufReader::new(stdin);
+            let mut line = String::new();
+            let mut parsed: Vec<claurst_core::types::Message> = Vec::new();
+            loop {
+                line.clear();
+                let n = reader.read_line(&mut line).await?;
+                if n == 0 {
+                    break;
+                }
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                match serde_json::from_str::<serde_json::Value>(trimmed) {
+                    Ok(v) => {
+                        let role = v.get("role").and_then(|r| r.as_str()).unwrap_or("user");
+                        let content = v
+                            .get("content")
+                            .and_then(|c| c.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        if role == "assistant" {
+                            parsed.push(claurst_core::types::Message::assistant(content));
+                        } else {
+                            parsed.push(claurst_core::types::Message::user(content));
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "Warning: skipping malformed JSON line: {} ({:?})",
+                            trimmed, e
+                        );
                     }
                 }
-                Err(e) => {
-                    eprintln!("Warning: skipping malformed JSON line: {} ({:?})", trimmed, e);
+            }
+            if parsed.is_empty() {
+                // Also check positional arg as fallback
+                if let Some(ref p) = cli.prompt {
+                    parsed.push(claurst_core::types::Message::user(p.clone()));
                 }
             }
-        }
-        if parsed.is_empty() {
-            // Also check positional arg as fallback
-            if let Some(ref p) = cli.prompt {
-                parsed.push(claurst_core::types::Message::user(p.clone()));
-            }
-        }
-        parsed
-    } else {
-        // Plain text mode
-        let prompt = if let Some(ref p) = cli.prompt {
-            p.clone()
+            parsed
         } else {
-            use tokio::io::{self, AsyncReadExt};
-            let mut stdin = io::stdin();
-            let mut buf = String::new();
-            stdin.read_to_string(&mut buf).await?;
-            buf.trim().to_string()
+            // Plain text mode
+            let prompt = if let Some(ref p) = cli.prompt {
+                p.clone()
+            } else {
+                use tokio::io::{self, AsyncReadExt};
+                let mut stdin = io::stdin();
+                let mut buf = String::new();
+                stdin.read_to_string(&mut buf).await?;
+                buf.trim().to_string()
+            };
+
+            if prompt.is_empty() {
+                eprintln!("Error: No prompt provided. Use --print <prompt> or pipe text to stdin.");
+                std::process::exit(1);
+            }
+
+            vec![claurst_core::types::Message::user(prompt)]
         };
-
-        if prompt.is_empty() {
-            eprintln!("Error: No prompt provided. Use --print <prompt> or pipe text to stdin.");
-            std::process::exit(1);
-        }
-
-        vec![claurst_core::types::Message::user(prompt)]
-    };
 
     // --prefill: inject a partial assistant turn before the query so the model
     // continues from that text (mirrors TS --prefill flag).
     if let Some(ref prefill_text) = cli.prefill {
-        messages.push(claurst_core::types::Message::assistant(prefill_text.clone()));
+        messages.push(claurst_core::types::Message::assistant(
+            prefill_text.clone(),
+        ));
     }
 
     if messages.is_empty() {
@@ -1559,7 +1613,10 @@ async fn run_headless(
         std::process::exit(1);
     }
 
-    let is_json_output = matches!(cli.output_format, CliOutputFormat::Json | CliOutputFormat::StreamJson);
+    let is_json_output = matches!(
+        cli.output_format,
+        CliOutputFormat::Json | CliOutputFormat::StreamJson
+    );
     let is_stream_json = matches!(cli.output_format, CliOutputFormat::StreamJson);
 
     let (event_tx, mut event_rx) = mpsc::unbounded_channel::<QueryEvent>();
@@ -1635,35 +1692,33 @@ async fn run_headless(
 
     // Final output
     match cli.output_format {
-        CliOutputFormat::Json => {
-            match outcome {
-                QueryOutcome::EndTurn { message, usage } => {
-                    let result_text = if full_text.is_empty() {
-                        message.get_all_text()
-                    } else {
-                        full_text
-                    };
-                    let out = serde_json::json!({
-                        "type": "result",
-                        "result": result_text,
-                        "usage": {
-                            "input_tokens": usage.input_tokens,
-                            "output_tokens": usage.output_tokens,
-                            "cache_creation_input_tokens": usage.cache_creation_input_tokens,
-                            "cache_read_input_tokens": usage.cache_read_input_tokens,
-                        },
-                        "cost_usd": cost_tracker.total_cost_usd(),
-                    });
-                    println!("{}", out);
-                }
-                QueryOutcome::Error(e) => {
-                    let out = serde_json::json!({ "type": "error", "error": e.to_string() });
-                    eprintln!("{}", out);
-                    std::process::exit(1);
-                }
-                _ => {}
+        CliOutputFormat::Json => match outcome {
+            QueryOutcome::EndTurn { message, usage } => {
+                let result_text = if full_text.is_empty() {
+                    message.get_all_text()
+                } else {
+                    full_text
+                };
+                let out = serde_json::json!({
+                    "type": "result",
+                    "result": result_text,
+                    "usage": {
+                        "input_tokens": usage.input_tokens,
+                        "output_tokens": usage.output_tokens,
+                        "cache_creation_input_tokens": usage.cache_creation_input_tokens,
+                        "cache_read_input_tokens": usage.cache_read_input_tokens,
+                    },
+                    "cost_usd": cost_tracker.total_cost_usd(),
+                });
+                println!("{}", out);
             }
-        }
+            QueryOutcome::Error(e) => {
+                let out = serde_json::json!({ "type": "error", "error": e.to_string() });
+                eprintln!("{}", out);
+                std::process::exit(1);
+            }
+            _ => {}
+        },
         CliOutputFormat::StreamJson => {
             // Already streamed above; emit final result event
             match outcome {
@@ -1702,7 +1757,10 @@ async fn run_headless(
                     eprintln!("Error: {}", e);
                     std::process::exit(1);
                 }
-                QueryOutcome::BudgetExceeded { cost_usd, limit_usd } => {
+                QueryOutcome::BudgetExceeded {
+                    cost_usd,
+                    limit_usd,
+                } => {
                     eprintln!(
                         "Budget limit ${:.4} reached (spent ${:.4}). Stopping.",
                         limit_usd, cost_usd
@@ -1742,21 +1800,23 @@ fn permission_request_from_core(
                 command,
                 suggested_prefix,
             )
-        },
+        }
         ("PowerShell", Some(command)) => claurst_tui::dialogs::PermissionRequest::powershell(
             tool_use_id,
             tool_name,
             reason,
             command,
         ),
-        ("Read", Some(path)) => claurst_tui::dialogs::PermissionRequest::file_read(
-            tool_use_id,
-            tool_name,
-            reason,
-            path,
-        ),
+        ("Read", Some(path)) => {
+            claurst_tui::dialogs::PermissionRequest::file_read(tool_use_id, tool_name, reason, path)
+        }
         (_, Some(path)) if matches!(tool_name.as_str(), "Write" | "Edit" | "NotebookEdit") => {
-            claurst_tui::dialogs::PermissionRequest::file_write(tool_use_id, tool_name, reason, path)
+            claurst_tui::dialogs::PermissionRequest::file_write(
+                tool_use_id,
+                tool_name,
+                reason,
+                path,
+            )
         }
         _ => claurst_tui::dialogs::PermissionRequest::from_reason(
             tool_use_id,
@@ -1766,7 +1826,6 @@ fn permission_request_from_core(
         ),
     }
 }
-
 
 async fn run_interactive(
     config: Config,
@@ -1781,17 +1840,18 @@ async fn run_interactive(
     bridge_config: Option<claurst_bridge::BridgeConfig>,
     has_credentials: bool,
     model_registry: Arc<claurst_api::ModelRegistry>,
-    user_question_rx: Option<tokio::sync::mpsc::UnboundedReceiver<claurst_tools::UserQuestionEvent>>,
+    user_question_rx: Option<
+        tokio::sync::mpsc::UnboundedReceiver<claurst_tools::UserQuestionEvent>,
+    >,
     pending_project_mcp: Vec<claurst_core::config::McpServerConfig>,
     mcp_project_root: Option<PathBuf>,
 ) -> anyhow::Result<()> {
-    use claurst_commands::{execute_command, CommandContext, CommandResult};
     use claurst_bridge::{BridgeOutbound, TuiBridgeEvent};
+    use claurst_commands::{execute_command, CommandContext, CommandResult};
     use claurst_query::{QueryEvent, QueryOutcome};
     use claurst_tui::{
-        bridge_state::BridgeConnectionState, notifications::NotificationKind,
-        render::render_app, restore_terminal, setup_terminal, App,
-        device_auth_dialog::DeviceAuthEvent,
+        bridge_state::BridgeConnectionState, device_auth_dialog::DeviceAuthEvent,
+        notifications::NotificationKind, render::render_app, restore_terminal, setup_terminal, App,
     };
     use crossterm::event::{self, Event, KeyCode, KeyModifiers};
     use std::time::Duration;
@@ -1832,21 +1892,22 @@ async fn run_interactive(
                 session
             }
             Err(e) => {
-                resume_warning = Some(format!("Could not load session {}: {}. Starting new session.", id, e));
-                let mut session =
-                    claurst_core::history::ConversationSession::new(
-                        claurst_api::effective_model_for_config(&config, &model_registry),
-                    );
+                resume_warning = Some(format!(
+                    "Could not load session {}: {}. Starting new session.",
+                    id, e
+                ));
+                let mut session = claurst_core::history::ConversationSession::new(
+                    claurst_api::effective_model_for_config(&config, &model_registry),
+                );
                 session.id = tool_ctx.session_id.clone();
                 session.working_dir = Some(tool_ctx.working_dir.display().to_string());
                 session
             }
         }
     } else {
-        let mut session =
-            claurst_core::history::ConversationSession::new(
-                claurst_api::effective_model_for_config(&config, &model_registry),
-            );
+        let mut session = claurst_core::history::ConversationSession::new(
+            claurst_api::effective_model_for_config(&config, &model_registry),
+        );
         session.id = tool_ctx.session_id.clone();
         session.working_dir = Some(tool_ctx.working_dir.display().to_string());
         session
@@ -1865,11 +1926,11 @@ async fn run_interactive(
     if !session.model.is_empty() {
         live_config.model = Some(session.model.clone());
     }
-    let pending_permissions = tool_ctx
-        .pending_permissions
-        .clone()
-        .unwrap_or_else(|| Arc::new(ParkingMutex::new(claurst_tools::PendingPermissionStore::default())));
-
+    let pending_permissions = tool_ctx.pending_permissions.clone().unwrap_or_else(|| {
+        Arc::new(ParkingMutex::new(
+            claurst_tools::PendingPermissionStore::default(),
+        ))
+    });
 
     // Set up terminal
     let mut terminal = setup_terminal(live_config.mouse_capture_enabled())?;
@@ -1970,7 +2031,8 @@ async fn run_interactive(
             if !settings.has_completed_onboarding {
                 app.onboarding_dialog.show();
             } else {
-                app.status_message = Some("No provider configured. Run /connect to set one up.".to_string());
+                app.status_message =
+                    Some("No provider configured. Run /connect to set one up.".to_string());
             }
         } else if !settings.has_completed_onboarding {
             // User has credentials but hasn't formally completed onboarding — mark it done
@@ -2039,9 +2101,7 @@ async fn run_interactive(
 
     // Preserve the bridge token before consuming bridge_config so we can reconstruct
     // a BridgeSessionInfo once the bridge worker reports it has connected.
-    let bridge_token: Option<String> = bridge_config
-        .as_ref()
-        .and_then(|c| c.session_token.clone());
+    let bridge_token: Option<String> = bridge_config.as_ref().and_then(|c| c.session_token.clone());
 
     let mut bridge_runtime: Option<BridgeRuntime> = if let Some(cfg) = bridge_config {
         let bridge_cancel = CancellationToken::new();
@@ -2053,7 +2113,9 @@ async fn run_interactive(
 
         let cancel_clone = bridge_cancel.clone();
         tokio::spawn(async move {
-            if let Err(e) = claurst_bridge::run_bridge_loop(cfg, tui_tx, outbound_rx, cancel_clone).await {
+            if let Err(e) =
+                claurst_bridge::run_bridge_loop(cfg, tui_tx, outbound_rx, cancel_clone).await
+            {
                 warn!("Bridge loop exited with error: {}", e);
             }
         });
@@ -2173,7 +2235,9 @@ async fn run_interactive(
         app.notifications.tick();
 
         // Process file injection dialog outcome (if any)
-        if let Some((outcome, pending_input, pending_imgs)) = app.file_injection_dialog.take_outcome() {
+        if let Some((outcome, pending_input, pending_imgs)) =
+            app.file_injection_dialog.take_outcome()
+        {
             use claurst_tui::FileInjectionOutcome;
 
             if matches!(outcome, FileInjectionOutcome::Abort) {
@@ -2274,9 +2338,7 @@ async fn run_interactive(
                     // flood as one paste (human typing never queues 2+ chars
                     // in the same instant). Must run BEFORE the Enter/submit
                     // handling below so pasted newlines can't submit.
-                    if key.modifiers == KeyModifiers::NONE
-                        || key.modifiers == KeyModifiers::SHIFT
-                    {
+                    if key.modifiers == KeyModifiers::NONE || key.modifiers == KeyModifiers::SHIFT {
                         if let KeyCode::Char(c) = key.code {
                             if app.paste_burst_allowed() {
                                 if let Some(burst) = app.try_detect_paste_burst(c) {
@@ -2321,10 +2383,9 @@ async fn run_interactive(
                         // If a file-ref suggestion is active, accept it instead of submitting.
                         if !app.prompt_input.suggestions.is_empty()
                             && app.prompt_input.suggestion_index.is_some_and(|index| {
-                                app.prompt_input
-                                    .suggestions
-                                    .get(index)
-                                    .is_some_and(|s| s.source == claurst_tui::prompt_input::TypeaheadSource::FileRef)
+                                app.prompt_input.suggestions.get(index).is_some_and(|s| {
+                                    s.source == claurst_tui::prompt_input::TypeaheadSource::FileRef
+                                })
                             })
                         {
                             app.prompt_input.accept_suggestion();
@@ -2367,8 +2428,15 @@ async fn run_interactive(
                             let skip_tui_for_args = !cmd_args.is_empty()
                                 && matches!(
                                     cmd_name.as_str(),
-                                    "model" | "theme" | "resume" | "session"
-                                        | "vim" | "vi" | "voice" | "fast" | "speed"
+                                    "model"
+                                        | "theme"
+                                        | "resume"
+                                        | "session"
+                                        | "vim"
+                                        | "vi"
+                                        | "voice"
+                                        | "fast"
+                                        | "speed"
                                 );
                             let handled_by_tui = if skip_tui_for_args {
                                 false
@@ -2406,8 +2474,7 @@ async fn run_interactive(
                                     app.replace_messages(Vec::new());
                                     session.messages.clear();
                                     session.updated_at = chrono::Utc::now();
-                                    app.status_message =
-                                        Some("Conversation cleared.".to_string());
+                                    app.status_message = Some("Conversation cleared.".to_string());
                                 }
                                 Some(CommandResult::NewSession) => {
                                     // Fresh lazy-home session (opencode /new):
@@ -2434,16 +2501,14 @@ async fn run_interactive(
                                     tool_ctx.file_history = Arc::new(ParkingMutex::new(
                                         claurst_core::file_history::FileHistory::new(),
                                     ));
-                                    tool_ctx.current_turn = Arc::new(
-                                        std::sync::atomic::AtomicUsize::new(0),
-                                    );
+                                    tool_ctx.current_turn =
+                                        Arc::new(std::sync::atomic::AtomicUsize::new(0));
                                     app.attach_turn_diff_state(
                                         tool_ctx.file_history.clone(),
                                         tool_ctx.current_turn.clone(),
                                     );
                                     claurst_tui::update_terminal_title(None);
-                                    app.status_message =
-                                        Some("Started a new session.".to_string());
+                                    app.status_message = Some("Started a new session.".to_string());
                                 }
                                 Some(CommandResult::MoveSession {
                                     destination,
@@ -2462,11 +2527,12 @@ async fn run_interactive(
                                     app.config.project_dir = Some(destination.clone());
                                     base_query_config.working_directory =
                                         Some(destination.display().to_string());
-                                    session.working_dir =
-                                        Some(destination.display().to_string());
+                                    session.working_dir = Some(destination.display().to_string());
                                     session.updated_at = chrono::Utc::now();
-                                    let _ =
-                                        claurst_core::history::save_session(&session).await;
+                                    app.refresh_discovered_skills();
+                                    app.rebuild_command_palette();
+                                    app.rebuild_help_overlay();
+                                    let _ = claurst_core::history::save_session(&session).await;
                                     // NOTE: opencode appends a synthetic
                                     // <system-reminder> prompt after a move. claurst
                                     // re-derives working_directory into every turn's
@@ -2487,8 +2553,7 @@ async fn run_interactive(
                                     ));
                                 }
                                 Some(CommandResult::SetMessages(new_msgs)) => {
-                                    let removed =
-                                        messages.len().saturating_sub(new_msgs.len());
+                                    let removed = messages.len().saturating_sub(new_msgs.len());
                                     messages = new_msgs.clone();
                                     app.replace_messages(new_msgs);
                                     session.messages = messages.clone();
@@ -2532,44 +2597,34 @@ async fn run_interactive(
                                     tool_ctx.file_history = Arc::new(ParkingMutex::new(
                                         claurst_core::file_history::FileHistory::new(),
                                     ));
-                                    tool_ctx.current_turn = Arc::new(
-                                        std::sync::atomic::AtomicUsize::new(0),
-                                    );
+                                    tool_ctx.current_turn =
+                                        Arc::new(std::sync::atomic::AtomicUsize::new(0));
                                     cmd_ctx.session_id = session.id.clone();
                                     cmd_ctx.session_title = session.title.clone();
                                     if let Some(saved_dir) = session.working_dir.as_ref() {
-                                        let saved_path =
-                                            std::path::PathBuf::from(saved_dir);
+                                        let saved_path = std::path::PathBuf::from(saved_dir);
                                         if saved_path.exists() {
                                             tool_ctx.working_dir = saved_path.clone();
                                             cmd_ctx.working_dir = saved_path;
                                         }
                                     }
-                                    app.config.project_dir =
-                                        Some(tool_ctx.working_dir.clone());
+                                    app.config.project_dir = Some(tool_ctx.working_dir.clone());
                                     app.attach_turn_diff_state(
                                         tool_ctx.file_history.clone(),
                                         tool_ctx.current_turn.clone(),
                                     );
-                                    claurst_tui::update_terminal_title(
-                                        session.title.as_deref(),
-                                    );
-                                    app.status_message = Some(format!(
-                                        "Resumed session {}.",
-                                        &session.id[..8]
-                                    ));
+                                    claurst_tui::update_terminal_title(session.title.as_deref());
+                                    app.status_message =
+                                        Some(format!("Resumed session {}.", &session.id[..8]));
                                 }
                                 Some(CommandResult::RenameSession(title)) => {
                                     session.title = Some(title.clone());
                                     session.updated_at = chrono::Utc::now();
                                     cmd_ctx.session_title = session.title.clone();
-                                    let _ =
-                                        claurst_core::history::save_session(&session).await;
+                                    let _ = claurst_core::history::save_session(&session).await;
                                     claurst_tui::update_terminal_title(Some(&title));
-                                    app.status_message = Some(format!(
-                                        "Session renamed to \"{}\".",
-                                        title
-                                    ));
+                                    app.status_message =
+                                        Some(format!("Session renamed to \"{}\".", title));
                                 }
                                 Some(CommandResult::RefreshProviderState) => {
                                     if app.is_streaming || current_query.is_some() {
@@ -2578,7 +2633,8 @@ async fn run_interactive(
                                                 .to_string(),
                                         );
                                     } else {
-                                        match refresh_provider_runtime_state(&cmd_ctx.config).await {
+                                        match refresh_provider_runtime_state(&cmd_ctx.config).await
+                                        {
                                             Ok(refreshed) => {
                                                 cmd_ctx.config = refreshed.config.clone();
                                                 tool_ctx.config = refreshed.config.clone();
@@ -2609,10 +2665,8 @@ async fn run_interactive(
                                                 );
                                             }
                                             Err(err) => {
-                                                app.status_message = Some(format!(
-                                                    "Error: {}",
-                                                    err
-                                                ));
+                                                app.status_message =
+                                                    Some(format!("Error: {}", err));
                                             }
                                         }
                                     }
@@ -2632,9 +2686,9 @@ async fn run_interactive(
                                     // overlay for this command (e.g. /stats opens dialog
                                     // AND would push a text message — drop the text).
                                     if !handled_by_tui {
-                                        app.push_message(
-                                            claurst_core::types::Message::assistant(msg),
-                                        );
+                                        app.push_message(claurst_core::types::Message::assistant(
+                                            msg,
+                                        ));
                                     }
                                 }
                                 Some(CommandResult::ConfigChange(new_cfg)) => {
@@ -2648,7 +2702,8 @@ async fn run_interactive(
                                         app.set_model(model.clone());
                                     }
                                     // Sync fast_mode visual indicator.
-                                    app.fast_mode = applied_cfg.model
+                                    app.fast_mode = applied_cfg
+                                        .model
                                         .as_deref()
                                         .map(|m| m.contains("haiku"))
                                         .unwrap_or(false);
@@ -2661,8 +2716,10 @@ async fn run_interactive(
                                         &cmd_ctx.config,
                                         &model_registry,
                                     );
-                                    app.status_message =
-                                        Some("Configuration updated.".to_string());
+                                    app.refresh_discovered_skills();
+                                    app.rebuild_command_palette();
+                                    app.rebuild_help_overlay();
+                                    app.status_message = Some("Configuration updated.".to_string());
                                 }
                                 Some(CommandResult::ConfigChangeMessage(new_cfg, msg)) => {
                                     let mut applied_cfg = new_cfg;
@@ -2682,6 +2739,9 @@ async fn run_interactive(
                                         &cmd_ctx.config,
                                         &model_registry,
                                     );
+                                    app.refresh_discovered_skills();
+                                    app.rebuild_command_palette();
+                                    app.rebuild_help_overlay();
                                     app.status_message = Some(msg);
                                 }
                                 Some(CommandResult::UserMessage(msg)) => {
@@ -2690,11 +2750,7 @@ async fn run_interactive(
                                 }
                                 Some(CommandResult::StartOAuthFlow(with_claude_ai)) => {
                                     claurst_tui::restore_terminal(&mut terminal).ok();
-                                    match oauth_flow::run_oauth_login_flow(
-                                        with_claude_ai,
-                                    )
-                                    .await
-                                    {
+                                    match oauth_flow::run_oauth_login_flow(with_claude_ai).await {
                                         Ok(_) => {
                                             app.status_message =
                                                 Some("Login successful!".to_string());
@@ -2708,7 +2764,9 @@ async fn run_interactive(
                                             eprintln!("\nLogin failed: {}", e);
                                         }
                                     }
-                                    terminal = claurst_tui::setup_terminal(app.config.mouse_capture_enabled())?;
+                                    terminal = claurst_tui::setup_terminal(
+                                        app.config.mouse_capture_enabled(),
+                                    )?;
                                     app.kitty_keyboard_active =
                                         claurst_tui::keyboard_enhancement_active();
                                 }
@@ -2719,9 +2777,10 @@ async fn run_interactive(
                                 }) => {
                                     claurst_tui::restore_terminal(&mut terminal).ok();
                                     if provider == claurst_core::accounts::PROVIDER_CODEX {
-                                        let (tx, mut rx) = tokio::sync::mpsc::channel::<
-                                            claurst_tui::DeviceAuthEvent,
-                                        >(8);
+                                        let (tx, mut rx) =
+                                            tokio::sync::mpsc::channel::<
+                                                claurst_tui::DeviceAuthEvent,
+                                            >(8);
                                         tokio::spawn(async move {
                                             while let Some(evt) = rx.recv().await {
                                                 if let claurst_tui::DeviceAuthEvent::GotBrowserUrl {
@@ -2744,9 +2803,8 @@ async fn run_interactive(
                                         .await
                                         {
                                             Ok(_) => {
-                                                app.status_message = Some(
-                                                    "Codex login successful!".to_string(),
-                                                );
+                                                app.status_message =
+                                                    Some("Codex login successful!".to_string());
                                                 eprintln!("\nCodex login successful!");
                                                 break 'main;
                                             }
@@ -2775,7 +2833,9 @@ async fn run_interactive(
                                             }
                                         }
                                     }
-                                    terminal = claurst_tui::setup_terminal(app.config.mouse_capture_enabled())?;
+                                    terminal = claurst_tui::setup_terminal(
+                                        app.config.mouse_capture_enabled(),
+                                    )?;
                                     app.kitty_keyboard_active =
                                         claurst_tui::keyboard_enhancement_active();
                                 }
@@ -2789,10 +2849,7 @@ async fn run_interactive(
 
                             // Sync effort visual + API level when CLI handled
                             // /effort with explicit args (/effort high).
-                            if handled_by_cli
-                                && cmd_name == "effort"
-                                && !cmd_args.is_empty()
-                            {
+                            if handled_by_cli && cmd_name == "effort" && !cmd_args.is_empty() {
                                 if let Some(level) =
                                     claurst_core::effort::EffortLevel::from_str(&cmd_args)
                                 {
@@ -2816,10 +2873,8 @@ async fn run_interactive(
                             }
 
                             if !handled_by_cli && !handled_by_tui {
-                                app.status_message = Some(format!(
-                                    "Unknown command: /{}",
-                                    cmd_name
-                                ));
+                                app.status_message =
+                                    Some(format!("Unknown command: /{}", cmd_name));
                             }
 
                             // If a UserMessage was queued (e.g. /compact), submit it.
@@ -2869,22 +2924,42 @@ async fn run_interactive(
                             } else {
                                 app.config.file_injection_max_size
                             };
-                            let (within_limit, mut oversized) = parse_at_refs(&input, &tool_ctx.working_dir, effective_limit);
+                            let (within_limit, mut oversized) =
+                                parse_at_refs(&input, &tool_ctx.working_dir, effective_limit);
                             if was_force {
-                                oversized.retain(|f| !matches!(f.issue, Some(claurst_tui::AtFileIssue::IsDirectory)));
+                                oversized.retain(|f| {
+                                    !matches!(f.issue, Some(claurst_tui::AtFileIssue::IsDirectory))
+                                });
                             }
 
                             if !oversized.is_empty() {
                                 // Show either the directory warning or the file warning, never both.
                                 // Directories take precedence: if any are present, show only those.
-                                let has_dirs = oversized.iter().any(|f| matches!(f.issue, Some(claurst_tui::AtFileIssue::IsDirectory)));
-                                let oversized_summaries: Vec<(String, usize, claurst_tui::AtFileIssue)> = oversized
+                                let has_dirs = oversized.iter().any(|f| {
+                                    matches!(f.issue, Some(claurst_tui::AtFileIssue::IsDirectory))
+                                });
+                                let oversized_summaries: Vec<(
+                                    String,
+                                    usize,
+                                    claurst_tui::AtFileIssue,
+                                )> = oversized
                                     .iter()
                                     .filter(|f| {
-                                        let is_dir = matches!(f.issue, Some(claurst_tui::AtFileIssue::IsDirectory));
-                                        if has_dirs { is_dir } else { !is_dir }
+                                        let is_dir = matches!(
+                                            f.issue,
+                                            Some(claurst_tui::AtFileIssue::IsDirectory)
+                                        );
+                                        if has_dirs {
+                                            is_dir
+                                        } else {
+                                            !is_dir
+                                        }
                                     })
-                                    .filter_map(|f| f.issue.clone().map(|issue| (f.path.display().to_string(), f.size_kb, issue)))
+                                    .filter_map(|f| {
+                                        f.issue.clone().map(|issue| {
+                                            (f.path.display().to_string(), f.size_kb, issue)
+                                        })
+                                    })
                                     .collect();
 
                                 app.file_injection_dialog.show(
@@ -2899,19 +2974,24 @@ async fn run_interactive(
                             }
 
                             // No oversized files: inject within-limit files and send
-                            let file_prefix = claurst_tui::file_injection::build_file_blocks(&within_limit);
+                            let file_prefix =
+                                claurst_tui::file_injection::build_file_blocks(&within_limit);
 
                             let user_msg = if !file_prefix.is_empty() || !pending_imgs.is_empty() {
                                 let mut blocks: Vec<claurst_core::types::ContentBlock> = Vec::new();
 
                                 // Add file blocks if there's any file content
                                 if !file_prefix.is_empty() {
-                                    blocks.push(claurst_core::types::ContentBlock::Text { text: file_prefix });
+                                    blocks.push(claurst_core::types::ContentBlock::Text {
+                                        text: file_prefix,
+                                    });
                                 }
 
                                 // Add image blocks
                                 for img in &pending_imgs {
-                                    if let Some(b64) = claurst_tui::image_paste::encode_image_base64(&img.path) {
+                                    if let Some(b64) =
+                                        claurst_tui::image_paste::encode_image_base64(&img.path)
+                                    {
                                         blocks.push(claurst_core::types::ContentBlock::Image {
                                             source: claurst_core::types::ImageSource {
                                                 source_type: "base64".to_string(),
@@ -2924,7 +3004,9 @@ async fn run_interactive(
                                 }
 
                                 // Add the original input text
-                                blocks.push(claurst_core::types::ContentBlock::Text { text: input.clone() });
+                                blocks.push(claurst_core::types::ContentBlock::Text {
+                                    text: input.clone(),
+                                });
 
                                 claurst_core::types::Message::user_blocks(blocks)
                             } else {
@@ -2940,21 +3022,28 @@ async fn run_interactive(
                             let user_msg = if pending_imgs.is_empty() {
                                 claurst_core::types::Message::user(input.clone())
                             } else {
-                                let mut blocks: Vec<claurst_core::types::ContentBlock> = pending_imgs
-                                    .iter()
-                                    .filter_map(|img| {
-                                        claurst_tui::image_paste::encode_image_base64(&img.path)
-                                            .map(|b64| claurst_core::types::ContentBlock::Image {
-                                                source: claurst_core::types::ImageSource {
-                                                    source_type: "base64".to_string(),
-                                                    media_type: Some("image/png".to_string()),
-                                                    data: Some(b64),
-                                                    url: None,
-                                                },
-                                            })
-                                    })
-                                    .collect();
-                                blocks.push(claurst_core::types::ContentBlock::Text { text: input.clone() });
+                                let mut blocks: Vec<claurst_core::types::ContentBlock> =
+                                    pending_imgs
+                                        .iter()
+                                        .filter_map(|img| {
+                                            claurst_tui::image_paste::encode_image_base64(&img.path)
+                                                .map(|b64| {
+                                                    claurst_core::types::ContentBlock::Image {
+                                                        source: claurst_core::types::ImageSource {
+                                                            source_type: "base64".to_string(),
+                                                            media_type: Some(
+                                                                "image/png".to_string(),
+                                                            ),
+                                                            data: Some(b64),
+                                                            url: None,
+                                                        },
+                                                    }
+                                                })
+                                        })
+                                        .collect();
+                                blocks.push(claurst_core::types::ContentBlock::Text {
+                                    text: input.clone(),
+                                });
                                 claurst_core::types::Message::user_blocks(blocks)
                             };
 
@@ -2988,7 +3077,10 @@ async fn run_interactive(
                         let tools_arc_clone = tools_arc.clone();
                         let mut ctx_clone = tool_ctx.clone();
                         let mut qcfg = base_query_config.clone();
-                        qcfg.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
+                        qcfg.model = claurst_api::effective_model_for_config(
+                            &cmd_ctx.config,
+                            &model_registry,
+                        );
                         qcfg.max_tokens = cmd_ctx.config.effective_max_tokens();
                         qcfg.append_system_prompt = cmd_ctx.config.append_system_prompt.clone();
                         qcfg.system_prompt = base_query_config.system_prompt.clone();
@@ -3005,12 +3097,13 @@ async fn run_interactive(
                         // Wire completion_notifier if a command queue is available.
                         if let Some(ref cq) = qcfg.command_queue {
                             let cq = cq.clone();
-                            ctx_clone.completion_notifier = Some(claurst_tools::CompletionNotifier::new(move |msg| {
-                                cq.push(
-                                    claurst_query::QueuedCommand::InjectSystemMessage(msg),
-                                    claurst_query::CommandPriority::Normal,
-                                );
-                            }));
+                            ctx_clone.completion_notifier =
+                                Some(claurst_tools::CompletionNotifier::new(move |msg| {
+                                    cq.push(
+                                        claurst_query::QueuedCommand::InjectSystemMessage(msg),
+                                        claurst_query::CommandPriority::Normal,
+                                    );
+                                }));
                         }
                         let tracker = cost_tracker.clone();
                         let tx = event_tx.clone();
@@ -3052,9 +3145,20 @@ async fn run_interactive(
                                 .and_then(|p| p.request.path.clone());
                             let bash_prefix = if should_record_bash_prefix {
                                 match &pr.kind {
-                                    claurst_tui::dialogs::PermissionDialogKind::Bash { command, .. } => {
-                                        let first_word = command.split_whitespace().next().unwrap_or("").to_string();
-                                        if first_word.is_empty() { None } else { Some(first_word) }
+                                    claurst_tui::dialogs::PermissionDialogKind::Bash {
+                                        command,
+                                        ..
+                                    } => {
+                                        let first_word = command
+                                            .split_whitespace()
+                                            .next()
+                                            .unwrap_or("")
+                                            .to_string();
+                                        if first_word.is_empty() {
+                                            None
+                                        } else {
+                                            Some(first_word)
+                                        }
                                     }
                                     _ => None,
                                 }
@@ -3068,7 +3172,9 @@ async fn run_interactive(
                                 // "Always allow" must survive restarts: persist
                                 // the prefix to settings.json so it is reloaded
                                 // into the allowlist on the next launch.
-                                if let Ok(mut settings) = claurst_core::config::Settings::load_sync() {
+                                if let Ok(mut settings) =
+                                    claurst_core::config::Settings::load_sync()
+                                {
                                     if !settings.allowed_bash_prefixes.contains(&prefix) {
                                         settings.allowed_bash_prefixes.push(prefix);
                                         let _ = settings.save_sync();
@@ -3076,9 +3182,13 @@ async fn run_interactive(
                                 }
                             }
 
-                            if let Some(mut pending) = pending_permissions.lock().waiting.remove(&tool_use_id) {
+                            if let Some(mut pending) =
+                                pending_permissions.lock().waiting.remove(&tool_use_id)
+                            {
                                 let decision = match selected_key {
-                                    Some('n') => claurst_core::permissions::PermissionDecision::Deny,
+                                    Some('n') => {
+                                        claurst_core::permissions::PermissionDecision::Deny
+                                    }
                                     _ => claurst_core::permissions::PermissionDecision::Allow,
                                 };
 
@@ -3087,18 +3197,32 @@ async fn run_interactive(
                                         match selected_key {
                                             Some('Y') => {
                                                 if let Some(path) = selected_path.as_deref() {
-                                                    manager.add_session_allow_path(&pending.request.tool_name, path);
+                                                    manager.add_session_allow_path(
+                                                        &pending.request.tool_name,
+                                                        path,
+                                                    );
                                                 } else {
-                                                    manager.add_session_allow(&pending.request.tool_name);
+                                                    manager.add_session_allow(
+                                                        &pending.request.tool_name,
+                                                    );
                                                 }
                                             }
                                             Some('p') => {
-                                                let mut settings = claurst_core::config::Settings::load_sync().unwrap_or_default();
+                                                let mut settings =
+                                                    claurst_core::config::Settings::load_sync()
+                                                        .unwrap_or_default();
                                                 if let Some(path) = selected_path.as_deref() {
                                                     let pattern = format!("{}*", path);
-                                                    let _ = manager.add_persistent_allow_path(&pending.request.tool_name, &pattern, &mut settings);
+                                                    let _ = manager.add_persistent_allow_path(
+                                                        &pending.request.tool_name,
+                                                        &pattern,
+                                                        &mut settings,
+                                                    );
                                                 } else {
-                                                    let _ = manager.add_persistent_allow(&pending.request.tool_name, &mut settings);
+                                                    let _ = manager.add_persistent_allow(
+                                                        &pending.request.tool_name,
+                                                        &mut settings,
+                                                    );
                                                 }
                                             }
                                             _ => {}
@@ -3223,7 +3347,10 @@ async fn run_interactive(
                     Some(claurst_core::permissions::PermissionDecision::Ask { .. }) | None => {
                         let tool_use_id = pending.tool_use_id.clone();
                         app.permission_request = Some(permission_request_from_core(&pending));
-                        pending_permissions.lock().waiting.insert(tool_use_id, pending);
+                        pending_permissions
+                            .lock()
+                            .waiting
+                            .insert(tool_use_id, pending);
                         break;
                     }
                     Some(decision) => {
@@ -3248,26 +3375,31 @@ async fn run_interactive(
                         delta: text.clone(),
                         message_id: format!("msg-{}", index),
                     }),
-                    QueryEvent::ToolStart { tool_name, tool_id, input_json } => {
-                        Some(BridgeOutbound::ToolStart {
-                            id: tool_id.clone(),
-                            name: tool_name.clone(),
-                            input_preview: Some(input_json.clone()),
-                        })
-                    }
-                    QueryEvent::ToolEnd { tool_id, result, is_error, .. } => {
-                        Some(BridgeOutbound::ToolEnd {
-                            id: tool_id.clone(),
-                            output: result.clone(),
-                            is_error: *is_error,
-                        })
-                    }
-                    QueryEvent::TurnComplete { stop_reason, turn, .. } => {
-                        Some(BridgeOutbound::TurnComplete {
-                            message_id: format!("turn-{}", turn),
-                            stop_reason: stop_reason.clone(),
-                        })
-                    }
+                    QueryEvent::ToolStart {
+                        tool_name,
+                        tool_id,
+                        input_json,
+                    } => Some(BridgeOutbound::ToolStart {
+                        id: tool_id.clone(),
+                        name: tool_name.clone(),
+                        input_preview: Some(input_json.clone()),
+                    }),
+                    QueryEvent::ToolEnd {
+                        tool_id,
+                        result,
+                        is_error,
+                        ..
+                    } => Some(BridgeOutbound::ToolEnd {
+                        id: tool_id.clone(),
+                        output: result.clone(),
+                        is_error: *is_error,
+                    }),
+                    QueryEvent::TurnComplete {
+                        stop_reason, turn, ..
+                    } => Some(BridgeOutbound::TurnComplete {
+                        message_id: format!("turn-{}", turn),
+                        stop_reason: stop_reason.clone(),
+                    }),
                     QueryEvent::Error(msg) => Some(BridgeOutbound::Error {
                         message: msg.clone(),
                     }),
@@ -3284,27 +3416,41 @@ async fn run_interactive(
                     QueryEvent::Stream(claurst_api::AnthropicStreamEvent::ContentBlockDelta {
                         delta: claurst_api::streaming::ContentDelta::TextDelta { text },
                         ..
-                    }) => Some(serde_json::json!({
-                        "type": "text_chunk",
-                        "text": text,
-                    }).to_string()),
-                    QueryEvent::ToolStart { tool_name, tool_id, input_json } => {
-                        Some(serde_json::json!({
+                    }) => Some(
+                        serde_json::json!({
+                            "type": "text_chunk",
+                            "text": text,
+                        })
+                        .to_string(),
+                    ),
+                    QueryEvent::ToolStart {
+                        tool_name,
+                        tool_id,
+                        input_json,
+                    } => Some(
+                        serde_json::json!({
                             "type": "tool_start",
                             "tool_name": tool_name,
                             "tool_id": tool_id,
                             "input": input_json,
-                        }).to_string())
-                    }
-                    QueryEvent::ToolEnd { tool_name, tool_id, result, is_error } => {
-                        Some(serde_json::json!({
+                        })
+                        .to_string(),
+                    ),
+                    QueryEvent::ToolEnd {
+                        tool_name,
+                        tool_id,
+                        result,
+                        is_error,
+                    } => Some(
+                        serde_json::json!({
                             "type": "tool_end",
                             "tool_name": tool_name,
                             "tool_id": tool_id,
                             "result": result,
                             "is_error": is_error,
-                        }).to_string())
-                    }
+                        })
+                        .to_string(),
+                    ),
                     _ => None,
                 };
                 if let Some(payload) = relay_payload {
@@ -3321,7 +3467,8 @@ async fn run_interactive(
             && current_query.is_none()
             && !app.auto_compact_running
         {
-            let used_pct = (app.context_used_tokens as f64 / app.context_window_size as f64 * 100.0) as u64;
+            let used_pct =
+                (app.context_used_tokens as f64 / app.context_window_size as f64 * 100.0) as u64;
             if used_pct >= 99 {
                 app.auto_compact_running = true;
                 let msg_count = messages.len();
@@ -3347,7 +3494,8 @@ async fn run_interactive(
                 let tools_arc_clone = tools_arc.clone();
                 let ctx_clone = tool_ctx.clone();
                 let mut qcfg = base_query_config.clone();
-                qcfg.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
+                qcfg.model =
+                    claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
                 qcfg.max_tokens = cmd_ctx.config.effective_max_tokens();
                 // Auto-compact is a maintenance turn, not a goal turn: never let
                 // it trigger in-loop goal continuation.
@@ -3383,7 +3531,10 @@ async fn run_interactive(
         if let Some(runtime) = bridge_runtime.as_mut() {
             loop {
                 match runtime.tui_rx.try_recv() {
-                    Ok(TuiBridgeEvent::Connected { session_url, session_id: conn_sid }) => {
+                    Ok(TuiBridgeEvent::Connected {
+                        session_url,
+                        session_id: conn_sid,
+                    }) => {
                         let short = if session_url.len() > 60 {
                             format!("{}…", &session_url[..60])
                         } else {
@@ -3423,11 +3574,9 @@ async fn run_interactive(
                                 tokio::spawn(async move {
                                     let mut rx = rx;
                                     while let Some(payload) = rx.recv().await {
-                                        let _ = claurst_bridge::post_bridge_event(
-                                            &info_relay,
-                                            payload,
-                                        )
-                                        .await;
+                                        let _ =
+                                            claurst_bridge::post_bridge_event(&info_relay, payload)
+                                                .await;
                                     }
                                 });
                             }
@@ -3453,17 +3602,14 @@ async fn run_interactive(
                                                         .send(msg.content.clone())
                                                         .await
                                                         .is_err()
-                                                    {
-                                                        return;
-                                                    }
+                                                {
+                                                    return;
+                                                }
                                             }
                                         }
                                         _ => {}
                                     }
-                                    tokio::time::sleep(
-                                        std::time::Duration::from_secs(2),
-                                    )
-                                    .await;
+                                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
                                 }
                             });
                         }
@@ -3503,7 +3649,10 @@ async fn run_interactive(
                         let tools_arc_clone = tools_arc.clone();
                         let ctx_clone = tool_ctx.clone();
                         let mut qcfg = base_query_config.clone();
-                        qcfg.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
+                        qcfg.model = claurst_api::effective_model_for_config(
+                            &cmd_ctx.config,
+                            &model_registry,
+                        );
                         qcfg.max_tokens = cmd_ctx.config.effective_max_tokens();
                         let tracker = cost_tracker.clone();
                         let tx = event_tx.clone();
@@ -3533,18 +3682,21 @@ async fn run_interactive(
                                 ct.cancel();
                             }
                             app.is_streaming = false;
-                            app.status_message =
-                                Some("Cancelled by remote control.".to_string());
+                            app.status_message = Some("Cancelled by remote control.".to_string());
                         }
                     }
-                    Ok(TuiBridgeEvent::PermissionResponse { tool_use_id, response }) => {
+                    Ok(TuiBridgeEvent::PermissionResponse {
+                        tool_use_id,
+                        response,
+                    }) => {
                         // Resolve a pending permission dialog if IDs match.
                         if let Some(ref pr) = app.permission_request {
                             if pr.tool_use_id == tool_use_id {
                                 use claurst_bridge::PermissionResponseKind;
                                 let _allow = matches!(
                                     response,
-                                    PermissionResponseKind::Allow | PermissionResponseKind::AllowSession
+                                    PermissionResponseKind::Allow
+                                        | PermissionResponseKind::AllowSession
                                 );
                                 app.permission_request = None;
                             }
@@ -3611,7 +3763,8 @@ async fn run_interactive(
                 let tools_arc_clone = tools_arc.clone();
                 let ctx_clone = tool_ctx.clone();
                 let mut qcfg = base_query_config.clone();
-                qcfg.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
+                qcfg.model =
+                    claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
                 qcfg.max_tokens = cmd_ctx.config.effective_max_tokens();
                 let tracker = cost_tracker.clone();
                 let tx = event_tx.clone();
@@ -3698,8 +3851,7 @@ async fn run_interactive(
                     app.model_picker.loading_models = false;
                     app.model_fetch_rx = None;
                 }
-                Ok(Err(()))
-                | Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                Ok(Err(())) | Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
                     app.model_picker.loading_models = false;
                     app.model_fetch_rx = None;
                 }
@@ -3714,11 +3866,8 @@ async fn run_interactive(
         if let Some(ref mut rx) = app.user_question_rx {
             match rx.try_recv() {
                 Ok(event) => {
-                    app.ask_user_dialog.open(
-                        event.question,
-                        event.options,
-                        event.reply_tx,
-                    );
+                    app.ask_user_dialog
+                        .open(event.question, event.options, event.reply_tx);
                 }
                 Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {}
                 Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
@@ -3860,14 +4009,18 @@ async fn run_interactive(
                             COPILOT_CLIENT_ID,
                             "read:user",
                             "https://github.com/login/device/code",
-                        ).await {
+                        )
+                        .await
+                        {
                             Ok(resp) => {
-                                let _ = tx2.send(DeviceAuthEvent::GotCode {
-                                    user_code: resp.user_code,
-                                    verification_uri: resp.verification_uri,
-                                    device_code: resp.device_code.clone(),
-                                    interval: resp.interval,
-                                }).await;
+                                let _ = tx2
+                                    .send(DeviceAuthEvent::GotCode {
+                                        user_code: resp.user_code,
+                                        verification_uri: resp.verification_uri,
+                                        device_code: resp.device_code.clone(),
+                                        interval: resp.interval,
+                                    })
+                                    .await;
                                 // Step 2: Poll for access token
                                 match claurst_core::device_code::poll_for_token(
                                     COPILOT_CLIENT_ID,
@@ -3875,9 +4028,12 @@ async fn run_interactive(
                                     "https://github.com/login/oauth/access_token",
                                     resp.interval,
                                     300,
-                                ).await {
+                                )
+                                .await
+                                {
                                     Ok(token) => {
-                                        let _ = tx2.send(DeviceAuthEvent::TokenReceived(token)).await;
+                                        let _ =
+                                            tx2.send(DeviceAuthEvent::TokenReceived(token)).await;
                                     }
                                     Err(e) => {
                                         let _ = tx2.send(DeviceAuthEvent::Error(e)).await;
@@ -3923,14 +4079,17 @@ async fn run_interactive(
                     tokio::spawn(async move {
                         match crate::codex_oauth_flow::run_oauth_flow(tx2.clone()).await {
                             Ok(tokens) => {
-                                let _ = tx2.send(DeviceAuthEvent::TokenReceived(
-                                    tokens.access_token,
-                                )).await;
+                                let _ = tx2
+                                    .send(DeviceAuthEvent::TokenReceived(tokens.access_token))
+                                    .await;
                             }
                             Err(e) => {
-                                let _ = tx2.send(DeviceAuthEvent::Error(
-                                    format!("Codex OAuth failed: {}", e),
-                                )).await;
+                                let _ = tx2
+                                    .send(DeviceAuthEvent::Error(format!(
+                                        "Codex OAuth failed: {}",
+                                        e
+                                    )))
+                                    .await;
                             }
                         }
                     });
@@ -3958,8 +4117,12 @@ async fn run_interactive(
                     // Auto-open the verification URL in the browser
                     let _ = open::that(&verification_uri);
 
-                    app.device_auth_dialog
-                        .set_code(user_code, verification_uri, device_code, interval);
+                    app.device_auth_dialog.set_code(
+                        user_code,
+                        verification_uri,
+                        device_code,
+                        interval,
+                    );
 
                     app.notifications.push(
                         claurst_tui::NotificationKind::Info,
@@ -4028,7 +4191,8 @@ async fn run_interactive(
                 messages = msgs_arc.lock().await.clone();
                 session.messages = messages.clone();
                 session.updated_at = chrono::Utc::now();
-                session.model = claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
+                session.model =
+                    claurst_api::effective_model_for_config(&cmd_ctx.config, &model_registry);
                 session.working_dir = Some(tool_ctx.working_dir.display().to_string());
                 app.is_streaming = false;
                 app.status_message = None;
@@ -4061,8 +4225,16 @@ async fn run_interactive(
                         for msg in &session.messages {
                             let content_str = match &msg.content {
                                 claurst_core::types::MessageContent::Text(t) => t.clone(),
-                                claurst_core::types::MessageContent::Blocks(blocks) => blocks.iter()
-                                    .filter_map(|b| if let claurst_core::types::ContentBlock::Text { text } = b { Some(text.as_str()) } else { None })
+                                claurst_core::types::MessageContent::Blocks(blocks) => blocks
+                                    .iter()
+                                    .filter_map(|b| {
+                                        if let claurst_core::types::ContentBlock::Text { text } = b
+                                        {
+                                            Some(text.as_str())
+                                        } else {
+                                            None
+                                        }
+                                    })
                                     .collect::<Vec<_>>()
                                     .join(" "),
                             };
@@ -4071,7 +4243,8 @@ async fn run_interactive(
                                 claurst_core::types::Role::Assistant => "assistant",
                             };
                             let msg_id = msg.uuid.as_deref().unwrap_or("unknown");
-                            let _ = store.save_message(&session.id, msg_id, role, &content_str, None);
+                            let _ =
+                                store.save_message(&session.id, msg_id, role, &content_str, None);
                         }
                     }
                 }
@@ -4128,10 +4301,8 @@ async fn run_interactive(
                             ));
                         }
                         Err(error) => {
-                            app.status_message = Some(format!(
-                                "MCP auth failed for '{}': {}",
-                                server_name, error
-                            ));
+                            app.status_message =
+                                Some(format!("MCP auth failed for '{}': {}", server_name, error));
                         }
                     }
                 } else {
@@ -4156,8 +4327,7 @@ async fn run_interactive(
                 Ok(refreshed) => {
                     cmd_ctx.config = refreshed.config.clone();
                     tool_ctx.config = refreshed.config.clone();
-                    base_query_config.provider_registry =
-                        Some(refreshed.provider_registry.clone());
+                    base_query_config.provider_registry = Some(refreshed.provider_registry.clone());
                     base_query_config.model_registry = Some(refreshed.model_registry.clone());
                     base_query_config.model = claurst_api::effective_model_for_config(
                         &cmd_ctx.config,
@@ -4173,8 +4343,7 @@ async fn run_interactive(
                     app.has_credentials = true;
                 }
                 Err(err) => {
-                    app.status_message =
-                        Some(format!("Could not activate credentials: {}", err));
+                    app.status_message = Some(format!("Could not activate credentials: {}", err));
                 }
             }
         }
@@ -4217,10 +4386,7 @@ async fn run_interactive(
         // Prompt for any project-defined MCP servers awaiting approval (#123).
         // Hold off while the startup bypass-permissions dialog is up so the two
         // modals don't fight over the screen.
-        if !app.is_streaming
-            && current_query.is_none()
-            && !app.bypass_permissions_dialog.visible
-        {
+        if !app.is_streaming && current_query.is_none() && !app.bypass_permissions_dialog.visible {
             app.maybe_prompt_next_mcp_server();
         }
 
@@ -4357,13 +4523,23 @@ fn print_account_list(provider: &str, display_name: &str) {
     let active = registry.active(provider).map(String::from);
     if profiles.is_empty() {
         println!("No {} accounts stored.", display_name);
-        println!("Use `claurst {} login` to add one.",
-            if provider == "anthropic" { "auth" } else { provider });
+        println!(
+            "Use `claurst {} login` to add one.",
+            if provider == "anthropic" {
+                "auth"
+            } else {
+                provider
+            }
+        );
         return;
     }
     println!("{} accounts:", display_name);
     for p in profiles {
-        let marker = if active.as_deref() == Some(&p.id) { "*" } else { " " };
+        let marker = if active.as_deref() == Some(&p.id) {
+            "*"
+        } else {
+            " "
+        };
         let email = p.email.as_deref().unwrap_or("");
         let label = p
             .label
@@ -4391,8 +4567,14 @@ fn switch_account(provider: &str, display_name: &str, id: Option<&str>) -> ! {
                 std::process::exit(1);
             }
             // No id: print the picker and exit with usage.
-            eprintln!("Usage: claurst {} switch <profile-id>",
-                if provider == "anthropic" { "auth" } else { provider });
+            eprintln!(
+                "Usage: claurst {} switch <profile-id>",
+                if provider == "anthropic" {
+                    "auth"
+                } else {
+                    provider
+                }
+            );
             eprintln!();
             print_account_list(provider, display_name);
             std::process::exit(1);
@@ -4425,25 +4607,21 @@ async fn handle_codex_account_command(args: &[String]) -> anyhow::Result<()> {
             // login we still spin up the OAuth listener but route the URL
             // through a no-op channel; the user opens the URL in their browser
             // either way.
-            let (tx, mut rx) =
-                tokio::sync::mpsc::channel::<claurst_tui::DeviceAuthEvent>(8);
+            let (tx, mut rx) = tokio::sync::mpsc::channel::<claurst_tui::DeviceAuthEvent>(8);
             tokio::spawn(async move {
                 while let Some(evt) = rx.recv().await {
                     if let claurst_tui::DeviceAuthEvent::GotBrowserUrl { url } = evt {
                         println!("Opening browser for Codex authentication...");
-                        println!(
-                            "If the browser did not open, visit:\n\n  {}\n",
-                            url
-                        );
+                        println!("If the browser did not open, visit:\n\n  {}\n", url);
                     }
                 }
             });
-            match crate::codex_oauth_flow::run_oauth_flow_with_label(tx, label.as_deref()).await
-            {
+            match crate::codex_oauth_flow::run_oauth_flow_with_label(tx, label.as_deref()).await {
                 Ok(_) => {
                     let registry = claurst_core::accounts::AccountRegistry::load();
                     println!("Successfully logged in to Codex!");
-                    if let Some(p) = registry.active_profile(claurst_core::accounts::PROVIDER_CODEX) {
+                    if let Some(p) = registry.active_profile(claurst_core::accounts::PROVIDER_CODEX)
+                    {
                         if let Some(email) = &p.email {
                             println!("  Account: {}", email);
                         }
@@ -4457,18 +4635,16 @@ async fn handle_codex_account_command(args: &[String]) -> anyhow::Result<()> {
                 }
             }
         }
-        Some("logout") => {
-            match claurst_core::oauth_config::clear_codex_tokens() {
-                Ok(_) => {
-                    println!("Logged out of the active Codex account.");
-                    std::process::exit(0);
-                }
-                Err(e) => {
-                    eprintln!("Logout failed: {}", e);
-                    std::process::exit(1);
-                }
+        Some("logout") => match claurst_core::oauth_config::clear_codex_tokens() {
+            Ok(_) => {
+                println!("Logged out of the active Codex account.");
+                std::process::exit(0);
             }
-        }
+            Err(e) => {
+                eprintln!("Logout failed: {}", e);
+                std::process::exit(1);
+            }
+        },
         Some("list") | Some("ls") | Some("accounts") => {
             print_account_list(claurst_core::accounts::PROVIDER_CODEX, "Codex");
             std::process::exit(0);
@@ -4738,7 +4914,10 @@ async fn auth_status(json_output: bool) {
             } else if let Some(env_var) =
                 claurst_core::config::primary_api_key_env_var_for_provider(active_provider)
             {
-                format!("Set {} or store a credential for {}.", env_var, api_provider)
+                format!(
+                    "Set {} or store a credential for {}.",
+                    env_var, api_provider
+                )
             } else {
                 format!("Configure credentials for {}.", api_provider)
             };
@@ -4878,7 +5057,10 @@ mod bare_mode_tests {
             .map(|v| v.len())
             .sum();
         assert_eq!(hook_count, 0, "no plugin hooks");
-        assert!(registry.all_mcp_servers().is_empty(), "no plugin MCP servers");
+        assert!(
+            registry.all_mcp_servers().is_empty(),
+            "no plugin MCP servers"
+        );
     }
 
     #[test]

--- a/src-rust/crates/commands/src/lib.rs
+++ b/src-rust/crates/commands/src/lib.rs
@@ -9,9 +9,9 @@ use claurst_core::config::{Config, Settings, Theme};
 use claurst_core::cost::CostTracker;
 use claurst_core::types::{ContentBlock, Message};
 use std::collections::BTreeMap;
-use std::sync::Arc;
 #[allow(unused_imports)]
 use std::path::PathBuf;
+use std::sync::Arc;
 
 // ---------------------------------------------------------------------------
 // Core trait
@@ -167,10 +167,14 @@ fn resolve_fast_model_id(config: &Config) -> String {
     provider_lookup_ids(provider_id)
         .into_iter()
         .find_map(|lookup_id| registry.best_small_model_for_provider(lookup_id))
-        .unwrap_or_else(|| stripped_model_for_provider(provider_id, config.effective_model()).to_string())
+        .unwrap_or_else(|| {
+            stripped_model_for_provider(provider_id, config.effective_model()).to_string()
+        })
 }
 
-async fn provider_for_config(config: &Config) -> Option<std::sync::Arc<dyn claurst_api::LlmProvider>> {
+async fn provider_for_config(
+    config: &Config,
+) -> Option<std::sync::Arc<dyn claurst_api::LlmProvider>> {
     let anthropic_auth = config.resolve_anthropic_auth_async().await;
     let registry = claurst_api::ProviderRegistry::from_config(
         config,
@@ -189,7 +193,11 @@ async fn provider_for_config(config: &Config) -> Option<std::sync::Arc<dyn claur
 
     provider_lookup_ids(config.selected_provider_id())
         .into_iter()
-        .find_map(|lookup_id| registry.get(&claurst_core::ProviderId::new(lookup_id)).cloned())
+        .find_map(|lookup_id| {
+            registry
+                .get(&claurst_core::ProviderId::new(lookup_id))
+                .cloned()
+        })
 }
 
 fn text_from_content_blocks(blocks: &[ContentBlock]) -> String {
@@ -417,10 +425,7 @@ fn generate_keybindings_template() -> anyhow::Result<String> {
             .collect(),
     };
 
-    Ok(format!(
-        "{}\n",
-        serde_json::to_string_pretty(&template)?
-    ))
+    Ok(format!("{}\n", serde_json::to_string_pretty(&template)?))
 }
 
 fn parse_theme(name: &str) -> Option<Theme> {
@@ -499,34 +504,40 @@ fn execute_named_command_from_slash(
 /// Category labels for help grouping.
 fn command_category(name: &str) -> &'static str {
     match name {
-        "clear" | "new" | "compact" | "rewind" | "summary" | "export" | "rename" | "branch" | "fork" => {
-            "Conversation"
-        }
-        "model" | "config" | "theme" | "color" | "vim" | "fast" | "effort"
-        | "voice" | "statusline" | "output-style" | "keybindings"
-        | "privacy-settings" | "rate-limit-options" | "sandbox-toggle" => "Settings",
+        "clear" | "new" | "compact" | "rewind" | "summary" | "export" | "rename" | "branch"
+        | "fork" => "Conversation",
+        "model" | "config" | "theme" | "color" | "vim" | "fast" | "effort" | "voice"
+        | "statusline" | "output-style" | "keybindings" | "privacy-settings"
+        | "rate-limit-options" | "sandbox-toggle" => "Settings",
         "cost" | "stats" | "usage" | "extra-usage" | "context" | "ctx-viz" => "Usage & Cost",
         "status" | "doctor" | "terminal-setup" | "version" | "update" | "upgrade"
         | "release-notes" => "System",
         "login" | "logout" | "refresh" | "permissions" => "Auth & Permissions",
-        "memory" | "files" | "diff" | "init" | "commit" | "review"
-        | "security-review" | "import-config" => "Project",
+        "memory" | "files" | "diff" | "init" | "commit" | "review" | "security-review"
+        | "import-config" => "Project",
         "mcp" | "hooks" | "ide" | "chrome" => "Integrations",
-        "session" | "resume" | "remote-control" | "remote-env"
-        | "teleport" | "move" => "Sessions & Remote",
+        "session" | "resume" | "remote-control" | "remote-env" | "teleport" | "move" => {
+            "Sessions & Remote"
+        }
         "help" | "exit" => "General",
         "think-back" | "thinkback-play" | "thinking" | "plan" | "tasks" => "AI & Thinking",
-        "copy" | "skills" | "agents" | "plugin" | "reload-plugins"
-        | "stickers" | "passes" | "desktop" | "mobile" | "btw" => "Tools & Extras",
+        "copy" | "skills" | "agents" | "plugin" | "reload-plugins" | "stickers" | "passes"
+        | "desktop" | "mobile" | "btw" => "Tools & Extras",
         _ => "Other",
     }
 }
 
 #[async_trait]
 impl SlashCommand for HelpCommand {
-    fn name(&self) -> &str { "help" }
-    fn aliases(&self) -> Vec<&str> { vec!["h", "?"] }
-    fn description(&self) -> &str { "Show available commands and usage information" }
+    fn name(&self) -> &str {
+        "help"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["h", "?"]
+    }
+    fn description(&self) -> &str {
+        "Show available commands and usage information"
+    }
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         if !args.is_empty() {
@@ -538,7 +549,11 @@ impl SlashCommand for HelpCommand {
                 } else {
                     format!(
                         "\nAliases: {}",
-                        aliases.iter().map(|a| format!("/{}", a)).collect::<Vec<_>>().join(", ")
+                        aliases
+                            .iter()
+                            .map(|a| format!("/{}", a))
+                            .collect::<Vec<_>>()
+                            .join(", ")
                     )
                 };
                 return CommandResult::Message(format!(
@@ -583,13 +598,18 @@ impl SlashCommand for HelpCommand {
             } else {
                 format!(
                     " ({})",
-                    aliases.iter().map(|a| format!("/{}", a)).collect::<Vec<_>>().join(", ")
+                    aliases
+                        .iter()
+                        .map(|a| format!("/{}", a))
+                        .collect::<Vec<_>>()
+                        .join(", ")
                 )
             };
-            by_cat
-                .entry(cat)
-                .or_default()
-                .push(format!("  /{:<20} {}", format!("{}{}", cmd.name(), alias_str), cmd.description()));
+            by_cat.entry(cat).or_default().push(format!(
+                "  /{:<20} {}",
+                format!("{}{}", cmd.name(), alias_str),
+                cmd.description()
+            ));
         }
 
         let mut output = String::from("Claurst — Slash Commands\n");
@@ -613,9 +633,15 @@ impl SlashCommand for HelpCommand {
 
 #[async_trait]
 impl SlashCommand for ClearCommand {
-    fn name(&self) -> &str { "clear" }
-    fn aliases(&self) -> Vec<&str> { vec!["c", "reset"] }
-    fn description(&self) -> &str { "Clear the conversation history" }
+    fn name(&self) -> &str {
+        "clear"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["c", "reset"]
+    }
+    fn description(&self) -> &str {
+        "Clear the conversation history"
+    }
 
     async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
         CommandResult::ClearConversation
@@ -626,8 +652,12 @@ impl SlashCommand for ClearCommand {
 
 #[async_trait]
 impl SlashCommand for CompactCommand {
-    fn name(&self) -> &str { "compact" }
-    fn description(&self) -> &str { "Compact the conversation to reduce token usage" }
+    fn name(&self) -> &str {
+        "compact"
+    }
+    fn description(&self) -> &str {
+        "Compact the conversation to reduce token usage"
+    }
 
     async fn execute(&self, args: &str, ctx: &mut CommandContext) -> CommandResult {
         let msg_count = ctx.messages.len();
@@ -651,8 +681,12 @@ impl SlashCommand for CompactCommand {
 
 #[async_trait]
 impl SlashCommand for CostCommand {
-    fn name(&self) -> &str { "cost" }
-    fn description(&self) -> &str { "Show token usage and cost for this session" }
+    fn name(&self) -> &str {
+        "cost"
+    }
+    fn description(&self) -> &str {
+        "Show token usage and cost for this session"
+    }
     fn help(&self) -> &str {
         "Usage: /cost\n\n\
          Shows per-category token counts and the estimated cost for this session.\n\
@@ -674,10 +708,10 @@ impl SlashCommand for CostCommand {
         let cost = tracker.total_cost_usd();
 
         // Per-category cost breakdown.
-        let input_cost    = (input as f64 * pricing.input_per_mtk) / 1_000_000.0;
-        let output_cost   = (output as f64 * pricing.output_per_mtk) / 1_000_000.0;
-        let cc_cost       = (cache_create as f64 * pricing.cache_creation_per_mtk) / 1_000_000.0;
-        let cr_cost       = (cache_read as f64 * pricing.cache_read_per_mtk) / 1_000_000.0;
+        let input_cost = (input as f64 * pricing.input_per_mtk) / 1_000_000.0;
+        let output_cost = (output as f64 * pricing.output_per_mtk) / 1_000_000.0;
+        let cc_cost = (cache_create as f64 * pricing.cache_creation_per_mtk) / 1_000_000.0;
+        let cr_cost = (cache_read as f64 * pricing.cache_read_per_mtk) / 1_000_000.0;
 
         // Pricing info line.
         let pricing_line = format!(
@@ -691,10 +725,12 @@ impl SlashCommand for CostCommand {
         // Cache savings note: how much input cost was avoided by using cache-read
         // instead of re-sending those tokens as normal input.
         let savings = if cache_read > 0 {
-            let saved =
-                (cache_read as f64 * (pricing.input_per_mtk - pricing.cache_read_per_mtk))
-                    / 1_000_000.0;
-            format!("\n  Cache savings:  ${:.4}  ({} tokens served from cache)", saved, cache_read)
+            let saved = (cache_read as f64 * (pricing.input_per_mtk - pricing.cache_read_per_mtk))
+                / 1_000_000.0;
+            format!(
+                "\n  Cache savings:  ${:.4}  ({} tokens served from cache)",
+                saved, cache_read
+            )
         } else {
             String::new()
         };
@@ -732,9 +768,15 @@ impl SlashCommand for CostCommand {
 
 #[async_trait]
 impl SlashCommand for ExitCommand {
-    fn name(&self) -> &str { "exit" }
-    fn aliases(&self) -> Vec<&str> { vec!["quit", "q"] }
-    fn description(&self) -> &str { "Exit Claurst" }
+    fn name(&self) -> &str {
+        "exit"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["quit", "q"]
+    }
+    fn description(&self) -> &str {
+        "Exit Claurst"
+    }
 
     async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
         CommandResult::Exit
@@ -745,8 +787,12 @@ impl SlashCommand for ExitCommand {
 
 #[async_trait]
 impl SlashCommand for ModelCommand {
-    fn name(&self) -> &str { "model" }
-    fn description(&self) -> &str { "Show or change the current model" }
+    fn name(&self) -> &str {
+        "model"
+    }
+    fn description(&self) -> &str {
+        "Show or change the current model"
+    }
     fn help(&self) -> &str {
         "Usage: /model [<model-id>]\n\n\
          Without arguments, shows the current model.\n\n\
@@ -763,10 +809,7 @@ impl SlashCommand for ModelCommand {
     async fn execute(&self, args: &str, ctx: &mut CommandContext) -> CommandResult {
         let args = args.trim();
         if args.is_empty() {
-            CommandResult::Message(format!(
-                "Current model: {}",
-                ctx.config.effective_model()
-            ))
+            CommandResult::Message(format!("Current model: {}", ctx.config.effective_model()))
         } else {
             // Accept both "provider/model" and bare model names.
             // The config stores the full string (including provider prefix when present)
@@ -795,15 +838,18 @@ impl SlashCommand for ModelCommand {
 
 #[async_trait]
 impl SlashCommand for VersionCommand {
-    fn name(&self) -> &str { "version" }
-    fn aliases(&self) -> Vec<&str> { vec!["v"] }
-    fn description(&self) -> &str { "Show version information" }
+    fn name(&self) -> &str {
+        "version"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["v"]
+    }
+    fn description(&self) -> &str {
+        "Show version information"
+    }
 
     async fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
-        CommandResult::Message(format!(
-            "Claurst v{}",
-            claurst_core::constants::APP_VERSION
-        ))
+        CommandResult::Message(format!("Claurst v{}", claurst_core::constants::APP_VERSION))
     }
 }
 
@@ -811,9 +857,15 @@ impl SlashCommand for VersionCommand {
 
 #[async_trait]
 impl SlashCommand for ResumeCommand {
-    fn name(&self) -> &str { "resume" }
-    fn aliases(&self) -> Vec<&str> { vec!["r", "continue"] }
-    fn description(&self) -> &str { "Resume a previous conversation" }
+    fn name(&self) -> &str {
+        "resume"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["r", "continue"]
+    }
+    fn description(&self) -> &str {
+        "Resume a previous conversation"
+    }
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         if args.is_empty() {
@@ -824,19 +876,16 @@ impl SlashCommand for ResumeCommand {
             let last = &sessions[0];
             match claurst_core::history::load_session(&last.id).await {
                 Ok(session) => CommandResult::ResumeSession(session),
-                Err(e) => CommandResult::Error(format!(
-                    "Failed to load session {}: {}",
-                    last.id, e
-                )),
+                Err(e) => {
+                    CommandResult::Error(format!("Failed to load session {}: {}", last.id, e))
+                }
             }
         } else {
             match claurst_core::history::load_session(args.trim()).await {
                 Ok(session) => CommandResult::ResumeSession(session),
-                Err(e) => CommandResult::Error(format!(
-                    "Failed to load session {}: {}",
-                    args.trim(),
-                    e
-                )),
+                Err(e) => {
+                    CommandResult::Error(format!("Failed to load session {}: {}", args.trim(), e))
+                }
             }
         }
     }
@@ -846,8 +895,12 @@ impl SlashCommand for ResumeCommand {
 
 #[async_trait]
 impl SlashCommand for StatusCommand {
-    fn name(&self) -> &str { "status" }
-    fn description(&self) -> &str { "Show comprehensive system and session status" }
+    fn name(&self) -> &str {
+        "status"
+    }
+    fn description(&self) -> &str {
+        "Show comprehensive system and session status"
+    }
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         // Auth status
@@ -933,8 +986,12 @@ impl SlashCommand for StatusCommand {
 
 #[async_trait]
 impl SlashCommand for DiffCommand {
-    fn name(&self) -> &str { "diff" }
-    fn description(&self) -> &str { "Show git diff of changes in the working directory" }
+    fn name(&self) -> &str {
+        "diff"
+    }
+    fn description(&self) -> &str {
+        "Show git diff of changes in the working directory"
+    }
     fn help(&self) -> &str {
         "Usage: /diff [--stat|--staged|<ref>]\n\n\
          Shows git diff output for the current working directory.\n\n\
@@ -1005,8 +1062,12 @@ impl SlashCommand for DiffCommand {
 
 #[async_trait]
 impl SlashCommand for InitCommand {
-    fn name(&self) -> &str { "init" }
-    fn description(&self) -> &str { "Initialize a new project with AGENTS.md" }
+    fn name(&self) -> &str {
+        "init"
+    }
+    fn description(&self) -> &str {
+        "Initialize a new project with AGENTS.md"
+    }
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         let path = ctx.working_dir.join("AGENTS.md");
@@ -1025,10 +1086,7 @@ impl SlashCommand for InitCommand {
             - List important files and their purposes\n";
 
         match tokio::fs::write(&path, default_content).await {
-            Ok(()) => CommandResult::Message(format!(
-                "Created AGENTS.md at {}",
-                path.display()
-            )),
+            Ok(()) => CommandResult::Message(format!("Created AGENTS.md at {}", path.display())),
             Err(e) => CommandResult::Error(format!("Failed to create AGENTS.md: {}", e)),
         }
     }
@@ -1038,8 +1096,12 @@ impl SlashCommand for InitCommand {
 
 #[async_trait]
 impl SlashCommand for ImportConfigCommand {
-    fn name(&self) -> &str { "import-config" }
-    fn description(&self) -> &str { "Import CLAUDE.md and settings.json from ~/.claude" }
+    fn name(&self) -> &str {
+        "import-config"
+    }
+    fn description(&self) -> &str {
+        "Import CLAUDE.md and settings.json from ~/.claude"
+    }
     fn help(&self) -> &str {
         "Usage: /import-config\n\
          Import user-level Claude Code configuration from ~/.claude:\n\
@@ -1057,8 +1119,12 @@ impl SlashCommand for ImportConfigCommand {
 
 #[async_trait]
 impl SlashCommand for HooksCommand {
-    fn name(&self) -> &str { "hooks" }
-    fn description(&self) -> &str { "Show configured event hooks" }
+    fn name(&self) -> &str {
+        "hooks"
+    }
+    fn description(&self) -> &str {
+        "Show configured event hooks"
+    }
     fn help(&self) -> &str {
         "Usage: /hooks\n\
          Show hooks configured in settings.json under 'hooks'.\n\
@@ -1097,9 +1163,15 @@ impl SlashCommand for HooksCommand {
 
 #[async_trait]
 impl SlashCommand for ThinkingCommand {
-    fn name(&self) -> &str { "thinking" }
-    fn description(&self) -> &str { "Toggle extended thinking mode" }
-    fn aliases(&self) -> Vec<&str> { vec!["think"] }
+    fn name(&self) -> &str {
+        "thinking"
+    }
+    fn description(&self) -> &str {
+        "Toggle extended thinking mode"
+    }
+    fn aliases(&self) -> Vec<&str> {
+        vec!["think"]
+    }
 
     async fn execute(&self, _args: &str, ctx: &mut CommandContext) -> CommandResult {
         // Extended thinking is configured through the model; just inform the user
@@ -1107,7 +1179,8 @@ impl SlashCommand for ThinkingCommand {
         if model.contains("claude-3-5") || model.contains("claude-3.5") {
             CommandResult::Message(
                 "Extended thinking is not available for Claude 3.5 models.\n\
-                 Use claude-opus-4-6 or claude-sonnet-4-6 for extended thinking.".to_string()
+                 Use claude-opus-4-6 or claude-sonnet-4-6 for extended thinking."
+                    .to_string(),
             )
         } else {
             CommandResult::Message(format!(
@@ -1124,13 +1197,21 @@ impl SlashCommand for ThinkingCommand {
 
 #[async_trait]
 impl SlashCommand for NamedCommandAdapter {
-    fn name(&self) -> &str { self.slash_name }
+    fn name(&self) -> &str {
+        self.slash_name
+    }
 
-    fn aliases(&self) -> Vec<&str> { self.slash_aliases.to_vec() }
+    fn aliases(&self) -> Vec<&str> {
+        self.slash_aliases.to_vec()
+    }
 
-    fn description(&self) -> &str { self.slash_description }
+    fn description(&self) -> &str {
+        self.slash_description
+    }
 
-    fn help(&self) -> &str { self.slash_help }
+    fn help(&self) -> &str {
+        self.slash_help
+    }
 
     async fn execute(&self, args: &str, ctx: &mut CommandContext) -> CommandResult {
         execute_named_command_from_slash(self.target_name, args, ctx)
@@ -1335,9 +1416,9 @@ pub fn all_commands() -> Vec<Box<dyn SlashCommand>> {
 /// Find a command by name or alias.
 pub fn find_command(name: &str) -> Option<Box<dyn SlashCommand>> {
     let name = name.trim_start_matches('/');
-    all_commands().into_iter().find(|c| {
-        c.name() == name || c.aliases().contains(&name)
-    })
+    all_commands()
+        .into_iter()
+        .find(|c| c.name() == name || c.aliases().contains(&name))
 }
 
 /// Build `HelpEntry` values for all non-hidden commands, suitable for
@@ -1367,18 +1448,31 @@ struct TemplateCommand {
 
 #[async_trait]
 impl SlashCommand for TemplateCommand {
-    fn name(&self) -> &str { &self.name }
+    fn name(&self) -> &str {
+        &self.name
+    }
     fn description(&self) -> &str {
-        self.template.description.as_deref().unwrap_or("Custom command")
+        self.template
+            .description
+            .as_deref()
+            .unwrap_or("Custom command")
     }
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let mut words = args.split_whitespace();
         let arg1 = words.next().unwrap_or("");
         let arg2 = words.next().unwrap_or("");
-        let prompt = self.template.template
-            .replace("$ARGUMENTS", args)
-            .replace("$1", arg1)
-            .replace("$2", arg2);
+        let prompt = if !args.trim().is_empty()
+            && !self.template.template.contains("$ARGUMENTS")
+            && !self.template.template.contains("$1")
+        {
+            format!("{}\n\n{}", self.template.template, args.trim())
+        } else {
+            self.template
+                .template
+                .replace("$ARGUMENTS", args)
+                .replace("$1", arg1)
+                .replace("$2", arg2)
+        };
         CommandResult::UserMessage(prompt)
     }
 }
@@ -1386,12 +1480,16 @@ impl SlashCommand for TemplateCommand {
 /// Build slash commands from user-defined command templates stored in
 /// `settings.commands`.
 pub fn commands_from_settings(settings: &claurst_core::Settings) -> Vec<Box<dyn SlashCommand>> {
-    settings.commands.iter().map(|(name, template)| {
-        Box::new(TemplateCommand {
-            name: name.clone(),
-            template: template.clone(),
-        }) as Box<dyn SlashCommand>
-    }).collect()
+    settings
+        .commands
+        .iter()
+        .map(|(name, template)| {
+            Box::new(TemplateCommand {
+                name: name.clone(),
+                template: template.clone(),
+            }) as Box<dyn SlashCommand>
+        })
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -1407,17 +1505,28 @@ struct SkillCommand {
 
 #[async_trait]
 impl SlashCommand for SkillCommand {
-    fn name(&self) -> &str { &self.name }
-    fn description(&self) -> &str { &self.description }
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn description(&self) -> &str {
+        &self.description
+    }
 
     async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> CommandResult {
         let mut words = args.split_whitespace();
         let arg1 = words.next().unwrap_or("");
         let arg2 = words.next().unwrap_or("");
-        let prompt = self.template
-            .replace("$ARGUMENTS", args)
-            .replace("$1", arg1)
-            .replace("$2", arg2);
+        let prompt = if !args.trim().is_empty()
+            && !self.template.contains("$ARGUMENTS")
+            && !self.template.contains("$1")
+        {
+            format!("{}\n\n{}", self.template, args.trim())
+        } else {
+            self.template
+                .replace("$ARGUMENTS", args)
+                .replace("$1", arg1)
+                .replace("$2", arg2)
+        };
         CommandResult::UserMessage(prompt)
     }
 }
@@ -1435,10 +1544,8 @@ pub fn commands_from_discovered_skills(
     let discovered = claurst_core::discover_skills(cwd, skills_config);
     // Build a set of built-in command names so we can skip collisions.
     let all_cmds = all_commands();
-    let builtin_names: std::collections::HashSet<&str> = all_cmds
-        .iter()
-        .map(|c| c.name())
-        .collect();
+    let builtin_names: std::collections::HashSet<&str> =
+        all_cmds.iter().map(|c| c.name()).collect();
 
     discovered
         .into_values()
@@ -1454,11 +1561,10 @@ pub fn commands_from_discovered_skills(
 }
 
 /// Execute a slash command string (with leading /).
-pub async fn execute_command(
-    input: &str,
-    ctx: &mut CommandContext,
-) -> Option<CommandResult> {
-    if !claurst_tui::input::is_slash_command(input) { return None; }
+pub async fn execute_command(input: &str, ctx: &mut CommandContext) -> Option<CommandResult> {
+    if !claurst_tui::input::is_slash_command(input) {
+        return None;
+    }
     let (name, args) = claurst_tui::input::parse_slash_command(input);
 
     // First check built-in commands.
@@ -1469,7 +1575,10 @@ pub async fn execute_command(
     // Check user-defined command templates from settings.
     let cmd_name = name.trim_start_matches('/');
     if let Some(tmpl) = ctx.config.commands.get(cmd_name).cloned() {
-        let tc = TemplateCommand { name: cmd_name.to_string(), template: tmpl };
+        let tc = TemplateCommand {
+            name: cmd_name.to_string(),
+            template: tmpl,
+        };
         return Some(tc.execute(args, ctx).await);
     }
 
@@ -1592,13 +1701,40 @@ mod tests {
     #[test]
     fn test_core_commands_present() {
         let expected = [
-            "help", "clear", "compact", "cost", "exit", "model",
-            "config", "version", "status", "diff", "memory", "hooks",
-            "permissions", "plan", "tasks", "session", "login", "logout", "refresh",
-            "usage", "plugin", "reload-plugins",
-            "add-dir", "agents", "branch", "tag",
-            "passes", "ide", "pr-comments", "desktop", "mobile",
-            "install-github-app", "web-setup", "stickers",
+            "help",
+            "clear",
+            "compact",
+            "cost",
+            "exit",
+            "model",
+            "config",
+            "version",
+            "status",
+            "diff",
+            "memory",
+            "hooks",
+            "permissions",
+            "plan",
+            "tasks",
+            "session",
+            "login",
+            "logout",
+            "refresh",
+            "usage",
+            "plugin",
+            "reload-plugins",
+            "add-dir",
+            "agents",
+            "branch",
+            "tag",
+            "passes",
+            "ide",
+            "pr-comments",
+            "desktop",
+            "mobile",
+            "install-github-app",
+            "web-setup",
+            "stickers",
         ];
         for name in &expected {
             assert!(
@@ -1631,7 +1767,10 @@ mod tests {
         let CommandResult::Message(text) = result else {
             panic!("empty /output-style should list styles, got {result:?}");
         };
-        assert!(text.contains("caveman"), "personas must appear in the list: {text}");
+        assert!(
+            text.contains("caveman"),
+            "personas must appear in the list: {text}"
+        );
         assert!(text.contains("rocky"));
         assert!(text.contains("default"));
         // Default config → default is the current style.
@@ -1679,7 +1818,10 @@ mod tests {
         let template = generate_keybindings_template().expect("template must generate");
         let parsed: serde_json::Value =
             serde_json::from_str(&template).expect("template must be valid JSON");
-        assert!(parsed.get("bindings").is_some(), "template needs a bindings block");
+        assert!(
+            parsed.get("bindings").is_some(),
+            "template needs a bindings block"
+        );
     }
 
     #[test]
@@ -1807,9 +1949,7 @@ mod tests {
         let result = cmd.execute("--codex --label work", &mut ctx).await;
         match result {
             CommandResult::StartLoginForProvider {
-                provider,
-                label,
-                ..
+                provider, label, ..
             } => {
                 assert_eq!(provider, claurst_core::accounts::PROVIDER_CODEX);
                 assert_eq!(label.as_deref(), Some("work"));

--- a/src-rust/crates/core/src/skill_discovery.rs
+++ b/src-rust/crates/core/src/skill_discovery.rs
@@ -70,10 +70,19 @@ pub fn parse_skill_file(content: &str, path: &Path) -> Option<DiscoveredSkill> {
     };
 
     let name = name.unwrap_or_else(|| {
-        path.file_stem()
+        let stem = path
+            .file_stem()
             .and_then(|s| s.to_str())
-            .unwrap_or("unnamed")
-            .to_string()
+            .unwrap_or("unnamed");
+        if stem.eq_ignore_ascii_case("skill") {
+            path.parent()
+                .and_then(|p| p.file_name())
+                .and_then(|s| s.to_str())
+                .unwrap_or(stem)
+                .to_string()
+        } else {
+            stem.to_string()
+        }
     });
     let description = description.unwrap_or_else(|| "Custom skill".to_string());
 
@@ -93,11 +102,27 @@ pub fn parse_skill_file(content: &str, path: &Path) -> Option<DiscoveredSkill> {
 // Directory scanning
 // ---------------------------------------------------------------------------
 
-/// Scan a single directory for `*.md` skill files.
+/// Scan a single directory for skill files:
+/// - Flat `*.md` files directly in `dir`
+/// - Subdirectories containing `SKILL.md` or `skill.md` (e.g. `dir/<skill-name>/SKILL.md`)
+/// - `dir` itself if it directly contains `SKILL.md` or `skill.md`
 fn scan_dir(dir: &Path) -> Vec<DiscoveredSkill> {
     let mut skills = Vec::new();
     if !dir.is_dir() {
         return skills;
+    }
+
+    // If `dir` directly contains a SKILL.md/skill.md file, parse it as a single skill.
+    for skill_file in ["SKILL.md", "skill.md", "SKILL.MD", "Skill.md"] {
+        let candidate = dir.join(skill_file);
+        if candidate.is_file() {
+            if let Ok(content) = std::fs::read_to_string(&candidate) {
+                if let Some(skill) = parse_skill_file(&content, &candidate) {
+                    skills.push(skill);
+                    return skills;
+                }
+            }
+        }
     }
 
     let entries = match std::fs::read_dir(dir) {
@@ -110,15 +135,43 @@ fn scan_dir(dir: &Path) -> Vec<DiscoveredSkill> {
 
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) == Some("md") {
-            match std::fs::read_to_string(&path) {
-                Ok(content) => {
-                    if let Some(skill) = parse_skill_file(&content, &path) {
-                        skills.push(skill);
+        let file_name = entry.file_name();
+        let file_name_str = file_name.to_string_lossy();
+
+        // Skip hidden files/directories (e.g. .git, .DS_Store).
+        if file_name_str.starts_with('.') {
+            continue;
+        }
+
+        if path.is_file() {
+            if path.extension().and_then(|e| e.to_str()) == Some("md") {
+                match std::fs::read_to_string(&path) {
+                    Ok(content) => {
+                        if let Some(skill) = parse_skill_file(&content, &path) {
+                            skills.push(skill);
+                        }
+                    }
+                    Err(err) => {
+                        tracing::debug!(path = %path.display(), error = %err, "skill_discovery: read failed");
                     }
                 }
-                Err(err) => {
-                    tracing::debug!(path = %path.display(), error = %err, "skill_discovery: read failed");
+            }
+        } else if path.is_dir() {
+            // Check subdirectories for SKILL.md / skill.md
+            for skill_file in ["SKILL.md", "skill.md", "SKILL.MD", "Skill.md"] {
+                let candidate = path.join(skill_file);
+                if candidate.is_file() {
+                    match std::fs::read_to_string(&candidate) {
+                        Ok(content) => {
+                            if let Some(skill) = parse_skill_file(&content, &candidate) {
+                                skills.push(skill);
+                            }
+                        }
+                        Err(err) => {
+                            tracing::debug!(path = %candidate.display(), error = %err, "skill_discovery: read failed");
+                        }
+                    }
+                    break;
                 }
             }
         }
@@ -127,11 +180,49 @@ fn scan_dir(dir: &Path) -> Vec<DiscoveredSkill> {
     skills
 }
 
+/// Resolve a configured path string, expanding `~` to the user's home directory.
+fn resolve_path(path_str: &str, cwd: &Path) -> PathBuf {
+    let trimmed = path_str.trim();
+    if trimmed == "~" {
+        dirs::home_dir().unwrap_or_else(|| PathBuf::from("."))
+    } else if let Some(stripped) = trimmed.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            home.join(stripped)
+        } else {
+            PathBuf::from(trimmed)
+        }
+    } else if trimmed.starts_with('~') {
+        if let Some(home) = dirs::home_dir() {
+            if let Some(pos) = trimmed.find('/') {
+                home.join(&trimmed[pos + 1..])
+            } else {
+                home
+            }
+        } else {
+            PathBuf::from(trimmed)
+        }
+    } else {
+        let p = Path::new(trimmed);
+        if p.is_absolute() {
+            p.to_path_buf()
+        } else {
+            cwd.join(p)
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Top-level discovery
 // ---------------------------------------------------------------------------
 
 /// Discover all skills from all configured sources.
+///
+/// Search priority (first match wins for a given skill name):
+///   1. Project `.claurst/skills/` and `.agents/skills/` — walk up from `cwd`
+///   2. Global `~/.claurst/skills/`
+///   3. Global `~/.agents/skills/`
+///   4. Configured extra paths from `SkillsConfig.paths`
+///   5. Git-URL repos from `SkillsConfig.urls` (cloned once, then cached)
 ///
 /// Returns a `HashMap` of `skill_name → DiscoveredSkill` (first match wins;
 /// duplicates from lower-priority sources are warned via `tracing::warn`).
@@ -176,18 +267,18 @@ pub fn discover_skills(
         &crate::config::Settings::config_dir().join("skills"),
     ));
 
-    // ---- 3. Configured extra paths ------------------------------------------
+    // ---- 3. Global .agents skills: ~/.agents/skills/ -------------------------
+    if let Some(home) = dirs::home_dir() {
+        add(scan_dir(&home.join(".agents").join("skills")));
+    }
+
+    // ---- 4. Configured extra paths ------------------------------------------
     for path_str in &config_skills.paths {
-        let path = Path::new(path_str);
-        let path = if path.is_absolute() {
-            path.to_path_buf()
-        } else {
-            cwd.join(path)
-        };
+        let path = resolve_path(path_str, cwd);
         add(scan_dir(&path));
     }
 
-    // ---- 4. Git URL skills (cached) -----------------------------------------
+    // ---- 5. Git URL skills (cached) -----------------------------------------
     for url in &config_skills.urls {
         if let Some(git_skills) = fetch_git_skills(url) {
             add(git_skills);
@@ -215,10 +306,7 @@ fn fetch_git_skills(url: &str) -> Option<Vec<DiscoveredSkill>> {
     let cache_dir = dirs::cache_dir()?.join("claurst").join("skills");
 
     // Use the last path segment of the URL as the local directory name.
-    let repo_name = url
-        .split('/')
-        .next_back()?
-        .trim_end_matches(".git");
+    let repo_name = url.split('/').next_back()?.trim_end_matches(".git");
 
     if repo_name.is_empty() {
         tracing::warn!(url, "skill_discovery: cannot derive repo name from git URL");
@@ -292,7 +380,8 @@ mod tests {
 
     #[test]
     fn test_parse_with_frontmatter() {
-        let content = "---\nname: review\ndescription: Review code changes\n---\n\nPlease review $ARGUMENTS";
+        let content =
+            "---\nname: review\ndescription: Review code changes\n---\n\nPlease review $ARGUMENTS";
         let path = PathBuf::from("review.md");
         let skill = parse_skill_file(content, &path).unwrap();
         assert_eq!(skill.name, "review");
@@ -338,7 +427,11 @@ mod tests {
     #[test]
     fn test_scan_dir_finds_skills() {
         let tmp = make_temp_dir();
-        write_file(tmp.path(), "review.md", "---\nname: review\n---\nReview $ARGUMENTS");
+        write_file(
+            tmp.path(),
+            "review.md",
+            "---\nname: review\n---\nReview $ARGUMENTS",
+        );
         write_file(tmp.path(), "debug.md", "Debug help.");
         write_file(tmp.path(), "not-md.txt", "ignored");
 
@@ -355,6 +448,87 @@ mod tests {
         assert!(skills.is_empty());
     }
 
+    #[test]
+    fn test_parse_skill_md_in_subdir_uses_parent_dir_name() {
+        let content = "Use clean code principles.";
+        let path = PathBuf::from("/home/user/.agents/skills/clean-code/SKILL.md");
+        let skill = parse_skill_file(content, &path).unwrap();
+        assert_eq!(skill.name, "clean-code");
+        assert_eq!(skill.description, "Custom skill");
+        assert_eq!(skill.template, "Use clean code principles.");
+    }
+
+    #[test]
+    fn test_scan_dir_finds_subdirectories_with_skill_md() {
+        let tmp = make_temp_dir();
+        // Flat file
+        write_file(
+            tmp.path(),
+            "flat.md",
+            "---\nname: flat\n---\nFlat template.",
+        );
+        // Subdirectory with SKILL.md
+        write_file(
+            tmp.path(),
+            "brainstorming/SKILL.md",
+            "---\ndescription: Brainstorm ideas\n---\nBrainstorm $ARGUMENTS",
+        );
+        // Subdirectory with lowercase skill.md
+        write_file(
+            tmp.path(),
+            "git-master/skill.md",
+            "---\nname: git-guru\ndescription: Git helpers\n---\nGit commands",
+        );
+        // Ignored non-skill dir
+        write_file(tmp.path(), "other_folder/readme.txt", "not a skill");
+
+        let skills = scan_dir(tmp.path());
+        assert_eq!(skills.len(), 3);
+        let names: Vec<&str> = skills.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"flat"));
+        assert!(names.contains(&"brainstorming"));
+        assert!(names.contains(&"git-guru"));
+    }
+
+    #[test]
+    fn test_scan_dir_direct_skill_folder() {
+        let tmp = make_temp_dir();
+        let skill_dir = tmp.path().join("my-custom-skill");
+        write_file(
+            &skill_dir,
+            "SKILL.md",
+            "---\ndescription: Direct folder\n---\nDo work",
+        );
+
+        let skills = scan_dir(&skill_dir);
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].name, "my-custom-skill");
+        assert_eq!(skills[0].description, "Direct folder");
+    }
+
+    #[test]
+    fn test_resolve_path() {
+        let cwd = PathBuf::from("/workspace/project");
+        // Absolute path
+        assert_eq!(
+            resolve_path("/Users/test/.agents/skills", &cwd),
+            PathBuf::from("/Users/test/.agents/skills")
+        );
+        // Relative path
+        assert_eq!(
+            resolve_path("custom/skills", &cwd),
+            PathBuf::from("/workspace/project/custom/skills")
+        );
+        // Tilde path
+        if let Some(home) = dirs::home_dir() {
+            assert_eq!(
+                resolve_path("~/.agents/skills", &cwd),
+                home.join(".agents/skills")
+            );
+            assert_eq!(resolve_path("~", &cwd), home);
+        }
+    }
+
     // ---- discover_skills ----------------------------------------------------
 
     #[test]
@@ -362,7 +536,11 @@ mod tests {
         let tmp = make_temp_dir();
         let skills_dir = tmp.path().join(".claurst").join("skills");
         std::fs::create_dir_all(&skills_dir).unwrap();
-        write_file(&skills_dir, "myskill.md", "---\nname: myskill\ndescription: Test\n---\nDo it.");
+        write_file(
+            &skills_dir,
+            "myskill.md",
+            "---\nname: myskill\ndescription: Test\n---\nDo it.",
+        );
 
         let config = crate::config::SkillsConfig::default();
         let discovered = discover_skills(tmp.path(), &config);
@@ -371,10 +549,31 @@ mod tests {
     }
 
     #[test]
+    fn test_discover_from_project_agents_skills_subdir() {
+        let tmp = make_temp_dir();
+        let skills_dir = tmp.path().join(".agents").join("skills").join("sub-skill");
+        std::fs::create_dir_all(&skills_dir).unwrap();
+        write_file(
+            &skills_dir,
+            "SKILL.md",
+            "---\ndescription: Sub agent skill\n---\nSub agent prompt.",
+        );
+
+        let config = crate::config::SkillsConfig::default();
+        let discovered = discover_skills(tmp.path(), &config);
+        assert!(discovered.contains_key("sub-skill"));
+        assert_eq!(discovered["sub-skill"].description, "Sub agent skill");
+    }
+
+    #[test]
     fn test_discover_extra_paths() {
         let tmp = make_temp_dir();
         let extra = make_temp_dir();
-        write_file(extra.path(), "extra.md", "---\nname: extra\n---\nExtra skill.");
+        write_file(
+            extra.path(),
+            "extra.md",
+            "---\nname: extra\n---\nExtra skill.",
+        );
 
         let config = crate::config::SkillsConfig {
             paths: vec![extra.path().to_str().unwrap().to_string()],
@@ -389,10 +588,18 @@ mod tests {
         let tmp = make_temp_dir();
         let proj_skills = tmp.path().join(".claurst").join("skills");
         std::fs::create_dir_all(&proj_skills).unwrap();
-        write_file(&proj_skills, "dup.md", "---\nname: dup\ndescription: project\n---\nProject.");
+        write_file(
+            &proj_skills,
+            "dup.md",
+            "---\nname: dup\ndescription: project\n---\nProject.",
+        );
 
         let extra = make_temp_dir();
-        write_file(extra.path(), "dup.md", "---\nname: dup\ndescription: extra\n---\nExtra.");
+        write_file(
+            extra.path(),
+            "dup.md",
+            "---\nname: dup\ndescription: extra\n---\nExtra.",
+        );
 
         let config = crate::config::SkillsConfig {
             paths: vec![extra.path().to_str().unwrap().to_string()],

--- a/src-rust/crates/tui/src/app.rs
+++ b/src-rust/crates/tui/src/app.rs
@@ -3,15 +3,13 @@
 use crate::bridge_state::BridgeConnectionState;
 use crate::context_viz::ContextVizState;
 use crate::dialog_select::{DialogSelectState, SelectItem};
+use crate::dialogs::McpApprovalDialogState;
+use crate::dialogs::PermissionRequest;
+use crate::diff_viewer::{build_turn_diff, DiffViewerState};
 use crate::export_dialog::{ExportDialogState, ExportFormat};
 use crate::import_config_dialog::ImportConfigDialogState;
-use crate::dialogs::PermissionRequest;
-use crate::diff_viewer::{DiffViewerState, build_turn_diff};
-use crate::model_picker::{EffortLevel, ModelPickerState};
-use crate::session_browser::SessionBrowserState;
-use crate::tasks_overlay::TasksOverlay;
-use crate::dialogs::McpApprovalDialogState;
 use crate::mcp_view::{McpServerView, McpToolView, McpViewState, McpViewStatus};
+use crate::model_picker::{EffortLevel, ModelPickerState};
 use crate::notifications::{NotificationKind, NotificationQueue};
 use crate::overlays::{
     GlobalSearchState, HelpEntry, HelpOverlay, HistorySearchOverlay, MessageSelectorOverlay,
@@ -20,18 +18,23 @@ use crate::overlays::{
 use crate::plugin_views::PluginHintBanner;
 use crate::prompt_input::{InputMode, PromptInputState, VimMode};
 use crate::render;
+use crate::session_browser::SessionBrowserState;
 use crate::settings_screen::SettingsScreen;
 use crate::stats_dialog::StatsDialogState;
+use crate::tasks_overlay::TasksOverlay;
 use crate::theme_screen::ThemeScreen;
-use crate::{agents_view::{AgentInfo, AgentStatus, AgentsMenuState, AgentsRoute}, diff_viewer::DiffPane};
+use crate::{
+    agents_view::{AgentInfo, AgentStatus, AgentsMenuState, AgentsRoute},
+    diff_viewer::DiffPane,
+};
 use claurst_core::config::{Config, Settings, Theme};
 use claurst_core::cost::CostTracker;
 use claurst_core::file_history::FileHistory;
-use claurst_core::{sample_completion_verb, sample_spinner_verb};
 use claurst_core::keybindings::{
     KeyContext, KeybindingResolver, KeybindingResult, ParsedKeystroke, UserKeybindings,
 };
 use claurst_core::types::{ContentBlock, Message, Role};
+use claurst_core::{sample_completion_verb, sample_spinner_verb};
 use claurst_query::QueryEvent;
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use ratatui::backend::CrosstermBackend;
@@ -65,19 +68,34 @@ const PROMPT_SLASH_COMMANDS: &[(&str, &str)] = &[
     ("heapdump", "Show process memory and diagnostic information"),
     ("help", "Show help"),
     ("hooks", "Browse configured hooks (read-only)"),
-    ("import-config", "Import CLAUDE.md and settings.json from ~/.claude"),
+    (
+        "import-config",
+        "Import CLAUDE.md and settings.json from ~/.claude",
+    ),
     ("init", "Initialize AGENTS.md for this project"),
-    ("insights", "Generate a session analysis report with conversation statistics"),
+    (
+        "insights",
+        "Generate a session analysis report with conversation statistics",
+    ),
     ("keybindings", "Show keybinding configuration"),
     ("links", "Open URLs from this session in your browser"),
     ("login", "Log in to Claurst"),
     ("logout", "Log out of Claurst"),
-    ("managed-agents", "Configure manager-executor managed agent system"),
+    (
+        "managed-agents",
+        "Configure manager-executor managed agent system",
+    ),
     ("mcp", "Browse configured MCP servers"),
     ("memory", "Browse and open AGENTS.md memory files"),
     ("model", "Change the AI model"),
-    ("move", "Re-home this session to another worktree of the same project"),
-    ("new", "Start a fresh session (keeps model, provider & directory)"),
+    (
+        "move",
+        "Re-home this session to another worktree of the same project",
+    ),
+    (
+        "new",
+        "Start a fresh session (keeps model, provider & directory)",
+    ),
     ("output-style", "Show or switch the output style / persona"),
     ("plugin", "Manage plugins (list/info/enable/disable/reload)"),
     ("providers", "List available AI providers and their status"),
@@ -92,21 +110,37 @@ const PROMPT_SLASH_COMMANDS: &[(&str, &str)] = &[
     ("rewind", "Rewind to an earlier turn"),
     ("session", "Browse and manage sessions"),
     ("settings", "Open settings"),
-    ("share", "Upload the current session as a secret gist and get a shareable URL"),
+    (
+        "share",
+        "Upload the current session as a secret gist and get a shareable URL",
+    ),
     ("stats", "Open token and cost stats"),
     ("survey", "Open session feedback survey"),
     ("theme", "Open the theme picker"),
-    ("ultrareview", "Run an exhaustive multi-dimensional code review"),
-    ("update", "Check for updates and upgrade to the latest version"),
-    ("upgrade", "Check for updates and upgrade to the latest version"),
+    (
+        "ultrareview",
+        "Run an exhaustive multi-dimensional code review",
+    ),
+    (
+        "update",
+        "Check for updates and upgrade to the latest version",
+    ),
+    (
+        "upgrade",
+        "Check for updates and upgrade to the latest version",
+    ),
     ("vim", "Toggle vim keybindings"),
     ("voice", "Toggle voice input mode"),
 ];
 
 fn help_command_category(name: &str) -> &'static str {
     match name {
-        "connect" | "model" | "providers" | "refresh" | "fast" | "effort" | "voice" => "Model & Provider",
-        "changes" | "diff" | "review" | "rewind" | "export" | "copy" | "share" | "links" => "Review & History",
+        "connect" | "model" | "providers" | "refresh" | "fast" | "effort" | "voice" => {
+            "Model & Provider"
+        }
+        "changes" | "diff" | "review" | "rewind" | "export" | "copy" | "share" | "links" => {
+            "Review & History"
+        }
         "stats" | "cost" | "context" | "insights" | "heapdump" | "doctor" => "Diagnostics",
         "config" | "settings" | "theme" | "keybindings" | "hooks" | "mcp" | "import-config" => {
             "Workspace"
@@ -213,7 +247,6 @@ fn get_url_for_provider(id: &str) -> &'static str {
     }
 }
 
-
 fn import_config_picker_items() -> Vec<SelectItem> {
     vec![
         SelectItem {
@@ -242,61 +275,391 @@ fn import_config_picker_items() -> Vec<SelectItem> {
 
 fn provider_picker_items() -> Vec<SelectItem> {
     vec![
-        SelectItem { id: "free".into(), title: "Free Mode".into(), description: "OpenCode Zen → OpenRouter free fallback (no spend)".into(), category: "Popular".into(), badge: Some("FREE".into()) },
-        SelectItem { id: "openai".into(), title: "OpenAI".into(), description: "(API key)".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "openai-codex".into(), title: "OpenAI Codex".into(), description: "(ChatGPT Plus/Pro — browser login)".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "github-copilot".into(), title: "GitHub Copilot".into(), description: "(GitHub subscription or token)".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "google".into(), title: "Google".into(), description: "(API key)".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "anthropic".into(), title: "Anthropic".into(), description: "(API key)".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "anthropic-oauth".into(), title: "Anthropic (Claude Pro/Max)".into(), description: "(subscription — browser login; draws from extra-usage)".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "custom-openai".into(), title: "Custom OpenAI-Compatible".into(), description: "Custom URL + API key".into(), category: "Advanced".into(), badge: None },
-        SelectItem { id: "openrouter".into(), title: "OpenRouter".into(), description: "100+ models with one key".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "vercel".into(), title: "Vercel AI Gateway".into(), description: "Gateway for AI SDK models".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "groq".into(), title: "Groq".into(), description: "Fast hosted inference".into(), category: "Popular".into(), badge: Some("FREE".into()) },
-        SelectItem { id: "ollama".into(), title: "Ollama".into(), description: "Local inference + cloud models".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "zai".into(), title: "Z.AI".into(), description: "GLM-5.1 / GLM-5 / GLM-4.7 Coding Plan".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "opencode-go".into(), title: "OpenCode Go".into(), description: "$10/mo flat-rate · Kimi · DeepSeek · GLM · MiniMax".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "opencode-zen".into(), title: "OpenCode Zen".into(), description: "Free models + paid · Nemotron · Ring · MiniMax · DeepSeek".into(), category: "Popular".into(), badge: Some("FREE".into()) },
-        SelectItem { id: "synthetic".into(), title: "Synthetic.dev".into(), description: "Hosted open weights".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "routing".into(), title: "routing.run".into(), description: "Hosted open weights · DeepSeek · Llama · Mixtral · Qwen".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "neuralwatt".into(), title: "NeuralWatt".into(), description: "Hosted open weights - energy-efficient".into(), category: "Popular".into(), badge: None },
-        SelectItem { id: "cerebras".into(), title: "Cerebras".into(), description: "Fast hosted inference".into(), category: "Other".into(), badge: Some("FREE".into()) },
-        SelectItem { id: "sambanova".into(), title: "SambaNova".into(), description: "Fast hosted inference".into(), category: "Other".into(), badge: Some("FREE".into()) },
-        SelectItem { id: "lmstudio".into(), title: "LM Studio".into(), description: "Local model server".into(), category: "Other".into(), badge: Some("LOCAL".into()) },
-        SelectItem { id: "llamacpp".into(), title: "llama.cpp".into(), description: "Local inference server".into(), category: "Other".into(), badge: Some("LOCAL".into()) },
-        SelectItem { id: "deepseek".into(), title: "DeepSeek".into(), description: "Reasoning and coding models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "mistral".into(), title: "Mistral".into(), description: "Hosted Mistral models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "togetherai".into(), title: "Together AI".into(), description: "Open model hosting".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "perplexity".into(), title: "Perplexity".into(), description: "Search-augmented models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "cohere".into(), title: "Cohere".into(), description: "Command models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "xai".into(), title: "xAI".into(), description: "Grok models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "deepinfra".into(), title: "DeepInfra".into(), description: "Hosted open models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "azure".into(), title: "Azure OpenAI".into(), description: "Enterprise OpenAI deployments".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "amazon-bedrock".into(), title: "AWS Bedrock".into(), description: "Enterprise foundation models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "google-vertex".into(), title: "Google Vertex AI".into(), description: "Enterprise Google models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "sap-ai-core".into(), title: "SAP AI Core".into(), description: "Enterprise AI platform".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "gitlab".into(), title: "GitLab Duo".into(), description: "AI in GitLab".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "cloudflare-ai-gateway".into(), title: "Cloudflare AI Gateway".into(), description: "Gateway for multiple providers".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "cloudflare-workers-ai".into(), title: "Cloudflare Workers AI".into(), description: "Edge AI inference".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "helicone".into(), title: "Helicone".into(), description: "AI gateway and observability".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "huggingface".into(), title: "Hugging Face".into(), description: "Hosted community models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "nvidia".into(), title: "NVIDIA".into(), description: "Hosted NVIDIA models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "alibaba".into(), title: "Alibaba".into(), description: "Qwen and hosted models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "venice".into(), title: "Venice AI".into(), description: "Privacy-first AI".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "moonshotai".into(), title: "Moonshot AI".into(), description: "Hosted Moonshot models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "zhipuai".into(), title: "Zhipu AI".into(), description: "Hosted GLM models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "siliconflow".into(), title: "SiliconFlow".into(), description: "Hosted open models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "nebius".into(), title: "Nebius".into(), description: "Cloud inference".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "novita".into(), title: "Novita".into(), description: "Cloud inference".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "minimax".into(), title: "MiniMax".into(), description: "Anthropic-compatible (M3)".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "ovhcloud".into(), title: "OVHcloud".into(), description: "EU-hosted AI".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "scaleway".into(), title: "Scaleway".into(), description: "EU cloud AI".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "vultr".into(), title: "Vultr".into(), description: "Cloud inference".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "baseten".into(), title: "Baseten".into(), description: "Model serving".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "friendli".into(), title: "Friendli".into(), description: "Serverless inference".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "upstage".into(), title: "Upstage".into(), description: "Hosted Upstage models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "stepfun".into(), title: "StepFun".into(), description: "Hosted reasoning models".into(), category: "Other".into(), badge: None },
-        SelectItem { id: "fireworks".into(), title: "Fireworks AI".into(), description: "Fast inference".into(), category: "Other".into(), badge: None },
+        SelectItem {
+            id: "free".into(),
+            title: "Free Mode".into(),
+            description: "OpenCode Zen → OpenRouter free fallback (no spend)".into(),
+            category: "Popular".into(),
+            badge: Some("FREE".into()),
+        },
+        SelectItem {
+            id: "openai".into(),
+            title: "OpenAI".into(),
+            description: "(API key)".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "openai-codex".into(),
+            title: "OpenAI Codex".into(),
+            description: "(ChatGPT Plus/Pro — browser login)".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "github-copilot".into(),
+            title: "GitHub Copilot".into(),
+            description: "(GitHub subscription or token)".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "google".into(),
+            title: "Google".into(),
+            description: "(API key)".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "anthropic".into(),
+            title: "Anthropic".into(),
+            description: "(API key)".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "anthropic-oauth".into(),
+            title: "Anthropic (Claude Pro/Max)".into(),
+            description: "(subscription — browser login; draws from extra-usage)".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "custom-openai".into(),
+            title: "Custom OpenAI-Compatible".into(),
+            description: "Custom URL + API key".into(),
+            category: "Advanced".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "openrouter".into(),
+            title: "OpenRouter".into(),
+            description: "100+ models with one key".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "vercel".into(),
+            title: "Vercel AI Gateway".into(),
+            description: "Gateway for AI SDK models".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "groq".into(),
+            title: "Groq".into(),
+            description: "Fast hosted inference".into(),
+            category: "Popular".into(),
+            badge: Some("FREE".into()),
+        },
+        SelectItem {
+            id: "ollama".into(),
+            title: "Ollama".into(),
+            description: "Local inference + cloud models".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "zai".into(),
+            title: "Z.AI".into(),
+            description: "GLM-5.1 / GLM-5 / GLM-4.7 Coding Plan".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "opencode-go".into(),
+            title: "OpenCode Go".into(),
+            description: "$10/mo flat-rate · Kimi · DeepSeek · GLM · MiniMax".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "opencode-zen".into(),
+            title: "OpenCode Zen".into(),
+            description: "Free models + paid · Nemotron · Ring · MiniMax · DeepSeek".into(),
+            category: "Popular".into(),
+            badge: Some("FREE".into()),
+        },
+        SelectItem {
+            id: "synthetic".into(),
+            title: "Synthetic.dev".into(),
+            description: "Hosted open weights".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "routing".into(),
+            title: "routing.run".into(),
+            description: "Hosted open weights · DeepSeek · Llama · Mixtral · Qwen".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "neuralwatt".into(),
+            title: "NeuralWatt".into(),
+            description: "Hosted open weights - energy-efficient".into(),
+            category: "Popular".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "cerebras".into(),
+            title: "Cerebras".into(),
+            description: "Fast hosted inference".into(),
+            category: "Other".into(),
+            badge: Some("FREE".into()),
+        },
+        SelectItem {
+            id: "sambanova".into(),
+            title: "SambaNova".into(),
+            description: "Fast hosted inference".into(),
+            category: "Other".into(),
+            badge: Some("FREE".into()),
+        },
+        SelectItem {
+            id: "lmstudio".into(),
+            title: "LM Studio".into(),
+            description: "Local model server".into(),
+            category: "Other".into(),
+            badge: Some("LOCAL".into()),
+        },
+        SelectItem {
+            id: "llamacpp".into(),
+            title: "llama.cpp".into(),
+            description: "Local inference server".into(),
+            category: "Other".into(),
+            badge: Some("LOCAL".into()),
+        },
+        SelectItem {
+            id: "deepseek".into(),
+            title: "DeepSeek".into(),
+            description: "Reasoning and coding models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "mistral".into(),
+            title: "Mistral".into(),
+            description: "Hosted Mistral models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "togetherai".into(),
+            title: "Together AI".into(),
+            description: "Open model hosting".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "perplexity".into(),
+            title: "Perplexity".into(),
+            description: "Search-augmented models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "cohere".into(),
+            title: "Cohere".into(),
+            description: "Command models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "xai".into(),
+            title: "xAI".into(),
+            description: "Grok models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "deepinfra".into(),
+            title: "DeepInfra".into(),
+            description: "Hosted open models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "azure".into(),
+            title: "Azure OpenAI".into(),
+            description: "Enterprise OpenAI deployments".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "amazon-bedrock".into(),
+            title: "AWS Bedrock".into(),
+            description: "Enterprise foundation models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "google-vertex".into(),
+            title: "Google Vertex AI".into(),
+            description: "Enterprise Google models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "sap-ai-core".into(),
+            title: "SAP AI Core".into(),
+            description: "Enterprise AI platform".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "gitlab".into(),
+            title: "GitLab Duo".into(),
+            description: "AI in GitLab".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "cloudflare-ai-gateway".into(),
+            title: "Cloudflare AI Gateway".into(),
+            description: "Gateway for multiple providers".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "cloudflare-workers-ai".into(),
+            title: "Cloudflare Workers AI".into(),
+            description: "Edge AI inference".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "helicone".into(),
+            title: "Helicone".into(),
+            description: "AI gateway and observability".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "huggingface".into(),
+            title: "Hugging Face".into(),
+            description: "Hosted community models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "nvidia".into(),
+            title: "NVIDIA".into(),
+            description: "Hosted NVIDIA models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "alibaba".into(),
+            title: "Alibaba".into(),
+            description: "Qwen and hosted models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "venice".into(),
+            title: "Venice AI".into(),
+            description: "Privacy-first AI".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "moonshotai".into(),
+            title: "Moonshot AI".into(),
+            description: "Hosted Moonshot models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "zhipuai".into(),
+            title: "Zhipu AI".into(),
+            description: "Hosted GLM models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "siliconflow".into(),
+            title: "SiliconFlow".into(),
+            description: "Hosted open models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "nebius".into(),
+            title: "Nebius".into(),
+            description: "Cloud inference".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "novita".into(),
+            title: "Novita".into(),
+            description: "Cloud inference".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "minimax".into(),
+            title: "MiniMax".into(),
+            description: "Anthropic-compatible (M3)".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "ovhcloud".into(),
+            title: "OVHcloud".into(),
+            description: "EU-hosted AI".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "scaleway".into(),
+            title: "Scaleway".into(),
+            description: "EU cloud AI".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "vultr".into(),
+            title: "Vultr".into(),
+            description: "Cloud inference".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "baseten".into(),
+            title: "Baseten".into(),
+            description: "Model serving".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "friendli".into(),
+            title: "Friendli".into(),
+            description: "Serverless inference".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "upstage".into(),
+            title: "Upstage".into(),
+            description: "Hosted Upstage models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "stepfun".into(),
+            title: "StepFun".into(),
+            description: "Hosted reasoning models".into(),
+            category: "Other".into(),
+            badge: None,
+        },
+        SelectItem {
+            id: "fireworks".into(),
+            title: "Fireworks AI".into(),
+            description: "Fast inference".into(),
+            category: "Other".into(),
+            badge: None,
+        },
     ]
 }
 
@@ -332,7 +695,10 @@ pub enum DisplayMessage {
     /// A real conversation turn.
     Conversation(Message),
     /// An injected system notice (e.g. compact boundary).
-    System { text: String, style: SystemMessageStyle },
+    System {
+        text: String,
+        style: SystemMessageStyle,
+    },
 }
 
 /// Context menu state: position and currently selected item index.
@@ -535,7 +901,11 @@ pub fn try_copy_to_clipboard(text: &str) -> bool {
     #[cfg(target_os = "linux")]
     {
         use std::io::Write;
-        for cmd in &["wl-copy", "xclip -selection clipboard", "xsel --clipboard --input"] {
+        for cmd in &[
+            "wl-copy",
+            "xclip -selection clipboard",
+            "xsel --clipboard --input",
+        ] {
             let parts: Vec<&str> = cmd.split_whitespace().collect();
             if let Some((prog, args)) = parts.split_first() {
                 if let Ok(mut child) = std::process::Command::new(prog)
@@ -577,20 +947,38 @@ fn layout_to_latin(c: char) -> String {
     let lower = c.to_lowercase().next().unwrap_or(c);
     let mapped: Option<char> = match lower {
         // Row 1
-        'й' => Some('q'), 'ц' => Some('w'), 'у' => Some('e'),
-        'к' => Some('r'), 'е' => Some('t'), 'н' => Some('y'),
-        'г' => Some('u'), 'ш' => Some('i'), 'щ' => Some('o'),
+        'й' => Some('q'),
+        'ц' => Some('w'),
+        'у' => Some('e'),
+        'к' => Some('r'),
+        'е' => Some('t'),
+        'н' => Some('y'),
+        'г' => Some('u'),
+        'ш' => Some('i'),
+        'щ' => Some('o'),
         'з' => Some('p'),
         // Row 2
-        'ф' => Some('a'), 'ы' => Some('s'), 'в' => Some('d'),
-        'а' => Some('f'), 'п' => Some('g'), 'р' => Some('h'),
-        'о' => Some('j'), 'л' => Some('k'), 'д' => Some('l'),
+        'ф' => Some('a'),
+        'ы' => Some('s'),
+        'в' => Some('d'),
+        'а' => Some('f'),
+        'п' => Some('g'),
+        'р' => Some('h'),
+        'о' => Some('j'),
+        'л' => Some('k'),
+        'д' => Some('l'),
         // Row 3
-        'я' => Some('z'), 'ч' => Some('x'), 'с' => Some('c'),
-        'м' => Some('v'), 'и' => Some('b'), 'т' => Some('n'),
+        'я' => Some('z'),
+        'ч' => Some('x'),
+        'с' => Some('c'),
+        'м' => Some('v'),
+        'и' => Some('b'),
+        'т' => Some('n'),
         'ь' => Some('m'),
         // Ukrainian-specific letters on standard positions
-        'і' => Some('s'), 'ї' => Some(']'), 'є' => Some('\''),
+        'і' => Some('s'),
+        'ї' => Some(']'),
+        'є' => Some('\''),
         _ => None,
     };
     mapped.unwrap_or(lower).to_string()
@@ -646,23 +1034,23 @@ fn normalize_char_with_shift(c: char, modifiers: KeyModifiers) -> char {
 
 fn key_event_to_keystroke(key: &KeyEvent) -> Option<ParsedKeystroke> {
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-    let alt  = key.modifiers.contains(KeyModifiers::ALT);
+    let alt = key.modifiers.contains(KeyModifiers::ALT);
 
     let normalized_key = match key.code {
         KeyCode::Backspace => "backspace".to_string(),
-        KeyCode::Delete    => "delete".to_string(),
-        KeyCode::Down      => "down".to_string(),
-        KeyCode::End       => "end".to_string(),
-        KeyCode::Enter     => "enter".to_string(),
-        KeyCode::Esc       => "escape".to_string(),
-        KeyCode::Home      => "home".to_string(),
-        KeyCode::Left      => "left".to_string(),
-        KeyCode::PageDown  => "pagedown".to_string(),
-        KeyCode::PageUp    => "pageup".to_string(),
-        KeyCode::Right     => "right".to_string(),
-        KeyCode::Tab       => "tab".to_string(),
-        KeyCode::Up        => "up".to_string(),
-        KeyCode::BackTab   => "tab".to_string(),
+        KeyCode::Delete => "delete".to_string(),
+        KeyCode::Down => "down".to_string(),
+        KeyCode::End => "end".to_string(),
+        KeyCode::Enter => "enter".to_string(),
+        KeyCode::Esc => "escape".to_string(),
+        KeyCode::Home => "home".to_string(),
+        KeyCode::Left => "left".to_string(),
+        KeyCode::PageDown => "pagedown".to_string(),
+        KeyCode::PageUp => "pageup".to_string(),
+        KeyCode::Right => "right".to_string(),
+        KeyCode::Tab => "tab".to_string(),
+        KeyCode::Up => "up".to_string(),
+        KeyCode::BackTab => "tab".to_string(),
         KeyCode::Char(' ') => "space".to_string(),
         KeyCode::Char(c) => {
             // For modifier-key combos (Ctrl/Alt + letter), normalize to the
@@ -853,20 +1241,17 @@ pub struct App {
     pub cursor_pos: usize,
 
     // ---- Scrollback / auto-scroll -----------------------------------------
-
     /// When `true`, the message pane follows the latest messages automatically.
     pub auto_scroll: bool,
     /// Count of messages that arrived while the user was scrolled up.
     pub new_messages_while_scrolled: usize,
 
     // ---- Token warning tracking -------------------------------------------
-
     /// Which threshold (0 = none, 80, 95, 100) was last notified so we only
     /// show each banner once.
     pub token_warning_threshold_shown: u8,
 
     // ---- Session timing ---------------------------------------------------
-
     /// Instant the session started (used for elapsed-time in the status bar).
     pub session_start: std::time::Instant,
     /// Current Rustle pose for rendering (updated each frame).
@@ -891,7 +1276,6 @@ pub struct App {
     pub transcript_version: Cell<u64>,
 
     // ---- New overlay / notification fields --------------------------------
-
     /// Full-screen help overlay (? / F1).
     pub help_overlay: HelpOverlay,
     /// Ctrl+R history search overlay.
@@ -908,6 +1292,8 @@ pub struct App {
     pub notifications: NotificationQueue,
     /// Scroll offset for error modal text (in lines).
     pub error_modal_scroll_offset: usize,
+    /// Discovered skills cached for autocomplete and command palette.
+    pub discovered_skills: Vec<(String, String)>,
     /// Plugin hint banners.
     pub plugin_hints: Vec<PluginHintBanner>,
     /// Optional session title shown in the status bar.
@@ -931,7 +1317,6 @@ pub struct App {
     pub current_turn: Option<Arc<std::sync::atomic::AtomicUsize>>,
 
     // ---- Visual mode indicators -------------------------------------------
-
     /// Plan mode — input border turns blue, [PLAN] shown in status bar.
     pub plan_mode: bool,
     /// "While you were away" summary text shown on the welcome screen.
@@ -940,7 +1325,6 @@ pub struct App {
     pub stall_start: Option<std::time::Instant>,
 
     // ---- Settings / theme / privacy screens --------------------------------
-
     /// Full-screen tabbed settings screen (/config, /settings).
     pub settings_screen: SettingsScreen,
     /// Theme picker overlay (/theme).
@@ -970,7 +1354,8 @@ pub struct App {
     /// Startup error dialog for malformed settings.json or AGENTS.md.
     pub invalid_config_dialog: crate::invalid_config_dialog::InvalidConfigDialogState,
     /// Memory update notification banner.
-    pub memory_update_notification: crate::memory_update_notification::MemoryUpdateNotificationState,
+    pub memory_update_notification:
+        crate::memory_update_notification::MemoryUpdateNotificationState,
     /// MCP elicitation dialog (form requested by an MCP server).
     pub elicitation: crate::elicitation_dialog::ElicitationDialogState,
     /// Model picker overlay (/model command).
@@ -1099,7 +1484,6 @@ pub struct App {
     pub auto_compact_running: bool,
 
     // ---- Voice hold-to-talk ------------------------------------------------
-
     /// The global voice recorder, Some when voice is enabled in config.
     pub voice_recorder: Option<Arc<Mutex<claurst_core::voice::VoiceRecorder>>>,
     /// True while recording is active (Alt+V toggled on).
@@ -1123,7 +1507,6 @@ pub struct App {
     pub ask_user_dialog: crate::ask_user_dialog::AskUserDialogState,
 
     // ---- Context window & rate limit info ----------------------------------
-
     /// Total context window size for the current model (tokens).
     pub context_window_size: u64,
     /// How many tokens are currently used in the context window.
@@ -1270,7 +1653,7 @@ impl App {
             reg.apply_model_overrides(&config.model_overrides);
             reg
         };
-        Self {
+        let mut app = Self {
             config,
             cost_tracker,
             messages: Vec::new(),
@@ -1313,10 +1696,12 @@ impl App {
             rustle_current_pose: crate::rustle::RustlePose::Default,
             rustle_pose_until: None,
             rustle_temp_pose: None,
-            rustle_next_blink: 200 + (std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .subsec_nanos() as u64 % 300),
+            rustle_next_blink: 200
+                + (std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .subsec_nanos() as u64
+                    % 300),
             turn_start: None,
             last_turn_elapsed: None,
             last_turn_verb: None,
@@ -1334,6 +1719,7 @@ impl App {
             bridge_state: BridgeConnectionState::Disconnected,
             notifications: NotificationQueue::new(),
             error_modal_scroll_offset: 0,
+            discovered_skills: Vec::new(),
             plugin_hints: Vec::new(),
             session_title: None,
             remote_session_url: None,
@@ -1360,7 +1746,8 @@ impl App {
             voice_mode_notice: crate::voice_mode_notice::VoiceModeNoticeState::new(),
             desktop_upsell: crate::desktop_upsell_startup::DesktopUpsellStartupState::new(),
             invalid_config_dialog: crate::invalid_config_dialog::InvalidConfigDialogState::new(),
-            memory_update_notification: crate::memory_update_notification::MemoryUpdateNotificationState::new(),
+            memory_update_notification:
+                crate::memory_update_notification::MemoryUpdateNotificationState::new(),
             elicitation: crate::elicitation_dialog::ElicitationDialogState::new(),
             model_picker: ModelPickerState::new(),
             session_browser: SessionBrowserState::new(),
@@ -1374,7 +1761,8 @@ impl App {
             mcp_session_trusted: std::collections::HashSet::new(),
             mcp_project_root: None,
             go_to_line_dialog: GoToLineDialog::new(),
-            bypass_permissions_dialog: crate::bypass_permissions_dialog::BypassPermissionsDialogState::new(),
+            bypass_permissions_dialog:
+                crate::bypass_permissions_dialog::BypassPermissionsDialogState::new(),
             bypass_permissions_dialog_shown: false,
             file_injection_dialog: crate::file_injection_dialog::FileInjectionDialogState::new(),
             file_injection_force: false,
@@ -1399,7 +1787,10 @@ impl App {
             queued_messages: std::collections::VecDeque::new(),
             pending_auto_submit: false,
             connect_dialog: DialogSelectState::new("Connect a provider", provider_picker_items()),
-            import_config_picker: DialogSelectState::new("Import config", import_config_picker_items()),
+            import_config_picker: DialogSelectState::new(
+                "Import config",
+                import_config_picker_items(),
+            ),
             import_config_dialog: ImportConfigDialogState::new(),
             command_palette: {
                 let items: Vec<SelectItem> = PROMPT_SLASH_COMMANDS
@@ -1419,12 +1810,15 @@ impl App {
             pr_number: None,
             pr_url: None,
             pr_state: None,
-            current_dir: std::env::current_dir().ok().and_then(|p| {
-                p.to_str().map(|s| s.to_string())
-            }),
+            current_dir: std::env::current_dir()
+                .ok()
+                .and_then(|p| p.to_str().map(|s| s.to_string())),
             git_branch: claurst_core::git_utils::get_repo_root(
-                std::env::current_dir().as_deref().unwrap_or_else(|_| std::path::Path::new("."))
-            ).map(|repo_root| claurst_core::git_utils::get_current_branch(&repo_root)),
+                std::env::current_dir()
+                    .as_deref()
+                    .unwrap_or_else(|_| std::path::Path::new(".")),
+            )
+            .map(|repo_root| claurst_core::git_utils::get_current_branch(&repo_root)),
             background_task_count: 0,
             background_task_status: None,
             status_line_override: None,
@@ -1439,8 +1833,8 @@ impl App {
                     .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
                     .unwrap_or(false)
                     || {
-                        let path = claurst_core::config::Settings::config_dir()
-                            .join("ui-settings.json");
+                        let path =
+                            claurst_core::config::Settings::config_dir().join("ui-settings.json");
                         std::fs::read_to_string(&path)
                             .ok()
                             .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
@@ -1498,7 +1892,11 @@ impl App {
             managed_agents_active: false,
             last_exit_key_warning: None,
             exit_key_sequence_start: None,
-        }
+        };
+        app.refresh_discovered_skills();
+        app.rebuild_command_palette();
+        app.rebuild_help_overlay();
+        app
     }
 
     /// Load token budget from environment or model defaults.
@@ -1522,7 +1920,8 @@ impl App {
     }
 
     pub fn open_import_config_picker(&mut self) {
-        self.import_config_picker = DialogSelectState::new("Import config", import_config_picker_items());
+        self.import_config_picker =
+            DialogSelectState::new("Import config", import_config_picker_items());
         self.import_config_picker.open();
     }
 
@@ -1746,7 +2145,12 @@ impl App {
         );
     }
 
-    fn activate_provider(&mut self, provider_id: String, provider_name: String, status_prefix: &str) {
+    fn activate_provider(
+        &mut self,
+        provider_id: String,
+        provider_name: String,
+        status_prefix: &str,
+    ) {
         let picker_title = provider_name.clone();
         self.fast_mode = false;
         self.set_provider_default(provider_id.clone());
@@ -1758,7 +2162,10 @@ impl App {
 
     fn persist_custom_provider_base_url(&self, base_url: &str) {
         let mut settings = Settings::load_sync().unwrap_or_default();
-        let entry = settings.providers.entry("custom-openai".to_string()).or_default();
+        let entry = settings
+            .providers
+            .entry("custom-openai".to_string())
+            .or_default();
         entry.api_base = Some(base_url.to_string());
         entry.enabled = true;
         let _ = settings.save_sync();
@@ -1861,7 +2268,9 @@ impl App {
         // Check if a temporary pose is active.
         if let Some(until) = self.rustle_pose_until {
             if std::time::Instant::now() < until {
-                self.rustle_current_pose = self.rustle_temp_pose.clone()
+                self.rustle_current_pose = self
+                    .rustle_temp_pose
+                    .clone()
                     .unwrap_or(crate::rustle::RustlePose::Default);
                 return;
             }
@@ -1873,9 +2282,8 @@ impl App {
         // Random eye-shift: every ~200-500 frames, briefly look right.
         if self.frame_count >= self.rustle_next_blink {
             self.rustle_temp_pose = Some(crate::rustle::RustlePose::LookRight);
-            self.rustle_pose_until = Some(
-                std::time::Instant::now() + std::time::Duration::from_millis(800)
-            );
+            self.rustle_pose_until =
+                Some(std::time::Instant::now() + std::time::Duration::from_millis(800));
             // Schedule next blink 200-500 frames from now (random-ish).
             let jitter = (self.frame_count.wrapping_mul(7) % 300) + 200;
             self.rustle_next_blink = self.frame_count + jitter;
@@ -1889,9 +2297,8 @@ impl App {
     /// Trigger Rustle looking down briefly (called on Tab / mode switch).
     pub fn rustle_look_down(&mut self) {
         self.rustle_temp_pose = Some(crate::rustle::RustlePose::LookDown);
-        self.rustle_pose_until = Some(
-            std::time::Instant::now() + std::time::Duration::from_secs(1)
-        );
+        self.rustle_pose_until =
+            Some(std::time::Instant::now() + std::time::Duration::from_secs(1));
     }
 
     /// Cycle to the next agent mode: build → plan → build.
@@ -1920,7 +2327,8 @@ impl App {
     /// Update the context window size from the model registry for the current model.
     pub fn refresh_context_window_size(&mut self) {
         let provider = self.config.provider.as_deref().unwrap_or("anthropic");
-        let model_id = self.model_name
+        let model_id = self
+            .model_name
             .strip_prefix(&format!("{}/", provider))
             .unwrap_or(&self.model_name);
         if let Some(entry) = self.model_registry.get(provider, model_id) {
@@ -1979,14 +2387,17 @@ impl App {
         self.provider_registry = provider_registry;
         self.model_registry = claurst_api::ModelRegistry::new();
         // Re-layer user metadata overrides (issue #309) onto the fresh registry.
-        self.model_registry.apply_model_overrides(&self.config.model_overrides);
+        self.model_registry
+            .apply_model_overrides(&self.config.model_overrides);
         self.auth_store = auth_store;
         self.connect_dialog = DialogSelectState::new("Connect a provider", provider_picker_items());
-        self.import_config_picker = DialogSelectState::new("Import config", import_config_picker_items());
+        self.import_config_picker =
+            DialogSelectState::new("Import config", import_config_picker_items());
         self.import_config_dialog = ImportConfigDialogState::new();
         self.model_picker = ModelPickerState::new();
         self.key_input_dialog = crate::key_input_dialog::KeyInputDialogState::new();
-        self.custom_provider_dialog = crate::custom_provider_dialog::CustomProviderDialogState::new();
+        self.custom_provider_dialog =
+            crate::custom_provider_dialog::CustomProviderDialogState::new();
         self.free_mode_dialog = crate::free_mode_dialog::FreeModeDialogState::new();
         self.device_auth_dialog = crate::device_auth_dialog::DeviceAuthDialogState::new();
         self.device_auth_pending = None;
@@ -2119,14 +2530,22 @@ impl App {
             }
             "vim" => {
                 self.prompt_input.vim_enabled = !self.prompt_input.vim_enabled;
-                let status = if self.prompt_input.vim_enabled { "enabled" } else { "disabled" };
+                let status = if self.prompt_input.vim_enabled {
+                    "enabled"
+                } else {
+                    "disabled"
+                };
                 self.status_message = Some(format!("Vim mode {}.", status));
                 self.refresh_prompt_input();
                 true
             }
             "fast" => {
                 self.fast_mode = !self.fast_mode;
-                let status = if self.fast_mode { "enabled" } else { "disabled" };
+                let status = if self.fast_mode {
+                    "enabled"
+                } else {
+                    "disabled"
+                };
                 self.status_message = Some(format!("Fast mode {}.", status));
                 true
             }
@@ -2152,7 +2571,10 @@ impl App {
             }
             "copy" => {
                 // Copy last assistant message to clipboard. Attempt arboard; fall back to notification.
-                let last = self.messages.iter().rev()
+                let last = self
+                    .messages
+                    .iter()
+                    .rev()
                     .find(|m| m.role == Role::Assistant)
                     .map(|m| m.get_all_text());
                 if let Some(text) = last {
@@ -2167,7 +2589,10 @@ impl App {
                     } else {
                         self.push_notification(
                             NotificationKind::Info,
-                            format!("Last response: {} chars (clipboard unavailable)", text.len()),
+                            format!(
+                                "Last response: {} chars (clipboard unavailable)",
+                                text.len()
+                            ),
                             Some(5),
                         );
                     }
@@ -2199,11 +2624,8 @@ impl App {
                     .model_name
                     .strip_prefix(&format!("{}/", provider))
                     .unwrap_or(&self.model_name);
-                let levels = claurst_api::supported_efforts(
-                    provider,
-                    model_id,
-                    Some(&self.model_registry),
-                );
+                let levels =
+                    claurst_api::supported_efforts(provider, model_id, Some(&self.model_registry));
                 self.effort_picker.open(self.effort_level, levels);
                 true
             }
@@ -2235,9 +2657,8 @@ impl App {
                     }
                     self.voice_recorder = Some(recorder);
                     self.voice_mode_notice = crate::voice_mode_notice::VoiceModeNoticeState::new();
-                    self.status_message = Some(
-                        "Voice mode enabled. Press Alt+V to start recording.".to_string(),
-                    );
+                    self.status_message =
+                        Some("Voice mode enabled. Press Alt+V to start recording.".to_string());
                 }
                 true
             }
@@ -2273,7 +2694,8 @@ impl App {
             }
             "keybindings" => {
                 // Open the keybindings.json file in the external editor
-                let keybindings_path = claurst_core::config::Settings::config_dir().join("keybindings.json");
+                let keybindings_path =
+                    claurst_core::config::Settings::config_dir().join("keybindings.json");
 
                 if let Err(e) = open_file_externally(&keybindings_path) {
                     eprintln!("Failed to open keybindings file: {}", e);
@@ -2594,7 +3016,12 @@ impl App {
     /// It will appear after the current last message.
     /// Push a notification and, for Error-kind notifications, reset the error
     /// modal scroll offset so a newly arrived error is always shown from the top.
-    pub fn push_notification(&mut self, kind: NotificationKind, msg: String, duration_secs: Option<u64>) {
+    pub fn push_notification(
+        &mut self,
+        kind: NotificationKind,
+        msg: String,
+        duration_secs: Option<u64>,
+    ) {
         if kind == NotificationKind::Error {
             self.error_modal_scroll_offset = 0;
         }
@@ -2617,8 +3044,7 @@ impl App {
             // Auto-scroll: keep offset at 0 so render shows the bottom.
             self.scroll_offset = 0;
         } else {
-            self.new_messages_while_scrolled =
-                self.new_messages_while_scrolled.saturating_add(1);
+            self.new_messages_while_scrolled = self.new_messages_while_scrolled.saturating_add(1);
         }
     }
 
@@ -2630,8 +3056,7 @@ impl App {
     /// Check current token usage and push token warning notifications as
     /// appropriate.  Call this after updating `token_count`.
     pub fn check_token_warnings(&mut self) {
-        let window =
-            claurst_query::context_window_for_model(&self.model_name) as u32;
+        let window = claurst_query::context_window_for_model(&self.model_name) as u32;
         if window == 0 {
             return;
         }
@@ -2698,7 +3123,8 @@ impl App {
     /// wheel) stay at the base 3-line step.
     fn scroll_step(&mut self) -> usize {
         let now = std::time::Instant::now();
-        let elapsed_ms = self.scroll_last_time
+        let elapsed_ms = self
+            .scroll_last_time
             .map(|t| now.duration_since(t).as_millis())
             .unwrap_or(u128::MAX);
         self.scroll_last_time = Some(now);
@@ -2761,6 +3187,101 @@ impl App {
         self.history_index = self.prompt_input.history_pos;
     }
 
+    /// Refresh the list of discovered skills from disk and settings.
+    pub fn refresh_discovered_skills(&mut self) {
+        let cwd = self
+            .config
+            .project_dir
+            .as_deref()
+            .or_else(|| self.current_dir.as_deref().map(std::path::Path::new))
+            .unwrap_or_else(|| std::path::Path::new("."));
+        let discovered = claurst_core::discover_skills(cwd, &self.config.skills);
+        let mut list: Vec<(String, String)> = discovered
+            .into_iter()
+            .map(|(name, skill)| (name, skill.description))
+            .collect();
+        list.sort_by(|a, b| a.0.cmp(&b.0));
+        self.discovered_skills = list;
+    }
+
+    /// Return all slash commands available: built-in, custom templates, and discovered skills.
+    pub fn all_slash_commands(&self) -> Vec<(String, String)> {
+        let mut cmds: Vec<(String, String)> = PROMPT_SLASH_COMMANDS
+            .iter()
+            .map(|(n, d)| ((*n).to_string(), (*d).to_string()))
+            .collect();
+
+        // Add custom command templates from settings
+        for (name, template) in &self.config.commands {
+            if !cmds.iter().any(|(n, _)| n == name) {
+                let desc = template.description.as_deref().unwrap_or("Custom command");
+                cmds.push((name.clone(), desc.to_string()));
+            }
+        }
+
+        // Add discovered skills
+        for (name, desc) in &self.discovered_skills {
+            if !cmds.iter().any(|(n, _)| n == name) {
+                cmds.push((name.clone(), desc.clone()));
+            }
+        }
+
+        cmds
+    }
+
+    /// Rebuild command palette items to include built-in commands, templates, and discovered skills.
+    pub fn rebuild_command_palette(&mut self) {
+        let all_cmds = self.all_slash_commands();
+        let items: Vec<SelectItem> = all_cmds
+            .into_iter()
+            .map(|(name, desc)| {
+                let is_skill = self.discovered_skills.iter().any(|(s, _)| s == &name);
+                let is_custom = self.config.commands.contains_key(&name);
+                let category = if is_skill {
+                    "Skills".to_string()
+                } else if is_custom {
+                    "Custom".to_string()
+                } else {
+                    help_command_category(&name).to_string()
+                };
+                SelectItem {
+                    id: format!("/{}", name),
+                    title: format!("/{}", name),
+                    description: desc,
+                    category,
+                    badge: None,
+                }
+            })
+            .collect();
+        self.command_palette = DialogSelectState::new("Command Palette", items);
+    }
+
+    /// Rebuild full-screen help overlay entries.
+    pub fn rebuild_help_overlay(&mut self) {
+        let all_cmds = self.all_slash_commands();
+        let entries: Vec<HelpEntry> = all_cmds
+            .into_iter()
+            .map(|(name, description)| {
+                let is_skill = self.discovered_skills.iter().any(|(s, _)| s == &name);
+                let is_custom = self.config.commands.contains_key(&name);
+                let category = if is_skill {
+                    "Skills".to_string()
+                } else if is_custom {
+                    "Custom".to_string()
+                } else {
+                    help_command_category(&name).to_string()
+                };
+                HelpEntry {
+                    name,
+                    aliases: String::new(),
+                    description,
+                    category,
+                }
+            })
+            .collect();
+        self.help_overlay.populate_from_commands(entries);
+    }
+
     pub fn refresh_prompt_input(&mut self) {
         self.prompt_input.mode = self.prompt_mode();
         if self.file_injection_dialog.visible {
@@ -2770,7 +3291,16 @@ impl App {
         }
         let file_autocomplete_limit = self.config.file_autocomplete_limit;
         let file_autocomplete_show_hidden = self.config.file_autocomplete_show_hidden_files;
-        self.prompt_input.update_suggestions(PROMPT_SLASH_COMMANDS, file_autocomplete_limit, file_autocomplete_show_hidden);
+        let all_cmds = self.all_slash_commands();
+        let cmd_refs: Vec<(&str, &str)> = all_cmds
+            .iter()
+            .map(|(n, d)| (n.as_str(), d.as_str()))
+            .collect();
+        self.prompt_input.update_suggestions(
+            &cmd_refs,
+            file_autocomplete_limit,
+            file_autocomplete_show_hidden,
+        );
         self.sync_legacy_prompt_fields();
     }
 
@@ -2803,7 +3333,8 @@ impl App {
                 }
             });
         }
-        self.status_message = Some("Recording\u{2026} release V or press Enter to transcribe".to_string());
+        self.status_message =
+            Some("Recording\u{2026} release V or press Enter to transcribe".to_string());
     }
 
     /// Stop PTT recording: flip the AtomicBool inside VoiceRecorder so the
@@ -2932,10 +3463,8 @@ impl App {
                 self.pending_mcp_reconnect = true;
             }
             McpApprovalChoice::Deny => {
-                self.status_message = Some(format!(
-                    "Skipped project MCP server '{}'.",
-                    server.name
-                ));
+                self.status_message =
+                    Some(format!("Skipped project MCP server '{}'.", server.name));
             }
         }
     }
@@ -3107,7 +3636,6 @@ impl App {
             return false;
         }
 
-
         if self.global_search.visible {
             return self.handle_global_search_key(key);
         }
@@ -3242,9 +3770,15 @@ impl App {
                     self.device_auth_dialog.close();
                     self.device_auth_pending = None;
                 }
-                _ if matches!(self.device_auth_dialog.status, crate::device_auth_dialog::DeviceAuthStatus::Success(_)) => {
+                _ if matches!(
+                    self.device_auth_dialog.status,
+                    crate::device_auth_dialog::DeviceAuthStatus::Success(_)
+                ) =>
+                {
                     // Any key after success -> store credential and close
-                    if let crate::device_auth_dialog::DeviceAuthStatus::Success(ref token) = self.device_auth_dialog.status {
+                    if let crate::device_auth_dialog::DeviceAuthStatus::Success(ref token) =
+                        self.device_auth_dialog.status
+                    {
                         let provider_id = self.device_auth_dialog.provider_id.clone();
                         let provider_name = self.device_auth_dialog.provider_name.clone();
                         let token = token.clone();
@@ -3275,17 +3809,18 @@ impl App {
                         } else {
                             claurst_core::StoredCredential::ApiKey { key: token }
                         };
-                        self.auth_store.set(
-                            &provider_id,
-                            credential,
-                        );
+                        self.auth_store.set(&provider_id, credential);
                         self.device_auth_pending = None;
                         self.device_auth_dialog.close();
                         self.activate_provider(provider_id, provider_name, "Connected to");
                         return false;
                     }
                 }
-                _ if matches!(self.device_auth_dialog.status, crate::device_auth_dialog::DeviceAuthStatus::Error(_)) => {
+                _ if matches!(
+                    self.device_auth_dialog.status,
+                    crate::device_auth_dialog::DeviceAuthStatus::Error(_)
+                ) =>
+                {
                     // Any key after error -> close
                     self.device_auth_dialog.close();
                     self.device_auth_pending = None;
@@ -3356,17 +3891,28 @@ impl App {
                 KeyCode::Backspace => {
                     self.key_input_dialog.backspace();
                 }
-                KeyCode::Char('v') if key.modifiers.contains(KeyModifiers::CONTROL) || key.modifiers.contains(KeyModifiers::SUPER) => {
+                KeyCode::Char('v')
+                    if key.modifiers.contains(KeyModifiers::CONTROL)
+                        || key.modifiers.contains(KeyModifiers::SUPER) =>
+                {
                     if let Some(text) = crate::image_paste::read_clipboard_text() {
                         if text.is_empty() {
-                            self.push_notification(NotificationKind::Warning, "Clipboard is empty".to_string(), Some(2));
+                            self.push_notification(
+                                NotificationKind::Warning,
+                                "Clipboard is empty".to_string(),
+                                Some(2),
+                            );
                         } else {
                             for ch in text.chars() {
                                 self.key_input_dialog.insert_char(ch);
                             }
                         }
                     } else {
-                        self.push_notification(NotificationKind::Warning, "Could not read clipboard".to_string(), Some(2));
+                        self.push_notification(
+                            NotificationKind::Warning,
+                            "Could not read clipboard".to_string(),
+                            Some(2),
+                        );
                     }
                 }
                 KeyCode::Char(c) => {
@@ -3395,10 +3941,8 @@ impl App {
                     if self.free_mode_dialog.can_submit() {
                         let values = self.free_mode_dialog.take_values();
                         for (provider_id, key) in values {
-                            self.auth_store.set(
-                                provider_id,
-                                claurst_core::StoredCredential::ApiKey { key },
-                            );
+                            self.auth_store
+                                .set(provider_id, claurst_core::StoredCredential::ApiKey { key });
                         }
                         self.activate_provider(
                             "free".to_string(),
@@ -3463,15 +4007,33 @@ impl App {
         // Connect-a-provider dialog (/connect command)
         if self.connect_dialog.visible {
             match key.code {
-                KeyCode::Esc => { self.connect_dialog.close(); }
-                KeyCode::Home => { self.connect_dialog.move_home(); }
-                KeyCode::End => { self.connect_dialog.move_end(); }
-                KeyCode::Up => { self.connect_dialog.move_up(); }
-                KeyCode::Down => { self.connect_dialog.move_down(); }
-                KeyCode::PageUp => { self.connect_dialog.page_up(); }
-                KeyCode::PageDown => { self.connect_dialog.page_down(); }
-                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => { self.connect_dialog.move_up(); }
-                KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => { self.connect_dialog.move_down(); }
+                KeyCode::Esc => {
+                    self.connect_dialog.close();
+                }
+                KeyCode::Home => {
+                    self.connect_dialog.move_home();
+                }
+                KeyCode::End => {
+                    self.connect_dialog.move_end();
+                }
+                KeyCode::Up => {
+                    self.connect_dialog.move_up();
+                }
+                KeyCode::Down => {
+                    self.connect_dialog.move_down();
+                }
+                KeyCode::PageUp => {
+                    self.connect_dialog.page_up();
+                }
+                KeyCode::PageDown => {
+                    self.connect_dialog.page_down();
+                }
+                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.connect_dialog.move_up();
+                }
+                KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.connect_dialog.move_down();
+                }
                 KeyCode::Enter => {
                     if let Some(selected) = self.connect_dialog.selected().cloned() {
                         self.connect_dialog.close();
@@ -3479,58 +4041,74 @@ impl App {
                         match selected.id.as_str() {
                             // Local providers — activate immediately, no key needed
                             "ollama" | "lmstudio" | "llamacpp" => {
-                                self.activate_provider(selected.id.clone(), selected.title.clone(), "Switched to");
+                                self.activate_provider(
+                                    selected.id.clone(),
+                                    selected.title.clone(),
+                                    "Switched to",
+                                );
                             }
                             // "Free" composite mode — collects any subset of the
                             // free-tier upstreams (min 1; more = better availability).
                             "free" => {
-                                let existing: Vec<(&'static str, String)> = claurst_api::FREE_CATALOG
-                                    .iter()
-                                    .filter_map(|upstream| {
-                                        let key = match upstream.id {
-                                            "opencode-zen" => self
-                                                .auth_store
-                                                .api_key_for(claurst_core::ProviderId::OPENCODE_ZEN)
-                                                .or_else(|| {
-                                                    self.auth_store.api_key_for(
-                                                        claurst_core::ProviderId::OPENCODE_GO,
+                                let existing: Vec<(&'static str, String)> =
+                                    claurst_api::FREE_CATALOG
+                                        .iter()
+                                        .filter_map(|upstream| {
+                                            let key = match upstream.id {
+                                                "opencode-zen" => self
+                                                    .auth_store
+                                                    .api_key_for(
+                                                        claurst_core::ProviderId::OPENCODE_ZEN,
                                                     )
-                                                }),
-                                            other => self.auth_store.api_key_for(other),
-                                        };
-                                        key.filter(|k| !k.is_empty())
-                                            .map(|k| (upstream.id, k))
-                                    })
-                                    .collect();
+                                                    .or_else(|| {
+                                                        self.auth_store.api_key_for(
+                                                            claurst_core::ProviderId::OPENCODE_GO,
+                                                        )
+                                                    }),
+                                                other => self.auth_store.api_key_for(other),
+                                            };
+                                            key.filter(|k| !k.is_empty()).map(|k| (upstream.id, k))
+                                        })
+                                        .collect();
                                 self.free_mode_dialog.open(&existing);
                             }
                             "anthropic" => {
                                 // Anthropic: API key from console.anthropic.com.
-                                self.key_input_dialog.open(selected.id.clone(), selected.title.clone());
+                                self.key_input_dialog
+                                    .open(selected.id.clone(), selected.title.clone());
                             }
                             "anthropic-oauth" => {
                                 // Claude Pro/Max subscription: claude.ai OAuth via
                                 // the browser (loopback capture), spawned by the
                                 // main loop. Note: usage draws from the account's
                                 // extra-usage pool, not subscription quota.
-                                self.device_auth_dialog.open(selected.id.clone(), selected.title.clone());
+                                self.device_auth_dialog
+                                    .open(selected.id.clone(), selected.title.clone());
                                 self.device_auth_pending = Some("anthropic-oauth".to_string());
                             }
                             "custom-openai" => {
-                                let current_url = Settings::load_sync()
-                                    .ok()
-                                    .and_then(|settings| settings.providers.get("custom-openai").and_then(|p| p.api_base.clone()));
-                                self.custom_provider_dialog
-                                    .open(selected.id.clone(), selected.title.clone(), current_url);
+                                let current_url = Settings::load_sync().ok().and_then(|settings| {
+                                    settings
+                                        .providers
+                                        .get("custom-openai")
+                                        .and_then(|p| p.api_base.clone())
+                                });
+                                self.custom_provider_dialog.open(
+                                    selected.id.clone(),
+                                    selected.title.clone(),
+                                    current_url,
+                                );
                             }
                             "github-copilot" => {
                                 // GitHub Copilot: device code flow
-                                self.device_auth_dialog.open(selected.id.clone(), selected.title.clone());
+                                self.device_auth_dialog
+                                    .open(selected.id.clone(), selected.title.clone());
                                 self.device_auth_pending = Some("github-copilot".to_string());
                             }
                             "codex" | "openai-codex" => {
                                 // OpenAI Codex: browser OAuth flow (spawned by main loop)
-                                self.device_auth_dialog.open("openai-codex".into(), "OpenAI Codex".into());
+                                self.device_auth_dialog
+                                    .open("openai-codex".into(), "OpenAI Codex".into());
                                 self.device_auth_pending = Some("openai-codex".to_string());
                             }
                             // AWS Bedrock — accept a bearer token via key input dialog
@@ -3546,8 +4124,12 @@ impl App {
                         }
                     }
                 }
-                KeyCode::Backspace => { self.connect_dialog.filter_pop(); }
-                KeyCode::Char(c) => { self.connect_dialog.filter_push(c); }
+                KeyCode::Backspace => {
+                    self.connect_dialog.filter_pop();
+                }
+                KeyCode::Char(c) => {
+                    self.connect_dialog.filter_push(c);
+                }
                 _ => {}
             }
             return false;
@@ -3556,15 +4138,33 @@ impl App {
         // Import-config source picker
         if self.import_config_picker.visible {
             match key.code {
-                KeyCode::Esc => { self.import_config_picker.close(); }
-                KeyCode::Home => { self.import_config_picker.move_home(); }
-                KeyCode::End => { self.import_config_picker.move_end(); }
-                KeyCode::Up => { self.import_config_picker.move_up(); }
-                KeyCode::Down => { self.import_config_picker.move_down(); }
-                KeyCode::PageUp => { self.import_config_picker.page_up(); }
-                KeyCode::PageDown => { self.import_config_picker.page_down(); }
-                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => { self.import_config_picker.move_up(); }
-                KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => { self.import_config_picker.move_down(); }
+                KeyCode::Esc => {
+                    self.import_config_picker.close();
+                }
+                KeyCode::Home => {
+                    self.import_config_picker.move_home();
+                }
+                KeyCode::End => {
+                    self.import_config_picker.move_end();
+                }
+                KeyCode::Up => {
+                    self.import_config_picker.move_up();
+                }
+                KeyCode::Down => {
+                    self.import_config_picker.move_down();
+                }
+                KeyCode::PageUp => {
+                    self.import_config_picker.page_up();
+                }
+                KeyCode::PageDown => {
+                    self.import_config_picker.page_down();
+                }
+                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.import_config_picker.move_up();
+                }
+                KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.import_config_picker.move_down();
+                }
                 KeyCode::Enter => {
                     if let Some(selected) = self.import_config_picker.selected().cloned() {
                         self.import_config_picker.close();
@@ -3573,8 +4173,12 @@ impl App {
                         }
                     }
                 }
-                KeyCode::Backspace => { self.import_config_picker.filter_pop(); }
-                KeyCode::Char(c) => { self.import_config_picker.filter_push(c); }
+                KeyCode::Backspace => {
+                    self.import_config_picker.filter_pop();
+                }
+                KeyCode::Char(c) => {
+                    self.import_config_picker.filter_push(c);
+                }
                 _ => {}
             }
             return false;
@@ -3593,15 +4197,33 @@ impl App {
         // Command palette (Ctrl+K)
         if self.command_palette.visible {
             match key.code {
-                KeyCode::Esc => { self.command_palette.close(); }
-                KeyCode::Home => { self.command_palette.move_home(); }
-                KeyCode::End => { self.command_palette.move_end(); }
-                KeyCode::Up => { self.command_palette.move_up(); }
-                KeyCode::Down => { self.command_palette.move_down(); }
-                KeyCode::PageUp => { self.command_palette.page_up(); }
-                KeyCode::PageDown => { self.command_palette.page_down(); }
-                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => { self.command_palette.move_up(); }
-                KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => { self.command_palette.move_down(); }
+                KeyCode::Esc => {
+                    self.command_palette.close();
+                }
+                KeyCode::Home => {
+                    self.command_palette.move_home();
+                }
+                KeyCode::End => {
+                    self.command_palette.move_end();
+                }
+                KeyCode::Up => {
+                    self.command_palette.move_up();
+                }
+                KeyCode::Down => {
+                    self.command_palette.move_down();
+                }
+                KeyCode::PageUp => {
+                    self.command_palette.page_up();
+                }
+                KeyCode::PageDown => {
+                    self.command_palette.page_down();
+                }
+                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.command_palette.move_up();
+                }
+                KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.command_palette.move_down();
+                }
                 KeyCode::Enter => {
                     if let Some(selected) = self.command_palette.selected().cloned() {
                         self.command_palette.close();
@@ -3610,8 +4232,12 @@ impl App {
                         return true; // signal to submit this as input
                     }
                 }
-                KeyCode::Backspace => { self.command_palette.filter_pop(); }
-                KeyCode::Char(c) => { self.command_palette.filter_push(c); }
+                KeyCode::Backspace => {
+                    self.command_palette.filter_pop();
+                }
+                KeyCode::Char(c) => {
+                    self.command_palette.filter_push(c);
+                }
                 _ => {}
             }
             return false;
@@ -3638,13 +4264,19 @@ impl App {
                 KeyCode::Down => self.model_picker.select_next(),
                 KeyCode::Left => self.model_picker.effort_prev(),
                 KeyCode::Right => self.model_picker.effort_next(),
-                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => self.model_picker.select_prev(),
-                KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => self.model_picker.select_next(),
+                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.model_picker.select_prev()
+                }
+                KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.model_picker.select_next()
+                }
                 KeyCode::Enter => {
                     if let Some((model_id, effort)) = self.model_picker.confirm() {
                         // If user picked a model other than the fast-mode model
                         // while fast mode was active, turn fast mode off.
-                        if self.fast_mode && !self.model_picker.is_selected_fast_mode_model(&model_id) {
+                        if self.fast_mode
+                            && !self.model_picker.is_selected_fast_mode_model(&model_id)
+                        {
                             self.fast_mode = false;
                         }
                         if let Some(e) = effort {
@@ -3664,7 +4296,9 @@ impl App {
                         };
                         self.set_model(full_model.clone());
                         self.persist_provider_and_model();
-                        let effort_hint = effort.map(|e| format!(" [{}]", e.label())).unwrap_or_default();
+                        let effort_hint = effort
+                            .map(|e| format!(" [{}]", e.label()))
+                            .unwrap_or_default();
                         self.status_message = Some(format!("Model: {}{}", full_model, effort_hint));
                     }
                 }
@@ -3679,47 +4313,43 @@ impl App {
         if self.session_branching.visible {
             use crate::session_branching::BranchBrowserMode;
             match self.session_branching.mode {
-                BranchBrowserMode::Browse => {
-                    match key.code {
-                        KeyCode::Esc => self.session_branching.cancel(),
-                        KeyCode::Up => self.session_branching.select_prev(),
-                        KeyCode::Down => self.session_branching.select_next(),
-                        KeyCode::Char('n') => self.session_branching.start_create_new(),
-                        KeyCode::Char('d') => self.session_branching.start_delete_confirm(),
-                        KeyCode::Enter => {
-                            if let Some(branch) = self.session_branching.selected_branch() {
-                                self.status_message = Some(format!("Switched to branch: {}", branch.name));
-                                self.session_branching.close();
-                            }
+                BranchBrowserMode::Browse => match key.code {
+                    KeyCode::Esc => self.session_branching.cancel(),
+                    KeyCode::Up => self.session_branching.select_prev(),
+                    KeyCode::Down => self.session_branching.select_next(),
+                    KeyCode::Char('n') => self.session_branching.start_create_new(),
+                    KeyCode::Char('d') => self.session_branching.start_delete_confirm(),
+                    KeyCode::Enter => {
+                        if let Some(branch) = self.session_branching.selected_branch() {
+                            self.status_message =
+                                Some(format!("Switched to branch: {}", branch.name));
+                            self.session_branching.close();
                         }
-                        _ => {}
                     }
-                }
-                BranchBrowserMode::CreateNew => {
-                    match key.code {
-                        KeyCode::Esc => self.session_branching.cancel(),
-                        KeyCode::Enter => {
-                            if let Some((name, at_msg)) = self.session_branching.confirm_create_new() {
-                                self.status_message = Some(format!("Created branch: {} at message {}", name, at_msg));
-                                self.session_branching.close();
-                            }
+                    _ => {}
+                },
+                BranchBrowserMode::CreateNew => match key.code {
+                    KeyCode::Esc => self.session_branching.cancel(),
+                    KeyCode::Enter => {
+                        if let Some((name, at_msg)) = self.session_branching.confirm_create_new() {
+                            self.status_message =
+                                Some(format!("Created branch: {} at message {}", name, at_msg));
+                            self.session_branching.close();
                         }
-                        KeyCode::Backspace => self.session_branching.pop_create_char(),
-                        KeyCode::Char(c) => self.session_branching.push_create_char(c),
-                        _ => {}
                     }
-                }
-                BranchBrowserMode::ConfirmDelete => {
-                    match key.code {
-                        KeyCode::Esc | KeyCode::Char('n') => self.session_branching.cancel(),
-                        KeyCode::Enter | KeyCode::Char('y') => {
-                            if let Some(branch_id) = self.session_branching.confirm_delete() {
-                                self.status_message = Some(format!("Deleted branch: {}", branch_id));
-                            }
+                    KeyCode::Backspace => self.session_branching.pop_create_char(),
+                    KeyCode::Char(c) => self.session_branching.push_create_char(c),
+                    _ => {}
+                },
+                BranchBrowserMode::ConfirmDelete => match key.code {
+                    KeyCode::Esc | KeyCode::Char('n') => self.session_branching.cancel(),
+                    KeyCode::Enter | KeyCode::Char('y') => {
+                        if let Some(branch_id) = self.session_branching.confirm_delete() {
+                            self.status_message = Some(format!("Deleted branch: {}", branch_id));
                         }
-                        _ => {}
                     }
-                }
+                    _ => {}
+                },
             }
             return false;
         }
@@ -3728,38 +4358,32 @@ impl App {
         if self.session_browser.visible {
             use crate::session_browser::SessionBrowserMode;
             match self.session_browser.mode {
-                SessionBrowserMode::Browse => {
-                    match key.code {
-                        KeyCode::Esc => self.session_browser.close(),
-                        KeyCode::Up => self.session_browser.select_prev(),
-                        KeyCode::Down => self.session_browser.select_next(),
-                        KeyCode::Char('r') => self.session_browser.start_rename(),
-                        _ => {}
-                    }
-                }
-                SessionBrowserMode::Rename => {
-                    match key.code {
-                        KeyCode::Esc => self.session_browser.cancel(),
-                        KeyCode::Enter => {
-                            if let Some((_id, name)) = self.session_browser.confirm_rename() {
-                                self.session_title = Some(name.clone());
-                                self.status_message = Some(format!("Renamed to: {}", name));
-                            }
+                SessionBrowserMode::Browse => match key.code {
+                    KeyCode::Esc => self.session_browser.close(),
+                    KeyCode::Up => self.session_browser.select_prev(),
+                    KeyCode::Down => self.session_browser.select_next(),
+                    KeyCode::Char('r') => self.session_browser.start_rename(),
+                    _ => {}
+                },
+                SessionBrowserMode::Rename => match key.code {
+                    KeyCode::Esc => self.session_browser.cancel(),
+                    KeyCode::Enter => {
+                        if let Some((_id, name)) = self.session_browser.confirm_rename() {
+                            self.session_title = Some(name.clone());
+                            self.status_message = Some(format!("Renamed to: {}", name));
                         }
-                        KeyCode::Backspace => self.session_browser.pop_rename_char(),
-                        KeyCode::Char(c) => self.session_browser.push_rename_char(c),
-                        _ => {}
                     }
-                }
-                SessionBrowserMode::Confirm => {
-                    match key.code {
-                        KeyCode::Esc | KeyCode::Char('n') => self.session_browser.cancel(),
-                        KeyCode::Enter | KeyCode::Char('y') => {
-                            self.session_browser.close();
-                        }
-                        _ => {}
+                    KeyCode::Backspace => self.session_browser.pop_rename_char(),
+                    KeyCode::Char(c) => self.session_browser.push_rename_char(c),
+                    _ => {}
+                },
+                SessionBrowserMode::Confirm => match key.code {
+                    KeyCode::Esc | KeyCode::Char('n') => self.session_browser.cancel(),
+                    KeyCode::Enter | KeyCode::Char('y') => {
+                        self.session_browser.close();
                     }
-                }
+                    _ => {}
+                },
             }
             return false;
         }
@@ -3771,7 +4395,9 @@ impl App {
                 KeyCode::Up => self.tasks_overlay.select_prev(),
                 KeyCode::Down => self.tasks_overlay.select_next(),
                 KeyCode::Enter => {
-                    if let Some((task_id, new_status)) = self.tasks_overlay.cycle_and_persist_status() {
+                    if let Some((task_id, new_status)) =
+                        self.tasks_overlay.cycle_and_persist_status()
+                    {
                         self.status_message = Some(format!("Task {} → {}", task_id, new_status));
                     }
                 }
@@ -3828,7 +4454,9 @@ impl App {
 
         // MCP approval dialog
         if self.mcp_approval.visible {
-            if let Some(choice) = crate::dialogs::handle_mcp_approval_key(&mut self.mcp_approval, key) {
+            if let Some(choice) =
+                crate::dialogs::handle_mcp_approval_key(&mut self.mcp_approval, key)
+            {
                 self.handle_mcp_approval_decision(choice);
             }
             return false;
@@ -4091,7 +4719,8 @@ impl App {
         }
 
         // Clear any active text selection on key press (except Ctrl+C which copies it).
-        let is_copy = key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL);
+        let is_copy =
+            key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL);
         if !is_copy && self.selection_anchor.is_some() {
             self.selection_anchor = None;
             self.selection_focus = None;
@@ -4181,7 +4810,9 @@ impl App {
                     | crate::prompt_input::VimMode::VisualBlock
             )
         {
-            use crate::image_paste::{read_clipboard_image, read_clipboard_text, read_primary_text};
+            use crate::image_paste::{
+                read_clipboard_image, read_clipboard_text, read_primary_text,
+            };
             if let Some(img) = read_clipboard_image() {
                 let label = img.label.clone();
                 let dims = img.dimensions;
@@ -4206,10 +4837,7 @@ impl App {
         }
 
         // ---- Enter while PTT recording: stop capture instead of submitting ----
-        if key.code == KeyCode::Enter
-            && self.voice_recording
-            && self.voice_recorder.is_some()
-        {
+        if key.code == KeyCode::Enter && self.voice_recording && self.voice_recorder.is_some() {
             self.handle_voice_ptt_stop();
             return false;
         }
@@ -4227,8 +4855,9 @@ impl App {
                 KeyCode::PageUp | KeyCode::PageDown => {
                     // Let these fall through to the normal scroll handling below.
                 }
-                KeyCode::Char(_) if !key.modifiers.contains(KeyModifiers::CONTROL)
-                    && !key.modifiers.contains(KeyModifiers::ALT) =>
+                KeyCode::Char(_)
+                    if !key.modifiers.contains(KeyModifiers::CONTROL)
+                        && !key.modifiers.contains(KeyModifiers::ALT) =>
                 {
                     // Printable char: switch focus to Input and process normally.
                     self.focus = FocusTarget::Input;
@@ -4252,7 +4881,9 @@ impl App {
             // ---- Quit / cancel ----------------------------------------
             // Accept both 'c' and 'C' so Shift+Ctrl+C also triggers copy
             // (issue #149 follow-up).
-            KeyCode::Char(c) if (c == 'c' || c == 'C') && key.modifiers.contains(KeyModifiers::CONTROL) => {
+            KeyCode::Char(c)
+                if (c == 'c' || c == 'C') && key.modifiers.contains(KeyModifiers::CONTROL) =>
+            {
                 // If text is selected, copy it to clipboard instead of quitting.
                 let sel_text = self.selection_text.borrow().clone();
                 if self.selection_anchor.is_some() && !sel_text.is_empty() {
@@ -4262,7 +4893,11 @@ impl App {
                     self.selection_focus = None;
                     *self.selection_text.borrow_mut() = String::new();
                     if copied {
-                        self.push_notification(NotificationKind::Info, "Copied to clipboard".to_string(), Some(2));
+                        self.push_notification(
+                            NotificationKind::Info,
+                            "Copied to clipboard".to_string(),
+                            Some(2),
+                        );
                     }
                 } else if self.is_streaming {
                     // Cancel streaming.
@@ -4535,7 +5170,10 @@ impl App {
             // when the cursor is already on the first/last visual row
             // (issue #149 follow-up).
             KeyCode::Up => {
-                if !self.prompt_input.suggestions.is_empty() && (self.prompt_input.text.starts_with('/') || self.prompt_input.has_active_file_ref()) {
+                if !self.prompt_input.suggestions.is_empty()
+                    && (self.prompt_input.text.starts_with('/')
+                        || self.prompt_input.has_active_file_ref())
+                {
                     self.prompt_input.suggestion_prev();
                 } else {
                     let area = self.last_input_area.get();
@@ -4549,7 +5187,10 @@ impl App {
                 self.refresh_prompt_input();
             }
             KeyCode::Down => {
-                if !self.prompt_input.suggestions.is_empty() && (self.prompt_input.text.starts_with('/') || self.prompt_input.has_active_file_ref()) {
+                if !self.prompt_input.suggestions.is_empty()
+                    && (self.prompt_input.text.starts_with('/')
+                        || self.prompt_input.has_active_file_ref())
+                {
                     self.prompt_input.suggestion_next();
                 } else {
                     let area = self.last_input_area.get();
@@ -4580,12 +5221,12 @@ impl App {
 
             // ---- Toggle last thinking block (t key) -------------------
             // (Removed: shadowed by KeyCode::Char(c) prompt input handler.)
-
             _ => {}
         }
 
         // Reset exit confirmation sequence if user presses any key other than Ctrl+C or Ctrl+D.
-        let is_exit_key = key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char(c) if c == 'c' || c == 'd' || c == 'C' || c == 'D');
+        let is_exit_key = key.modifiers.contains(KeyModifiers::CONTROL)
+            && matches!(key.code, KeyCode::Char(c) if c == 'c' || c == 'd' || c == 'C' || c == 'D');
         if !is_exit_key {
             self.last_exit_key_warning = None;
             self.exit_key_sequence_start = None;
@@ -4662,10 +5303,12 @@ impl App {
                 self.pending_mcp_reconnect = true;
                 self.status_message = Some("Reconnecting MCP runtime...".to_string());
             }
-            KeyCode::Char(c) if key.modifiers.is_empty()
-                && self.mcp_view.active_pane != crate::mcp_view::McpViewPane::ServerList => {
-                    self.mcp_view.push_search_char(c);
-                }
+            KeyCode::Char(c)
+                if key.modifiers.is_empty()
+                    && self.mcp_view.active_pane != crate::mcp_view::McpViewPane::ServerList =>
+            {
+                self.mcp_view.push_search_char(c);
+            }
             _ => {}
         }
         false
@@ -4732,10 +5375,9 @@ impl App {
             }
             KeyCode::PageUp => self.diff_viewer.scroll_detail_up(),
             KeyCode::PageDown => self.diff_viewer.scroll_detail_down(),
-            KeyCode::Char(' ')
-                if self.diff_viewer.active_pane == DiffPane::FileList => {
-                    self.diff_viewer.toggle_file_collapse();
-                }
+            KeyCode::Char(' ') if self.diff_viewer.active_pane == DiffPane::FileList => {
+                self.diff_viewer.toggle_file_collapse();
+            }
             _ => {}
         }
     }
@@ -4936,7 +5578,11 @@ impl App {
         }
 
         // Start new sequence (or show message for wrong key)
-        self.push_notification(NotificationKind::Info, exit_message(key_char).to_string(), Some(2));
+        self.push_notification(
+            NotificationKind::Info,
+            exit_message(key_char).to_string(),
+            Some(2),
+        );
         self.last_exit_key_warning = Some(std::time::Instant::now());
         self.exit_key_sequence_start = Some(key_char);
     }
@@ -4959,7 +5605,9 @@ impl App {
                         self.refresh_prompt_input();
                     }
 
-                    let elapsed = self.last_exit_key_warning.map(|t| t.elapsed().as_secs_f64());
+                    let elapsed = self
+                        .last_exit_key_warning
+                        .map(|t| t.elapsed().as_secs_f64());
                     let is_valid = elapsed.map(|e| e <= 2.0).unwrap_or(false);
 
                     if self.last_exit_key_warning.is_some() && is_valid {
@@ -4969,7 +5617,11 @@ impl App {
                         self.exit_key_sequence_start = None;
                     } else {
                         // First press or timeout expired: show exit confirmation.
-                        self.push_notification(NotificationKind::Info, "Press Ctrl+C again to exit".to_string(), Some(2));
+                        self.push_notification(
+                            NotificationKind::Info,
+                            "Press Ctrl+C again to exit".to_string(),
+                            Some(2),
+                        );
                         self.last_exit_key_warning = Some(std::time::Instant::now());
                         self.exit_key_sequence_start = Some('c');
                     }
@@ -5012,7 +5664,8 @@ impl App {
             "historyPrev" => {
                 // Suggestions (slash commands or file refs) take priority over cursor/history.
                 if !self.prompt_input.suggestions.is_empty()
-                    && (self.prompt_input.text.starts_with('/') || self.prompt_input.has_active_file_ref())
+                    && (self.prompt_input.text.starts_with('/')
+                        || self.prompt_input.has_active_file_ref())
                 {
                     self.prompt_input.suggestion_prev();
                     self.refresh_prompt_input();
@@ -5030,7 +5683,8 @@ impl App {
             "historyNext" => {
                 // Suggestions (slash commands or file refs) take priority over cursor/history.
                 if !self.prompt_input.suggestions.is_empty()
-                    && (self.prompt_input.text.starts_with('/') || self.prompt_input.has_active_file_ref())
+                    && (self.prompt_input.text.starts_with('/')
+                        || self.prompt_input.has_active_file_ref())
                 {
                     self.prompt_input.suggestion_next();
                     self.refresh_prompt_input();
@@ -5272,7 +5926,7 @@ impl App {
                         self.refresh_prompt_input();
                     } else if self.prompt_input.is_empty() {
                         self.cycle_agent_mode();
-                    self.rustle_look_down();
+                        self.rustle_look_down();
                     }
                 }
                 false
@@ -5440,7 +6094,8 @@ impl App {
             (Some(last_time), Some(last_pos)) => {
                 let elapsed = now.duration_since(last_time);
                 let distance = ((current_pos.0 as i32 - last_pos.0 as i32).abs()
-                    + (current_pos.1 as i32 - last_pos.1 as i32).abs()) as u16;
+                    + (current_pos.1 as i32 - last_pos.1 as i32).abs())
+                    as u16;
                 elapsed.as_millis() < 500 && distance <= 5
             }
             _ => false,
@@ -5477,7 +6132,10 @@ impl App {
         while end + 1 < chars.len() && is_word(chars[end + 1]) {
             end += 1;
         }
-        Some((selectable_area.x + start as u16, selectable_area.x + end as u16))
+        Some((
+            selectable_area.x + start as u16,
+            selectable_area.x + end as u16,
+        ))
     }
 
     /// Find paragraph boundaries (run of non-blank rows) around `row` and
@@ -5502,7 +6160,11 @@ impl App {
         let mut start = row;
         while start > selectable_area.y {
             let prev = start - 1;
-            if cache.get(&prev).map(|s| s.trim().is_empty()).unwrap_or(true) {
+            if cache
+                .get(&prev)
+                .map(|s| s.trim().is_empty())
+                .unwrap_or(true)
+            {
                 break;
             }
             start = prev;
@@ -5510,7 +6172,11 @@ impl App {
         let mut end = row;
         while end < max_row {
             let next = end + 1;
-            if cache.get(&next).map(|s| s.trim().is_empty()).unwrap_or(true) {
+            if cache
+                .get(&next)
+                .map(|s| s.trim().is_empty())
+                .unwrap_or(true)
+            {
                 break;
             }
             end = next;
@@ -5527,7 +6193,10 @@ impl App {
     fn find_line_boundaries(&self, row: u16) -> Option<(u16, u16)> {
         let selectable_area = self.last_selectable_area.get();
         let line_start = selectable_area.y;
-        let line_end = selectable_area.y.saturating_add(selectable_area.height).saturating_sub(1);
+        let line_end = selectable_area
+            .y
+            .saturating_add(selectable_area.height)
+            .saturating_sub(1);
 
         if row >= line_start && row <= line_end {
             Some((row, row))
@@ -5645,9 +6314,12 @@ impl App {
             ContextMenuItem::Fork => {
                 if let ContextMenuKind::Message { message_index } = kind {
                     let branch_point = message_index + 1;
-                    self.prompt_input.replace_text(format!("/fork {}", branch_point));
-                    self.status_message =
-                        Some(format!("Fork at message {} - press Enter to confirm", branch_point));
+                    self.prompt_input
+                        .replace_text(format!("/fork {}", branch_point));
+                    self.status_message = Some(format!(
+                        "Fork at message {} - press Enter to confirm",
+                        branch_point
+                    ));
                 }
             }
         }
@@ -5671,8 +6343,8 @@ impl App {
             return false;
         }
 
-        if let Some(text) = crate::image_paste::read_primary_text()
-            .or_else(crate::image_paste::read_clipboard_text)
+        if let Some(text) =
+            crate::image_paste::read_primary_text().or_else(crate::image_paste::read_clipboard_text)
         {
             self.focus = FocusTarget::Input;
             self.clear_selection();
@@ -5693,8 +6365,8 @@ impl App {
     /// Otherwise the text goes through the normal `prompt_input.paste()` path
     /// which applies the multi-line summary placeholder for large pastes.
     pub fn handle_paste_data(&mut self, data: String) {
-        use crate::prompt_input::detect_pasted_path;
         use crate::image_paste::PastedImage;
+        use crate::prompt_input::detect_pasted_path;
 
         if let Some(path) = detect_pasted_path(&data) {
             let ext = path
@@ -5711,7 +6383,11 @@ impl App {
                     .and_then(|n| n.to_str())
                     .unwrap_or("image")
                     .to_string();
-                let img = PastedImage { path, label: label.clone(), dimensions: None };
+                let img = PastedImage {
+                    path,
+                    label: label.clone(),
+                    dimensions: None,
+                };
                 self.prompt_input.add_image(img);
                 self.push_notification(
                     crate::notifications::NotificationKind::Info,
@@ -5749,8 +6425,7 @@ impl App {
     /// queued composition, and a raw-key paste flood must be captured there
     /// too instead of submitting on every pasted newline.
     pub fn paste_burst_allowed(&self) -> bool {
-        !self.any_modal_open()
-            && self.prompt_input.vim_mode == crate::prompt_input::VimMode::Insert
+        !self.any_modal_open() && self.prompt_input.vim_mode == crate::prompt_input::VimMode::Insert
     }
 
     /// Drain any immediately-available key events from the crossterm event
@@ -5771,10 +6446,7 @@ impl App {
     /// single keystroke.  If a non-character key is encountered while
     /// draining, it is stored in `self.pending_key` and will be replayed at
     /// the top of the next event-loop iteration.
-    pub fn try_detect_paste_burst(
-        &mut self,
-        first: char,
-    ) -> Option<String> {
+    pub fn try_detect_paste_burst(&mut self, first: char) -> Option<String> {
         use crossterm::event::{Event, KeyCode, KeyEventKind};
 
         // Minimum number of chars (including `first`) to classify as a paste.
@@ -5806,7 +6478,8 @@ impl App {
                         // map it back to a newline or Unix pastes lose their
                         // line breaks (they'd insert a literal 'j').
                         KeyCode::Char('j')
-                            if k.modifiers.contains(crossterm::event::KeyModifiers::CONTROL) =>
+                            if k.modifiers
+                                .contains(crossterm::event::KeyModifiers::CONTROL) =>
                         {
                             buf.push('\n')
                         }
@@ -5889,7 +6562,8 @@ impl App {
         }
         let target_row = scroll + (row - text_start_y) as usize;
         let target_col = col.saturating_sub(rect.x + 2) as usize;
-        self.prompt_input.set_cursor_at_visual(target_row, target_col, width);
+        self.prompt_input
+            .set_cursor_at_visual(target_row, target_col, width);
         // Clicking a [Pasted text #N ...] placeholder opens the read-only
         // viewer so the body can be read without splicing it into the
         // prompt; Alt+E remains the in-place expansion for editing.
@@ -5964,15 +6638,29 @@ impl App {
         if matches!(mouse_event.kind, MouseEventKind::Moved) {
             if let Some(menu) = self.context_menu_state.as_mut() {
                 let items = Self::context_menu_items(menu.kind);
-                let item_labels: Vec<&str> = items.iter().map(|i| match i {
-                    ContextMenuItem::Copy => "Copy",
-                    ContextMenuItem::Fork => "Fork new chat",
-                }).collect();
-                let menu_width = (item_labels.iter().map(|l| l.len()).max().unwrap_or(4) + 4) as u16;
+                let item_labels: Vec<&str> = items
+                    .iter()
+                    .map(|i| match i {
+                        ContextMenuItem::Copy => "Copy",
+                        ContextMenuItem::Fork => "Fork new chat",
+                    })
+                    .collect();
+                let menu_width =
+                    (item_labels.iter().map(|l| l.len()).max().unwrap_or(4) + 4) as u16;
                 let menu_height = items.len() as u16 + 2;
                 let screen = self.last_msg_area.get();
-                let menu_x = menu.x.min(screen.x.saturating_add(screen.width).saturating_sub(menu_width + 1));
-                let menu_y = menu.y.min(screen.y.saturating_add(screen.height).saturating_sub(menu_height + 1));
+                let menu_x = menu.x.min(
+                    screen
+                        .x
+                        .saturating_add(screen.width)
+                        .saturating_sub(menu_width + 1),
+                );
+                let menu_y = menu.y.min(
+                    screen
+                        .y
+                        .saturating_add(screen.height)
+                        .saturating_sub(menu_height + 1),
+                );
                 let inner_y = menu_y + 1;
                 let col = mouse_event.column;
                 let row = mouse_event.row;
@@ -6009,11 +6697,14 @@ impl App {
                 MouseEventKind::Down(MouseButton::Left) => {
                     // DialogSelect dialogs — check if click is inside for item selection
                     let in_dialog = if self.connect_dialog.visible {
-                        self.connect_dialog.contains(mouse_event.column, mouse_event.row)
+                        self.connect_dialog
+                            .contains(mouse_event.column, mouse_event.row)
                     } else if self.import_config_picker.visible {
-                        self.import_config_picker.contains(mouse_event.column, mouse_event.row)
+                        self.import_config_picker
+                            .contains(mouse_event.column, mouse_event.row)
                     } else if self.command_palette.visible {
-                        self.command_palette.contains(mouse_event.column, mouse_event.row)
+                        self.command_palette
+                            .contains(mouse_event.column, mouse_event.row)
                     } else {
                         // Other dialogs (model_picker, settings, export, etc.) —
                         // treat any click as "inside" to prevent accidental dismiss.
@@ -6026,7 +6717,8 @@ impl App {
                         if self.connect_dialog.visible {
                             self.connect_dialog.handle_mouse_click(mouse_event.row);
                         } else if self.import_config_picker.visible {
-                            self.import_config_picker.handle_mouse_click(mouse_event.row);
+                            self.import_config_picker
+                                .handle_mouse_click(mouse_event.row);
                         } else if self.command_palette.visible {
                             self.command_palette.handle_mouse_click(mouse_event.row);
                         }
@@ -6039,14 +6731,22 @@ impl App {
                 }
                 MouseEventKind::ScrollUp => {
                     // Scroll through dialog items
-                    if self.connect_dialog.visible { self.connect_dialog.move_up(); }
-                    else if self.import_config_picker.visible { self.import_config_picker.move_up(); }
-                    else if self.command_palette.visible { self.command_palette.move_up(); }
+                    if self.connect_dialog.visible {
+                        self.connect_dialog.move_up();
+                    } else if self.import_config_picker.visible {
+                        self.import_config_picker.move_up();
+                    } else if self.command_palette.visible {
+                        self.command_palette.move_up();
+                    }
                 }
                 MouseEventKind::ScrollDown => {
-                    if self.connect_dialog.visible { self.connect_dialog.move_down(); }
-                    else if self.import_config_picker.visible { self.import_config_picker.move_down(); }
-                    else if self.command_palette.visible { self.command_palette.move_down(); }
+                    if self.connect_dialog.visible {
+                        self.connect_dialog.move_down();
+                    } else if self.import_config_picker.visible {
+                        self.import_config_picker.move_down();
+                    } else if self.command_palette.visible {
+                        self.command_palette.move_down();
+                    }
                 }
                 _ => {}
             }
@@ -6112,16 +6812,30 @@ impl App {
                 // Must replicate the same position clamping as the renderer.
                 if let Some(menu) = self.context_menu_state {
                     let items = Self::context_menu_items(menu.kind);
-                    let item_labels: Vec<&str> = items.iter().map(|i| match i {
-                        ContextMenuItem::Copy => "Copy",
-                        ContextMenuItem::Fork => "Fork new chat",
-                    }).collect();
-                    let menu_width = (item_labels.iter().map(|l| l.len()).max().unwrap_or(4) + 4) as u16;
+                    let item_labels: Vec<&str> = items
+                        .iter()
+                        .map(|i| match i {
+                            ContextMenuItem::Copy => "Copy",
+                            ContextMenuItem::Fork => "Fork new chat",
+                        })
+                        .collect();
+                    let menu_width =
+                        (item_labels.iter().map(|l| l.len()).max().unwrap_or(4) + 4) as u16;
                     let menu_height = items.len() as u16 + 2; // +2 for border
-                    // Clamp to screen bounds (same as render_context_menu)
+                                                              // Clamp to screen bounds (same as render_context_menu)
                     let screen = self.last_msg_area.get();
-                    let menu_x = menu.x.min(screen.x.saturating_add(screen.width).saturating_sub(menu_width + 1));
-                    let menu_y = menu.y.min(screen.y.saturating_add(screen.height).saturating_sub(menu_height + 1));
+                    let menu_x = menu.x.min(
+                        screen
+                            .x
+                            .saturating_add(screen.width)
+                            .saturating_sub(menu_width + 1),
+                    );
+                    let menu_y = menu.y.min(
+                        screen
+                            .y
+                            .saturating_add(screen.height)
+                            .saturating_sub(menu_height + 1),
+                    );
                     let col = mouse_event.column;
                     let row = mouse_event.row;
                     // Inner area starts 1 past the border
@@ -6133,7 +6847,8 @@ impl App {
                     {
                         let clicked_index = (row - inner_y) as usize;
                         if clicked_index < items.len() {
-                            self.context_menu_state.as_mut().unwrap().selected_index = clicked_index;
+                            self.context_menu_state.as_mut().unwrap().selected_index =
+                                clicked_index;
                             self.execute_context_menu_item();
                             return;
                         }
@@ -6146,13 +6861,15 @@ impl App {
                 let input_area = self.last_input_area.get();
                 let selectable_area = self.last_selectable_area.get();
 
-                let in_input = input_area.width > 0 && input_area.height > 0
+                let in_input = input_area.width > 0
+                    && input_area.height > 0
                     && mouse_event.row >= input_area.y
                     && mouse_event.row < input_area.y.saturating_add(input_area.height)
                     && mouse_event.column >= input_area.x
                     && mouse_event.column < input_area.x.saturating_add(input_area.width);
 
-                let in_selectable = selectable_area.width > 0 && selectable_area.height > 0
+                let in_selectable = selectable_area.width > 0
+                    && selectable_area.height > 0
                     && mouse_event.row >= selectable_area.y
                     && mouse_event.row < selectable_area.y.saturating_add(selectable_area.height)
                     && mouse_event.column >= selectable_area.x
@@ -6206,7 +6923,9 @@ impl App {
                             self.click_count = 0; // Reset for next click sequence
                         } else {
                             // Double-click: select word
-                            if let Some((start, end)) = self.find_word_boundaries(current_pos.0, current_pos.1) {
+                            if let Some((start, end)) =
+                                self.find_word_boundaries(current_pos.0, current_pos.1)
+                            {
                                 self.selection_anchor = Some((start, current_pos.1));
                                 self.selection_focus = Some((end, current_pos.1));
                             }
@@ -6235,12 +6954,18 @@ impl App {
                 if self.selection_anchor.is_some() {
                     let selectable_area = self.last_selectable_area.get();
                     if selectable_area.width > 0 && selectable_area.height > 0 {
-                        let clamped_col = mouse_event.column
-                            .max(selectable_area.x)
-                            .min(selectable_area.x.saturating_add(selectable_area.width).saturating_sub(1));
-                        let clamped_row = mouse_event.row
-                            .max(selectable_area.y)
-                            .min(selectable_area.y.saturating_add(selectable_area.height).saturating_sub(1));
+                        let clamped_col = mouse_event.column.max(selectable_area.x).min(
+                            selectable_area
+                                .x
+                                .saturating_add(selectable_area.width)
+                                .saturating_sub(1),
+                        );
+                        let clamped_row = mouse_event.row.max(selectable_area.y).min(
+                            selectable_area
+                                .y
+                                .saturating_add(selectable_area.height)
+                                .saturating_sub(1),
+                        );
                         self.selection_focus = Some((clamped_col, clamped_row));
                         self.click_count = 0; // Reset on drag to prevent further double-clicks
                     }
@@ -6339,7 +7064,11 @@ impl App {
                 }
             }
 
-            QueryEvent::ToolStart { tool_name, tool_id, input_json } => {
+            QueryEvent::ToolStart {
+                tool_name,
+                tool_id,
+                input_json,
+            } => {
                 if !self.is_streaming && self.spinner_verb.is_none() {
                     let seed = self.frame_count as usize ^ (self.messages.len() * 17);
                     self.spinner_verb = Some(sample_spinner_verb(seed).to_string());
@@ -6347,9 +7076,7 @@ impl App {
                 self.is_streaming = true;
                 self.status_message = Some(format!("Running {}…", tool_name));
                 let turn_index = self.current_user_turn_index();
-                if let Some(existing) =
-                    self.tool_use_blocks.iter_mut().find(|b| b.id == tool_id)
-                {
+                if let Some(existing) = self.tool_use_blocks.iter_mut().find(|b| b.id == tool_id) {
                     existing.turn_index = turn_index;
                     existing.status = ToolStatus::Running;
                     existing.output_preview = None;
@@ -6381,9 +7108,7 @@ impl App {
                 if remaining > 0 {
                     preview.push_str(&format!("\n\u{2026} {} more lines", remaining));
                 }
-                if let Some(block) =
-                    self.tool_use_blocks.iter_mut().find(|b| b.id == tool_id)
-                {
+                if let Some(block) = self.tool_use_blocks.iter_mut().find(|b| b.id == tool_id) {
                     block.status = if is_error {
                         ToolStatus::Error
                     } else {
@@ -6400,28 +7125,38 @@ impl App {
                 self.refresh_turn_diff_from_history();
             }
 
-            QueryEvent::TurnComplete { turn, stop_reason, usage, .. } => {
+            QueryEvent::TurnComplete {
+                turn,
+                stop_reason,
+                usage,
+                ..
+            } => {
                 debug!(turn, stop_reason, "Turn complete");
                 self.is_streaming = false;
                 self.spinner_verb = None;
 
                 // Update context window usage from the usage info.
                 if let Some(ref u) = usage {
-                    let turn_tokens = u.input_tokens + u.output_tokens
-                        + u.cache_creation_input_tokens + u.cache_read_input_tokens;
+                    let turn_tokens = u.input_tokens
+                        + u.output_tokens
+                        + u.cache_creation_input_tokens
+                        + u.cache_read_input_tokens;
                     self.context_used_tokens = self.context_used_tokens.saturating_add(turn_tokens);
                 }
                 // Record elapsed time and pick a completion verb
                 let seed = self.frame_count as usize ^ (self.messages.len() * 7);
-                let elapsed = self.turn_start.take()
+                let elapsed = self
+                    .turn_start
+                    .take()
                     .map(|start| format_elapsed_ms(start.elapsed().as_millis()));
-                self.last_turn_elapsed = Some(
-                    elapsed.unwrap_or_else(|| "0s".to_string())
-                );
+                self.last_turn_elapsed = Some(elapsed.unwrap_or_else(|| "0s".to_string()));
                 self.last_turn_verb = Some(sample_completion_verb(seed));
                 self.flush_streamed_assistant_message();
-                self.tool_use_blocks.retain(|b| b.status != ToolStatus::Running);
-                self.complete_current_turn_snapshot(stop_reason.contains("abort") || stop_reason.contains("cancel"));
+                self.tool_use_blocks
+                    .retain(|b| b.status != ToolStatus::Running);
+                self.complete_current_turn_snapshot(
+                    stop_reason.contains("abort") || stop_reason.contains("cancel"),
+                );
                 self.invalidate_transcript();
                 self.refresh_turn_diff_from_history();
             }
@@ -6454,7 +7189,10 @@ impl App {
                         self.token_warning_threshold_shown = 80;
                         self.push_notification(
                             NotificationKind::Warning,
-                            format!("Context window {:.0}% full. Consider /compact.", pct_used * 100.0),
+                            format!(
+                                "Context window {:.0}% full. Consider /compact.",
+                                pct_used * 100.0
+                            ),
                             Some(30),
                         );
                     }
@@ -6462,7 +7200,10 @@ impl App {
                         self.token_warning_threshold_shown = 95;
                         self.push_notification(
                             NotificationKind::Error,
-                            format!("Context window {:.0}% full! Run /compact now.", pct_used * 100.0),
+                            format!(
+                                "Context window {:.0}% full! Run /compact now.",
+                                pct_used * 100.0
+                            ),
                             None,
                         );
                     }
@@ -6513,8 +7254,7 @@ impl App {
                     let entries: Vec<crate::session_browser::SessionEntry> = sessions
                         .into_iter()
                         .map(|s| {
-                            let age = chrono::Utc::now()
-                                .signed_duration_since(s.updated_at);
+                            let age = chrono::Utc::now().signed_duration_since(s.updated_at);
                             let last_updated = if age.num_minutes() < 1 {
                                 "just now".to_string()
                             } else if age.num_hours() < 1 {
@@ -6596,8 +7336,7 @@ impl App {
                         }
                         VoiceEvent::RecordingStopped => {
                             self.voice_recording = false;
-                            self.status_message =
-                                Some("Transcribing\u{2026}".to_string());
+                            self.status_message = Some("Transcribing\u{2026}".to_string());
                         }
                         VoiceEvent::TranscriptReady(text) => {
                             if !text.is_empty() {
@@ -6610,9 +7349,8 @@ impl App {
                                 }
                                 self.prompt_input.paste(&text);
                                 self.refresh_prompt_input();
-                                self.status_message = Some(
-                                    format!("Transcribed: {}", &text[..text.len().min(60)])
-                                );
+                                self.status_message =
+                                    Some(format!("Transcribed: {}", &text[..text.len().min(60)]));
                             }
                             // Clear the channel once we have the result.
                             self.voice_event_rx = None;
@@ -6654,8 +7392,7 @@ impl App {
             let pending = self.pending_key.take();
 
             // Poll for events with a short timeout so we can redraw for animation
-            let got_event = pending.is_some()
-                || event::poll(std::time::Duration::from_millis(50))?;
+            let got_event = pending.is_some() || event::poll(std::time::Duration::from_millis(50))?;
 
             if got_event {
                 let event = if let Some(k) = pending {
@@ -6720,8 +7457,7 @@ impl App {
                             // Check if this is a slash command that should open a UI screen
                             if crate::input::is_slash_command(&self.prompt_input.text) {
                                 let slash_input = self.prompt_input.text.clone();
-                                let (cmd, args) =
-                                        crate::input::parse_slash_command(&slash_input);
+                                let (cmd, args) = crate::input::parse_slash_command(&slash_input);
                                 if self.intercept_slash_command_with_args(cmd, args) {
                                     self.clear_prompt();
                                     continue;
@@ -6764,9 +7500,9 @@ impl App {
             let content = msg.get_all_text().to_lowercase();
 
             // Check if message contains error keywords
-            let has_error = ERROR_KEYWORDS.iter().any(|keyword| {
-                content.contains(keyword)
-            });
+            let has_error = ERROR_KEYWORDS
+                .iter()
+                .any(|keyword| content.contains(keyword));
 
             if has_error && i > (self.messages.len().saturating_sub(self.scroll_offset / 2)) {
                 // Found an error message, scroll to it
@@ -6792,9 +7528,9 @@ impl App {
             let content = msg.get_all_text().to_lowercase();
 
             // Check if message contains error keywords
-            let has_error = ERROR_KEYWORDS.iter().any(|keyword| {
-                content.contains(keyword)
-            });
+            let has_error = ERROR_KEYWORDS
+                .iter()
+                .any(|keyword| content.contains(keyword));
 
             if has_error && i < (self.messages.len().saturating_sub(self.scroll_offset / 2)) {
                 // Found an error message, scroll to it
@@ -6815,17 +7551,13 @@ fn open_file_externally(path: &std::path::Path) -> Result<(), Box<dyn std::error
     // Try to open with the system's default application
     #[cfg(target_os = "macos")]
     {
-        std::process::Command::new("open")
-            .arg(path)
-            .spawn()?;
+        std::process::Command::new("open").arg(path).spawn()?;
         Ok(())
     }
 
     #[cfg(target_os = "linux")]
     {
-        std::process::Command::new("xdg-open")
-            .arg(path)
-            .spawn()?;
+        std::process::Command::new("xdg-open").arg(path).spawn()?;
         Ok(())
     }
 
@@ -6842,10 +7574,7 @@ fn open_file_externally(path: &std::path::Path) -> Result<(), Box<dyn std::error
     {
         // Fallback for other systems: try common editors in order
         for editor in &["nano", "vi", "vim", "emacs"] {
-            match std::process::Command::new(editor)
-                .arg(path)
-                .spawn()
-            {
+            match std::process::Command::new(editor).arg(path).spawn() {
                 Ok(_) => return Ok(()),
                 Err(_) => continue,
             }
@@ -6887,10 +7616,7 @@ mod tests {
 
     #[test]
     fn recent_session_label_falls_back_to_first_prompt_line() {
-        let label = recent_session_label(
-            None,
-            Some("  fix the bug\nand more details".to_string()),
-        );
+        let label = recent_session_label(None, Some("  fix the bug\nand more details".to_string()));
         assert_eq!(label, "fix the bug");
     }
 
@@ -6937,7 +7663,10 @@ mod tests {
         assert_eq!(app.scroll_offset, 0);
         app.last_max_scroll.set(50);
         app.handle_mouse_event(scroll_up_event());
-        assert!(app.scroll_offset > 0, "scroll should advance when capture is on");
+        assert!(
+            app.scroll_offset > 0,
+            "scroll should advance when capture is on"
+        );
         assert!(app.scroll_offset <= 50, "scroll stays within max_scroll");
     }
 
@@ -6948,7 +7677,12 @@ mod tests {
         let mut app = make_app();
         // Bottom pane as rendered: 1 status row (height > 2), then the top
         // separator at y=21, text rows from y=22. Prefix "❯ " is 2 cells.
-        app.last_input_area.set(ratatui::layout::Rect { x: 0, y: 20, width: 80, height: 8 });
+        app.last_input_area.set(ratatui::layout::Rect {
+            x: 0,
+            y: 20,
+            width: 80,
+            height: 8,
+        });
         for c in "hi ".chars() {
             app.prompt_input.insert_char(c);
         }
@@ -6973,7 +7707,12 @@ mod tests {
     #[test]
     fn paste_viewer_alt_e_expands_into_prompt() {
         let mut app = make_app();
-        app.last_input_area.set(ratatui::layout::Rect { x: 0, y: 20, width: 80, height: 8 });
+        app.last_input_area.set(ratatui::layout::Rect {
+            x: 0,
+            y: 20,
+            width: 80,
+            height: 8,
+        });
         for c in "hi ".chars() {
             app.prompt_input.insert_char(c);
         }
@@ -6994,7 +7733,12 @@ mod tests {
     #[test]
     fn prompt_click_off_placeholder_moves_cursor_only() {
         let mut app = make_app();
-        app.last_input_area.set(ratatui::layout::Rect { x: 0, y: 20, width: 80, height: 8 });
+        app.last_input_area.set(ratatui::layout::Rect {
+            x: 0,
+            y: 20,
+            width: 80,
+            height: 8,
+        });
         for c in "hello ".chars() {
             app.prompt_input.insert_char(c);
         }
@@ -7049,7 +7793,10 @@ mod tests {
         for _ in 0..20 {
             app.scroll_up_by(10);
         }
-        assert_eq!(app.scroll_offset, 0, "no scroll room means no offset growth");
+        assert_eq!(
+            app.scroll_offset, 0,
+            "no scroll room means no offset growth"
+        );
     }
 
     #[test]
@@ -7060,7 +7807,10 @@ mod tests {
         app.config.mouse_capture = Some(false);
         assert!(!app.config.mouse_capture_enabled());
         app.handle_mouse_event(scroll_up_event());
-        assert_eq!(app.scroll_offset, 0, "scroll must not move when capture is off");
+        assert_eq!(
+            app.scroll_offset, 0,
+            "scroll must not move when capture is off"
+        );
     }
 
     // ---- normalize_char_with_shift tests ----
@@ -7121,7 +7871,10 @@ mod tests {
         // CTRL or ALT without SHIFT should not shift the character
         assert_eq!(normalize_char_with_shift('a', KeyModifiers::CONTROL), 'a');
         assert_eq!(normalize_char_with_shift('1', KeyModifiers::ALT), '1');
-        assert_eq!(normalize_char_with_shift('a', KeyModifiers::CONTROL | KeyModifiers::ALT), 'a');
+        assert_eq!(
+            normalize_char_with_shift('a', KeyModifiers::CONTROL | KeyModifiers::ALT),
+            'a'
+        );
     }
 
     #[test]
@@ -7207,7 +7960,10 @@ mod tests {
 
         let should_submit = app.handle_key_event(press_key(KeyCode::Enter, KeyModifiers::NONE));
 
-        assert!(should_submit, "Enter should submit/run the highlighted command");
+        assert!(
+            should_submit,
+            "Enter should submit/run the highlighted command"
+        );
         assert_eq!(app.prompt_input.text, "/help");
         assert!(
             app.prompt_input.suggestions.is_empty(),
@@ -7279,7 +8035,10 @@ mod tests {
         }
         let submitted = app.handle_key_event(press_key(KeyCode::Char('j'), KeyModifiers::CONTROL));
         assert!(!submitted, "Ctrl+J must not submit");
-        assert_eq!(app.prompt_input.text, "hi\n", "Ctrl+J should insert a newline, not 'j'");
+        assert_eq!(
+            app.prompt_input.text, "hi\n",
+            "Ctrl+J should insert a newline, not 'j'"
+        );
     }
 
     #[test]
@@ -7291,7 +8050,10 @@ mod tests {
         }
         let submitted = app.handle_key_event(press_key(KeyCode::Enter, KeyModifiers::NONE));
         assert!(submitted, "bare Enter should submit");
-        assert_eq!(app.prompt_input.text, "hi", "bare Enter must not insert a newline");
+        assert_eq!(
+            app.prompt_input.text, "hi",
+            "bare Enter must not insert a newline"
+        );
         assert!(!app.prompt_input.text.contains('\n'));
     }
 
@@ -7669,20 +8431,14 @@ mod tests {
     #[test]
     fn test_key_event_to_keystroke_maps_ctrl_cyrillic_to_latin() {
         // Ctrl+С (Cyrillic) on a non-Latin layout must resolve to the Latin "c".
-        let ks = key_event_to_keystroke(&press_key(
-            KeyCode::Char('с'),
-            KeyModifiers::CONTROL,
-        ))
-        .expect("keystroke");
+        let ks = key_event_to_keystroke(&press_key(KeyCode::Char('с'), KeyModifiers::CONTROL))
+            .expect("keystroke");
         assert_eq!(ks.key, "c");
         assert!(ks.ctrl);
 
         // Ctrl+О (Cyrillic, the physical J key) → "j" so Ctrl+J newline works.
-        let ks = key_event_to_keystroke(&press_key(
-            KeyCode::Char('о'),
-            KeyModifiers::CONTROL,
-        ))
-        .expect("keystroke");
+        let ks = key_event_to_keystroke(&press_key(KeyCode::Char('о'), KeyModifiers::CONTROL))
+            .expect("keystroke");
         assert_eq!(ks.key, "j");
     }
 
@@ -7699,10 +8455,8 @@ mod tests {
     #[test]
     fn test_normalize_layout_shortcut_key_rewrites_pure_ctrl() {
         // Pure Ctrl + Cyrillic → Latin letter at the same physical position.
-        let out = normalize_layout_shortcut_key(press_key(
-            KeyCode::Char('с'),
-            KeyModifiers::CONTROL,
-        ));
+        let out =
+            normalize_layout_shortcut_key(press_key(KeyCode::Char('с'), KeyModifiers::CONTROL));
         assert_eq!(out.code, KeyCode::Char('c'));
         assert!(out.modifiers.contains(KeyModifiers::CONTROL));
     }
@@ -7728,7 +8482,8 @@ mod tests {
     #[test]
     fn test_normalize_layout_shortcut_key_passes_ascii_through() {
         // ASCII Ctrl combos (English layout) are unchanged — no regression.
-        let out = normalize_layout_shortcut_key(press_key(KeyCode::Char('c'), KeyModifiers::CONTROL));
+        let out =
+            normalize_layout_shortcut_key(press_key(KeyCode::Char('c'), KeyModifiers::CONTROL));
         assert_eq!(out.code, KeyCode::Char('c'));
     }
 

--- a/src-rust/crates/tui/src/messages/markdown_enhanced.rs
+++ b/src-rust/crates/tui/src/messages/markdown_enhanced.rs
@@ -1,19 +1,17 @@
 //! Enhanced markdown rendering with tables, italic, strikethrough support.
 //! This module complements markdown.rs with additional features.
 
+use once_cell::sync::Lazy;
 use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
 };
-use unicode_width::UnicodeWidthStr;
-use once_cell::sync::Lazy;
 use regex::Regex;
+use unicode_width::UnicodeWidthStr;
 
 /// Regex pattern to detect markdown table rows (lines starting/ending with |)
-static TABLE_ROW_PATTERN: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"^\s*\|.+\|\s*$")
-        .expect("Invalid table row regex pattern")
-});
+static TABLE_ROW_PATTERN: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^\s*\|.+\|\s*$").expect("Invalid table row regex pattern"));
 
 /// Regex pattern to detect markdown table separator row (dashes/colons/pipes)
 static TABLE_SEPARATOR_PATTERN: Lazy<Regex> = Lazy::new(|| {
@@ -57,7 +55,7 @@ impl Table {
     fn parse_row(line: &str) -> Vec<String> {
         let trimmed = line.trim();
         let without_pipes = if trimmed.starts_with('|') && trimmed.ends_with('|') {
-            &trimmed[1..trimmed.len()-1]
+            &trimmed[1..trimmed.len() - 1]
         } else {
             trimmed
         };
@@ -116,7 +114,14 @@ pub fn detect_table(lines: &[&str], start_idx: usize) -> Option<(Table, usize)> 
         }
     }
 
-    Some((Table { headers, rows, alignments }, end_idx))
+    Some((
+        Table {
+            headers,
+            rows,
+            alignments,
+        },
+        end_idx,
+    ))
 }
 
 /// Render a markdown table as styled lines with box-drawing characters
@@ -124,7 +129,8 @@ pub fn render_table(table: &Table) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
 
     // Calculate column widths
-    let mut col_widths: Vec<usize> = table.headers
+    let mut col_widths: Vec<usize> = table
+        .headers
         .iter()
         .map(|h| UnicodeWidthStr::width(h.as_str()).max(3))
         .collect();
@@ -152,17 +158,29 @@ pub fn render_table(table: &Table) -> Vec<Line<'static>> {
     )]));
 
     // Header row with bold styling
-    let mut header_spans = vec![Span::styled("  │ ".to_string(), Style::default().fg(Color::DarkGray))];
+    let mut header_spans = vec![Span::styled(
+        "  │ ".to_string(),
+        Style::default().fg(Color::DarkGray),
+    )];
     for (i, header) in table.headers.iter().enumerate() {
         let width = col_widths[i];
-        let padded = match table.alignments.get(i).copied().unwrap_or(TableAlignment::Left) {
+        let padded = match table
+            .alignments
+            .get(i)
+            .copied()
+            .unwrap_or(TableAlignment::Left)
+        {
             TableAlignment::Left => format!("{:<width$}", header, width = width),
             TableAlignment::Right => format!("{:>width$}", header, width = width),
             TableAlignment::Center => {
                 let hdr_width = UnicodeWidthStr::width(header.as_str());
                 let total_pad = width.saturating_sub(hdr_width);
                 let left_pad = total_pad / 2;
-                format!("{:>width$}", &format!("{}{}", " ".repeat(left_pad), header), width = width + left_pad)
+                format!(
+                    "{:>width$}",
+                    format!("{}{}", " ".repeat(left_pad), header),
+                    width = width + left_pad
+                )
             }
         };
         header_spans.push(Span::styled(
@@ -171,7 +189,10 @@ pub fn render_table(table: &Table) -> Vec<Line<'static>> {
                 .fg(Color::White)
                 .add_modifier(Modifier::BOLD),
         ));
-        header_spans.push(Span::styled(" │ ".to_string(), Style::default().fg(Color::DarkGray)));
+        header_spans.push(Span::styled(
+            " │ ".to_string(),
+            Style::default().fg(Color::DarkGray),
+        ));
     }
     lines.push(Line::from(header_spans));
 
@@ -191,23 +212,38 @@ pub fn render_table(table: &Table) -> Vec<Line<'static>> {
 
     // Data rows
     for row in &table.rows {
-        let mut row_spans = vec![Span::styled("  │ ".to_string(), Style::default().fg(Color::DarkGray))];
+        let mut row_spans = vec![Span::styled(
+            "  │ ".to_string(),
+            Style::default().fg(Color::DarkGray),
+        )];
         for (i, cell) in row.iter().enumerate() {
             if i < col_widths.len() {
                 let width = col_widths[i];
-                let padded = match table.alignments.get(i).copied().unwrap_or(TableAlignment::Left) {
+                let padded = match table
+                    .alignments
+                    .get(i)
+                    .copied()
+                    .unwrap_or(TableAlignment::Left)
+                {
                     TableAlignment::Left => format!("{:<width$}", cell, width = width),
                     TableAlignment::Right => format!("{:>width$}", cell, width = width),
                     TableAlignment::Center => {
                         let cell_width = UnicodeWidthStr::width(cell.as_str());
                         let total_pad = width.saturating_sub(cell_width);
                         let left_pad = total_pad / 2;
-                        format!("{:>width$}", &format!("{}{}", " ".repeat(left_pad), cell), width = width + left_pad)
+                        format!(
+                            "{:>width$}",
+                            format!("{}{}", " ".repeat(left_pad), cell),
+                            width = width + left_pad
+                        )
                     }
                 };
                 row_spans.push(Span::raw(padded));
             }
-            row_spans.push(Span::styled(" │ ".to_string(), Style::default().fg(Color::DarkGray)));
+            row_spans.push(Span::styled(
+                " │ ".to_string(),
+                Style::default().fg(Color::DarkGray),
+            ));
         }
         lines.push(Line::from(row_spans));
     }
@@ -267,39 +303,40 @@ pub fn parse_inline_formatting(text: &str) -> Vec<Span<'static>> {
 
         // Check for ** or __ (bold) - with limited nesting support
         if idx + 1 < chars.len()
-            && ((chars[idx] == '*' && chars[idx + 1] == '*') ||
-               (chars[idx] == '_' && chars[idx + 1] == '_')) {
-                let marker = chars[idx];
+            && ((chars[idx] == '*' && chars[idx + 1] == '*')
+                || (chars[idx] == '_' && chars[idx + 1] == '_'))
+        {
+            let marker = chars[idx];
 
-                // Flush current text
-                if !current_text.is_empty() {
-                    spans.push(Span::raw(current_text.clone()));
-                    current_text.clear();
-                }
-
-                // Find closing marker (search within 500 chars max to prevent runaway)
-                let mut bold_content = String::new();
-                idx += 2;
-                let max_search = (idx + 500).min(chars.len());
-                while idx < max_search {
-                    if idx + 1 < chars.len() && chars[idx] == marker && chars[idx + 1] == marker {
-                        break;
-                    }
-                    bold_content.push(chars[idx]);
-                    idx += 1;
-                }
-
-                if idx + 1 < chars.len() && chars[idx] == marker && chars[idx + 1] == marker {
-                    idx += 2; // skip closing marker
-                }
-
-                // Apply bold style
-                spans.push(Span::styled(
-                    bold_content,
-                    Style::default().add_modifier(Modifier::BOLD),
-                ));
-                continue;
+            // Flush current text
+            if !current_text.is_empty() {
+                spans.push(Span::raw(current_text.clone()));
+                current_text.clear();
             }
+
+            // Find closing marker (search within 500 chars max to prevent runaway)
+            let mut bold_content = String::new();
+            idx += 2;
+            let max_search = (idx + 500).min(chars.len());
+            while idx < max_search {
+                if idx + 1 < chars.len() && chars[idx] == marker && chars[idx + 1] == marker {
+                    break;
+                }
+                bold_content.push(chars[idx]);
+                idx += 1;
+            }
+
+            if idx + 1 < chars.len() && chars[idx] == marker && chars[idx + 1] == marker {
+                idx += 2; // skip closing marker
+            }
+
+            // Apply bold style
+            spans.push(Span::styled(
+                bold_content,
+                Style::default().add_modifier(Modifier::BOLD),
+            ));
+            continue;
+        }
 
         // Check for ~~ (strikethrough) - no nesting
         if idx + 1 < chars.len() && chars[idx] == '~' && chars[idx + 1] == '~' {
@@ -334,13 +371,12 @@ pub fn parse_inline_formatting(text: &str) -> Vec<Span<'static>> {
         }
 
         // Check for * or _ (italic) - no nesting
-        if idx < chars.len() &&
-           (chars[idx] == '*' || chars[idx] == '_') {
+        if idx < chars.len() && (chars[idx] == '*' || chars[idx] == '_') {
             let marker = chars[idx];
 
             // Make sure it's not part of ** or __
-            let is_bold_marker = (idx + 1 < chars.len() && chars[idx + 1] == marker) ||
-                                 (idx > 0 && chars[idx - 1] == marker);
+            let is_bold_marker = (idx + 1 < chars.len() && chars[idx + 1] == marker)
+                || (idx > 0 && chars[idx - 1] == marker);
 
             if !is_bold_marker {
                 // Flush current text


### PR DESCRIPTION
## Summary

This PR addresses issues with skill discovery and TUI slash command handling:

- **Directory-based skill structure**: `scan_dir` now discovers skills housed in subdirectories with `SKILL.md` (or `skill.md`), as well as directories pointing directly to a skill folder. It also falls back to the parent directory name when `SKILL.md` does not specify `name:` in frontmatter.
- **Tilde expansion**: Paths configured in `skills.paths` (e.g. `~/.agents/skills`) now expand `~` to the user's home directory.
- **Global search locations**: Added `~/.agents/skills/` to default global discovery locations.
- **Dynamic TUI Autocomplete & Palette**: Updated `PromptInputState` suggestion list, `Command Palette` (`Ctrl+K`), and help overlay to dynamically include discovered skills and custom templates alongside built-in commands.
- **Skill arguments**: Appends arguments to the prompt body when executing skill commands whose template does not contain `$ARGUMENTS` or `$1`.

## Testing
- Added unit tests in `claurst-core` for subdirectory scanning, parent directory naming, path resolution, and agent skill locations.
- Ran full workspace checks:
  - `cargo check --workspace` passed
  - `cargo clippy --workspace --all-targets -- -D warnings` passed (0 warnings)
  - `cargo test --workspace` passed (all 658+ unit and integration tests)
- Verified interactively with local debug and release builds.
