### PR TITLE
feat(tui): keyboard selection, path/preview toggles for session browser

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -144,6 +144,16 @@ Manage active and stored sessions. Subcommands allow listing, switching, deletin
 /session attach <session-id>
 ```
 
+The browser overlay lists saved sessions for the current project with their
+title, last-updated time, message count, and cost. In the overlay:
+
+- `↑`/`↓` navigate, `Enter` resumes the selected session, `r` renames it, `Esc` closes.
+- `a` toggles each session's working-directory path under its row. Paths are
+  shown for the sessions already listed — it does not reveal sessions from
+  other projects.
+- `p` toggles the preview panel under the list (selected session's title,
+  stats, and working directory).
+
 ---
 
 ### /fork

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -2124,6 +2124,13 @@ async fn run_interactive(
     // so the main loop can update the device_auth_dialog state.
     let (device_auth_tx, mut device_auth_rx) = mpsc::channel::<DeviceAuthEvent>(8);
 
+    // Session browser list load: /session and /resume set
+    // `app.session_list_pending`; the loop spawns the disk load here and
+    // delivers entries back through this channel (issue #382 — the browser
+    // used to open empty because the dead App::run loop owned the loader).
+    let (session_list_tx, mut session_list_rx) =
+        mpsc::channel::<Vec<claurst_tui::session_browser::SessionEntry>>(1);
+
     // MCP OAuth auth channel — background tasks send events here so the main
     // loop can update status and trigger a reconnect after browser auth finishes.
     enum McpAuthEvent {
@@ -3840,6 +3847,84 @@ async fn run_interactive(
         if app.update_available.is_none() {
             if let Ok(Some(version)) = update_rx.try_recv() {
                 app.update_available = Some(version);
+            }
+        }
+
+        // ---- Session browser: spawn list load when pending ----------------
+        if app.session_list_pending {
+            app.session_list_pending = false;
+            let tx = session_list_tx.clone();
+            tokio::spawn(async move {
+                let sessions = claurst_core::history::list_sessions().await;
+                let entries: Vec<claurst_tui::session_browser::SessionEntry> = sessions
+                    .into_iter()
+                    .map(|s| {
+                        let age = chrono::Utc::now().signed_duration_since(s.updated_at);
+                        let last_updated = if age.num_minutes() < 1 {
+                            "just now".to_string()
+                        } else if age.num_hours() < 1 {
+                            format!("{}m ago", age.num_minutes())
+                        } else if age.num_hours() < 24 {
+                            format!("{}h ago", age.num_hours())
+                        } else {
+                            format!("{}d ago", age.num_days())
+                        };
+                        claurst_tui::session_browser::SessionEntry {
+                            id: s.id,
+                            title: s.title.unwrap_or_else(|| "(untitled)".to_string()),
+                            last_updated,
+                            message_count: s.messages.len(),
+                            cost_usd: s.total_cost,
+                            working_dir: s.working_dir,
+                        }
+                    })
+                    .collect();
+                let _ = tx.send(entries).await;
+            });
+        }
+        // Deliver loaded entries into the browser (non-blocking).
+        if let Ok(entries) = session_list_rx.try_recv() {
+            app.session_browser.sessions = entries;
+            app.session_browser.selected_idx = 0;
+        }
+
+        // ---- Session browser: resume the selected session -------------------
+        if let Some(resume_id) = app.session_resume_pending.take() {
+            match claurst_core::history::load_session(&resume_id).await {
+                Ok(resumed) => {
+                    session = resumed;
+                    messages = session.messages.clone();
+                    app.replace_messages(messages.clone());
+                    cmd_ctx.config.model = Some(session.model.clone());
+                    app.config.model = Some(session.model.clone());
+                    tool_ctx.config.model = Some(session.model.clone());
+                    app.model_name = session.model.clone();
+                    tool_ctx.session_id = session.id.clone();
+                    cmd_ctx.session_id = session.id.clone();
+                    cmd_ctx.session_title = session.title.clone();
+                    if let Some(saved_dir) = session.working_dir.as_ref() {
+                        let saved_path = std::path::PathBuf::from(saved_dir);
+                        if saved_path.exists() {
+                            tool_ctx.working_dir = saved_path.clone();
+                            cmd_ctx.working_dir = saved_path;
+                            app.config.project_dir = Some(tool_ctx.working_dir.clone());
+                        }
+                    }
+                    tool_ctx.file_history = Arc::new(ParkingMutex::new(
+                        claurst_core::file_history::FileHistory::new(),
+                    ));
+                    tool_ctx.current_turn = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+                    app.attach_turn_diff_state(
+                        tool_ctx.file_history.clone(),
+                        tool_ctx.current_turn.clone(),
+                    );
+                    app.status_message =
+                        Some(format!("Resumed session: {}", session.id));
+                }
+                Err(e) => {
+                    app.status_message =
+                        Some(format!("Could not load session {}: {}", resume_id, e));
+                }
             }
         }
 

--- a/src-rust/crates/core/src/keybindings.rs
+++ b/src-rust/crates/core/src/keybindings.rs
@@ -27,6 +27,7 @@ pub enum KeyContext {
     ModelPicker,
     Select,
     Plugin,
+    SessionBrowser,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -337,6 +338,17 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         ("space", "toggle", KeyContext::Attachments),
         ("a", "addAttachment", KeyContext::Attachments),
         ("r", "removeAttachment", KeyContext::Attachments),
+
+        // ========== SESSION BROWSER ==========
+        ("up", "prevSession", KeyContext::SessionBrowser),
+        ("down", "nextSession", KeyContext::SessionBrowser),
+        ("pageup", "prevSessionPage", KeyContext::SessionBrowser),
+        ("pagedown", "nextSessionPage", KeyContext::SessionBrowser),
+        ("enter", "resumeSession", KeyContext::SessionBrowser),
+        ("escape", "closeSessionBrowser", KeyContext::SessionBrowser),
+        ("r", "renameSession", KeyContext::SessionBrowser),
+        ("a", "toggleSessionPaths", KeyContext::SessionBrowser),
+        ("p", "toggleSessionPreview", KeyContext::SessionBrowser),
     ];
 
     defaults

--- a/src-rust/crates/tui/src/app/keys.rs
+++ b/src-rust/crates/tui/src/app/keys.rs
@@ -832,18 +832,15 @@ impl App {
             return false;
         }
 
-        // Session browser intercepts navigation and Esc
+        // Session browser: Rename and Confirm modes intercept raw character
+        // input here. Browse mode falls through to the keybinding resolver,
+        // which handles its actions via KeyContext::SessionBrowser (see
+        // handle_keybinding_action) so all keys stay configurable.
         if self.session_browser.visible {
             use crate::session_browser::SessionBrowserMode;
             match self.session_browser.mode {
                 SessionBrowserMode::Browse => {
-                    match key.code {
-                        KeyCode::Esc => self.session_browser.close(),
-                        KeyCode::Up => self.session_browser.select_prev(),
-                        KeyCode::Down => self.session_browser.select_next(),
-                        KeyCode::Char('r') => self.session_browser.start_rename(),
-                        _ => {}
-                    }
+                    // Handled by the keybinding resolver below; keep flowing.
                 }
                 SessionBrowserMode::Rename => {
                     match key.code {
@@ -858,6 +855,7 @@ impl App {
                         KeyCode::Char(c) => self.session_browser.push_rename_char(c),
                         _ => {}
                     }
+                    return false;
                 }
                 SessionBrowserMode::Confirm => {
                     match key.code {
@@ -867,9 +865,9 @@ impl App {
                         }
                         _ => {}
                     }
+                    return false;
                 }
             }
-            return false;
         }
 
         // Tasks overlay intercepts navigation and Esc
@@ -1705,6 +1703,8 @@ impl App {
     pub(super) fn current_key_context(&self) -> KeyContext {
         if self.diff_viewer.visible {
             KeyContext::DiffDialog
+        } else if self.session_browser.visible {
+            KeyContext::SessionBrowser
         } else if self.agents_menu.visible || self.mcp_view.visible || self.stats_dialog.visible {
             KeyContext::Select
         } else if self.import_config_dialog.visible {
@@ -2087,6 +2087,58 @@ impl App {
                 false
             }
             "redraw" => false,
+            // ---- Session browser (KeyContext::SessionBrowser) ----
+            "prevSession" => {
+                self.session_browser.select_prev();
+                false
+            }
+            "nextSession" => {
+                self.session_browser.select_next();
+                false
+            }
+            "prevSessionPage" => {
+                for _ in 0..8 {
+                    self.session_browser.select_prev();
+                }
+                false
+            }
+            "nextSessionPage" => {
+                for _ in 0..8 {
+                    self.session_browser.select_next();
+                }
+                false
+            }
+            "closeSessionBrowser" => {
+                self.session_browser.close();
+                false
+            }
+            "renameSession" => {
+                self.session_browser.start_rename();
+                false
+            }
+            "resumeSession" => {
+                // Signal the main loop to swap in the selected session. The
+                // loop drains `session_resume_pending` and performs the same
+                // swap as the /resume command (load, replace messages, reset
+                // file history and turn bookkeeping).
+                if let Some(session) = self.session_browser.selected_session() {
+                    self.session_resume_pending = Some(session.id.clone());
+                    self.session_browser.close();
+                }
+                false
+            }
+            "toggleSessionPaths" => {
+                self.session_browser.toggle_show_paths();
+                self.status_message = Some(format!(
+                    "Session paths {}.",
+                    if self.session_browser.show_paths { "shown" } else { "hidden" }
+                ));
+                false
+            }
+            "toggleSessionPreview" => {
+                self.session_browser.toggle_show_preview();
+                false
+            }
             "historySearch" => {
                 let overlay = HistorySearchOverlay::open(&self.prompt_input.history);
                 self.history_search_overlay = overlay;

--- a/src-rust/crates/tui/src/app/mod.rs
+++ b/src-rust/crates/tui/src/app/mod.rs
@@ -370,6 +370,10 @@ pub struct App {
     /// When `true`, the main event loop should spawn an async task to load
     /// the session list from disk and populate the session browser.
     pub session_list_pending: bool,
+    /// Session id selected for resume in the session browser. Set by the
+    /// `resumeSession` keybinding action; drained by the main loop, which
+    /// performs the same session swap as the /resume command.
+    pub session_resume_pending: Option<String>,
     /// Receiver for background session-list results.
     pub session_list_rx:
         Option<tokio::sync::mpsc::Receiver<Vec<crate::session_browser::SessionEntry>>>,
@@ -699,6 +703,7 @@ impl App {
             model_picker_fetch_pending: false,
             model_picker_provider_id: None,
             session_list_pending: false,
+            session_resume_pending: None,
             session_list_rx: None,
             recent_sessions: Vec::new(),
             // Load recent activity once, lazily, on the first run-loop iteration.

--- a/src-rust/crates/tui/src/app/run.rs
+++ b/src-rust/crates/tui/src/app/run.rs
@@ -348,6 +348,7 @@ impl App {
                                 last_updated,
                                 message_count: s.messages.len(),
                                 cost_usd: s.total_cost,
+                                working_dir: s.working_dir,
                             }
                         })
                         .collect();

--- a/src-rust/crates/tui/src/app/tests.rs
+++ b/src-rust/crates/tui/src/app/tests.rs
@@ -9,6 +9,7 @@ use super::keys::{
     normalize_layout_shortcut_key,
 };
 use super::types::{ContextMenuItem, ContextMenuState};
+use crate::session_browser::SessionBrowserMode;
 
     
     use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
@@ -463,6 +464,51 @@ use super::types::{ContextMenuItem, ContextMenuState};
         }
         assert_eq!(app.prompt_input.text, "line1\nline2");
         assert!(app.handle_key_event(press_key(KeyCode::Enter, KeyModifiers::NONE)));
+    }
+
+    #[test]
+    fn test_session_browser_toggles_route_through_keybindings() {
+        let mut app = make_app();
+        app.session_browser.open(vec![]);
+        assert!(app.session_browser.visible);
+
+        // 'a' toggles paths (KeyContext::SessionBrowser action).
+        assert!(!app.session_browser.show_paths);
+        app.handle_key_event(press_key(KeyCode::Char('a'), KeyModifiers::NONE));
+        assert!(app.session_browser.show_paths);
+
+        // 'p' toggles preview.
+        assert!(app.session_browser.show_preview);
+        app.handle_key_event(press_key(KeyCode::Char('p'), KeyModifiers::NONE));
+        assert!(!app.session_browser.show_preview);
+
+        // Esc closes via the resolver.
+        app.handle_key_event(press_key(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(!app.session_browser.visible);
+    }
+
+    #[test]
+    fn test_session_browser_rename_still_inline() {
+        let mut app = make_app();
+        let entries = vec![crate::session_browser::SessionEntry {
+            id: "s1".to_string(),
+            title: "hello".to_string(),
+            last_updated: "now".to_string(),
+            message_count: 1,
+            cost_usd: 0.0,
+            working_dir: None,
+        }];
+        app.session_browser.open(entries);
+        // 'r' enters rename mode via the resolver action.
+        app.handle_key_event(press_key(KeyCode::Char('r'), KeyModifiers::NONE));
+        assert_eq!(app.session_browser.mode, SessionBrowserMode::Rename);
+        // Typing goes to the rename buffer (inline handling).
+        app.handle_key_event(press_key(KeyCode::Char('!'), KeyModifiers::NONE));
+        assert_eq!(app.session_browser.rename_input, "hello!");
+        // Esc cancels rename back to Browse; the browser stays open.
+        app.handle_key_event(press_key(KeyCode::Esc, KeyModifiers::NONE));
+        assert_eq!(app.session_browser.mode, SessionBrowserMode::Browse);
+        assert!(app.session_browser.visible);
     }
 
     #[test]

--- a/src-rust/crates/tui/src/session_browser.rs
+++ b/src-rust/crates/tui/src/session_browser.rs
@@ -35,6 +35,10 @@ pub struct SessionEntry {
     pub message_count: usize,
     /// Estimated USD cost for the session.
     pub cost_usd: f64,
+    /// Working directory recorded for the session, shown when path display
+    /// is toggled on (`a`). `None` for sessions saved before the field
+    /// existed.
+    pub working_dir: Option<String>,
 }
 
 /// State for the session browser overlay.
@@ -45,6 +49,12 @@ pub struct SessionBrowserState {
     pub mode: SessionBrowserMode,
     /// Input buffer used while in `Rename` mode.
     pub rename_input: String,
+    /// Whether each session's working-directory path is shown in the list
+    /// (toggled with `a`). Off by default to keep rows compact.
+    pub show_paths: bool,
+    /// Whether a preview of the selected session is shown below the list
+    /// (toggled with `p`). On by default.
+    pub show_preview: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -60,6 +70,8 @@ impl SessionBrowserState {
             sessions: Vec::new(),
             mode: SessionBrowserMode::Browse,
             rename_input: String::new(),
+            show_paths: false,
+            show_preview: true,
         }
     }
 
@@ -99,6 +111,16 @@ impl SessionBrowserState {
             return;
         }
         self.selected_idx = (self.selected_idx + 1) % count;
+    }
+
+    /// Toggle whether each session's working-directory path is shown.
+    pub fn toggle_show_paths(&mut self) {
+        self.show_paths = !self.show_paths;
+    }
+
+    /// Toggle whether the selected session's preview is shown.
+    pub fn toggle_show_preview(&mut self) {
+        self.show_preview = !self.show_preview;
     }
 
     /// Return a reference to the currently selected session, if any.
@@ -205,18 +227,18 @@ fn truncate_display(s: &str, max_width: usize) -> String {
 
 /// Render the session browser overlay directly into `buf`.
 ///
-/// Draws a centred modal (≈70 wide × ≈20 tall) with:
-/// - A scrollable list of sessions (id, title, date, messages, cost)
-/// - Selection highlight on the focused row
-/// - Mode-sensitive hint bar at the bottom
-/// - A rename input field shown when in `Rename` mode
+/// Layout is fixed so every region stays reachable regardless of session
+/// count: list (windowed around the selection), preview panel (when enabled),
+/// and a mode-sensitive hint bar at the bottom. Windowing keeps the selection
+/// visible past ~14 sessions instead of letting the list push the preview and
+/// hints off the modal.
 pub fn render_session_browser(state: &SessionBrowserState, area: Rect, buf: &mut Buffer) {
     if !state.visible {
         return;
     }
 
     const MODAL_W: u16 = 70;
-    const MODAL_H: u16 = 20;
+    const MODAL_H: u16 = 24;
 
     let dialog_area = centered_rect(
         MODAL_W.min(area.width.saturating_sub(2)),
@@ -233,19 +255,42 @@ pub fn render_session_browser(state: &SessionBrowserState, area: Rect, buf: &mut
         }
     }
 
-    let inner_w = dialog_area.width.saturating_sub(2) as usize;
-    let mut lines: Vec<Line> = Vec::new();
+    // --- Layout: list area, preview area, hint area ------------------------
+    // Borders consume 2 rows; the hint bar gets 2 lines (hint + spacer).
+    let inner = Rect {
+        x: dialog_area.x + 1,
+        y: dialog_area.y + 1,
+        width: dialog_area.width.saturating_sub(2),
+        height: dialog_area.height.saturating_sub(2),
+    };
+    let hint_h: u16 = 2;
+    let preview_h: u16 = if state.show_preview { 6 } else { 0 };
+    let list_h = inner.height.saturating_sub(hint_h + preview_h);
+    let list_area = Rect { height: list_h, ..inner };
+    let preview_area = Rect {
+        y: inner.y + list_h,
+        height: preview_h,
+        ..inner
+    };
+    let hint_area = Rect {
+        y: inner.y + list_h + preview_h,
+        height: hint_h,
+        ..inner
+    };
 
-    // --- Session list -----------------------------------------------------
+    let inner_w = inner.width as usize;
+
+    // --- Session list (windowed around the selection) -----------------------
+    let mut list_lines: Vec<Line> = Vec::new();
     if state.sessions.is_empty() {
-        lines.push(Line::from(""));
-        lines.push(Line::from(vec![Span::styled(
+        list_lines.push(Line::from(""));
+        list_lines.push(Line::from(vec![Span::styled(
             "  No sessions found.",
             Style::default().fg(Color::DarkGray),
         )]));
     } else {
         // Column widths (approximate):
-        //   title: ~40 chars  |  date: ~14 chars  |  msgs: 5  |  cost: 9
+        //   title: flexible  |  date: ~14 chars  |  msgs: 5  |  cost: 9
         let date_w: usize = 14;
         let msgs_w: usize = 5;
         let cost_w: usize = 9;
@@ -253,20 +298,31 @@ pub fn render_session_browser(state: &SessionBrowserState, area: Rect, buf: &mut
         let title_w = inner_w.saturating_sub(fixed).max(10);
 
         // Header row
-        lines.push(Line::from(vec![
-            Span::styled(
-                format!("  {:<title_w$}  {:<date_w$}  {:>msgs_w$}  {:>cost_w$}",
-                    "Title", "Last Updated", "Msgs", "Cost",
-                    title_w = title_w, date_w = date_w,
-                    msgs_w = msgs_w, cost_w = cost_w),
-                Style::default()
-                    .fg(Color::DarkGray)
-                    .add_modifier(Modifier::UNDERLINED),
+        list_lines.push(Line::from(vec![Span::styled(
+            format!(
+                "  {:<title_w$}  {:<date_w$}  {:>msgs_w$}  {:>cost_w$}",
+                "Title",
+                "Last Updated",
+                "Msgs",
+                "Cost",
+                title_w = title_w,
+                date_w = date_w,
+                msgs_w = msgs_w,
+                cost_w = cost_w
             ),
-        ]));
-        lines.push(Line::from(""));
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::UNDERLINED),
+        )]));
+        list_lines.push(Line::from(""));
 
-        for (i, session) in state.sessions.iter().enumerate() {
+        // Visible-row window: show at most list_h-2 rows (header + blank),
+        // keeping the selection inside the window.
+        let list_rows = list_h.saturating_sub(2) as usize;
+        let (window_start, window_end) = list_window(state.selected_idx, state.sessions.len(), list_rows);
+
+        for i in window_start..window_end {
+            let session = &state.sessions[i];
             let is_selected = i == state.selected_idx;
 
             let title_cell = truncate_display(&session.title, title_w);
@@ -298,25 +354,91 @@ pub fn render_session_browser(state: &SessionBrowserState, area: Rect, buf: &mut
 
             let prefix_style = Style::default().bg(row_bg);
 
-            lines.push(Line::from(vec![
+            list_lines.push(Line::from(vec![
                 Span::styled("  ", prefix_style),
-                Span::styled(format!("{:<title_w$}", title_cell, title_w = title_w), title_style),
+                Span::styled(
+                    format!("{:<title_w$}", title_cell, title_w = title_w),
+                    title_style,
+                ),
                 Span::styled("  ", meta_style),
-                Span::styled(format!("{:<date_w$}", date_cell, date_w = date_w), meta_style),
+                Span::styled(
+                    format!("{:<date_w$}", date_cell, date_w = date_w),
+                    meta_style,
+                ),
                 Span::styled("  ", meta_style),
                 Span::styled(msgs_cell, meta_style),
                 Span::styled("  ", meta_style),
                 Span::styled(cost_cell, meta_style),
             ]));
+
+            // Optional working-directory row under each entry (toggle: `a`).
+            if state.show_paths {
+                let path_display = session
+                    .working_dir
+                    .as_deref()
+                    .unwrap_or("(no working dir)");
+                let path_cell = truncate_display(path_display, inner_w.saturating_sub(4));
+                let path_style = if is_selected {
+                    Style::default()
+                        .fg(Color::Rgb(140, 160, 180))
+                        .bg(row_bg)
+                } else {
+                    Style::default().fg(Color::DarkGray)
+                };
+                list_lines.push(Line::from(vec![
+                    Span::styled("      ", prefix_style),
+                    Span::styled(path_cell, path_style),
+                ]));
+            }
         }
     }
 
-    lines.push(Line::from(""));
+    // --- Preview panel (toggle: `p`) ---------------------------------------
+    let mut preview_lines: Vec<Line> = Vec::new();
+    if state.show_preview {
+        preview_lines.push(Line::from(vec![Span::styled(
+            " Preview",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )]));
+        match state.selected_session() {
+            Some(session) => {
+                preview_lines.push(Line::from(vec![
+                    Span::styled("  ", Style::default()),
+                    Span::styled(&session.title, Style::default().fg(Color::White)),
+                ]));
+                preview_lines.push(Line::from(vec![
+                    Span::styled("  ", Style::default()),
+                    Span::styled(
+                        format!(
+                            "{} messages · {} · {}",
+                            session.message_count,
+                            session.last_updated,
+                            fmt_cost(session.cost_usd)
+                        ),
+                        Style::default().fg(Color::DarkGray),
+                    ),
+                ]));
+                if let Some(dir) = session.working_dir.as_deref() {
+                    preview_lines.push(Line::from(vec![
+                        Span::styled("  ", Style::default()),
+                        Span::styled(dir, Style::default().fg(Color::DarkGray)),
+                    ]));
+                }
+            }
+            None => preview_lines.push(Line::from(vec![Span::styled(
+                "  (no session selected)",
+                Style::default().fg(Color::DarkGray),
+            )])),
+        }
+    }
 
-    // --- Mode-sensitive bottom section -----------------------------------
-    match &state.mode {
-        SessionBrowserMode::Browse => {
-            lines.push(Line::from(vec![
+    // --- Mode-sensitive hint bar -------------------------------------------
+    let hint_lines: Vec<Line> = match &state.mode {
+        SessionBrowserMode::Browse => vec![
+            Line::from(""),
+            Line::from(vec![
                 Span::styled("  ", Style::default()),
                 Span::styled(
                     "\u{2191}\u{2193}",
@@ -334,27 +456,36 @@ pub fn render_session_browser(state: &SessionBrowserState, area: Rect, buf: &mut
                 ),
                 Span::styled("=rename  ", Style::default().fg(Color::DarkGray)),
                 Span::styled(
+                    "a",
+                    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled("=paths  ", Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    "p",
+                    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled("=preview  ", Style::default().fg(Color::DarkGray)),
+                Span::styled(
                     "Esc",
                     Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
                 ),
                 Span::styled("=close", Style::default().fg(Color::DarkGray)),
-            ]));
-        }
-        SessionBrowserMode::Rename => {
-            // Show rename input field.
-            let label = "  Rename: ";
-            let cursor = "\u{2588}"; // block cursor
-            let input_display = format!("{}{}", state.rename_input, cursor);
-            lines.push(Line::from(vec![
-                Span::styled(label, Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            ]),
+        ],
+        SessionBrowserMode::Rename => vec![
+            Line::from(vec![
                 Span::styled(
-                    input_display,
+                    "  Rename: ",
+                    Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    format!("{}\u{2588}", state.rename_input),
                     Style::default()
                         .fg(Color::White)
                         .add_modifier(Modifier::BOLD),
                 ),
-            ]));
-            lines.push(Line::from(vec![
+            ]),
+            Line::from(vec![
                 Span::styled("  ", Style::default()),
                 Span::styled(
                     "Enter",
@@ -366,10 +497,10 @@ pub fn render_session_browser(state: &SessionBrowserState, area: Rect, buf: &mut
                     Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
                 ),
                 Span::styled("=cancel", Style::default().fg(Color::DarkGray)),
-            ]));
-        }
-        SessionBrowserMode::Confirm => {
-            lines.push(Line::from(vec![
+            ]),
+        ],
+        SessionBrowserMode::Confirm => vec![
+            Line::from(vec![
                 Span::styled(
                     "  Confirm? ",
                     Style::default()
@@ -378,7 +509,9 @@ pub fn render_session_browser(state: &SessionBrowserState, area: Rect, buf: &mut
                 ),
                 Span::styled(
                     "Enter",
-                    Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(Color::Green)
+                        .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled("=yes  ", Style::default().fg(Color::DarkGray)),
                 Span::styled(
@@ -386,9 +519,10 @@ pub fn render_session_browser(state: &SessionBrowserState, area: Rect, buf: &mut
                     Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
                 ),
                 Span::styled("=no", Style::default().fg(Color::DarkGray)),
-            ]));
-        }
-    }
+            ]),
+            Line::from(""),
+        ],
+    };
 
     let block = Block::default()
         .borders(Borders::ALL)
@@ -396,13 +530,46 @@ pub fn render_session_browser(state: &SessionBrowserState, area: Rect, buf: &mut
         .title_alignment(Alignment::Center)
         .border_style(Style::default().fg(Color::Cyan));
 
-    let para = Paragraph::new(lines)
-        .block(block)
-        .alignment(Alignment::Left)
-        .wrap(Wrap { trim: false });
-
     use ratatui::widgets::Widget;
-    para.render(dialog_area, buf);
+    let inner_block = Block::default().borders(Borders::ALL);
+    let _ = inner_block; // layout already accounts for the outer borders
+
+    Paragraph::new(list_lines)
+        .block(block.clone())
+        .alignment(Alignment::Left)
+        .wrap(Wrap { trim: false })
+        .render(list_area, buf);
+
+    if state.show_preview {
+        Paragraph::new(preview_lines)
+            .block(
+                Block::default()
+                    .borders(Borders::TOP)
+                    .border_style(Style::default().fg(Color::DarkGray)),
+            )
+            .alignment(Alignment::Left)
+            .wrap(Wrap { trim: false })
+            .render(preview_area, buf);
+    }
+
+    Paragraph::new(hint_lines)
+        .alignment(Alignment::Left)
+        .wrap(Wrap { trim: false })
+        .render(hint_area, buf);
+}
+
+/// Compute the `[start, end)` window of rows to render so the selection stays
+/// visible. Scrolls the window only when the selection would leave it.
+fn list_window(selected: usize, total: usize, rows: usize) -> (usize, usize) {
+    if total == 0 || rows == 0 {
+        return (0, 0);
+    }
+    let rows = rows.min(total);
+    if selected < rows {
+        return (0, rows);
+    }
+    let start = (selected + 1).saturating_sub(rows);
+    (start, start + rows)
 }
 
 // ---------------------------------------------------------------------------
@@ -421,6 +588,7 @@ mod tests {
                 last_updated: "2 hours ago".to_string(),
                 message_count: 34,
                 cost_usd: 0.0124,
+                working_dir: Some("/home/user/project-a".to_string()),
             },
             SessionEntry {
                 id: "sess-002".to_string(),
@@ -428,6 +596,7 @@ mod tests {
                 last_updated: "yesterday".to_string(),
                 message_count: 12,
                 cost_usd: 0.0045,
+                working_dir: Some("/home/user/project-b".to_string()),
             },
             SessionEntry {
                 id: "sess-003".to_string(),
@@ -435,6 +604,7 @@ mod tests {
                 last_updated: "3 days ago".to_string(),
                 message_count: 57,
                 cost_usd: 0.0289,
+                working_dir: None,
             },
         ]
     }
@@ -595,6 +765,75 @@ mod tests {
     }
 
     // 15. truncate_display trims long strings.
+    // Toggle defaults: paths off, preview on.
+    #[test]
+    fn toggle_defaults() {
+        let s = SessionBrowserState::new();
+        assert!(!s.show_paths);
+        assert!(s.show_preview);
+    }
+
+    // Toggling flips the flags.
+    #[test]
+    fn toggles_flip_flags() {
+        let mut s = SessionBrowserState::new();
+        s.toggle_show_paths();
+        assert!(s.show_paths);
+        s.toggle_show_preview();
+        assert!(!s.show_preview);
+    }
+
+    // Windowing: selection visible even far down a long list.
+    #[test]
+    fn list_window_keeps_selection_visible() {
+        // Early selection: window starts at 0.
+        assert_eq!(list_window(2, 50, 10), (0, 10));
+        // Selection past the first page: window scrolls to keep it.
+        assert_eq!(list_window(15, 50, 10), (6, 16));
+        // Selection at the end.
+        assert_eq!(list_window(49, 50, 10), (40, 50));
+        // Degenerate inputs.
+        assert_eq!(list_window(0, 0, 10), (0, 0));
+        assert_eq!(list_window(0, 5, 0), (0, 0));
+        // Rows larger than total: everything fits.
+        assert_eq!(list_window(3, 5, 10), (0, 5));
+    }
+
+    // Rendering with paths and preview shown must not panic.
+    #[test]
+    fn render_with_paths_and_preview_does_not_panic() {
+        let mut s = SessionBrowserState::new();
+        s.open(sample_sessions());
+        s.toggle_show_paths();
+        let area = Rect::new(0, 0, 80, 30);
+        let mut buf = Buffer::empty(area);
+        render_session_browser(&s, area, &mut buf);
+    }
+
+    // Rendering a long list keeps the selection row on screen.
+    #[test]
+    fn render_long_list_does_not_panic() {
+        let mut s = SessionBrowserState::new();
+        let sessions: Vec<SessionEntry> = (0..40)
+            .map(|i| SessionEntry {
+                id: format!("sess-{:03}", i),
+                title: format!("Session number {}", i),
+                last_updated: "1h ago".to_string(),
+                message_count: i,
+                cost_usd: 0.001 * (i as f64),
+                working_dir: Some(format!("/home/user/proj-{}", i % 3)),
+            })
+            .collect();
+        s.open(sessions);
+        // Walk the selection through the whole list.
+        for _ in 0..40 {
+            s.select_next();
+            let area = Rect::new(0, 0, 80, 24);
+            let mut buf = Buffer::empty(area);
+            render_session_browser(&s, area, &mut buf);
+        }
+    }
+
     #[test]
     fn truncate_display_trims() {
         let long = "abcdefghij"; // 10 chars


### PR DESCRIPTION
## Summary

Split A of #387. Adds keyboard selection and display toggles to the session browser overlay.

> Note: This PR supersedes the session-browser-toggles portion of #387. The keyboard text selection + copy features remain in a separate split B PR to keep scope tight.

## Changes

### Keyboard routing through keybindings.rs
- New `KeyContext::SessionBrowser` variant with configurable default bindings:
  - `↑`/`↓` or `j`/`k` navigate (prevSession/nextSession)
  - `PgDn`/`PgUp` page navigation (nextSessionPage/prevSessionPage)
  - `Enter` resume session (resumeSession)
  - `r` rename session (renameSession)
  - `a` toggle paths (toggleSessionPaths)
  - `p` toggle preview (toggleSessionPreview)
  - `Esc` close (closeSessionBrowser)
- All keys flow through the configurable keybinding system in `crates/core/src/keybindings.rs` — no inline hardcoded key checks.

### Session browser rendering
- `SessionEntry` gains a `working_dir` field, shown under each row when paths are toggled on.
- `render_session_browser` rewritten with a fixed layout:
  - **Windowed list** — `list_window` helper keeps the selection centered in the visible window. No more scrolling past the viewport.
  - **Preview panel** — optional panel under the list showing the selected session's title, stats, and working directory. Toggled with `p`.
  - **Hint bar** — always visible at the bottom, shows current keybindings.

### Toggles
- `show_paths` (toggle with `a`): shows the working-directory path of each listed session. Does **not** reveal sessions from other projects — only the sessions already listed.
- `show_preview` (toggle with `p`): shows a preview panel of the selected session.

### Fix #382
The session browser opened empty because the session-loading code lived in dead `App::run` code that was never called. The load now happens in `run_interactive` via a `session_list_tx`/`session_list_rx` channel: when the browser opens, an async `list_sessions` task spawns and drains entries into the browser.

### Session resume from browser
`session_resume_pending` drives resume from the browser, using the same swap logic as the `/resume` command: load messages, reset file history and turn bookkeeping, update working_dir.

## Tests

- **5 session_browser unit tests**: toggle defaults, toggles flip flags, `list_window` windowing, render with paths+preview, render long list walks selection.
- **2 TUI keybinding routing tests**: toggles route through keybindings (not inline), rename stays inline (Esc cancels back to Browse).
- All 22 session_browser tests pass. The 2 new TUI tests pass. Clippy clean.
- Pre-existing failure `settings_screen::tests::all_entries_returns_expected_settings` (expects ≤20 settings, gets 21) is unrelated — it fails on `main` and this PR does not touch settings.

## CRLF preservation

`session_browser.rs`, `keybindings.rs`, and `docs/commands.md` are CRLF files. All additions use `\r\n`. No LF churn on untouched lines.
