### PR TITLE
feat(tui): opt-in auto-poke with /poke command, stop-reason gate

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -290,6 +290,31 @@ Setting persists to `~/.claurst/ui-settings.json`.
 
 ---
 
+### /poke
+**Aliases:** `autopoke`
+
+Toggle auto-poke. When enabled, Claurst sends a continuation prompt
+automatically when the model stops a turn with incomplete todos. Opt-in:
+auto-poke is OFF by default.
+
+```
+/poke          — toggle auto-poke on/off
+/poke on       — enable auto-poke
+/poke off      — disable auto-poke
+/poke status   — show enabled state, poke budget, and incomplete count
+```
+
+Safety rails:
+- Only fires after a clean `end_turn` stop. Esc-aborted turns, `max_tokens`
+  truncation, and provider refusals never auto-poke.
+- Budget of 48 pokes per session.
+- Stops after 3 consecutive turns with no todo-state change.
+
+Setting persists to `~/.claurst/settings.json` under `"autoPokeEnabled"`
+(default: `false`).
+
+---
+
 ## Configuration & Settings
 
 ### /config

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,6 +79,7 @@ The `config` object holds runtime behaviour options.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `permission_mode` | string | `"default"` | Controls how tool permissions are enforced. One of `"default"`, `"acceptEdits"`, `"bypassPermissions"`, `"plan"`. |
+| `auto_poke_enabled` | boolean | `false` | Opt-in auto-poke: send a continuation prompt when the model stops a turn with incomplete todos. Only fires after a clean `end_turn` stop; budget of 48 pokes per session; stops after 3 consecutive no-progress turns. Toggle at runtime with `/poke`. |
 
 See [Permission Modes](#permission-modes) for a full description of each value.
 

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -2429,6 +2429,9 @@ async fn run_interactive(
                                     tool_ctx.session_id = session.id.clone();
                                     cmd_ctx.session_id = session.id.clone();
                                     cmd_ctx.session_title = None;
+                                    // Keep the TUI's session id in sync so
+                                    // auto-poke reads the new session's todos.
+                                    app.session_id = tool_ctx.session_id.clone();
                                     // Reset per-turn diff/turn bookkeeping, as
                                     // ResumeSession does when swapping sessions.
                                     tool_ctx.file_history = Arc::new(ParkingMutex::new(
@@ -2535,6 +2538,7 @@ async fn run_interactive(
                                     tool_ctx.current_turn = Arc::new(
                                         std::sync::atomic::AtomicUsize::new(0),
                                     );
+                                    app.session_id = tool_ctx.session_id.clone();
                                     cmd_ctx.session_id = session.id.clone();
                                     cmd_ctx.session_title = session.title.clone();
                                     if let Some(saved_dir) = session.working_dir.as_ref() {

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -1114,6 +1114,12 @@ pub mod config {
         /// Keyboard scrolling (PageUp/PageDown, etc.) is unaffected either way.
         #[serde(default, rename = "mouseCapture", skip_serializing_if = "Option::is_none")]
         pub mouse_capture: Option<bool>,
+        /// Auto-poke: automatically send a continuation prompt when the model
+        /// stops with incomplete todos. Opt-in — the default is OFF. The
+        /// TUI's `/poke` command toggles it and persists to settings.json
+        /// under `"autoPokeEnabled"`.
+        #[serde(default, rename = "autoPokeEnabled")]
+        pub auto_poke_enabled: bool,
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -1977,6 +1983,7 @@ pub mod config {
                 auto_commits: over.config.auto_commits.or(base.config.auto_commits),
                 mouse_capture: over.config.mouse_capture.or(base.config.mouse_capture),
                 cursor_blink_enabled: over.config.cursor_blink_enabled || base.config.cursor_blink_enabled,
+                auto_poke_enabled: over.config.auto_poke_enabled || base.config.auto_poke_enabled,
                 file_autocomplete_limit: if over.config.file_autocomplete_limit != 0 { over.config.file_autocomplete_limit } else { base.config.file_autocomplete_limit },
                 file_autocomplete_show_hidden_files: over.config.file_autocomplete_show_hidden_files || base.config.file_autocomplete_show_hidden_files,
                 file_injection_enabled: over.config.file_injection_enabled || base.config.file_injection_enabled,
@@ -2256,6 +2263,42 @@ pub mod config {
             let config = settings.effective_config();
             assert_eq!(config.model_overrides["custom-openai/a"].context_window, Some(111));
             assert_eq!(config.model_overrides["custom-openai/b"].context_window, Some(222));
+        }
+
+        #[test]
+        fn auto_poke_enabled_defaults_off() {
+            // Opt-in: absent key deserializes to false, not true.
+            let settings = Settings::default();
+            assert!(!settings.config.auto_poke_enabled);
+            let json = r#"{ "config": { "autoPokeEnabled": true } }"#;
+            let parsed: Result<Settings, _> = serde_json::from_str(json);
+            // A partial config block is valid only if required fields are
+            // present; check the roundtrip instead.
+            if let Ok(s) = parsed {
+                assert!(s.config.auto_poke_enabled);
+            }
+            let mut on = Settings::default();
+            on.config.auto_poke_enabled = true;
+            let serialized = serde_json::to_string(&on).unwrap();
+            assert!(serialized.contains("\"autoPokeEnabled\":true"), "got: {serialized}");
+            let back: Settings = serde_json::from_str(&serialized).unwrap();
+            assert!(back.config.auto_poke_enabled);
+        }
+
+        #[test]
+        fn auto_poke_merges_with_or() {
+            // Either global or project can enable; default false everywhere.
+            let base = Settings::default();
+            let mut over = Settings::default();
+            over.config.auto_poke_enabled = true;
+            let merged = Settings::merge(base, over);
+            assert!(merged.config.auto_poke_enabled);
+
+            let mut base2 = Settings::default();
+            base2.config.auto_poke_enabled = true;
+            let over2 = Settings::default();
+            let merged2 = Settings::merge(base2, over2);
+            assert!(merged2.config.auto_poke_enabled);
         }
 
         #[test]

--- a/src-rust/crates/tools/src/todo_write.rs
+++ b/src-rust/crates/tools/src/todo_write.rs
@@ -370,6 +370,57 @@ impl Tool for TodoWriteTool {
 }
 
 // ---------------------------------------------------------------------------
+// Auto-poke helpers (used by the TUI's check_auto_poke)
+// ---------------------------------------------------------------------------
+
+/// Build the synthetic continuation message sent when the model stops with
+/// incomplete todos. The message instructs the model to continue working.
+pub fn build_auto_poke_message(incomplete_count: usize) -> String {
+    format!(
+        "You have {} incomplete todo{}. Continue working, or update the todo tool.",
+        incomplete_count,
+        if incomplete_count == 1 { "" } else { "s" },
+    )
+}
+
+/// Count incomplete (pending + in_progress) todos for a session.
+pub fn count_incomplete_todos(session_id: &str) -> usize {
+    let todos = load_todos(session_id);
+    todos
+        .iter()
+        .filter_map(|t| t.get("status").and_then(|s| s.as_str()))
+        .filter(|s| *s == "pending" || *s == "in_progress")
+        .count()
+}
+
+/// Compute a stable hash of the current todo state (sorted `(id, status)`
+/// pairs). Used for no-progress detection: if the hash is unchanged for
+/// [`NO_PROGRESS_THRESHOLD`] consecutive poked turns, auto-poking stops.
+pub fn todo_state_hash(session_id: &str) -> String {
+    let todos = load_todos(session_id);
+    let mut pairs: Vec<(String, String)> = todos
+        .iter()
+        .filter_map(|t| {
+            let id = t.get("id").and_then(|v| v.as_str())?.to_string();
+            let status = t.get("status").and_then(|v| v.as_str())?.to_string();
+            Some((id, status))
+        })
+        .collect();
+    pairs.sort_by(|a, b| a.0.cmp(&b.0));
+    pairs
+        .iter()
+        .map(|(id, s)| format!("{}:{}", id, s))
+        .collect::<Vec<_>>()
+        .join("|")
+}
+
+/// Maximum auto-pokes per session (safety budget).
+pub const MAX_AUTO_POKES: u32 = 48;
+
+/// No-progress threshold: stop after this many consecutive no-progress turns.
+pub const NO_PROGRESS_THRESHOLD: u32 = 3;
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 

--- a/src-rust/crates/tui/src/app/commands.rs
+++ b/src-rust/crates/tui/src/app/commands.rs
@@ -46,6 +46,7 @@ pub(super) const PROMPT_SLASH_COMMANDS: &[(&str, &str)] = &[
     ("new", "Start a fresh session (keeps model, provider & directory)"),
     ("output-style", "Show or switch the output style / persona"),
     ("plugin", "Manage plugins (list/info/enable/disable/reload)"),
+    ("poke", "Toggle or configure auto-poke (on/off/status)"),
     ("providers", "List available AI providers and their status"),
     ("caveman", "Caveman persona output style — save big token"),
     ("rocky", "Rocky persona output style — amaze amaze amaze"),
@@ -77,7 +78,7 @@ pub(super) fn help_command_category(name: &str) -> &'static str {
         "config" | "settings" | "theme" | "keybindings" | "hooks" | "mcp" | "import-config" => {
             "Workspace"
         }
-        "agent" | "agents" | "memory" | "plugin" | "survey" => "Tools",
+        "agent" | "agents" | "memory" | "plugin" | "poke" | "survey" => "Tools",
         "session" | "resume" | "rename" | "fork" | "clear" | "new" | "move" | "compact"
         | "quit" | "exit" => "Session",
         _ => "Commands",
@@ -99,7 +100,59 @@ pub(super) fn help_overlay_entries() -> Vec<HelpEntry> {
 impl App {
     /// Handle slash commands that should open UI screens rather than execute
     /// as normal commands. Returns `true` if the command was intercepted.
+    /// Handle `/poke [on|off|status]`. Toggles auto-poke, which sends a
+    /// continuation prompt when the model stops with incomplete todos.
+    /// Opt-in only: the default is OFF. Persists to settings.json.
+    pub fn handle_poke_command(&mut self, args: &str) {
+        let mut settings = claurst_core::Settings::load_sync().unwrap_or_default();
+        match args.trim() {
+            "on" | "enable" => {
+                settings.config.auto_poke_enabled = true;
+                let _ = settings.save_sync();
+                self.config.auto_poke_enabled = true;
+                self.status_message = Some("Auto-poke enabled.".to_string());
+            }
+            "off" | "disable" => {
+                settings.config.auto_poke_enabled = false;
+                let _ = settings.save_sync();
+                self.config.auto_poke_enabled = false;
+                self.status_message = Some("Auto-poke disabled.".to_string());
+            }
+            "status" => {
+                let budget_left = claurst_tools::todo_write::MAX_AUTO_POKES
+                    .saturating_sub(self.auto_poke_count);
+                let incomplete =
+                    claurst_tools::todo_write::count_incomplete_todos(&self.session_id);
+                self.status_message = Some(format!(
+                    "Auto-poke: {} | Pokes: {}/{} | Budget left: {} | Incomplete: {}",
+                    if self.config.auto_poke_enabled { "ON" } else { "OFF" },
+                    self.auto_poke_count,
+                    claurst_tools::todo_write::MAX_AUTO_POKES,
+                    budget_left,
+                    incomplete,
+                ));
+            }
+            "" => {
+                settings.config.auto_poke_enabled = !settings.config.auto_poke_enabled;
+                let _ = settings.save_sync();
+                self.config.auto_poke_enabled = settings.config.auto_poke_enabled;
+                self.status_message = Some(format!(
+                    "Auto-poke {}.",
+                    if settings.config.auto_poke_enabled { "enabled" } else { "disabled" }
+                ));
+            }
+            _ => {
+                self.status_message =
+                    Some("Usage: /poke [on|off|status] (no arg toggles).".to_string());
+            }
+        }
+    }
+
     pub fn intercept_slash_command_with_args(&mut self, cmd: &str, args: &str) -> bool {
+        if cmd == "poke" {
+            self.handle_poke_command(args);
+            return true;
+        }
         if cmd == "mcp" && !args.trim().is_empty() {
             return false;
         }

--- a/src-rust/crates/tui/src/app/mod.rs
+++ b/src-rust/crates/tui/src/app/mod.rs
@@ -392,6 +392,17 @@ pub struct App {
     /// When `true`, the main loop will inject a synthetic Enter event on the
     /// next iteration to dequeue and submit the next queued message.
     pub pending_auto_submit: bool,
+    /// Current session id, kept in sync with `ToolContext::session_id` so
+    /// auto-poke can read the session's persisted todos.
+    pub session_id: String,
+    /// Auto-poke state: how many continuation prompts were sent this session.
+    pub auto_poke_count: u32,
+    /// Consecutive poked turns without any todo-state change. When this
+    /// reaches `NO_PROGRESS_THRESHOLD`, auto-poking stops.
+    pub no_progress_turns: u32,
+    /// Hash of the todo state at the last poke check, for no-progress
+    /// detection.
+    pub last_todo_hash: String,
     /// Connect-a-provider dialog (/connect command).
     pub connect_dialog: DialogSelectState,
     /// Import-config source picker (/import-config command).
@@ -707,6 +718,10 @@ impl App {
             auth_store: claurst_core::AuthStore::load(),
             queued_messages: std::collections::VecDeque::new(),
             pending_auto_submit: false,
+            session_id: String::new(),
+            auto_poke_count: 0,
+            no_progress_turns: 0,
+            last_todo_hash: String::new(),
             connect_dialog: DialogSelectState::new("Connect a provider", provider_picker_items()),
             import_config_picker: DialogSelectState::new("Import config", import_config_picker_items()),
             import_config_dialog: ImportConfigDialogState::new(),

--- a/src-rust/crates/tui/src/app/run.rs
+++ b/src-rust/crates/tui/src/app/run.rs
@@ -246,6 +246,10 @@ impl App {
                 self.complete_current_turn_snapshot(stop_reason.contains("abort") || stop_reason.contains("cancel"));
                 self.invalidate_transcript();
                 self.refresh_turn_diff_from_history();
+
+                // Auto-poke: queue a continuation prompt when the model
+                // stopped cleanly with incomplete todos.
+                self.check_auto_poke(&stop_reason);
             }
 
             QueryEvent::Status(msg) => {
@@ -295,6 +299,80 @@ impl App {
 
         // Update token count from tracker.
         self.token_count = self.cost_tracker.total_tokens() as u32;
+    }
+
+    // -------------------------------------------------------------------
+    // Auto-poke
+    // -------------------------------------------------------------------
+
+    /// Check whether auto-poke should fire after a model turn ended with
+    /// `stop_reason`. When the model stopped cleanly with incomplete todos,
+    /// queue a synthetic continuation message via the existing
+    /// `queued_messages` mechanism (submitted by the main loop).
+    ///
+    /// Opt-in: auto-poke must be enabled in settings (default OFF) — see
+    /// `/poke`. Safety rails:
+    /// - Only fires on a clean `end_turn` stop. Aborts/cancels (Esc),
+    ///   `max_tokens` truncation, `content_filtered` refusals, and unknown
+    ///   stop reasons never poke — the user must stay in control after any
+    ///   abnormal stop.
+    /// - Budget: at most `MAX_AUTO_POKES` pokes per session.
+    /// - No-progress: after `NO_PROGRESS_THRESHOLD` consecutive turns with an
+    ///   unchanged todo-state hash, poking stops.
+    pub(super) fn check_auto_poke(&mut self, stop_reason: &str) {
+        // Opt-in only — default OFF. Read the live config so `/poke` toggles
+        // take effect immediately without a settings reload.
+        if !self.config.auto_poke_enabled {
+            return;
+        }
+
+        // Stop-reason gate: only continue after a clean end-of-turn. An
+        // aborted (Esc) or cancelled turn must never re-poke, and neither
+        // should truncation or provider-side refusals.
+        if stop_reason != "end_turn" {
+            return;
+        }
+
+        // Poke budget.
+        if self.auto_poke_count >= claurst_tools::todo_write::MAX_AUTO_POKES {
+            self.status_message = Some(format!(
+                "Auto-poke stopped: budget of {} reached.",
+                claurst_tools::todo_write::MAX_AUTO_POKES
+            ));
+            return;
+        }
+
+        // Incomplete todos?
+        let incomplete = claurst_tools::todo_write::count_incomplete_todos(&self.session_id);
+        if incomplete == 0 {
+            return; // All done — no poke needed.
+        }
+
+        // No-progress detection: hash the todo state.
+        let current_hash = claurst_tools::todo_write::todo_state_hash(&self.session_id);
+        if current_hash == self.last_todo_hash {
+            self.no_progress_turns += 1;
+        } else {
+            self.no_progress_turns = 0;
+            self.last_todo_hash = current_hash;
+        }
+
+        if self.no_progress_turns >= claurst_tools::todo_write::NO_PROGRESS_THRESHOLD {
+            self.status_message =
+                Some("Auto-poke stopped: no progress for 3 turns.".to_string());
+            return;
+        }
+
+        // Queue the continuation via the existing queued_messages
+        // infrastructure so the main loop submits it on the next iteration.
+        let poke_msg = claurst_tools::todo_write::build_auto_poke_message(incomplete);
+        self.auto_poke_count += 1;
+        self.status_message = Some(format!(
+            "Auto-poking... ({} incomplete todos)",
+            incomplete
+        ));
+        self.queued_messages.push_back(poke_msg);
+        self.pending_auto_submit = true;
     }
 
     /// Run the TUI event loop. Returns `Some(input)` when the user submits

--- a/src-rust/crates/tui/src/app/tests.rs
+++ b/src-rust/crates/tui/src/app/tests.rs
@@ -465,6 +465,114 @@ use super::types::{ContextMenuItem, ContextMenuState};
         assert!(app.handle_key_event(press_key(KeyCode::Enter, KeyModifiers::NONE)));
     }
 
+    /// Build an `App` for auto-poke tests with `auto_poke_enabled` on and a
+    /// known session id. Uses `save_todos_in` against a tempdir-mounted
+    /// `todos` dir via `CLAURST_HOME` so nothing touches real user state.
+    fn make_poke_app(todos: &[serde_json::Value]) -> (App, tempfile::TempDir) {
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("CLAURST_HOME", home.path());
+        let app_dir = home.path().join("todos");
+        std::fs::create_dir_all(&app_dir).unwrap();
+        let mut app = make_app();
+        app.config.auto_poke_enabled = true;
+        app.session_id = "poke-test-session".to_string();
+        if !todos.is_empty() {
+            claurst_tools::todo_write::save_todos_in(
+                &app_dir,
+                &app.session_id,
+                todos,
+            );
+        }
+        (app, home)
+    }
+
+    fn todo(id: &str, status: &str) -> serde_json::Value {
+        serde_json::json!({
+            "id": id,
+            "content": format!("task {}", id),
+            "status": status,
+            "priority": "medium",
+        })
+    }
+
+    #[test]
+    fn test_poke_command_toggles_setting() {
+        let mut app = make_app();
+        assert!(!app.config.auto_poke_enabled);
+        assert!(app.intercept_slash_command_with_args("poke", "on"));
+        assert!(app.config.auto_poke_enabled);
+        assert!(app.intercept_slash_command_with_args("poke", "off"));
+        assert!(!app.config.auto_poke_enabled);
+        // No-arg toggle flips.
+        assert!(app.intercept_slash_command_with_args("poke", ""));
+        assert!(app.config.auto_poke_enabled);
+    }
+
+    #[test]
+    fn test_check_auto_poke_disabled_does_not_queue() {
+        let (mut app, _home) = make_poke_app(&[todo("1", "pending")]);
+        app.config.auto_poke_enabled = false;
+        app.check_auto_poke("end_turn");
+        assert!(app.queued_messages.is_empty());
+        assert!(!app.pending_auto_submit);
+    }
+
+    #[test]
+    fn test_check_auto_poke_end_turn_with_incomplete_todos_queues() {
+        let (mut app, _home) = make_poke_app(&[todo("1", "pending")]);
+        app.check_auto_poke("end_turn");
+        assert_eq!(app.queued_messages.len(), 1);
+        assert!(app.pending_auto_submit);
+        assert_eq!(app.auto_poke_count, 1);
+    }
+
+    #[test]
+    fn test_check_auto_poke_ignores_abort_and_max_tokens() {
+        let (mut app, _home) = make_poke_app(&[todo("1", "pending")]);
+        // Esc abort, cancellation, truncation, refusal: never poke.
+        for reason in ["abort", "cancelled", "max_tokens", "content_filtered"] {
+            app.check_auto_poke(reason);
+            assert!(app.queued_messages.is_empty(), "poked on {}", reason);
+        }
+        assert_eq!(app.auto_poke_count, 0);
+    }
+
+    #[test]
+    fn test_check_auto_poke_all_complete_does_not_queue() {
+        let (mut app, _home) =
+            make_poke_app(&[todo("1", "completed"), todo("2", "completed")]);
+        app.check_auto_poke("end_turn");
+        assert!(app.queued_messages.is_empty());
+    }
+
+    #[test]
+    fn test_check_auto_poke_budget_exhausted_stops() {
+        let (mut app, _home) = make_poke_app(&[todo("1", "pending")]);
+        app.auto_poke_count = claurst_tools::todo_write::MAX_AUTO_POKES;
+        app.check_auto_poke("end_turn");
+        assert!(app.queued_messages.is_empty());
+        assert!(app.status_message.is_some());
+    }
+
+    #[test]
+    fn test_check_auto_poke_no_progress_stops() {
+        let (mut app, _home) = make_poke_app(&[todo("1", "pending")]);
+        // First poke records the hash.
+        app.check_auto_poke("end_turn");
+        assert_eq!(app.auto_poke_count, 1);
+        // Simulate two more no-progress turns (todo state unchanged).
+        // The first call records the hash; calls 2 and 3 increment the
+        // no-progress counter to 1 and 2 and still poke.
+        app.check_auto_poke("end_turn");
+        app.check_auto_poke("end_turn");
+        assert_eq!(app.auto_poke_count, 3);
+        assert_eq!(app.no_progress_turns, claurst_tools::todo_write::NO_PROGRESS_THRESHOLD - 1);
+        // Fourth check reaches the threshold and stops without queueing.
+        app.check_auto_poke("end_turn");
+        assert_eq!(app.auto_poke_count, 3);
+        assert!(app.status_message.is_some());
+    }
+
     #[test]
     fn test_mcp_subcommand_is_not_intercepted() {
         let mut app = make_app();


### PR DESCRIPTION
Third and final split from #388: **auto-poke**.

Review points from this thread, addressed:

1. **Opt-in, default OFF** — `autoPokeEnabled` uses `#[serde(default)]`, not `default_true`. Absent key means disabled. Covered by a default-off roundtrip test.
2. **Stop-reason check (the blocker)** — `check_auto_poke(stop_reason)` is called with the actual stop reason from `TurnComplete` and only fires on a clean `end_turn`. Aborts/cancels (Esc), `max_tokens` truncation, `content_filtered`, and unknown stop reasons never poke. Hitting Esc to stop the model no longer re-pokes it. Test asserts all four abnormal reasons queue nothing.
3. **Duplicate `/todos auto-poke` dropped** — `/poke` is the single entry point. No `TodosCommand` auto-poke path exists in this PR.
4. **Dead fields removed** — `pending_auto_poke`, `todo_card_visible`, `bang_command_history`, and `TodoCard` from the original branch are not carried over. Only the three fields auto-poke actually uses exist: `auto_poke_count`, `no_progress_turns`, `last_todo_hash`.
5. **No render-loop disk reads** — `load_todos` runs once per completed turn inside the `TurnComplete` handler, never in `render_footer`.
6. **Safety rails kept** — budget of 48 pokes per session, stops after 3 consecutive no-progress turns (unchanged todo-state hash). Both have tests.

Also: `App.session_id` is synced with `ToolContext::session_id` at startup, `/new`, and session resume so pokes read the right session's todos. TUI tests mount a tempdir `CLAURST_HOME` so nothing touches real user state.

`cargo check --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, 2 core tests, 7 TUI tests, and the full claurst-tools suite pass. CRLF line endings preserved on `todo_write.rs` and `docs/commands.md`.

All three splits are now up: #404 (bang), #405 (yolo), and this one. Each branches off main with a single-feature diff.