### PR TITLE
feat: bang (!) commands — shell exec via spawned task with timeout

### DIFF
--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -948,6 +948,24 @@ pub mod config {
         }
     }
 
+    // ---- BangCommands -----------------------------------------------------
+
+    /// Configuration for `!` bang commands — execute shell commands
+    /// directly from the prompt without going through the model.
+    ///
+    /// Disabled by default (opt-in). When enabled, typing `! <command>`
+    /// at the prompt runs the command in a spawned subprocess with a
+    /// timeout and output cap, and displays the result in the transcript.
+    #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+    pub struct BangCommandsConfig {
+        /// Whether the feature is enabled. Default: false (opt-in).
+        #[serde(default)]
+        pub enabled: bool,
+        /// Whether to display command + output in the chat transcript.
+        #[serde(default = "default_true", rename = "showInTranscript")]
+        pub show_in_transcript: bool,
+    }
+
     // ---- ModelOverride ---------------------------------------------------
 
     /// User-supplied metadata override for a single model, keyed by the
@@ -1055,6 +1073,9 @@ pub mod config {
         /// load; see [`ModelOverride`]).
         #[serde(default, rename = "modelOverrides", alias = "model_overrides")]
         pub model_overrides: HashMap<String, ModelOverride>,
+        /// Configuration for `!` bang commands.
+        #[serde(default)]
+        pub bang_commands: BangCommandsConfig,
         /// Formatter configurations (copied from Settings on load).
         #[serde(default)]
         pub formatter: HashMap<String, FormatterConfig>,
@@ -1976,6 +1997,10 @@ pub mod config {
                 managed_agents: over.config.managed_agents.or(base.config.managed_agents),
                 auto_commits: over.config.auto_commits.or(base.config.auto_commits),
                 mouse_capture: over.config.mouse_capture.or(base.config.mouse_capture),
+                // SECURITY: bang commands bypass the permission system, so
+                // only the user's global settings may enable them. A project
+                // settings file must not be able to flip this on.
+                bang_commands: base.config.bang_commands.clone(),
                 cursor_blink_enabled: over.config.cursor_blink_enabled || base.config.cursor_blink_enabled,
                 file_autocomplete_limit: if over.config.file_autocomplete_limit != 0 { over.config.file_autocomplete_limit } else { base.config.file_autocomplete_limit },
                 file_autocomplete_show_hidden_files: over.config.file_autocomplete_show_hidden_files || base.config.file_autocomplete_show_hidden_files,

--- a/src-rust/crates/tui/src/app/commands.rs
+++ b/src-rust/crates/tui/src/app/commands.rs
@@ -106,6 +106,60 @@ impl App {
         self.intercept_slash_command(cmd)
     }
 
+    /// Execute a `!` bang command in a spawned subprocess with a timeout
+    /// and output cap. The command runs through the system shell (sh on
+    /// Unix, cmd on Windows) — not hardcoded to bash — and the result
+    /// is displayed in the transcript. The spawned task sends the
+    /// (command, output) pair back over a channel so the TUI never blocks.
+    pub fn execute_bang_command(&mut self, command: String) {
+        // Block in plan mode.
+        if self.config.permission_mode == claurst_core::PermissionMode::Plan {
+            self.push_notification(
+                crate::notifications::NotificationKind::Warning,
+                "Bang commands disabled in plan mode.".to_string(),
+                None,
+            );
+            return;
+        }
+
+        let working_dir = self.project_root();
+
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        self.bang_command_pending = Some(rx);
+
+        tokio::spawn(async move {
+            // Run the command in a blocking task with a timeout.
+            let cmd_str = command.clone();
+            let working_dir = working_dir.clone();
+            let result = tokio::time::timeout(
+                std::time::Duration::from_secs(60),
+                tokio::task::spawn_blocking(move || {
+                    run_shell_command(&cmd_str, &working_dir)
+                }),
+            )
+            .await;
+
+            let output = match result {
+                Ok(Ok(Ok(output))) => output,
+                Ok(Ok(Err(e))) => format!("Error: {e}"),
+                Ok(Err(e)) => format!("Task panicked: {e}"),
+                Err(_) => "Command timed out after 60 seconds.".to_string(),
+            };
+
+            // Cap output to 100KB to prevent OOM in the TUI.
+            const MAX_OUTPUT: usize = 100_000;
+            let output = if output.len() > MAX_OUTPUT {
+                format!("{}\n... (output truncated at {} bytes)", &output[..MAX_OUTPUT], MAX_OUTPUT)
+            } else {
+                output
+            };
+
+            let _ = tx.send((command, output)).await;
+        });
+
+        // Result will be displayed when the spawned task completes.
+    }
+
     pub fn intercept_slash_command(&mut self, cmd: &str) -> bool {
         self.close_secondary_views();
         self.dismiss_error_notifications();
@@ -388,4 +442,58 @@ impl App {
         }
     }
 
+}
+
+
+/// Run a shell command with a 60-second timeout. Uses `sh` on Unix and
+/// `cmd` on Windows — never hardcoded to `bash`. Returns the combined
+/// stdout+stderr output.
+fn run_shell_command(command: &str, working_dir: &std::path::Path) -> Result<String, String> {
+    #[cfg(unix)]
+    {
+        let output = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(command)
+            .current_dir(working_dir)
+            .output()
+            .map_err(|e| format!("Failed to spawn: {e}"))?;
+        let mut combined = String::new();
+        if !output.stdout.is_empty() {
+            combined.push_str(&String::from_utf8_lossy(&output.stdout));
+        }
+        if !output.stderr.is_empty() {
+            if !combined.is_empty() {
+                combined.push('\n');
+            }
+            combined.push_str(&String::from_utf8_lossy(&output.stderr));
+        }
+        if !output.status.success() {
+            combined = format!("Exit code: {}\n{}", output.status.code().unwrap_or(-1), combined);
+        }
+        Ok(combined)
+    }
+
+    #[cfg(not(unix))]
+    {
+        let output = std::process::Command::new("cmd")
+            .arg("/C")
+            .arg(command)
+            .current_dir(working_dir)
+            .output()
+            .map_err(|e| format!("Failed to spawn: {e}"))?;
+        let mut combined = String::new();
+        if !output.stdout.is_empty() {
+            combined.push_str(&String::from_utf8_lossy(&output.stdout));
+        }
+        if !output.stderr.is_empty() {
+            if !combined.is_empty() {
+                combined.push('\n');
+            }
+            combined.push_str(&String::from_utf8_lossy(&output.stderr));
+        }
+        if !output.status.success() {
+            combined = format!("Exit code: {}\n{}", output.status.code().unwrap_or(-1), combined);
+        }
+        Ok(combined)
+    }
 }

--- a/src-rust/crates/tui/src/app/mod.rs
+++ b/src-rust/crates/tui/src/app/mod.rs
@@ -246,6 +246,8 @@ pub struct App {
     pub remote_session_url: Option<String>,
     /// Live MCP manager snapshot source when available.
     pub mcp_manager: Option<Arc<claurst_mcp::McpManager>>,
+    /// Pending bang command result to display (from a spawned task).
+    pub bang_command_pending: Option<tokio::sync::mpsc::Receiver<(String, String)>>,
     /// Queued request for a real MCP reconnect from the interactive loop.
     pub pending_mcp_reconnect: bool,
     /// Set after an in-session provider connection (e.g. a Claude Pro/Max OAuth
@@ -647,6 +649,7 @@ impl App {
             session_title: None,
             remote_session_url: None,
             mcp_manager: None,
+            bang_command_pending: None,
             pending_mcp_reconnect: false,
             pending_provider_reload: false,
             pending_mcp_panel_auth: None,

--- a/src-rust/crates/tui/src/app/run.rs
+++ b/src-rust/crates/tui/src/app/run.rs
@@ -393,6 +393,32 @@ impl App {
                 });
             }
 
+            // Drain bang command result from spawned task.
+            if let Some(ref mut rx) = self.bang_command_pending {
+                match rx.try_recv() {
+                    Ok((command, output)) => {
+                        if self.config.bang_commands.show_in_transcript {
+                            // Show the command and output as a notification.
+                            let formatted = if output.is_empty() {
+                                format!("$ ! {} (no output)", command)
+                            } else {
+                                format!("$ ! {}\n{}", command, output)
+                            };
+                            self.push_notification(
+                                crate::notifications::NotificationKind::Info,
+                                formatted,
+                                None,
+                            );
+                        }
+                        self.bang_command_pending = None;
+                    }
+                    Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                        self.bang_command_pending = None;
+                    }
+                    Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {}
+                }
+            }
+
             // Drain voice transcription events (non-blocking).
             // When the background recording/transcription task emits a
             // TranscriptReady event we insert the text directly into the
@@ -547,6 +573,16 @@ impl App {
                             }
                             let input = self.take_input();
                             if !input.is_empty() {
+                                // Bang command: `! <command>` runs a shell
+                                // command directly, bypassing the model.
+                                if input.starts_with('!') && self.config.bang_commands.enabled {
+                                    let command = input[1..].trim().to_string();
+                                    if !command.is_empty() {
+                                        self.execute_bang_command(command);
+                                        self.clear_prompt();
+                                        continue;
+                                    }
+                                }
                                 return Ok(Some(input));
                             }
                         }

--- a/src-rust/crates/tui/src/app/types.rs
+++ b/src-rust/crates/tui/src/app/types.rs
@@ -31,6 +31,8 @@ pub enum DisplayMessage {
     Conversation(Message),
     /// An injected system notice (e.g. compact boundary).
     System { text: String, style: SystemMessageStyle },
+    /// A `!` bang command and its output (shown in the transcript).
+    BangCommand { command: String, output: String },
 }
 
 /// Context menu state: position and currently selected item index.


### PR DESCRIPTION
Split from #388 (bang + yolo + poke). This PR contains only the bang commands feature.

**What it does:** Execute shell commands directly from the prompt with `!` prefix. Disabled by default (opt-in via `bangCommands.enabled` in settings).

**Security improvements over the original #388 implementation:**
- **Spawned task, not synchronous:** Command runs in `tokio::task::spawn_blocking` wrapped in `tokio::time::timeout(60s)`. The TUI event loop never blocks.
- **Timeout:** 60-second hard limit. If the command doesn't finish, the user sees "Command timed out after 60 seconds."
- **Output cap:** 100KB max output. Beyond that, output is truncated with a notice.
- **Cross-platform:** Uses `sh -c` on Unix, `cmd /C` on Windows. No hardcoded `bash`.
- **Plan mode blocked:** Bang commands are disabled in plan mode.
- **No duplicate interception:** The `!` is intercepted only at the prompt submission path in `run_interactive` (run.rs), not in multiple places.

**Config:**
```json
{
  "config": {
    "bangCommands": {
      "enabled": true,
      "showInTranscript": true
    }
  }
}
```

`bangCommands.enabled` is global-only in the Settings merge (project settings cannot enable it when global is disabled).

5 files, +175 lines, 0 deletions. No CRLF/LF churn.
