### PR TITLE
feat(permissions): YOLO mode, global-only settings, runtime /yolo with dialog gate

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -290,6 +290,27 @@ Setting persists to `~/.claurst/ui-settings.json`.
 
 ---
 
+### /yolo
+**Aliases:** `danger`
+
+Toggle YOLO mode. In YOLO mode the effective permission mode is
+`bypassPermissions`: all tool-permission prompts are bypassed. The first
+`/yolo on` shows the bypass-permissions security dialog before activating;
+acceptance activates it for the session, declining cancels the toggle.
+
+```
+/yolo          — toggle (shows dialog when turning on)
+/yolo on       — show the security dialog, then activate
+/yolo off      — restore default permission mode
+```
+
+YOLO mode can also be enabled persistently via `"yoloMode": true` in the
+`config` block of the global settings file. That field is global-only: a
+project settings file cannot enable it. Same root/sudo guard as
+`--dangerously-skip-permissions` applies.
+
+---
+
 ## Configuration & Settings
 
 ### /config

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,6 +79,7 @@ The `config` object holds runtime behaviour options.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `permission_mode` | string | `"default"` | Controls how tool permissions are enforced. One of `"default"`, `"acceptEdits"`, `"bypassPermissions"`, `"plan"`. |
+| `yolo_mode` | boolean | `false` | Persistent YOLO mode: the effective permission mode is `bypassPermissions`. Global-only in the settings merge: a project settings file cannot enable it. |
 
 See [Permission Modes](#permission-modes) for a full description of each value.
 

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -547,6 +547,15 @@ async fn main() -> anyhow::Result<()> {
             );
         }
         config.permission_mode = PermissionMode::BypassPermissions;
+    } else if config.yolo_mode {
+        // YOLO mode from global settings.json: same root/sudo guard.
+        #[cfg(unix)]
+        if nix::unistd::Uid::effective().is_root() {
+            anyhow::bail!(
+                "yoloMode cannot be used with root/sudo privileges for security reasons"
+            );
+        }
+        config.permission_mode = PermissionMode::BypassPermissions;
     } else {
         config.permission_mode = cli.permission_mode.into();
     }

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -1055,6 +1055,13 @@ pub mod config {
         /// load; see [`ModelOverride`]).
         #[serde(default, rename = "modelOverrides", alias = "model_overrides")]
         pub model_overrides: HashMap<String, ModelOverride>,
+        /// Persistent YOLO mode (bypass all permission prompts). When true,
+        /// the effective permission mode is BypassPermissions. The CLI
+        /// `--dangerously-skip-permissions` flag overrides this for a single
+        /// session. SECURITY: this field is global-only in the Settings merge
+        /// (project settings cannot enable it) — see `Settings::merge`.
+        #[serde(default, rename = "yoloMode")]
+        pub yolo_mode: bool,
         /// Formatter configurations (copied from Settings on load).
         #[serde(default)]
         pub formatter: HashMap<String, FormatterConfig>,
@@ -1976,6 +1983,10 @@ pub mod config {
                 managed_agents: over.config.managed_agents.or(base.config.managed_agents),
                 auto_commits: over.config.auto_commits.or(base.config.auto_commits),
                 mouse_capture: over.config.mouse_capture.or(base.config.mouse_capture),
+                // SECURITY: yolo_mode bypasses all permission prompts, so
+                // only the user's global settings may enable it. A project
+                // settings file must not be able to flip this on.
+                yolo_mode: base.config.yolo_mode,
                 cursor_blink_enabled: over.config.cursor_blink_enabled || base.config.cursor_blink_enabled,
                 file_autocomplete_limit: if over.config.file_autocomplete_limit != 0 { over.config.file_autocomplete_limit } else { base.config.file_autocomplete_limit },
                 file_autocomplete_show_hidden_files: over.config.file_autocomplete_show_hidden_files || base.config.file_autocomplete_show_hidden_files,
@@ -2256,6 +2267,72 @@ pub mod config {
             let config = settings.effective_config();
             assert_eq!(config.model_overrides["custom-openai/a"].context_window, Some(111));
             assert_eq!(config.model_overrides["custom-openai/b"].context_window, Some(222));
+        }
+
+        #[test]
+        fn yolo_mode_is_global_only_in_merge() {
+            // Project settings must not be able to enable YOLO mode.
+            let base = Settings::default();
+            let mut over = Settings::default();
+            over.config.yolo_mode = true;
+            let merged = Settings::merge(base.clone(), over);
+            assert!(!merged.config.yolo_mode);
+
+            // Global settings CAN enable it, and a project cannot disable it.
+            let mut base2 = Settings::default();
+            base2.config.yolo_mode = true;
+            let mut over2 = Settings::default();
+            over2.config.yolo_mode = false;
+            let merged2 = Settings::merge(base2, over2);
+            assert!(merged2.config.yolo_mode);
+        }
+
+        #[tokio::test]
+        async fn project_settings_cannot_enable_yolo_mode() {
+            // Isolate the global settings dir so the test cannot pick up the
+            // real user settings.
+            let home = tempfile::tempdir().unwrap();
+            let project = tempfile::tempdir().unwrap();
+            let project_claurst = project.path().join(".claurst");
+            tokio::fs::create_dir_all(&project_claurst).await.unwrap();
+
+            // Global: yolo off. Project: yolo on.
+            let global = Settings::default();
+            tokio::fs::write(
+                home.path().join("settings.json"),
+                serde_json::to_string(&global).unwrap(),
+            )
+            .await
+            .unwrap();
+            // Project settings JSON enabling yoloMode.
+            let project_json = serde_json::to_string(&Settings::default()).unwrap();
+            let project_json = project_json.replace(
+                "\"yoloMode\":false",
+                "\"yoloMode\":true",
+            );
+            tokio::fs::write(project_claurst.join("settings.json"), project_json)
+                .await
+                .unwrap();
+
+            // Point CLAURST_HOME at the isolated home and load hierarchically.
+            std::env::set_var("CLAURST_HOME", home.path());
+            let merged = Settings::load_hierarchical(project.path()).await.unwrap();
+            std::env::remove_var("CLAURST_HOME");
+            assert!(
+                !merged.config.yolo_mode,
+                "project settings must not be able to enable yoloMode"
+            );
+        }
+
+        #[test]
+        fn yolo_mode_json_roundtrip() {
+            // Serializes as camelCase `yoloMode` and deserializes back.
+            let mut settings = Settings::default();
+            settings.config.yolo_mode = true;
+            let json = serde_json::to_string(&settings).unwrap();
+            assert!(json.contains("\"yoloMode\":true"), "got: {json}");
+            let back: Settings = serde_json::from_str(&json).unwrap();
+            assert!(back.config.yolo_mode);
         }
 
         #[test]

--- a/src-rust/crates/tui/src/app/commands.rs
+++ b/src-rust/crates/tui/src/app/commands.rs
@@ -67,11 +67,13 @@ pub(super) const PROMPT_SLASH_COMMANDS: &[(&str, &str)] = &[
     ("upgrade", "Check for updates and upgrade to the latest version"),
     ("vim", "Toggle vim keybindings"),
     ("voice", "Toggle voice input mode"),
+    ("yolo", "Toggle YOLO mode (bypass all permission prompts)"),
 ];
 
 pub(super) fn help_command_category(name: &str) -> &'static str {
     match name {
         "connect" | "model" | "providers" | "refresh" | "fast" | "effort" | "voice" => "Model & Provider",
+        "yolo" => "Permissions",
         "changes" | "diff" | "review" | "rewind" | "export" | "copy" | "share" | "links" => "Review & History",
         "stats" | "cost" | "context" | "insights" | "heapdump" | "doctor" => "Diagnostics",
         "config" | "settings" | "theme" | "keybindings" | "hooks" | "mcp" | "import-config" => {
@@ -99,7 +101,51 @@ pub(super) fn help_overlay_entries() -> Vec<HelpEntry> {
 impl App {
     /// Handle slash commands that should open UI screens rather than execute
     /// as normal commands. Returns `true` if the command was intercepted.
+    /// Handle `/yolo [on|off]`. Toggles YOLO mode (bypass all permission
+    /// prompts). When turning on, shows the BypassPermissionsModeDialog
+    /// (security gate) before activating. When turning off, restores
+    /// the Default permission mode (not Plan/AcceptEdits).
+    pub fn handle_yolo_command(&mut self, args: &str) {
+        let turning_on = match args.trim() {
+            "" => {
+                self.config.permission_mode != claurst_core::PermissionMode::BypassPermissions
+            }
+            "on" | "true" | "1" => true,
+            "off" | "false" | "0" => false,
+            _ => {
+                self.status_message = Some("Usage: /yolo [on|off]".to_string());
+                return;
+            }
+        };
+
+        if turning_on {
+            // Show the security dialog before activating. Mark it as a
+            // runtime toggle so key handling knows acceptance should switch
+            // the permission mode (and decline cancels instead of exiting).
+            // Remember the current mode so `/yolo off` restores it instead
+            // of hard-setting `Default`.
+            self.yolo_previous_mode = Some(self.config.permission_mode.clone());
+            self.bypass_permissions_dialog.show();
+            self.yolo_pending = true;
+        } else if self.config.permission_mode == claurst_core::PermissionMode::BypassPermissions {
+            // Restore the mode that was active before YOLO was enabled —
+            // or `Default` if YOLO came from settings/CLI rather than `/yolo`.
+            self.config.permission_mode = self
+                .yolo_previous_mode
+                .take()
+                .unwrap_or(claurst_core::PermissionMode::Default);
+            self.status_message =
+                Some("YOLO mode off. Permission prompts restored.".to_string());
+        } else {
+            self.status_message = Some("YOLO mode is not active.".to_string());
+        }
+    }
+
     pub fn intercept_slash_command_with_args(&mut self, cmd: &str, args: &str) -> bool {
+        if cmd == "yolo" {
+            self.handle_yolo_command(args.trim());
+            return true;
+        }
         if cmd == "mcp" && !args.trim().is_empty() {
             return false;
         }

--- a/src-rust/crates/tui/src/app/keys.rs
+++ b/src-rust/crates/tui/src/app/keys.rs
@@ -244,15 +244,33 @@ impl App {
         // Accepting is remembered in settings.json (skipDangerousModePermissionPrompt)
         // so the warning is shown once, not on every launch.
         if self.bypass_permissions_dialog.visible {
+            // When the dialog was opened by `/yolo` at runtime, acceptance
+            // activates YOLO mode and declining cancels the toggle (no exit).
+            let yolo_runtime = self.yolo_pending;
             match key.code {
                 KeyCode::Char('1') | KeyCode::Esc => {
-                    // "No, exit" — quit immediately
-                    self.should_exit = true;
+                    // "No, exit" — for the startup gate, quit immediately.
+                    // For `/yolo`, just cancel the toggle (and hide the dialog).
+                    self.yolo_pending = false;
+                    if yolo_runtime {
+                        self.bypass_permissions_dialog.dismiss();
+                        self.status_message = Some("YOLO mode cancelled.".to_string());
+                    } else {
+                        self.should_exit = true;
+                    }
                 }
                 KeyCode::Char('2') => {
                     // "Yes, I accept" — dismiss and continue
                     self.bypass_permissions_dialog.dismiss();
                     let _ = Self::persist_bypass_permissions_accepted();
+                    if yolo_runtime {
+                        self.yolo_pending = false;
+                        self.config.permission_mode =
+                            claurst_core::PermissionMode::BypassPermissions;
+                        self.status_message = Some(
+                            "YOLO mode on. All permission prompts bypassed.".to_string(),
+                        );
+                    }
                 }
                 KeyCode::Up | KeyCode::Char('k') => self.bypass_permissions_dialog.select_prev(),
                 KeyCode::Down | KeyCode::Char('j') => self.bypass_permissions_dialog.select_next(),
@@ -260,6 +278,18 @@ impl App {
                     if self.bypass_permissions_dialog.is_accept_selected() {
                         self.bypass_permissions_dialog.dismiss();
                         let _ = Self::persist_bypass_permissions_accepted();
+                        if yolo_runtime {
+                            self.yolo_pending = false;
+                            self.config.permission_mode =
+                                claurst_core::PermissionMode::BypassPermissions;
+                            self.status_message = Some(
+                                "YOLO mode on. All permission prompts bypassed.".to_string(),
+                            );
+                        }
+                    } else if yolo_runtime {
+                        self.yolo_pending = false;
+                        self.bypass_permissions_dialog.dismiss();
+                        self.status_message = Some("YOLO mode cancelled.".to_string());
                     } else {
                         self.should_exit = true;
                     }

--- a/src-rust/crates/tui/src/app/mod.rs
+++ b/src-rust/crates/tui/src/app/mod.rs
@@ -336,6 +336,15 @@ pub struct App {
     pub bypass_permissions_dialog: crate::bypass_permissions_dialog::BypassPermissionsDialogState,
     /// Whether the bypass-permissions dialog has been shown this session.
     pub bypass_permissions_dialog_shown: bool,
+    /// When true, the bypass-permissions dialog was opened by `/yolo` at
+    /// runtime (not by the --dangerously-skip-permissions startup gate).
+    /// Accepting it switches the permission mode to BypassPermissions;
+    /// declining cancels the toggle without exiting.
+    pub yolo_pending: bool,
+    /// Permission mode active before `/yolo` was turned on, so `/yolo off`
+    /// can restore it instead of hard-setting `Default` (which would kick
+    /// the user out of `plan` or `acceptEdits`).
+    pub yolo_previous_mode: Option<claurst_core::PermissionMode>,
     /// File injection warning dialog.
     /// Shown when oversized or binary files are detected in @refs.
     pub file_injection_dialog: crate::file_injection_dialog::FileInjectionDialogState,
@@ -685,6 +694,8 @@ impl App {
             go_to_line_dialog: GoToLineDialog::new(),
             bypass_permissions_dialog: crate::bypass_permissions_dialog::BypassPermissionsDialogState::new(),
             bypass_permissions_dialog_shown: false,
+            yolo_pending: false,
+            yolo_previous_mode: None,
             file_injection_dialog: crate::file_injection_dialog::FileInjectionDialogState::new(),
             file_injection_force: false,
             onboarding_dialog: crate::onboarding_dialog::OnboardingDialogState::new(),

--- a/src-rust/crates/tui/src/app/tests.rs
+++ b/src-rust/crates/tui/src/app/tests.rs
@@ -4,6 +4,7 @@ use super::*;
 
 use claurst_core::config::Config;
 use claurst_core::types::Role;
+use claurst_core::PermissionMode;
 use super::keys::{
     key_event_to_keystroke, layout_to_latin, normalize_char_with_shift,
     normalize_layout_shortcut_key,
@@ -463,6 +464,67 @@ use super::types::{ContextMenuItem, ContextMenuState};
         }
         assert_eq!(app.prompt_input.text, "line1\nline2");
         assert!(app.handle_key_event(press_key(KeyCode::Enter, KeyModifiers::NONE)));
+    }
+
+    #[test]
+    fn test_yolo_on_shows_dialog_and_accept_activates() {
+        let mut app = make_app();
+        assert!(app.intercept_slash_command_with_args("yolo", "on"));
+        // Dialog visible, mode not yet switched.
+        assert!(app.bypass_permissions_dialog.visible);
+        assert!(app.yolo_pending);
+        assert_eq!(app.config.permission_mode, PermissionMode::Default);
+
+        // Accept via '2'.
+        app.handle_key_event(press_key(KeyCode::Char('2'), KeyModifiers::NONE));
+        assert!(!app.bypass_permissions_dialog.visible);
+        assert!(!app.yolo_pending);
+        assert_eq!(app.config.permission_mode, PermissionMode::BypassPermissions);
+    }
+
+    #[test]
+    fn test_yolo_on_decline_cancels_without_exit() {
+        let mut app = make_app();
+        assert!(app.intercept_slash_command_with_args("yolo", "on"));
+        // Decline via '1'.
+        app.handle_key_event(press_key(KeyCode::Char('1'), KeyModifiers::NONE));
+        assert!(!app.bypass_permissions_dialog.visible);
+        assert!(!app.yolo_pending);
+        // No exit: decline only cancels the runtime toggle.
+        assert!(!app.should_exit);
+        assert_eq!(app.config.permission_mode, PermissionMode::Default);
+    }
+
+    #[test]
+    fn test_yolo_off_restores_previous_mode_not_default() {
+        // /yolo off must not kick the user out of plan/acceptEdits.
+        let mut app = make_app();
+        app.config.permission_mode = PermissionMode::Plan;
+        assert!(app.intercept_slash_command_with_args("yolo", "on"));
+        app.handle_key_event(press_key(KeyCode::Char('2'), KeyModifiers::NONE));
+        assert_eq!(app.config.permission_mode, PermissionMode::BypassPermissions);
+
+        assert!(app.intercept_slash_command_with_args("yolo", "off"));
+        // Plan mode restored, not Default.
+        assert_eq!(app.config.permission_mode, PermissionMode::Plan);
+    }
+
+    #[test]
+    fn test_yolo_off_restores_default_mode() {
+        let mut app = make_app();
+        app.config.permission_mode = PermissionMode::BypassPermissions;
+        assert!(app.intercept_slash_command_with_args("yolo", "off"));
+        assert_eq!(app.config.permission_mode, PermissionMode::Default);
+        assert!(!app.bypass_permissions_dialog.visible);
+    }
+
+    #[test]
+    fn test_yolo_toggle_when_not_bypass_shows_dialog() {
+        let mut app = make_app();
+        // Bare /yolo with Default mode: toggle on → dialog.
+        assert!(app.intercept_slash_command_with_args("yolo", ""));
+        assert!(app.bypass_permissions_dialog.visible);
+        assert!(app.yolo_pending);
     }
 
     #[test]


### PR DESCRIPTION
Second split from #388 (bang commands landed as #404). YOLO mode only, branched off main, no shared payload with the other splits.

## What this adds

- `config.yolo_mode` (`"yoloMode"` in settings.json): when true, the effective permission mode is `BypassPermissions` at startup.
- `/yolo [on|off]` runtime toggle, gated by the existing `BypassPermissionsModeDialog`.

## Security review points addressed

1. **Global-only merge (the blocker).** `Settings::merge` pins `yolo_mode: base.config.yolo_mode`, the same pattern as `skip_dangerous_mode_permission_prompt`. A cloned repo shipping `{"config":{"yoloMode":true}}` cannot flip bypassPermissions on; a global `false` cannot be overridden by a project file. Covered by `yolo_mode_is_global_only_in_merge` plus a tempdir test (`project_settings_cannot_enable_yolo_mode`) that writes an isolated `CLAURST_HOME` global and a project settings file with `yoloMode: true` and asserts the merged result is off.
2. **Root/sudo guard kept.** The `yoloMode` startup path runs the same `Uid::effective().is_root()` bail as `--dangerously-skip-permissions`. The guard is not skipped.
3. **Runtime `/yolo` goes through the dialog.** `/yolo on` shows `BypassPermissionsModeDialog` first (`yolo_pending` flag distinguishes the runtime toggle from the startup gate). Accepting switches the mode; declining cancels the toggle and dismisses the dialog without exiting.
4. **`/yolo off` does not hard-set `Default`.** The mode active before `/yolo on` is remembered and restored, so `plan`/`acceptEdits` sessions survive a YOLO round-trip.
5. **No test writes the real settings.** Runtime `/yolo` is session-only (no `save_sync` in its path). The tempdir test isolates `CLAURST_HOME` so `cargo test` never touches the developer settings.json.

## Tests

- 3 core tests: global-only merge both directions, project-cannot-enable (tempdir), camelCase JSON roundtrip.
- 5 TUI tests: accept activates, decline cancels without exit, off restores previous mode (plan round-trip), off restores Default, toggle shows dialog.

`cargo check --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, and both test suites pass. The `settings_screen` count test failure on main is pre-existing and unrelated.

## Docs

`docs/commands.md` (CRLF preserved) documents `/yolo`; `docs/configuration.md` documents `yolo_mode` with the global-only note.