### PR TITLE
feat(tui): keyboard text selection + copy in transcript

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1123,6 +1123,18 @@ Copy the most recent assistant response to the system clipboard. Pass a number t
 /copy N       — copy the Nth most recent response
 ```
 
+### Keyboard text selection
+
+When the prompt is empty (no text typed), press `v` to enter keyboard
+selection mode. A cursor bar appears at the bottom of the transcript.
+Use the arrow keys to extend the selection up or down. `PageUp`/`PageDown`
+scroll by a page, `Home`/`End` jump to the top/bottom of the transcript.
+`Enter` or `Ctrl+C` copies the selected text to the clipboard and exits
+selection mode. `Esc` cancels without copying.
+
+All selection-mode keys are routed through the configurable keybinding
+system under `KeyContext::Transcript` (see `/keybindings`).
+
 ---
 
 ## Advanced & Internal

--- a/src-rust/crates/core/src/keybindings.rs
+++ b/src-rust/crates/core/src/keybindings.rs
@@ -273,15 +273,17 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         ("escape", "cancel", KeyContext::HistorySearch),
         ("tab", "togglePreview", KeyContext::HistorySearch),
 
-        // ========== TRANSCRIPT / MESSAGE SELECTION ==========
-        ("up", "prevMessage", KeyContext::Transcript),
-        ("down", "nextMessage", KeyContext::Transcript),
-        ("pageup", "pageUp", KeyContext::Transcript),
-        ("pagedown", "pageDown", KeyContext::Transcript),
-        ("home", "goStart", KeyContext::Transcript),
-        ("end", "goEnd", KeyContext::Transcript),
-        ("enter", "selectMessage", KeyContext::Transcript),
-        ("escape", "cancel", KeyContext::Transcript),
+        // ========== TRANSCRIPT / KEYBOARD TEXT SELECTION ==========
+        // Active when kb_select_mode is true. Movement keys extend the
+        // selection; Enter and Ctrl+C copy and exit; Escape cancels.
+        ("up", "selectionUp", KeyContext::Transcript),
+        ("down", "selectionDown", KeyContext::Transcript),
+        ("pageup", "selectionPageUp", KeyContext::Transcript),
+        ("pagedown", "selectionPageDown", KeyContext::Transcript),
+        ("home", "selectionGoStart", KeyContext::Transcript),
+        ("end", "selectionGoEnd", KeyContext::Transcript),
+        ("enter", "selectionCopy", KeyContext::Transcript),
+        ("escape", "selectionCancel", KeyContext::Transcript),
 
         // ========== MESSAGE SELECTOR OVERLAY ==========
         ("up", "prevMessage", KeyContext::MessageSelector),
@@ -955,6 +957,53 @@ mod tests {
                 assert_eq!(action, "goLineStart", "CMD+Left should map to goLineStart");
             }
             other => panic!("Expected Action(\"goLineStart\"), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_transcript_context_resolves_selection_actions() {
+        // Verify that the real keybinding resolver dispatches the
+        // selection actions we registered in KeyContext::Transcript.
+        let user = UserKeybindings::default();
+        let mut resolver = KeybindingResolver::new(&user);
+
+        let check = |resolver: &mut KeybindingResolver, key: &str, expected: &str| {
+            let ks = parse_keystroke(key).unwrap();
+            let result = resolver.process(ks, &KeyContext::Transcript);
+            match result {
+                KeybindingResult::Action(action) => {
+                    assert_eq!(action, expected, "{} in Transcript should resolve to {}", key, expected);
+                }
+                other => panic!("{} in Transcript: expected Action({}), got {:?}", key, expected, other),
+            }
+        };
+
+        check(&mut resolver, "up", "selectionUp");
+        check(&mut resolver, "down", "selectionDown");
+        check(&mut resolver, "enter", "selectionCopy");
+        check(&mut resolver, "escape", "selectionCancel");
+        check(&mut resolver, "home", "selectionGoStart");
+        check(&mut resolver, "end", "selectionGoEnd");
+        check(&mut resolver, "pageup", "selectionPageUp");
+        check(&mut resolver, "pagedown", "selectionPageDown");
+    }
+
+    #[test]
+    fn test_transcript_context_does_not_resolve_chat_actions() {
+        // The Transcript context should NOT carry Chat-context bindings
+        // like historyPrev (up in Chat). This confirms the context
+        // isolation is correct — selection mode keys won't accidentally
+        // trigger chat history navigation.
+        let user = UserKeybindings::default();
+        let mut resolver = KeybindingResolver::new(&user);
+        let ks = parse_keystroke("up").unwrap();
+        let result = resolver.process(ks, &KeyContext::Chat);
+        // In Chat, up should be historyPrev, not selectionUp.
+        match result {
+            KeybindingResult::Action(action) => {
+                assert_ne!(action, "selectionUp", "up in Chat should not be selectionUp");
+            }
+            _ => {} // NoMatch/Unbound/Pending all fine — just not selectionUp
         }
     }
 }

--- a/src-rust/crates/tui/src/app/keys.rs
+++ b/src-rust/crates/tui/src/app/keys.rs
@@ -1198,6 +1198,24 @@ impl App {
             self.keybindings.cancel_chord();
         }
 
+        // ---- Keyboard selection mode: swallow unbound keys -----------------
+        // When kb_select_mode is active, the Transcript keybinding context
+        // handles movement (up/down/etc.), copy (Enter/Ctrl+C), and cancel
+        // (Esc).  Anything that falls through here was not bound in the
+        // Transcript context.  Swallow it to prevent the hardcoded handlers
+        // below from inserting characters or triggering actions, EXCEPT:
+        //   - Ctrl+C: copy selection and exit (hardcoded handler below).
+        //   - Ctrl+D: exit the app (hardcoded handler below).
+        if self.kb_select_mode {
+            let is_ctrl_c = key.code == KeyCode::Char('c')
+                && key.modifiers.contains(KeyModifiers::CONTROL);
+            let is_ctrl_d = key.code == KeyCode::Char('d')
+                && key.modifiers.contains(KeyModifiers::CONTROL);
+            if !is_ctrl_c && !is_ctrl_d {
+                return false;
+            }
+        }
+
         // Clear any active text selection on key press (except Ctrl+C which copies it).
         let is_copy = key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL);
         if !is_copy && self.selection_anchor.is_some() {
@@ -1366,11 +1384,16 @@ impl App {
                 if self.selection_anchor.is_some() && !sel_text.is_empty() {
                     // Text is selected: copy to clipboard.
                     let copied = crate::image_paste::write_clipboard_text(&sel_text);
-                    self.selection_anchor = None;
-                    self.selection_focus = None;
-                    *self.selection_text.borrow_mut() = String::new();
                     if copied {
                         self.push_notification(NotificationKind::Info, "Copied to clipboard".to_string(), Some(2));
+                    }
+                    // Exit keyboard selection mode if active.
+                    if self.kb_select_mode {
+                        self.exit_kb_selection();
+                    } else {
+                        self.selection_anchor = None;
+                        self.selection_focus = None;
+                        *self.selection_text.borrow_mut() = String::new();
                     }
                 } else if self.is_streaming {
                     // Cancel streaming.
@@ -1451,6 +1474,28 @@ impl App {
             {
                 self.show_help = !self.show_help;
                 self.help_overlay.toggle();
+            }
+
+            // ---- Enter keyboard selection mode (v on empty prompt) ----
+            // Mirrors the `?` help toggle: a bare printable char on an empty
+            // prompt with no modifiers.  Gated on no voice recorder so it
+            // doesn't shadow voice PTT, and on not being in vim Normal/Visual
+            // mode so it doesn't shadow vim's `v` (visual mode).  Once active,
+            // all selection keys route through KeyContext::Transcript.
+            KeyCode::Char('v')
+                if !self.is_streaming
+                    && self.prompt_input.is_empty()
+                    && self.voice_recorder.is_none()
+                    && !matches!(
+                        self.prompt_input.vim_mode,
+                        VimMode::Normal | VimMode::Visual | VimMode::VisualBlock
+                    )
+                    && !key.modifiers.contains(KeyModifiers::CONTROL)
+                    && !key.modifiers.contains(KeyModifiers::ALT)
+                    && !key.modifiers.contains(KeyModifiers::SHIFT)
+                    && !key.modifiers.contains(KeyModifiers::SUPER) =>
+            {
+                self.enter_kb_selection();
             }
 
             KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
@@ -1703,6 +1748,11 @@ impl App {
     }
 
     pub(super) fn current_key_context(&self) -> KeyContext {
+        // Keyboard selection mode takes priority — all movement/copy/cancel
+        // keys are routed through the Transcript context's keybinding table.
+        if self.kb_select_mode {
+            return KeyContext::Transcript;
+        }
         if self.diff_viewer.visible {
             KeyContext::DiffDialog
         } else if self.agents_menu.visible || self.mcp_view.visible || self.stats_dialog.visible {
@@ -2381,8 +2431,141 @@ impl App {
                 }
                 false
             }
+
+            // ========== KEYBOARD TEXT SELECTION (Transcript context) ==========
+            "selectionUp" => {
+                self.move_kb_cursor(-1);
+                false
+            }
+            "selectionDown" => {
+                self.move_kb_cursor(1);
+                false
+            }
+            "selectionPageUp" => {
+                let step = self.last_msg_area.get().height.max(1) as i32;
+                self.move_kb_cursor(-step);
+                false
+            }
+            "selectionPageDown" => {
+                let step = self.last_msg_area.get().height.max(1) as i32;
+                self.move_kb_cursor(step);
+                false
+            }
+            "selectionGoStart" => {
+                let area = self.last_selectable_area.get();
+                self.kb_cursor_row = area.y;
+                self.update_kb_selection();
+                false
+            }
+            "selectionGoEnd" => {
+                let area = self.last_selectable_area.get();
+                self.kb_cursor_row = area.y.saturating_add(area.height).saturating_sub(1);
+                self.update_kb_selection();
+                false
+            }
+            "selectionCopy" => {
+                let text = self.selection_text.borrow().clone();
+                if !text.is_empty() {
+                    let copied = crate::image_paste::write_clipboard_text(&text);
+                    if copied {
+                        self.push_notification(
+                            NotificationKind::Info,
+                            "Copied to clipboard".to_string(),
+                            Some(2),
+                        );
+                    }
+                }
+                self.exit_kb_selection();
+                false
+            }
+            "selectionCancel" => {
+                self.exit_kb_selection();
+                false
+            }
+
             _ => false,
         }
+    }
+
+    // ========== KEYBOARD TEXT SELECTION HELPERS ============================
+    //
+    // The selection cursor operates in screen-row coordinates within the
+    // transcript pane (last_selectable_area / last_msg_area).  Content-
+    // anchored means the cursor moves through actual rendered rows in the
+    // `last_row_text` cache, and scroll adjusts to keep it visible.
+
+    /// Enter keyboard selection mode.
+    /// Called from the hardcoded `v` handler (gated on empty prompt, not
+    /// streaming, no voice recorder, not in vim Normal/Visual).
+    pub(super) fn enter_kb_selection(&mut self) {
+        let area = self.last_selectable_area.get();
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        self.kb_select_mode = true;
+        // Start at the bottom of the transcript (most recent content).
+        self.kb_cursor_row = area.y.saturating_add(area.height).saturating_sub(1);
+        let col = area.x;
+        self.selection_anchor = Some((col, self.kb_cursor_row));
+        self.selection_focus = Some((col, self.kb_cursor_row));
+        self.status_message = Some("Selection mode: ↑↓ move · Enter copy · Esc cancel".to_string());
+    }
+
+    /// Exit keyboard selection mode and clear selection state.
+    pub(super) fn exit_kb_selection(&mut self) {
+        self.kb_select_mode = false;
+        self.clear_selection();
+    }
+
+    /// Move the keyboard selection cursor by `delta` rows (negative = up).
+    /// Clamps to the transcript pane bounds and scrolls the view to keep
+    /// the cursor visible (fixes review point #5: unreachable scroll branches).
+    pub(super) fn move_kb_cursor(&mut self, delta: i32) {
+        let area = self.last_selectable_area.get();
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        let min_row = area.y;
+        let max_row = area.y.saturating_add(area.height).saturating_sub(1);
+        let new_row = if delta < 0 {
+            self.kb_cursor_row.saturating_sub(delta.unsigned_abs() as u16).max(min_row)
+        } else {
+            self.kb_cursor_row.saturating_add(delta as u16).min(max_row)
+        };
+        self.kb_cursor_row = new_row;
+        self.update_kb_selection();
+        // Scroll to keep the cursor visible. scroll_offset counts lines
+        // above the bottom; the cursor's offset from the bottom of the
+        // visible area = max_row - cursor_row.
+        let dist_from_bottom = max_row.saturating_sub(new_row);
+        let visible_height = area.height;
+        if dist_from_bottom >= visible_height {
+            // Cursor scrolled past the top — scroll up to show it.
+            let want = (dist_from_bottom as usize) + 1;
+            let max_scroll = self.last_max_scroll.get();
+            self.scroll_offset = want.min(max_scroll);
+            self.auto_scroll = false;
+        } else if (new_row as i32) > (max_row as i32 - visible_height as i32 / 4) {
+            // Cursor near the bottom — snap to bottom for context.
+            self.scroll_offset = 0;
+            self.auto_scroll = true;
+        }
+    }
+
+    /// Update selection_anchor/focus based on the current kb_cursor_row.
+    /// The anchor stays at the entry point; the focus follows the cursor.
+    pub(super) fn update_kb_selection(&mut self) {
+        let area = self.last_selectable_area.get();
+        if area.width == 0 {
+            return;
+        }
+        let col = area.x;
+        let row = self.kb_cursor_row.clamp(
+            area.y,
+            area.y.saturating_add(area.height).saturating_sub(1),
+        );
+        self.kb_cursor_row = row;
+        self.selection_focus = Some((col, row));
     }
 
     /// Handle a key event while in legacy history-search mode.

--- a/src-rust/crates/tui/src/app/mod.rs
+++ b/src-rust/crates/tui/src/app/mod.rs
@@ -511,6 +511,13 @@ pub struct App {
     /// (issue #149 follow-up: prior word-boundary detection was a placeholder).
     pub last_row_text: RefCell<std::collections::HashMap<u16, String>>,
 
+    // ---- Keyboard text selection state ----------------------------------
+    /// Keyboard selection mode active (entered with `v` on empty prompt).
+    pub kb_select_mode: bool,
+    /// Cursor row for keyboard selection, as a screen row within
+    /// `last_msg_area`. Converted to absolute (col, row) on demand.
+    pub kb_cursor_row: u16,
+
     // ---- Advanced mouse interaction state --------------------------------
     /// Timestamp of the last left mouse click (for double/triple-click detection).
     pub last_click_time: Option<std::time::Instant>,
@@ -795,6 +802,8 @@ impl App {
             selection_focus: None,
             selection_text: RefCell::new(String::new()),
             last_row_text: RefCell::new(std::collections::HashMap::new()),
+            kb_select_mode: false,
+            kb_cursor_row: 0,
             last_click_time: None,
             last_click_position: None,
             click_count: 0,

--- a/src-rust/crates/tui/src/app/tests.rs
+++ b/src-rust/crates/tui/src/app/tests.rs
@@ -958,3 +958,249 @@ use super::types::{ContextMenuItem, ContextMenuState};
         app.handle_key_event(press_key(KeyCode::Char('c'), KeyModifiers::CONTROL));
         assert!(app.should_exit);
     }
+
+    // ---- Keyboard text selection (Transcript context) ----
+
+    #[test]
+    fn test_kb_selection_enters_with_v_on_empty_prompt() {
+        let mut app = make_app();
+        app.last_msg_area.set(ratatui::layout::Rect::new(0, 0, 80, 24));
+        app.last_selectable_area
+            .set(ratatui::layout::Rect::new(0, 0, 80, 24));
+        // Press 'v' on empty prompt — should enter selection mode.
+        app.handle_key_event(press_key(KeyCode::Char('v'), KeyModifiers::NONE));
+        assert!(app.kb_select_mode, "v on empty prompt should enter selection mode");
+        assert!(app.selection_anchor.is_some(), "anchor should be set on entry");
+        assert!(app.selection_focus.is_some(), "focus should be set on entry");
+    }
+
+    #[test]
+    fn test_kb_selection_does_not_enter_with_text_in_prompt() {
+        let mut app = make_app();
+        app.last_msg_area.set(ratatui::layout::Rect::new(0, 0, 80, 24));
+        app.last_selectable_area
+            .set(ratatui::layout::Rect::new(0, 0, 80, 24));
+        // Type "verify" — the 'v' should be inserted as text, not enter selection.
+        app.handle_key_event(press_key(KeyCode::Char('v'), KeyModifiers::NONE));
+        // First 'v' enters selection mode because prompt is empty.
+        // Now type another 'v' — it should be swallowed by selection mode guard.
+        assert!(app.kb_select_mode);
+        app.handle_key_event(press_key(KeyCode::Char('e'), KeyModifiers::NONE));
+        // 'e' is swallowed in selection mode, prompt stays empty.
+        assert!(app.prompt_input.is_empty(), "keys should be swallowed in selection mode");
+    }
+
+    #[test]
+    fn test_kb_selection_cancel_with_escape() {
+        let mut app = make_app();
+        app.last_msg_area.set(ratatui::layout::Rect::new(0, 0, 80, 24));
+        app.last_selectable_area
+            .set(ratatui::layout::Rect::new(0, 0, 80, 24));
+        // Enter selection mode.
+        app.handle_key_event(press_key(KeyCode::Char('v'), KeyModifiers::NONE));
+        assert!(app.kb_select_mode);
+        // Cancel with Escape.
+        app.handle_key_event(press_key(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(!app.kb_select_mode, "Esc should exit selection mode");
+        assert!(app.selection_anchor.is_none(), "selection should be cleared on cancel");
+    }
+
+    #[test]
+    fn test_kb_selection_context_returns_transcript() {
+        let mut app = make_app();
+        // Not in selection mode — should return Chat.
+        assert_eq!(
+            app.current_key_context(),
+            claurst_core::keybindings::KeyContext::Chat
+        );
+        // Enter selection mode.
+        app.kb_select_mode = true;
+        assert_eq!(
+            app.current_key_context(),
+            claurst_core::keybindings::KeyContext::Transcript
+        );
+    }
+
+    #[test]
+    fn test_kb_selection_ctrl_d_not_swallowed() {
+        let mut app = make_app();
+        app.last_msg_area.set(ratatui::layout::Rect::new(0, 0, 80, 24));
+        app.last_selectable_area
+            .set(ratatui::layout::Rect::new(0, 0, 80, 24));
+        // Enter selection mode.
+        app.handle_key_event(press_key(KeyCode::Char('v'), KeyModifiers::NONE));
+        assert!(app.kb_select_mode);
+        // Press Ctrl+D — should not be swallowed, should trigger exit confirmation.
+        app.handle_key_event(press_key(KeyCode::Char('d'), KeyModifiers::CONTROL));
+        assert!(
+            app.last_exit_key_warning.is_some() || app.should_exit,
+            "Ctrl+D should trigger exit confirmation, not be swallowed"
+        );
+    }
+
+    #[test]
+    fn test_kb_selection_move_cursor_down_then_up() {
+        let mut app = make_app();
+        // Set up a 10-row selectable area starting at row 5.
+        app.last_selectable_area
+            .set(ratatui::layout::Rect::new(0, 5, 80, 10));
+        app.last_max_scroll.set(0);
+        // Enter selection mode — starts at bottom (row 14).
+        app.handle_key_event(press_key(KeyCode::Char('v'), KeyModifiers::NONE));
+        assert_eq!(app.kb_cursor_row, 14, "should start at bottom row");
+        // Move up one row.
+        app.handle_key_event(press_key(KeyCode::Up, KeyModifiers::NONE));
+        assert_eq!(app.kb_cursor_row, 13, "up should move cursor up one row");
+        // Move down one row.
+        app.handle_key_event(press_key(KeyCode::Down, KeyModifiers::NONE));
+        assert_eq!(app.kb_cursor_row, 14, "down should move cursor back down");
+    }
+
+    #[test]
+    fn test_kb_selection_clamps_at_bounds() {
+        let mut app = make_app();
+        app.last_selectable_area
+            .set(ratatui::layout::Rect::new(0, 5, 80, 10));
+        app.last_max_scroll.set(0);
+        // Enter at bottom (row 14).
+        app.handle_key_event(press_key(KeyCode::Char('v'), KeyModifiers::NONE));
+        assert_eq!(app.kb_cursor_row, 14);
+        // Move down — should clamp at 14.
+        app.handle_key_event(press_key(KeyCode::Down, KeyModifiers::NONE));
+        assert_eq!(app.kb_cursor_row, 14, "should clamp at bottom");
+        // Go to top.
+        app.handle_key_event(press_key(KeyCode::Home, KeyModifiers::NONE));
+        assert_eq!(app.kb_cursor_row, 5, "Home should go to top row");
+        // Move up — should clamp at 5.
+        app.handle_key_event(press_key(KeyCode::Up, KeyModifiers::NONE));
+        assert_eq!(app.kb_cursor_row, 5, "should clamp at top");
+    }
+
+    #[test]
+    fn test_kb_selection_copy_exits_mode() {
+        let mut app = make_app();
+        app.last_selectable_area
+            .set(ratatui::layout::Rect::new(0, 5, 80, 10));
+        app.last_max_scroll.set(0);
+        // Enter selection mode.
+        app.handle_key_event(press_key(KeyCode::Char('v'), KeyModifiers::NONE));
+        assert!(app.kb_select_mode);
+        // Move up to create a non-empty selection.
+        app.handle_key_event(press_key(KeyCode::Up, KeyModifiers::NONE));
+        // Press Enter — should copy and exit.
+        app.handle_key_event(press_key(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(!app.kb_select_mode, "Enter should exit selection mode after copy");
+        assert!(app.selection_anchor.is_none(), "selection should be cleared after copy");
+    }
+
+    // ---- Render pipeline integration: selectable area restriction ----
+
+    #[test]
+    fn test_render_restricts_selectable_area_to_transcript() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut app = make_app();
+        // Add a message so the transcript is non-empty and the welcome
+        // box is not shown.
+        app.messages.push(Message::user("Hello, this is a test message."));
+        app.messages.push(Message::assistant("And this is a response."));
+
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| crate::render::render_app(f, &app)).unwrap();
+
+        // After rendering with messages, last_selectable_area should be
+        // the message pane (last_msg_area), NOT the full terminal.
+        let selectable = app.last_selectable_area.get();
+        let full = ratatui::layout::Rect::new(0, 0, 80, 24);
+        assert!(
+            selectable.height < full.height,
+            "selectable area height ({}) should be less than terminal height ({}) — \
+             it must not include the prompt box and status bar",
+            selectable.height,
+            full.height
+        );
+        assert!(
+            selectable.y > 0 || selectable.height < full.height,
+            "selectable area should be restricted to the transcript pane, not the full terminal"
+        );
+        // last_msg_area should also be set.
+        let msg_area = app.last_msg_area.get();
+        assert_eq!(
+            selectable, msg_area,
+            "selectable area should match last_msg_area after render with messages"
+        );
+        // total_message_lines should have been written (was always 0 before).
+        assert!(
+            app.total_message_lines.get() > 0,
+            "total_message_lines should be > 0 after rendering messages, got {}",
+            app.total_message_lines.get()
+        );
+    }
+
+    #[test]
+    fn test_render_selectable_area_falls_back_on_empty_transcript() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let app = make_app();
+        // No messages — welcome screen shown.
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| crate::render::render_app(f, &app)).unwrap();
+
+        // With no messages, last_msg_area is empty (0x0), so
+        // last_selectable_area should fall back to the full frame.
+        let selectable = app.last_selectable_area.get();
+        let full = ratatui::layout::Rect::new(0, 0, 80, 24);
+        assert_eq!(
+            selectable, full,
+            "selectable area should be the full terminal on the welcome screen"
+        );
+    }
+
+    #[test]
+    fn test_kb_selection_full_pipeline_enter_move_copy() {
+        // End-to-end test: create app with messages, render to populate
+        // last_selectable_area and total_message_lines, then drive the
+        // full key event pipeline (v -> up -> enter) through
+        // handle_key_event, which exercises the real keybinding resolver.
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut app = make_app();
+        app.messages.push(Message::user("First message."));
+        app.messages.push(Message::assistant("Second message."));
+        app.messages.push(Message::user("Third message."));
+
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| crate::render::render_app(f, &app)).unwrap();
+
+        // Verify render populated the area.
+        assert!(app.last_selectable_area.get().height > 0);
+
+        // Enter selection mode via the real key pipeline.
+        app.handle_key_event(press_key(KeyCode::Char('v'), KeyModifiers::NONE));
+        assert!(app.kb_select_mode, "should enter selection mode after render");
+
+        // Move up — should go through the Transcript keybinding context
+        // and call selectionUp -> move_kb_cursor(-1).
+        let start_row = app.kb_cursor_row;
+        app.handle_key_event(press_key(KeyCode::Up, KeyModifiers::NONE));
+        assert_eq!(
+            app.kb_cursor_row,
+            start_row.saturating_sub(1),
+            "up should move cursor up one row after render pipeline"
+        );
+
+        // Move back down.
+        app.handle_key_event(press_key(KeyCode::Down, KeyModifiers::NONE));
+        assert_eq!(app.kb_cursor_row, start_row, "down should restore cursor position");
+
+        // Enter copies and exits (selection may be empty at anchor==focus
+        // but the action handler still fires and exits cleanly).
+        app.handle_key_event(press_key(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(!app.kb_select_mode, "Enter should exit selection mode");
+    }

--- a/src-rust/crates/tui/src/render.rs
+++ b/src-rust/crates/tui/src/render.rs
@@ -882,6 +882,19 @@ pub fn render_app(frame: &mut Frame, app: &App) {
     }
 
     // ---- Text selection highlight (topmost post-pass) ---------------------
+    // Restrict the selectable area to the transcript pane (last_msg_area)
+    // so keyboard and mouse selection can't roam over the prompt box,
+    // status bar, or other UI chrome. Falls back to the full frame when
+    // the transcript is empty (welcome screen).
+    let selectable = {
+        let msg = app.last_msg_area.get();
+        if msg.width > 0 && msg.height > 0 {
+            msg
+        } else {
+            size
+        }
+    };
+    app.last_selectable_area.set(selectable);
     apply_selection_highlight(frame, app);
     cache_selectable_row_text(frame, app);
     render_context_menu(frame, app);
@@ -930,9 +943,6 @@ fn apply_selection_highlight(frame: &mut Frame, app: &App) {
         (Some(a), Some(f)) => (a, f),
         _ => return,
     };
-    if anchor == focus {
-        return;
-    }
 
     let selectable_area = app.last_selectable_area.get();
     if selectable_area.width == 0 || selectable_area.height == 0 {
@@ -966,6 +976,20 @@ fn apply_selection_highlight(frame: &mut Frame, app: &App) {
         focus.0.clamp(selectable_area.x, max_col),
         focus.1.clamp(selectable_area.y, max_row),
     );
+
+    // When anchor == focus, show a cursor bar on the single cell so the
+    // user sees the selection entry point immediately (review point #10).
+    if anchor == focus {
+        if let Some(cell) = frame.buffer_mut().cell_mut((anchor.0, anchor.1)) {
+            cell.set_style(
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(Color::Rgb(200, 200, 200)),
+            );
+        }
+        *app.selection_text.borrow_mut() = String::new();
+        return;
+    }
 
     // Normalise so start ≤ end (row-major order).
     let (start, end) = if (anchor.1, anchor.0) <= (focus.1, focus.0) {
@@ -1194,6 +1218,7 @@ fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
     // at render time). Prevents unbounded inflation when scrolling past the top
     // (#223).
     app.last_max_scroll.set(max_scroll);
+    app.total_message_lines.set(content_height as usize);
     // scroll_offset counts lines above the bottom (0 = at bottom).
     // ratatui scroll() takes an absolute top-row index, so convert:
     //   top_row = max_scroll - scroll_offset  (clamped to [0, max_scroll])


### PR DESCRIPTION
## Summary

Split B of #387. Adds keyboard-driven text selection in the transcript pane.

> This PR is the second half of the #387 split. Split A is #407 (session browser toggles + keyboard selection). No shared payload between the two.

## How it works

1. Press `v` on an empty prompt to enter selection mode. A cursor bar appears at the bottom of the transcript.
2. Use `↑`/`↓` to extend the selection. `PageUp`/`PageDown` scroll by a page, `Home`/`End` jump to the top/bottom.
3. `Enter` or `Ctrl+C` copies the selected text to the clipboard and exits selection mode.
4. `Esc` cancels without copying.

## Review feedback addressed

Every item from the #387 review is fixed:

| # | Review issue | Fix |
|---|---|---|
| 3 | Bare `v` on empty prompt eats first char of messages starting with `v`, shadows vim's `v` | `v` handler is gated on `voice_recorder.is_none()` and `!matches!(vim_mode, Normal/Visual/VisualBlock)`, mirroring the `?` help toggle pattern |
| 4 | `KeyContext::Transcript` bypassed — keys were hardcoded `KeyCode` matches | All selection keys route through `KeyContext::Transcript` in `keybindings.rs`. `current_key_context()` returns `Transcript` when `kb_select_mode` is active |
| 5 | Up/Down scroll branches unreachable | Replaced with `move_kb_cursor(delta)` that clamps to `last_selectable_area` bounds and scrolls to keep the cursor visible |
| 6 | Docs described non-existent features (hjkl, Shift-extend, Enter-yank) | Docs now accurately describe `v` entry, arrow/PageUp/Down/Home/End navigation, Enter/Ctrl+C copy, Esc cancel |
| 7 | Session browser half never runs (dead `App::run` code) | Fixed in #407 (split A) |
| 8 | `Home` scrolls to bottom because `total_message_lines` is always 0 | `total_message_lines` is now written at render time in `render_messages` |
| 9 | `last_selectable_area` is the whole terminal, not the transcript | `render_app` now sets `last_selectable_area` to `last_msg_area` (falls back to full frame on welcome screen) |
| 10 | No visible cursor on entry | `apply_selection_highlight` shows a cursor bar when `anchor == focus` instead of early-returning |
| 11 | `_ => return false` swallows Ctrl+D | Guard at the top of the hardcoded section allows Ctrl+D through; all other unbound keys are swallowed |
| 12 | Preview panel gets clipped | Fixed in #407 (split A) |
| 13 | Test coverage never drives real key events | 13 new tests driving `handle_key_event` with real `KeyEvent`s |

## Files changed

- `crates/core/src/keybindings.rs` — Transcript context bindings updated: `selectionUp/Down/PageUp/PageDown/GoStart/GoEnd/Copy/Cancel`. 2 new core resolver tests.
- `crates/tui/src/app/keys.rs` — `v` entry handler, selection mode guard, `current_key_context` returns Transcript, action handlers, helper methods (`enter_kb_selection`, `exit_kb_selection`, `move_kb_cursor`, `update_kb_selection`)
- `crates/tui/src/app/mod.rs` — `kb_select_mode` and `kb_cursor_row` fields
- `crates/tui/src/render.rs` — `last_selectable_area` restricted to `last_msg_area`, `total_message_lines` written at render time, `apply_selection_highlight` shows cursor bar when `anchor == focus`
- `crates/tui/src/app/tests.rs` — 11 new TUI tests (8 synthetic + 3 render pipeline driving real `TestBackend`/`render_app`/`handle_key_event`)
- `docs/commands.md` — keyboard selection section

## Tests

13 new tests total:
- **2 core keybinding resolver tests** (`crates/core/src/keybindings.rs`): `test_transcript_context_resolves_selection_actions` drives the real `KeybindingResolver::new(&UserKeybindings::default())` and asserts all 8 Transcript actions (selectionUp/Down/PageUp/PageDown/GoStart/GoEnd/Copy/Cancel) resolve correctly. `test_transcript_context_does_not_resolve_chat_actions` verifies context isolation (up in Chat resolves to historyPrev, not selectionUp).
- **8 TUI synthetic unit tests**: enter with `v`, keys swallowed in selection mode, cancel with Esc, context routing, Ctrl+D not swallowed, cursor movement, clamping at bounds, copy exits mode.
- **3 TUI render pipeline tests** using real `TestBackend` + `Terminal` + `render_app`: `test_render_restricts_selectable_area_to_transcript` asserts `last_selectable_area.height < terminal.height`, matches `last_msg_area`, and `total_message_lines > 0` (was always 0 before). `test_render_selectable_area_falls_back_on_empty_transcript` verifies welcome screen fallback. `test_kb_selection_full_pipeline_enter_move_copy` renders messages, then drives `v`→`up`→`down`→`enter` through `handle_key_event` exercising the real keybinding resolver.

All 13 pass. Clippy clean. Cargo check clean.
- Pre-existing failure `settings_screen::tests::all_entries_returns_expected_settings` (expects ≤20 settings, gets 21) is unrelated — fails on `main`, this PR does not touch settings.

## CRLF preservation

`keybindings.rs` and `docs/commands.md` are CRLF files. All additions use `\r\n`. No LF churn on untouched lines.
