### PR TITLE
feat: custom providers and model picker overhaul (rebase of #386)

### DIFF
--- a/src-rust/Cargo.lock
+++ b/src-rust/Cargo.lock
@@ -769,6 +769,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",

--- a/src-rust/crates/api/Cargo.toml
+++ b/src-rust/crates/api/Cargo.toml
@@ -31,3 +31,6 @@ urlencoding = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
 hmac = "0.12"
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/src-rust/crates/api/src/model_registry.rs
+++ b/src-rust/crates/api/src/model_registry.rs
@@ -776,6 +776,10 @@ pub struct ModelRegistry {
     /// after every catalog merge so they stay authoritative across cache reloads
     /// and network refreshes (issue #309).
     overrides: HashMap<String, claurst_core::config::ModelOverride>,
+    /// User-defined custom providers (`customProviders` in settings.json),
+    /// keyed by provider id. Re-registered after every catalog merge so
+    /// custom models survive cache reloads and network refreshes.
+    custom_providers: HashMap<String, claurst_core::config::CustomProviderDef>,
 }
 
 impl ModelRegistry {
@@ -787,6 +791,7 @@ impl ModelRegistry {
             cache_path: None,
             refresh_interval: Duration::from_secs(5 * 60),
             overrides: HashMap::new(),
+            custom_providers: HashMap::new(),
         };
         registry.load_bundled_snapshot();
         registry
@@ -1115,8 +1120,10 @@ impl ModelRegistry {
                 if let Some(parsed) = parse_snapshot_str(&text) {
                     self.merge_entries(parsed.models);
                     self.providers.extend(parsed.providers);
-                    // Re-assert user overrides over the freshly fetched catalog.
+                    // Re-assert user overrides and custom providers over
+                    // the freshly fetched catalog.
                     self.reapply_overrides();
+                    register_custom_providers(&mut self.entries, &mut self.providers, &std::collections::HashMap::new(), &self.custom_providers);
                     if let Some(ref path) = self.cache_path.clone() {
                         // Write the raw response so future loads can re-parse
                         // it identically.  Best-effort; ignore I/O errors.
@@ -1161,8 +1168,10 @@ impl ModelRegistry {
             if !parsed.models.is_empty() {
                 self.merge_entries(parsed.models);
                 self.providers.extend(parsed.providers);
-                // Re-assert user overrides over the freshly merged catalog.
+                // Re-assert user overrides and custom providers over the
+                // freshly merged catalog.
                 self.reapply_overrides();
+                register_custom_providers(&mut self.entries, &mut self.providers, &std::collections::HashMap::new(), &self.custom_providers);
                 return;
             }
         }
@@ -1171,6 +1180,7 @@ impl ModelRegistry {
         if let Ok(entries) = serde_json::from_str::<HashMap<String, ModelEntry>>(&data) {
             self.merge_entries(entries);
             self.reapply_overrides();
+            register_custom_providers(&mut self.entries, &mut self.providers, &std::collections::HashMap::new(), &self.custom_providers);
         }
     }
 
@@ -1234,6 +1244,19 @@ impl ModelRegistry {
         apply_overrides_to_entries(&mut self.entries, &self.overrides);
     }
 
+    /// Register user-defined custom providers and their models into the
+    /// registry. Each model is keyed as `<provider_id>/<model_id>` and a
+    /// synthetic `ModelEntry` is created from the `CustomModelDef` metadata.
+    /// The definitions are retained and re-registered after every catalog
+    /// merge (cache reload, network refresh) so custom models survive.
+    pub fn apply_custom_providers(
+        &mut self,
+        custom_providers: &HashMap<String, claurst_core::config::CustomProviderDef>,
+    ) {
+        let old = std::mem::replace(&mut self.custom_providers, custom_providers.clone());
+        register_custom_providers(&mut self.entries, &mut self.providers, &old, &self.custom_providers);
+    }
+
     /// Re-apply the retained overrides after a catalog merge, so a cache reload
     /// or refresh never wipes out user-corrected metadata. No-op when no
     /// overrides are registered.
@@ -1242,6 +1265,102 @@ impl ModelRegistry {
             return;
         }
         apply_overrides_to_entries(&mut self.entries, &self.overrides);
+    }
+}
+
+/// Register user-defined custom providers and their models into the registry
+/// maps. Each model is keyed as `<provider_id>/<model_id>` and a synthetic
+/// `ModelEntry` is created from the `CustomModelDef` metadata. A
+/// `ProviderEntry` is also created per provider so it shows in `/providers`.
+/// Custom models are re-registered after every catalog merge so they survive
+/// cache reloads and network refreshes. Entries and provider rows for custom
+/// providers that are no longer declared are dropped, so re-applying a
+/// smaller set leaves no stale rows.
+fn register_custom_providers(
+    entries: &mut HashMap<String, ModelEntry>,
+    providers: &mut HashMap<String, ProviderEntry>,
+    old_custom: &HashMap<String, claurst_core::config::CustomProviderDef>,
+    new_custom: &HashMap<String, claurst_core::config::CustomProviderDef>,
+) {
+    // Only drop rows for providers that were PREVIOUSLY registered as custom
+    // but are no longer declared. Never touch catalog-loaded providers.
+    let stale_provider_keys: Vec<String> = old_custom
+        .keys()
+        .filter(|pid| !new_custom.contains_key(*pid))
+        .cloned()
+        .collect();
+    for pid in &stale_provider_keys {
+        providers.remove(pid);
+        let prefix = format!("{}/", pid);
+        entries.retain(|key, _| !key.starts_with(&prefix));
+    }
+
+    for (provider_id, def) in new_custom {
+        providers
+            .entry(provider_id.clone())
+            .or_insert_with(|| ProviderEntry {
+                id: ProviderId::new(provider_id),
+                name: def.name.clone(),
+                env: Vec::new(),
+                api: Some(def.api_base.clone()),
+                npm: None,
+                doc: None,
+            });
+        for (model_id, model_def) in &def.models {
+            let key = format!("{}/{}", provider_id, model_id);
+            // An unset contextWindow would fall through the registry lookup
+            // as "unknown" and the compact heuristic would assume 100k.
+            // Default explicitly instead (128k mirrors the generic fallback)
+            // and warn so the user knows to set a real value.
+            let context_window = match model_def.context_window {
+                Some(w) => w,
+                None => {
+                    tracing::warn!(
+                        provider = %provider_id,
+                        model = %model_id,
+                        "customProvider model has no contextWindow; defaulting to 128k"
+                    );
+                    128_000
+                }
+            };
+            entries.insert(
+                key,
+                ModelEntry {
+                    info: ModelInfo {
+                        id: ModelId::new(model_id),
+                        provider_id: ProviderId::new(provider_id),
+                        name: model_def.name.clone().unwrap_or_else(|| model_id.to_string()),
+                        context_window,
+                        max_output_tokens: model_def.max_output_tokens.unwrap_or(0),
+                        release_date: None,
+                        status: None,
+                    },
+                    family: None,
+                    status: Default::default(),
+                    release_date: None,
+                    last_updated: None,
+                    knowledge: None,
+                    open_weights: false,
+                    tool_calling: true,
+                    reasoning: model_def.reasoning_effort.is_some(),
+                    structured_output: false,
+                    temperature: true,
+                    attachment: false,
+                    interleaved: None,
+                    modalities_input: vec![Modality::Text],
+                    modalities_output: vec![Modality::Text],
+                    cost_input: None,
+                    cost_output: None,
+                    cost_cache_read: None,
+                    cost_cache_write: None,
+                    cost: Default::default(),
+                    provider_override: None,
+                    experimental_modes: Default::default(),
+                    options: Default::default(),
+                    headers: Default::default(),
+                },
+            );
+        }
     }
 }
 
@@ -1567,6 +1686,109 @@ pub fn effective_model_for_config(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- custom providers (settings `customProviders`) -----------------
+
+    fn sample_custom_providers() -> std::collections::HashMap<
+        String,
+        claurst_core::config::CustomProviderDef,
+    > {
+        use claurst_core::config::{CustomModelDef, CustomProviderDef};
+        let mut models = std::collections::HashMap::new();
+        models.insert(
+            "My-Model-X".to_string(),
+            CustomModelDef {
+                name: Some("My Model X".to_string()),
+                context_window: Some(64_000),
+                max_output_tokens: Some(8_192),
+                reasoning_effort: Some("high".to_string()),
+            },
+        );
+        models.insert(
+            "plain-model".to_string(),
+            CustomModelDef::default(),
+        );
+        let mut providers = std::collections::HashMap::new();
+        providers.insert(
+            "acme-gateway".to_string(),
+            CustomProviderDef {
+                name: "Acme Gateway".to_string(),
+                api_base: "https://gateway.internal.example/v1".to_string(),
+                api_key: Some("{env:ACME_GATEWAY_KEY}".to_string()),
+                headers: Default::default(),
+                models,
+                request_timeout_secs: Some(120),
+                include_usage_in_stream: Some(false),
+                reasoning_field: Some("reasoning_content".to_string()),
+            },
+        );
+        providers
+    }
+
+    #[test]
+    fn custom_providers_register_models_and_provider_entry() {
+        let mut reg = ModelRegistry::new();
+        reg.apply_custom_providers(&sample_custom_providers());
+
+        // Provider entry shows in /providers with the user's display name.
+        let provider = reg
+            .provider("acme-gateway")
+            .expect("custom provider registered");
+        assert_eq!(provider.name, "Acme Gateway");
+
+        // Mixed-case model keys register under the exact id.
+        let entry = reg
+            .get("acme-gateway", "My-Model-X")
+            .expect("exact-case key");
+        assert_eq!(entry.info.context_window, 64_000);
+        assert_eq!(entry.info.max_output_tokens, 8_192);
+        assert!(
+            entry.reasoning,
+            "reasoning_effort set means reasoning-capable"
+        );
+        assert_eq!(entry.info.name, "My Model X");
+
+        // Bare model with unset contextWindow defaults to 128k, not 0
+        // (0 would be rejected by MIN_PLAUSIBLE_REGISTRY_WINDOW).
+        let plain = reg
+            .get("acme-gateway", "plain-model")
+            .expect("plain model");
+        assert_eq!(plain.info.context_window, 128_000);
+        assert!(!plain.reasoning);
+
+        // list_by_provider surfaces both.
+        assert_eq!(reg.list_by_provider("acme-gateway").len(), 2);
+    }
+
+    #[test]
+    fn custom_providers_survive_cache_reload() {
+        // A cache load merges the cached catalog over the registry; the
+        // custom providers must be re-registered afterwards, not wiped.
+        let mut reg = ModelRegistry::new();
+        reg.apply_custom_providers(&sample_custom_providers());
+
+        let dir = tempfile::tempdir().unwrap();
+        let cache = dir.path().join("models.json");
+        std::fs::write(&cache, "{}").unwrap();
+        reg.load_cache(&cache);
+
+        assert!(
+            reg.get("acme-gateway", "My-Model-X").is_some(),
+            "custom model must survive a cache reload"
+        );
+        assert!(reg.provider("acme-gateway").is_some());
+    }
+
+    #[test]
+    fn apply_custom_providers_replaces_previous_set() {
+        // Re-applying with an empty map drops the old entries: the call
+        // replaces the retained set rather than merging into it.
+        let mut reg = ModelRegistry::new();
+        reg.apply_custom_providers(&sample_custom_providers());
+        reg.apply_custom_providers(&Default::default());
+        assert!(reg.get("acme-gateway", "My-Model-X").is_none());
+        assert!(reg.provider("acme-gateway").is_none());
+    }
 
     #[test]
     fn bundled_snapshot_loads() {

--- a/src-rust/crates/api/src/providers/openai_compat.rs
+++ b/src-rust/crates/api/src/providers/openai_compat.rs
@@ -210,6 +210,16 @@ impl OpenAiCompatProvider {
         self
     }
 
+    /// Override the HTTP client's request timeout. Used by custom providers
+    /// that declare `requestTimeoutSecs` in settings.json. Rebuilding the
+    /// reqwest client is the only way to change a `Client`'s timeout.
+    pub fn with_request_timeout(mut self, timeout: std::time::Duration) -> Self {
+        if let Ok(client) = reqwest::Client::builder().timeout(timeout).build() {
+            self.http_client = client;
+        }
+        self
+    }
+
     // -----------------------------------------------------------------------
     // Internal helpers
     // -----------------------------------------------------------------------

--- a/src-rust/crates/api/src/registry.rs
+++ b/src-rust/crates/api/src/registry.rs
@@ -266,6 +266,57 @@ pub fn provider_from_config(
         "codex" | "openai-codex" => {
             CodexProvider::from_stored().map(|provider| Arc::new(provider) as Arc<dyn LlmProvider>)
         }
+        // User-defined OpenAI-compatible providers (`customProviders` in
+        // settings.json): merged into `provider_configs` by
+        // `Settings::effective_config`. Recognized by a `provider_configs`
+        // entry with an api_base under a non-builtin id. Built as a generic
+        // OpenAI-compat provider with headers, reasoning-field quirk, and
+        // per-provider timeout from the definition.
+        id if provider_cfg.is_some()
+            && api_base.is_some()
+            && !claurst_core::provider_id::ProviderId::builtin_provider_ids()
+                .contains(&id) =>
+        {
+            let provider_cfg = provider_cfg.expect("checked by guard");
+            let api_base = api_base.expect("checked by guard");
+            let display_name = provider_cfg
+                .options
+                .get("display_name")
+                .and_then(|v| v.as_str())
+                .unwrap_or(provider_id);
+            let mut provider = crate::providers::openai_compat::OpenAiCompatProvider::new(
+                provider_id,
+                display_name,
+                api_base,
+            );
+            if let Some(key) = api_key {
+                provider = provider.with_api_key(key);
+            }
+            for (name, value) in &provider_cfg.headers {
+                provider = provider.with_header(name.clone(), value.clone());
+            }
+            let reasoning_field = provider_cfg
+                .options
+                .get("reasoning_field")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            let include_usage = provider_cfg
+                .options
+                .get("include_usage_in_stream")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(true);
+            if reasoning_field.is_some() || !include_usage {
+                provider = provider.with_quirks(crate::providers::openai_compat::ProviderQuirks {
+                    reasoning_field,
+                    include_usage_in_stream: include_usage,
+                    ..Default::default()
+                });
+            }
+            if let Some(secs) = provider_cfg.request_timeout_secs {
+                provider = provider.with_request_timeout(std::time::Duration::from_secs(secs));
+            }
+            Some(Arc::new(provider))
+        }
         _ => api_key.and_then(|key| provider_from_key(provider_id, key)),
     }
 }

--- a/src-rust/crates/cli/src/main.rs
+++ b/src-rust/crates/cli/src/main.rs
@@ -1045,10 +1045,11 @@ async fn run_models_command(args: &[String]) -> anyhow::Result<()> {
 
     // Layer user metadata overrides on top of the catalog (issue #309) so the
     // listing matches what the TUI picker and context logic use.
-    let overrides = claurst_core::config::Settings::load_sync()
-        .map(|s| s.effective_config().model_overrides)
+    let effective = claurst_core::config::Settings::load_sync()
+        .map(|s| s.effective_config())
         .unwrap_or_default();
-    registry.apply_model_overrides(&overrides);
+    registry.apply_model_overrides(&effective.model_overrides);
+    registry.apply_custom_providers(&effective.custom_providers);
 
     let mut entries: Vec<&claurst_api::ModelEntry> = match &provider_filter {
         Some(pid) => registry.list_by_provider(pid),
@@ -1191,6 +1192,10 @@ fn load_cached_model_registry(config: &Config) -> Arc<claurst_api::ModelRegistry
     // Layer user metadata overrides on top of the catalog (issue #309). Stored
     // in the registry, so any later cache reload re-asserts them automatically.
     reg.apply_model_overrides(&config.model_overrides);
+    // Register user-defined custom providers so their models appear in
+    // listings and resolve for routing. `config.custom_providers` was
+    // populated from settings at load time.
+    reg.apply_custom_providers(&config.custom_providers);
     Arc::new(reg)
 }
 
@@ -3799,6 +3804,7 @@ async fn run_interactive(
                                                                 ctx_for(&id, m.context_window),
                                                             ),
                                                         is_current: false,
+                                                        provider_id: String::new(),
                                                     }
                                                 })
                                             })
@@ -3815,6 +3821,7 @@ async fn run_interactive(
                                                             ctx_for(&id, m.context_window),
                                                         ),
                                                     id,
+                                                    provider_id: String::new(),
                                                     is_current: false,
                                                 }
                                             })

--- a/src-rust/crates/core/src/keybindings.rs
+++ b/src-rust/crates/core/src/keybindings.rs
@@ -329,6 +329,22 @@ pub fn default_bindings() -> Vec<ParsedBinding> {
         ("escape", "cancel", KeyContext::Select),
         ("/", "search", KeyContext::Select),
 
+        // ========== MODEL PICKER ==========
+        ("up", "prevModel", KeyContext::ModelPicker),
+        ("down", "nextModel", KeyContext::ModelPicker),
+        ("pageup", "pageUp", KeyContext::ModelPicker),
+        ("pagedown", "pageDown", KeyContext::ModelPicker),
+        ("home", "firstModel", KeyContext::ModelPicker),
+        ("end", "lastModel", KeyContext::ModelPicker),
+        ("enter", "selectModel", KeyContext::ModelPicker),
+        ("escape", "cancelModelPicker", KeyContext::ModelPicker),
+        ("left", "effortDown", KeyContext::ModelPicker),
+        ("right", "effortUp", KeyContext::ModelPicker),
+        ("tab", "nextProvider", KeyContext::ModelPicker),
+        ("shift+tab", "prevProvider", KeyContext::ModelPicker),
+        ("f", "toggleFavorite", KeyContext::ModelPicker),
+        ("a", "toggleShowAllProviders", KeyContext::ModelPicker),
+
         // ========== PLUGIN & ATTACHMENTS ==========
         ("up", "prev", KeyContext::Plugin),
         ("down", "next", KeyContext::Plugin),

--- a/src-rust/crates/core/src/lib.rs
+++ b/src-rust/crates/core/src/lib.rs
@@ -89,7 +89,7 @@ pub use types::{
     ContentBlock, ImageSource, DocumentSource, CitationsConfig, Message, MessageContent,
     MessageCost, Role, ToolDefinition, ToolResultContent, UsageInfo,
 };
-pub use config::{AgentDefinition, BudgetSplitPolicy, Config, CommandTemplate, FormatterConfig, ManagedAgentConfig, ManagedAgentPreset, McpServerConfig, McpServerOrigin, OutputFormat, PermissionMode, ProviderConfig, Settings, SkillsConfig, Theme, builtin_managed_agent_presets, default_agents, strip_jsonc_comments, substitute_env_vars};
+pub use config::{AgentDefinition, BudgetSplitPolicy, Config, CommandTemplate, CustomModelDef, CustomProviderDef, FormatterConfig, ManagedAgentConfig, ManagedAgentPreset, McpServerConfig, McpServerOrigin, OutputFormat, PermissionMode, ProviderConfig, Settings, SkillsConfig, Theme, builtin_managed_agent_presets, default_agents, strip_jsonc_comments, substitute_env_vars};
 pub use import_config::{ClaudeMdPreview, ImportExecutionResult, ImportPaths, ImportPreview, ImportSelection, PreviewAction, PreviewField, SettingsPreview, build_import_preview, execute_import, summarize_import_result};
 
 // Skill discovery: filesystem and git URL skill loading.
@@ -921,6 +921,11 @@ pub mod config {
         /// Provider-specific options (passed through to provider implementation)
         #[serde(default)]
         pub options: HashMap<String, serde_json::Value>,
+        /// Extra HTTP headers sent on every request to this provider.
+        /// Populated for user-defined custom providers from their
+        /// `headers` map; ignored by built-in providers that don't read it.
+        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        pub headers: HashMap<String, String>,
         /// Total request timeout in seconds for this provider's HTTP client.
         /// Overrides the global [`Config::request_timeout_secs`] when set.
         /// Useful for slow local models (CPU inference, large MoE) that can take
@@ -943,8 +948,160 @@ pub mod config {
                 models_whitelist: Vec::new(),
                 models_blacklist: Vec::new(),
                 options: HashMap::new(),
+                headers: HashMap::new(),
                 request_timeout_secs: None,
             }
+        }
+    }
+
+    impl ProviderConfig {
+        /// Build the `provider_configs` entry for a user-defined custom
+        /// provider: base URL + API key (raw, still `{env:VAR}`-substituted at
+        /// resolution time) + headers + per-provider timeout, plus the
+        /// OpenAI-compat options the custom-provider definition carries.
+        pub fn from_custom_provider(def: &CustomProviderDef) -> Self {
+            let mut options: HashMap<String, serde_json::Value> = HashMap::new();
+            options.insert(
+                "display_name".to_string(),
+                serde_json::Value::String(def.name.clone()),
+            );
+            if let Some(reasoning_field) = &def.reasoning_field {
+                options.insert(
+                    "reasoning_field".to_string(),
+                    serde_json::Value::String(reasoning_field.clone()),
+                );
+            }
+            if let Some(include_usage) = def.include_usage_in_stream {
+                options.insert(
+                    "include_usage_in_stream".to_string(),
+                    serde_json::Value::Bool(include_usage),
+                );
+            }
+            Self {
+                api_key: def.api_key.clone(),
+                api_base: Some(def.api_base.clone()),
+                enabled: true,
+                models_whitelist: Vec::new(),
+                models_blacklist: Vec::new(),
+                options,
+                headers: def.headers.clone(),
+                request_timeout_secs: def.request_timeout_secs,
+            }
+        }
+    }
+
+    // ---- CustomModelDef --------------------------------------------------
+
+    /// A model definition within a custom OpenAI-compatible provider.
+    #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+    pub struct CustomModelDef {
+        /// Total context window size in tokens.
+        #[serde(
+            default,
+            rename = "contextWindow",
+            alias = "context_window",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub context_window: Option<u32>,
+        /// Maximum tokens the model can emit in a single response.
+        #[serde(
+            default,
+            rename = "maxOutputTokens",
+            alias = "max_output_tokens",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub max_output_tokens: Option<u32>,
+        /// Human-readable display name shown in the model picker.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub name: Option<String>,
+        /// Reasoning effort level (e.g. "high", "max", "none").
+        #[serde(
+            default,
+            rename = "reasoningEffort",
+            alias = "reasoning_effort",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub reasoning_effort: Option<String>,
+    }
+
+    // ---- CustomProviderDef -----------------------------------------------
+
+    /// A user-defined OpenAI-compatible provider, stored in
+    /// [`Settings::custom_providers`] keyed by its unique id.
+    ///
+    /// Unlike [`ProviderConfig`] (which tweaks built-in providers), this is a
+    /// fully self-contained provider definition with its own base URL, API key,
+    /// custom headers, and model catalog. The id (map key) becomes the provider
+    /// id used in `provider/model` routing.
+    ///
+    /// Kept deliberately small: only knobs the request path actually consumes
+    /// (base URL, key, headers, timeout, reasoning field, usage-in-stream,
+    /// model catalog). Streaming is always on — the workspace has no
+    /// non-streaming fallback today, so a `streaming: false` knob would be dead
+    /// configuration.
+    #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+    pub struct CustomProviderDef {
+        /// Human-readable display name shown in the provider picker.
+        #[serde(default)]
+        pub name: String,
+        /// OpenAI-compatible base URL (claurst appends `/chat/completions`).
+        #[serde(rename = "apiBase", alias = "api_base")]
+        pub api_base: String,
+        /// API key. Supports `{env:VAR_NAME}` substitution at resolution time.
+        /// `None` means no key — provider is registered but health_check
+        /// returns `Unavailable`.
+        #[serde(
+            rename = "apiKey",
+            alias = "api_key",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub api_key: Option<String>,
+        /// Custom HTTP headers sent on every request to this provider.
+        #[serde(default)]
+        pub headers: HashMap<String, String>,
+        /// Model catalog local to this provider, keyed by model id.
+        #[serde(default)]
+        pub models: HashMap<String, CustomModelDef>,
+        /// Per-provider request timeout override in seconds.
+        #[serde(
+            default,
+            rename = "requestTimeoutSecs",
+            alias = "request_timeout_secs",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub request_timeout_secs: Option<u64>,
+        /// Whether to send `stream_options.include_usage` when streaming.
+        /// Default: true. Set to false for providers that don't support it.
+        #[serde(
+            default,
+            rename = "includeUsageInStream",
+            alias = "include_usage_in_stream",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub include_usage_in_stream: Option<bool>,
+        /// JSON field name for reasoning/thinking content (e.g.
+        /// "reasoning_content" for DeepSeek). None means no reasoning field.
+        #[serde(
+            default,
+            rename = "reasoningField",
+            alias = "reasoning_field",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub reasoning_field: Option<String>,
+    }
+
+    impl CustomProviderDef {
+        /// Resolve the API key, substituting `{env:VAR_NAME}` patterns with
+        /// the corresponding environment variable value. Uses the same
+        /// [`substitute_env_vars`] helper as the rest of the config system,
+        /// so embedded patterns like `Bearer {env:FOO}` work too. Returns
+        /// `None` if the key is absent or resolves to an empty string.
+        pub fn resolve_api_key(&self) -> Option<String> {
+            self.api_key
+                .as_ref()
+                .map(|raw| substitute_env_vars(raw))
+                .filter(|key| !key.is_empty())
         }
     }
 
@@ -1050,6 +1207,16 @@ pub mod config {
         /// Per-provider configurations
         #[serde(default)]
         pub provider_configs: HashMap<String, ProviderConfig>,
+        /// User-favorited model keys (`"provider/model"`), copied from
+        /// Settings on load. The picker reads this, not the settings file.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        pub favorite_models: Vec<String>,
+        /// User-defined OpenAI-compatible providers (`customProviders` in
+        /// settings.json), copied from Settings on load. The model registry
+        /// registers their model catalogs; request paths consume the merged
+        /// `provider_configs` entries instead.
+        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        pub custom_providers: HashMap<String, CustomProviderDef>,
         /// User-supplied model metadata overrides, keyed by `"provider/model"`.
         /// Take precedence over the models.dev catalog (copied from Settings on
         /// load; see [`ModelOverride`]).
@@ -1252,6 +1419,29 @@ pub mod config {
         /// Per-provider configurations stored in settings.json.
         #[serde(default)]
         pub providers: HashMap<String, ProviderConfig>,
+        /// User-defined OpenAI-compatible providers, keyed by unique id.
+        /// Each entry is a self-contained provider with its own base URL,
+        /// API key, headers, and model catalog. The id becomes the provider
+        /// id used in `provider/model` routing. Merged into
+        /// `Config::provider_configs` once at load time (see
+        /// [`Settings::effective_config`]) so request paths never re-read
+        /// the settings file.
+        #[serde(
+            default,
+            rename = "customProviders",
+            alias = "custom_providers"
+        )]
+        pub custom_providers: HashMap<String, CustomProviderDef>,
+        /// User-favorited model keys (`"provider/model"` format). Shown in a
+        /// dedicated section at the top of the /model picker. Matching uses
+        /// the full provider-prefixed key so `free/auto` and
+        /// `openai/gpt-4o` are distinguishable.
+        #[serde(
+            default,
+            rename = "favoriteModels",
+            alias = "favorite_models"
+        )]
+        pub favorite_models: Vec<String>,
         /// User-supplied model metadata overrides stored in settings.json,
         /// keyed by `"provider/model"`. Merged into
         /// [`Config::model_overrides`] by [`Settings::effective_config`] and
@@ -1514,8 +1704,12 @@ pub mod config {
                         .find_map(|var| std::env::var(var).ok().filter(|v| !v.is_empty()))
                 })
                 .or_else(|| crate::AuthStore::load().api_key_for(provider_id))
-                // Support {env:VAR_NAME} patterns in the resolved value
+                // Support {env:VAR_NAME} patterns in the resolved value.
+                // Filter AFTER substitution so an unset env var inside the
+                // pattern yields None instead of a blank key — otherwise
+                // the picker marks the provider connected and requests 401.
                 .map(|key| substitute_env_vars(&key))
+                .filter(|key| !key.is_empty())
         }
 
         pub fn resolve_anthropic_api_key(&self) -> Option<String> {
@@ -1533,8 +1727,11 @@ pub mod config {
                         .iter()
                         .find_map(|var| std::env::var(var).ok().filter(|v| !v.is_empty()))
                 })
-                // Support {env:VAR_NAME} patterns in the resolved value
+                // Support {env:VAR_NAME} patterns in the resolved value.
+                // Filter after substitution: an unset env var inside the
+                // pattern must yield None, not a blank key.
                 .map(|key| substitute_env_vars(&key))
+                .filter(|key| !key.is_empty())
         }
 
         /// Resolve the API key for the active provider.
@@ -1820,6 +2017,39 @@ pub mod config {
             for (id, pc) in &self.providers {
                 config.provider_configs.entry(id.clone()).or_insert_with(|| pc.clone());
             }
+            // Merge custom providers into provider_configs once, here, so
+            // request paths resolve keys/base URLs through the normal
+            // provider_configs lookup instead of re-reading settings.json.
+            // A custom provider whose id collides with a built-in provider
+            // would silently shadow the real one; skip those with a warning.
+            // An explicit `providers.<id>` entry also wins over a custom
+            // provider with the same id.
+            let builtin_ids = crate::provider_id::ProviderId::builtin_provider_ids();
+            for (id, cp) in &self.custom_providers {
+                if builtin_ids.contains(&id.as_str()) {
+                    tracing::warn!(
+                        provider = %id,
+                        "customProviders entry shadows a built-in provider id; ignoring it"
+                    );
+                    continue;
+                }
+                config
+                    .provider_configs
+                    .entry(id.clone())
+                    .or_insert_with(|| ProviderConfig::from_custom_provider(cp));
+            }
+            // Copy favorite model keys and custom provider defs onto Config
+            // so the picker and model registry do not read Settings per frame.
+            // Builtin-id collisions are excluded here too, so consumers of
+            // Config.custom_providers (model registry, picker, provider
+            // options) never see a shadowing entry.
+            config.favorite_models = self.favorite_models.clone();
+            config.custom_providers = self
+                .custom_providers
+                .iter()
+                .filter(|(id, _)| !builtin_ids.contains(&id.as_str()))
+                .map(|(id, def)| (id.clone(), def.clone()))
+                .collect();
             // Merge top-level `modelOverrides` into config.model_overrides
             // (nested `config` block wins for keys present in both).
             for (id, ov) in &self.model_overrides {
@@ -1962,6 +2192,16 @@ pub mod config {
                 hooks: merge_map(base.config.hooks, over.config.hooks),
                 provider: over.config.provider.or(base.config.provider),
                 provider_configs: merge_map(base.config.provider_configs, over.config.provider_configs),
+                custom_providers: merge_map(base.config.custom_providers, over.config.custom_providers),
+                favorite_models: {
+                    let mut v = base.config.favorite_models;
+                    for f in over.config.favorite_models {
+                        if !v.contains(&f) {
+                            v.push(f);
+                        }
+                    }
+                    v
+                },
                 model_overrides: merge_map(base.config.model_overrides, over.config.model_overrides),
                 formatter: merge_map(base.config.formatter, over.config.formatter),
                 commands: merge_map(base.config.commands, over.config.commands),
@@ -2007,6 +2247,8 @@ pub mod config {
                 last_seen_version: over.last_seen_version.or(base.last_seen_version),
                 provider: over.provider.or(base.provider),
                 providers: merge_map(base.providers, over.providers),
+                custom_providers: merge_map(base.custom_providers, over.custom_providers),
+                favorite_models: { let mut v = base.favorite_models; for f in over.favorite_models { if !v.contains(&f) { v.push(f); } } v },
                 model_overrides: merge_map(base.model_overrides, over.model_overrides),
                 commands: merge_map(base.commands, over.commands),
                 formatter: merge_map(base.formatter, over.formatter),
@@ -4596,6 +4838,131 @@ pub mod tasks {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- customProviders (Settings -> effective Config) -----------------
+
+    fn sample_custom_provider() -> crate::config::CustomProviderDef {
+        let mut models = std::collections::HashMap::new();
+        models.insert(
+            "my-model".to_string(),
+            crate::config::CustomModelDef {
+                context_window: Some(64_000),
+                max_output_tokens: Some(8_192),
+                name: Some("My Model".to_string()),
+                reasoning_effort: None,
+            },
+        );
+        crate::config::CustomProviderDef {
+            name: "Acme Gateway".to_string(),
+            api_base: "https://gateway.internal.example/v1".to_string(),
+            api_key: Some("{env:ACME_GATEWAY_KEY}".to_string()),
+            headers: Default::default(),
+            models,
+            request_timeout_secs: Some(120),
+            include_usage_in_stream: Some(false),
+            reasoning_field: Some("reasoning_content".to_string()),
+        }
+    }
+
+    #[test]
+    fn custom_providers_merge_into_effective_config() {
+        let mut settings = crate::config::Settings::default();
+        settings
+            .custom_providers
+            .insert("acme-gateway".to_string(), sample_custom_provider());
+        settings.favorite_models = vec!["acme-gateway/my-model".to_string()];
+
+        let config = settings.effective_config();
+
+        // Merged into provider_configs for the request path...
+        let pc = config
+            .provider_configs
+            .get("acme-gateway")
+            .expect("custom provider merged into provider_configs");
+        assert_eq!(
+            pc.api_base.as_deref(),
+            Some("https://gateway.internal.example/v1")
+        );
+        assert_eq!(pc.request_timeout_secs, Some(120));
+        // ...and the defs are copied onto Config for the picker/registry.
+        assert!(config.custom_providers.contains_key("acme-gateway"));
+        assert_eq!(config.favorite_models, vec!["acme-gateway/my-model"]);
+    }
+
+    #[test]
+    fn custom_provider_cannot_shadow_builtin_provider() {
+        let mut settings = crate::config::Settings::default();
+        settings
+            .custom_providers
+            .insert("openai".to_string(), sample_custom_provider());
+
+        let config = settings.effective_config();
+
+        // The builtin id is skipped with a warning rather than merged over
+        // the real OpenAI provider config.
+        if let Some(pc) = config.provider_configs.get("openai") {
+            assert_ne!(
+                pc.api_base.as_deref(),
+                Some("https://gateway.internal.example/v1"),
+                "customProviders.openai must not shadow the builtin provider"
+            );
+        }
+        assert!(
+            !config.custom_providers.contains_key("openai"),
+            "colliding custom provider id must be dropped from Config.custom_providers"
+        );
+    }
+
+    #[test]
+    fn explicit_providers_entry_wins_over_custom_provider() {
+        let mut settings = crate::config::Settings::default();
+        settings.providers.insert(
+            "acme-gateway".to_string(),
+            crate::config::ProviderConfig {
+                api_base: Some("https://explicit.example/v1".to_string()),
+                ..Default::default()
+            },
+        );
+        settings
+            .custom_providers
+            .insert("acme-gateway".to_string(), sample_custom_provider());
+
+        let config = settings.effective_config();
+        let pc = config
+            .provider_configs
+            .get("acme-gateway")
+            .expect("merged provider config");
+        assert_eq!(
+            pc.api_base.as_deref(),
+            Some("https://explicit.example/v1"),
+            "providers.<id> entry wins over customProviders.<id>"
+        );
+    }
+
+    #[test]
+    fn custom_provider_settings_serde_roundtrip() {
+        // camelCase keys round-trip: apiBase, apiKey, contextWindow, etc.
+        let mut settings = crate::config::Settings::default();
+        settings
+            .custom_providers
+            .insert("acme-gateway".to_string(), sample_custom_provider());
+        settings.favorite_models = vec!["acme-gateway/my-model".to_string()];
+
+        let json = serde_json::to_string(&settings).unwrap();
+        assert!(json.contains("\"customProviders\""), "{json}");
+        assert!(json.contains("\"apiBase\""), "{json}");
+        assert!(json.contains("\"favoriteModels\""), "{json}");
+
+        let back: crate::config::Settings = serde_json::from_str(&json).unwrap();
+        let def = back
+            .custom_providers
+            .get("acme-gateway")
+            .expect("roundtripped");
+        assert_eq!(def.api_base, "https://gateway.internal.example/v1");
+        assert!(back
+            .favorite_models
+            .contains(&"acme-gateway/my-model".to_string()));
+    }
 
     #[test]
     fn test_message_user() {

--- a/src-rust/crates/core/src/provider_id.rs
+++ b/src-rust/crates/core/src/provider_id.rs
@@ -79,6 +79,69 @@ impl ProviderId {
     pub const ROUTING: &'static str = "routing";
     pub const NEURALWATT: &'static str = "neuralwatt";
     pub const FREE: &'static str = "free";
+
+    /// All built-in provider ids. A `customProviders` entry with one of
+    /// these ids would silently shadow the real provider, so
+    /// `Settings::effective_config` skips those with a warning.
+    pub fn builtin_provider_ids() -> &'static [&'static str] {
+        &[
+            Self::ANTHROPIC,
+            Self::OPENAI,
+            Self::GOOGLE,
+            Self::GOOGLE_VERTEX,
+            Self::AMAZON_BEDROCK,
+            Self::AZURE,
+            Self::GITHUB_COPILOT,
+            Self::MISTRAL,
+            Self::XAI,
+            Self::GROQ,
+            Self::DEEPINFRA,
+            Self::CEREBRAS,
+            Self::COHERE,
+            Self::CROF,
+            Self::TOGETHER_AI,
+            Self::PERPLEXITY,
+            Self::OPENROUTER,
+            Self::OLLAMA,
+            Self::LM_STUDIO,
+            Self::LLAMA_CPP,
+            Self::DEEPSEEK,
+            Self::GITLAB,
+            Self::CLOUDFLARE,
+            Self::VENICE,
+            Self::SAP,
+            Self::SAMBANOVA,
+            Self::HUGGINGFACE,
+            Self::NVIDIA,
+            Self::SILICONFLOW,
+            Self::MOONSHOT,
+            Self::ZHIPU,
+            Self::ZAI,
+            Self::NEBIUS,
+            Self::OVHCLOUD,
+            Self::SCALEWAY,
+            Self::VULTR,
+            Self::BASETEN,
+            Self::FRIENDLI,
+            Self::UPSTAGE,
+            Self::STEPFUN,
+            Self::FIREWORKS,
+            Self::NOVITA,
+            Self::MINIMAX,
+            Self::CODEX,
+            Self::OPENCODE_GO,
+            Self::OPENCODE_ZEN,
+            Self::SYNTHETIC,
+            Self::ROUTING,
+            Self::NEURALWATT,
+            Self::FREE,
+            // OpenAI-compat aliases accepted by the registry.
+            "lmstudio",
+            "llamacpp",
+            "llama-server",
+            "openai-codex",
+        ]
+    }
 }
 
 impl fmt::Display for ProviderId {

--- a/src-rust/crates/query/src/lib.rs
+++ b/src-rust/crates/query/src/lib.rs
@@ -832,7 +832,13 @@ pub async fn run_query_loop(
                     "vultr", "vultr-ai",
                     "baseten", "friendli", "upstage", "stepfun",
                 ];
-                if known_providers.contains(&p) {
+                if known_providers.contains(&p)
+                    // Custom providers declared in settings (`customProviders`)
+                    // are dispatched by id the same way as built-ins. The
+                    // defs were copied onto Config at load time, so this is
+                    // an in-memory lookup, not a settings read per request.
+                    || tool_ctx.config.custom_providers.contains_key(p)
+                {
                     (p.to_string(), m.to_string())
                 } else {
                     // Treat the whole string as the model ID, fall through
@@ -992,6 +998,7 @@ pub async fn run_query_loop(
                             &model_id_str,
                             effective_effort_level,
                             effective_thinking_budget,
+                            &tool_ctx.config.custom_providers,
                         ),
                     };
 
@@ -2338,6 +2345,7 @@ mod tests {
             "gemini-3-flash-preview",
             Some(claurst_core::effort::EffortLevel::High),
             None,
+            &std::collections::HashMap::new(),
         );
         assert_eq!(
             options["thinkingConfig"]["thinkingLevel"],
@@ -2356,6 +2364,7 @@ mod tests {
             "gpt-5.4",
             Some(claurst_core::effort::EffortLevel::Medium),
             None,
+            &std::collections::HashMap::new(),
         );
         assert_eq!(options["reasoningEffort"], serde_json::json!("medium"));
         assert_eq!(options["textVerbosity"], serde_json::json!("low"));
@@ -2370,7 +2379,7 @@ mod tests {
             (claurst_core::effort::EffortLevel::Medium, "medium"),
             (claurst_core::effort::EffortLevel::High, "high"),
         ] {
-            let options = build_provider_options("openai-codex", "gpt-5.5", Some(level), None);
+            let options = build_provider_options("openai-codex", "gpt-5.5", Some(level), None, &std::collections::HashMap::new());
             assert_eq!(options["reasoningEffort"], serde_json::json!(expected));
         }
         // ...but the top "Max" tier becomes "xhigh" (extra high) on Codex.
@@ -2379,6 +2388,7 @@ mod tests {
             "gpt-5.5",
             Some(claurst_core::effort::EffortLevel::Max),
             None,
+            &std::collections::HashMap::new(),
         );
         assert_eq!(options["reasoningEffort"], serde_json::json!("xhigh"));
         assert_eq!(options["reasoningSummary"], serde_json::json!("auto"));
@@ -2389,6 +2399,7 @@ mod tests {
             "gpt-5.4",
             Some(claurst_core::effort::EffortLevel::Max),
             None,
+            &std::collections::HashMap::new(),
         );
         assert_eq!(other["reasoningEffort"], serde_json::json!("high"));
     }
@@ -2397,9 +2408,10 @@ mod tests {
     fn test_build_provider_options_for_bedrock_anthropic() {
         let options = build_provider_options(
             "amazon-bedrock",
-            "anthropic.claude-sonnet-4-6-v1",
+            "anthropic.claude-sonnet-sonnet-4-6-v1",
             Some(claurst_core::effort::EffortLevel::High),
             Some(10_000),
+            &std::collections::HashMap::new(),
         );
         assert_eq!(
             options["reasoningConfig"]["budgetTokens"],
@@ -2411,8 +2423,8 @@ mod tests {
     fn test_alibaba_is_openaiish_provider() {
         // "alibaba" is an alias for "qwen" (Alibaba's DashScope backend);
         // both must be treated as OpenAI-compatible providers.
-        assert!(is_openaiish_provider("alibaba"));
-        assert!(is_openaiish_provider("qwen"));
+        assert!(is_openaiish_provider("alibaba", &std::collections::HashMap::new()));
+        assert!(is_openaiish_provider("qwen", &std::collections::HashMap::new()));
     }
 
     // ---- apply_compact_result / #213 data-loss guard ------------------------

--- a/src-rust/crates/query/src/runner/provider_options.rs
+++ b/src-rust/crates/query/src/runner/provider_options.rs
@@ -51,7 +51,17 @@ pub(crate) fn is_openai_reasoning_model(model_id: &str) -> bool {
         || model_id.starts_with("o4")
 }
 
-pub(crate) fn is_openaiish_provider(provider_id: &str) -> bool {
+/// Whether `provider_id` routes through an OpenAI-compatible adapter.
+/// `custom_providers` are user-defined OpenAI-compatible providers from
+/// settings (`customProviders`); pass the effective Config's map so this
+/// stays an in-memory lookup, not a settings read per request.
+pub(crate) fn is_openaiish_provider(
+    provider_id: &str,
+    custom_providers: &std::collections::HashMap<String, claurst_core::config::CustomProviderDef>,
+) -> bool {
+    if custom_providers.contains_key(provider_id) {
+        return true;
+    }
     matches!(
         provider_id,
         "openai"
@@ -102,8 +112,13 @@ pub(crate) fn build_provider_options(
     model_id: &str,
     effort_level: Option<claurst_core::effort::EffortLevel>,
     thinking_budget: Option<u32>,
+    custom_providers: &std::collections::HashMap<String, claurst_core::config::CustomProviderDef>,
 ) -> Value {
     let mut options = serde_json::Map::new();
+    // The catalog contains mixed-case model ids; keep the original for
+    // exact map lookups in the custom-provider block below, and a
+    // lowercased copy for the substring heuristics.
+    let model_id_exact = model_id.to_string();
     let model_id = model_id.to_ascii_lowercase();
 
     if provider_id == "github-copilot" {
@@ -185,7 +200,7 @@ pub(crate) fn build_provider_options(
         }
     }
 
-    if is_openaiish_provider(provider_id) && is_openai_reasoning_model(&model_id) {
+    if is_openaiish_provider(provider_id, custom_providers) && is_openai_reasoning_model(&model_id) {
         let reasoning_effort = effort_level
             .map(reasoning_effort_for_level)
             .unwrap_or("medium");
@@ -264,6 +279,27 @@ pub(crate) fn build_provider_options(
                             serde_json::json!({"type": "disabled"}),
                         );
                     }
+                }
+            }
+        }
+    }
+
+    // Fallback for user-defined custom providers: when the model is not a
+    // GPT reasoning model (so no `reasoningEffort` was inserted above),
+    // consult the model definition's `reasoningEffort` override. Lookup is
+    // exact-case first, then lowercased, so mixed-case settings keys work.
+    if !options.contains_key("reasoningEffort") {
+        if let Some(cp) = custom_providers.get(provider_id) {
+            let model_def = cp
+                .models
+                .get(&model_id_exact)
+                .or_else(|| cp.models.get(&model_id));
+            if let Some(model_def) = model_def {
+                if let Some(ref effort) = model_def.reasoning_effort {
+                    options.insert(
+                        "reasoningEffort".to_string(),
+                        serde_json::json!(effort),
+                    );
                 }
             }
         }

--- a/src-rust/crates/tui/src/app/keys.rs
+++ b/src-rust/crates/tui/src/app/keys.rs
@@ -736,47 +736,31 @@ impl App {
             return false;
         }
 
-        // Model picker intercepts navigation and Esc
+        // Model picker: configurable bindings (ModelPicker context) with a
+        // filter-editing fallback for unbound keys.
         if self.model_picker.visible {
-            match key.code {
-                KeyCode::Esc => self.model_picker.close(),
-                KeyCode::Home => self.model_picker.select_first(),
-                KeyCode::End => self.model_picker.select_last(),
-                KeyCode::Up => self.model_picker.select_prev(),
-                KeyCode::Down => self.model_picker.select_next(),
-                KeyCode::Left => self.model_picker.effort_prev(),
-                KeyCode::Right => self.model_picker.effort_next(),
-                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => self.model_picker.select_prev(),
-                KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => self.model_picker.select_next(),
-                KeyCode::Enter => {
-                    if let Some((model_id, effort)) = self.model_picker.confirm() {
-                        // If user picked a model other than the fast-mode model
-                        // while fast mode was active, turn fast mode off.
-                        if self.fast_mode && !self.model_picker.is_selected_fast_mode_model(&model_id) {
-                            self.fast_mode = false;
-                        }
-                        if let Some(e) = effort {
-                            self.effort_level = e;
-                        }
-                        // Store explicit selections in the canonical
-                        // "provider/model" form for non-Anthropic providers.
-                        // The "free" composite's picker entries already carry
-                        // a routing prefix (`free/…`, `zen/…`, `openrouter/…`)
-                        // so re-prefixing would produce nonsense like
-                        // `free/free/auto`.
-                        let provider = self.config.provider.as_deref().unwrap_or("anthropic");
-                        let full_model = if provider == "anthropic" || provider == "free" {
-                            model_id.clone()
-                        } else {
-                            format!("{}/{}", provider, model_id)
-                        };
-                        self.set_model(full_model.clone());
-                        self.persist_provider_and_model();
-                        let effort_hint = effort.map(|e| format!(" [{}]", e.label())).unwrap_or_default();
-                        self.status_message = Some(format!("Model: {}{}", full_model, effort_hint));
+            if let Some(keystroke) = key_event_to_keystroke(&key) {
+                match self.keybindings.process(keystroke, &KeyContext::ModelPicker) {
+                    KeybindingResult::Action(action) => {
+                        self.handle_model_picker_action(&action);
+                        return false;
+                    }
+                    KeybindingResult::Pending => return false,
+                    KeybindingResult::NoMatch | KeybindingResult::Unbound => {
+                        // Fall through to filter editing below.
                     }
                 }
+            } else {
+                self.keybindings.cancel_chord();
+            }
+            match key.code {
                 KeyCode::Backspace => self.model_picker.pop_filter_char(),
+                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.model_picker.select_prev()
+                }
+                KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.model_picker.select_next()
+                }
                 KeyCode::Char(c) => self.model_picker.push_filter_char(c),
                 _ => {}
             }
@@ -1702,6 +1686,135 @@ impl App {
         false
     }
 
+    /// Execute a ModelPicker-context keybinding action. Mirrors the
+    /// hardcoded dialog handlers but consults the configurable binding map,
+    /// so users can remap picker keys via settings.json.
+    pub(super) fn handle_model_picker_action(&mut self, action: &str) {
+        match action {
+            "prevModel" => self.model_picker.select_prev(),
+            "nextModel" => self.model_picker.select_next(),
+            "pageUp" => {
+                for _ in 0..10 {
+                    self.model_picker.select_prev();
+                }
+            }
+            "pageDown" => {
+                for _ in 0..10 {
+                    self.model_picker.select_next();
+                }
+            }
+            "firstModel" => self.model_picker.select_first(),
+            "lastModel" => self.model_picker.select_last(),
+            "effortDown" => self.model_picker.effort_prev(),
+            "effortUp" => self.model_picker.effort_next(),
+            "nextProvider" => self.model_picker.select_next_provider(),
+            "prevProvider" => self.model_picker.select_prev_provider(),
+            "toggleShowAllProviders" => {
+                if self.model_picker.all_providers_mode {
+                    self.model_picker.toggle_show_all_providers();
+                }
+            }
+            "cancelModelPicker" => self.model_picker.close(),
+            "toggleFavorite" => {
+                let grouped = self.model_picker.filtered_models_grouped();
+                if let Some((m, _)) = grouped.get(self.model_picker.selected_idx) {
+                    // In all-providers mode the entry carries its own
+                    // provider; otherwise use the active config provider.
+                    let provider = if m.provider_id.is_empty() {
+                        self.config
+                            .provider
+                            .as_deref()
+                            .unwrap_or("anthropic")
+                            .to_string()
+                    } else {
+                        m.provider_id.clone()
+                    };
+                    let model_key = if provider == "anthropic" || provider == "free" {
+                        m.id.clone()
+                    } else {
+                        format!("{}/{}", provider, m.id)
+                    };
+                    self.model_picker.toggle_favorite(&model_key);
+                }
+            }
+            "selectModel" => {
+                // Capture all-providers mode AND the selected entry's
+                // provider_id BEFORE confirm() — confirm() calls close()
+                // which resets all_providers_mode and clears the filter,
+                // changing the grouped list and invalidating selected_idx.
+                let was_all_providers = self.model_picker.all_providers_mode;
+                let selected_provider_id = if was_all_providers {
+                    self.model_picker
+                        .filtered_models_grouped()
+                        .get(self.model_picker.selected_idx)
+                        .map(|(m, _)| m.provider_id.clone())
+                } else {
+                    None
+                };
+                if let Some((model_id, effort)) = self.model_picker.confirm() {
+                    // Default sentinel — clear the explicit model override
+                    // so the provider's best model is auto-selected.
+                    if model_id == crate::model_picker::DEFAULT_MODEL_SENTINEL {
+                        self.config.model = None;
+                        let provider = self.config.provider.as_deref().unwrap_or("anthropic");
+                        let best = self.display_default_model_for_provider(provider);
+                        self.model_name = best.clone();
+                        self.cost_tracker.set_model(&best);
+                        self.refresh_context_window_size();
+                        self.context_used_tokens = 0;
+                        self.persist_provider_and_model();
+                        self.status_message = Some(format!("Model: {} (default)", best));
+                        return;
+                    }
+                    // If user picked a model other than the fast-mode model
+                    // while fast mode was active, turn fast mode off.
+                    if self.fast_mode
+                        && !self.model_picker.is_selected_fast_mode_model(&model_id)
+                    {
+                        self.fast_mode = false;
+                    }
+                    if let Some(e) = effort {
+                        self.effort_level = e;
+                    }
+                    // Store explicit selections in the canonical
+                    // "provider/model" form for non-Anthropic providers.
+                    // The "free" composite's picker entries already carry
+                    // a routing prefix (`free/…`, `zen/…`, `openrouter/…`)
+                    // so re-prefixing would produce nonsense like
+                    // `free/free/auto`.
+                    //
+                    // In all-providers mode the provider comes from the
+                    // selected entry's provider_id, not config.provider.
+                    let full_model = if was_all_providers {
+                        if let Some(provider) = selected_provider_id {
+                            if provider == "anthropic" || provider == "free" {
+                                model_id.clone()
+                            } else {
+                                format!("{}/{}", provider, model_id)
+                            }
+                        } else {
+                            model_id.clone()
+                        }
+                    } else {
+                        let provider = self.config.provider.as_deref().unwrap_or("anthropic");
+                        if provider == "anthropic" || provider == "free" {
+                            model_id.clone()
+                        } else {
+                            format!("{}/{}", provider, model_id)
+                        }
+                    };
+                    self.set_model(full_model.clone());
+                    self.persist_provider_and_model();
+                    let effort_hint = effort
+                        .map(|e| format!(" [{}]", e.label()))
+                        .unwrap_or_default();
+                    self.status_message = Some(format!("Model: {}{}", full_model, effort_hint));
+                }
+            }
+            _ => {}
+        }
+    }
+
     pub(super) fn current_key_context(&self) -> KeyContext {
         if self.diff_viewer.visible {
             KeyContext::DiffDialog
@@ -2338,7 +2451,14 @@ impl App {
             }
             "openModelPicker" => {
                 if !self.is_streaming {
-                    self.intercept_slash_command("model");
+                    // When custom providers are configured, open the picker in
+                    // all-providers mode (grouped by provider, with favorites).
+                    // Otherwise fall back to the current provider's picker.
+                    if !self.config.custom_providers.is_empty() {
+                        self.open_model_picker_all_providers();
+                    } else {
+                        self.intercept_slash_command("model");
+                    }
                 }
                 false
             }

--- a/src-rust/crates/tui/src/app/mod.rs
+++ b/src-rust/crates/tui/src/app/mod.rs
@@ -577,6 +577,9 @@ impl App {
                 .join("models.json");
             reg.load_cache(&cache_path);
             reg.apply_model_overrides(&config.model_overrides);
+            // Register user-defined custom providers so their models appear
+            // in the picker and resolve for provider/model routing.
+            reg.apply_custom_providers(&config.custom_providers);
             reg
         };
         Self {

--- a/src-rust/crates/tui/src/app/providers.rs
+++ b/src-rust/crates/tui/src/app/providers.rs
@@ -286,12 +286,113 @@ impl App {
                 .to_string()
         };
 
+        self.model_picker
+            .load_favorites(self.config.favorite_models.clone());
         self.model_picker.open_with_title(
             title.unwrap_or_else(|| "Select model".to_string()),
             &current_model,
             self.effort_level,
             self.fast_mode,
         );
+    }
+
+    /// Check if a provider is connected: it has a resolvable API key, it is
+    /// a keyless local provider, or it is a configured custom provider with
+    /// a non-empty apiBase (internal gateways may not need auth).
+    pub(super) fn is_provider_connected(&self, provider_id: &str) -> bool {
+        match provider_id {
+            "ollama" | "lmstudio" | "lm-studio"
+            | "llamacpp" | "llama-cpp" | "llama-server" | "free" => true,
+            _ => {
+                if self.config.resolve_provider_api_key(provider_id).is_some() {
+                    return true;
+                }
+                if let Some(def) = self.config.custom_providers.get(provider_id) {
+                    return !def.api_base.trim().is_empty();
+                }
+                false
+            }
+        }
+    }
+
+    /// Open the model picker showing models from all connected providers,
+    /// grouped by provider name. Unconfigured providers are hidden by
+    /// default; press `a` in the picker to show them.
+    pub(super) fn open_model_picker_all_providers(&mut self) {
+        self.dismiss_error_notifications();
+
+        // Get ALL provider IDs from the registry (for the full model list).
+        let mut provider_ids: Vec<String> = self
+            .provider_registry
+            .as_ref()
+            .map(|registry| {
+                registry
+                    .provider_ids()
+                    .iter()
+                    .map(|id| id.to_string())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Custom providers are not in the provider registry's connected map
+        // until first use — include them from the config.
+        for pid in self.config.custom_providers.keys() {
+            if !provider_ids.contains(pid) {
+                provider_ids.push(pid.clone());
+            }
+        }
+        // Also include the current provider if not already listed.
+        if let Some(current) = &self.config.provider {
+            if !provider_ids.contains(current) {
+                provider_ids.push(current.clone());
+            }
+        }
+
+        // Determine which providers are connected.
+        let connected_ids: std::collections::HashSet<String> = provider_ids
+            .iter()
+            .filter(|pid| self.is_provider_connected(pid))
+            .cloned()
+            .collect();
+        self.model_picker.connected_provider_ids = connected_ids;
+
+        // Collect models from ALL providers (filtering happens at display time).
+        let mut all_models: Vec<crate::model_picker::ModelEntry> = Vec::new();
+        let mut provider_names = std::collections::HashMap::new();
+        for pid in &provider_ids {
+            // Look up the provider display name from the model registry.
+            if let Some(entry) = self
+                .model_registry
+                .list_providers()
+                .iter()
+                .find(|p| &*p.id == pid)
+            {
+                provider_names.insert(pid.clone(), entry.name.clone());
+            }
+            // Custom providers: use the user-configured display name.
+            if let Some(def) = self.config.custom_providers.get(pid) {
+                provider_names.insert(pid.clone(), def.name.clone());
+            }
+            let models = crate::model_picker::models_for_provider_from_registry(
+                pid,
+                &self.model_registry,
+            );
+            for mut m in models {
+                m.provider_id = pid.clone();
+                all_models.push(m);
+            }
+        }
+
+        self.model_picker.provider_names = provider_names;
+        self.model_picker.set_models(all_models);
+        self.model_picker_provider_id = None; // all-providers mode
+        self.model_picker.all_providers_mode = true;
+        self.model_picker.loading_models = false;
+        self.model_picker_fetch_pending = false;
+        self.model_picker.load_favorites(self.config.favorite_models.clone());
+
+        self.model_picker
+            .open_all_providers(&self.model_name, self.effort_level, self.fast_mode);
     }
 
     pub(super) fn activate_provider(&mut self, provider_id: String, provider_name: String, status_prefix: &str) {
@@ -415,8 +516,10 @@ impl App {
         self.config = config;
         self.provider_registry = provider_registry;
         self.model_registry = claurst_api::ModelRegistry::new();
-        // Re-layer user metadata overrides (issue #309) onto the fresh registry.
+        // Re-layer user metadata overrides (issue #309) and custom provider
+        // model catalogs onto the fresh registry.
         self.model_registry.apply_model_overrides(&self.config.model_overrides);
+        self.model_registry.apply_custom_providers(&self.config.custom_providers);
         self.auth_store = auth_store;
         self.connect_dialog = DialogSelectState::new("Connect a provider", provider_picker_items());
         self.import_config_picker = DialogSelectState::new("Import config", import_config_picker_items());

--- a/src-rust/crates/tui/src/model_picker.rs
+++ b/src-rust/crates/tui/src/model_picker.rs
@@ -24,6 +24,10 @@ use crate::overlays::{centered_rect, modal_search_line, CLAURST_PANEL_BG};
 /// support reasoning honour it.
 pub use claurst_core::effort::EffortLevel;
 
+/// Sentinel model id for the "Default" picker entry. When the user selects
+/// this, the app clears the explicit model override so the provider's best
+/// model is used.
+pub const DEFAULT_MODEL_SENTINEL: &str = "__default__";
 
 // ---------------------------------------------------------------------------
 // Model capability helpers — driven by the opencode variants() ladder
@@ -221,6 +225,8 @@ pub struct ModelEntry {
     pub description: String,
     /// Whether this is the currently active model.
     pub is_current: bool,
+    /// Provider ID this model belongs to (for all-providers mode).
+    pub provider_id: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -228,12 +234,13 @@ pub struct ModelEntry {
 // ---------------------------------------------------------------------------
 
 /// Helper to build a `ModelEntry` with `is_current = false`.
-fn model_entry(id: &str, name: &str, desc: &str) -> ModelEntry {
+fn model_entry(id: &str, name: &str, desc: &str, provider_id: &str) -> ModelEntry {
     ModelEntry {
         id: id.to_string(),
         display_name: name.to_string(),
         description: desc.to_string(),
         is_current: false,
+        provider_id: provider_id.to_string(),
     }
 }
 
@@ -254,7 +261,7 @@ pub fn models_for_provider_from_registry(
     // directly.  `free/auto` is the default routing entry; the rest pin a
     // specific upstream model for users who care.
     if provider_id == "free" {
-        return free_provider_models();
+        return free_provider_models(provider_id);
     }
     // Codex (ChatGPT-authenticated OpenAI) is not in the models.dev catalog —
     // serve the curated CODEX_MODELS list so the picker isn't empty.  Accept
@@ -262,7 +269,7 @@ pub fn models_for_provider_from_registry(
     // ("openai-codex"); without the alias a fresh Codex login lands on the
     // empty-registry fallback and the picker shows no models.
     if is_codex_provider(provider_id) {
-        return codex_provider_models(registry);
+        return codex_provider_models(registry, provider_id);
     }
 
     let mut entries = registry.list_visible_by_provider(provider_id);
@@ -280,6 +287,7 @@ pub fn models_for_provider_from_registry(
             "default",
             "Default model",
             "no catalog entry for this provider",
+            provider_id,
         )];
     }
 
@@ -307,6 +315,7 @@ pub fn models_for_provider_from_registry(
                 display_name: e.info.name.clone(),
                 description: cost_str,
                 is_current: false,
+                provider_id: provider_id.to_string(),
             }
         })
         .collect()
@@ -377,10 +386,20 @@ pub fn default_model_for_provider(
 /// event loop either replaces or merges the projection according to
 /// [`provider_has_authoritative_live_models`].
 pub fn provider_uses_catalog_projection(provider_id: &str) -> bool {
-    matches!(
+    if matches!(
         provider_id,
         "openai" | "google" | "azure" | "amazon-bedrock" | "cohere" | "minimax"
-    )
+    ) {
+        return true;
+    }
+    // Custom providers have a curated model list in settings — no live
+    // endpoint to fetch from, so skip the background fetch.
+    if let Ok(settings) = claurst_core::Settings::load_sync() {
+        if settings.custom_providers.contains_key(provider_id) {
+            return true;
+        }
+    }
+    false
 }
 
 /// Whether live discovery is the complete set of models usable through a local
@@ -417,7 +436,7 @@ fn is_codex_provider(provider_id: &str) -> bool {
 /// catalog yields nothing (e.g. an empty/old snapshot).
 ///
 /// [`codex_model_allowed`]: claurst_core::codex_oauth::codex_model_allowed
-fn codex_provider_models(registry: &claurst_api::ModelRegistry) -> Vec<ModelEntry> {
+fn codex_provider_models(registry: &claurst_api::ModelRegistry, provider_id: &str) -> Vec<ModelEntry> {
     use claurst_core::codex_oauth::{codex_limit_override, codex_model_allowed};
 
     let mut entries: Vec<&claurst_api::ModelEntry> = registry
@@ -427,7 +446,7 @@ fn codex_provider_models(registry: &claurst_api::ModelRegistry) -> Vec<ModelEntr
         .collect();
 
     if entries.is_empty() {
-        return codex_fallback_models();
+        return codex_fallback_models(provider_id);
     }
 
     // Newest release first, then by id for stability — matches the picker's
@@ -455,13 +474,14 @@ fn codex_provider_models(registry: &claurst_api::ModelRegistry) -> Vec<ModelEntr
                     format_context_window(ctx)
                 ),
                 is_current: false,
+                provider_id: provider_id.to_string(),
             }
         })
         .collect()
 }
 
 /// Static fallback used when the models.dev `openai` catalog is unavailable.
-fn codex_fallback_models() -> Vec<ModelEntry> {
+fn codex_fallback_models(provider_id: &str) -> Vec<ModelEntry> {
     use claurst_core::codex_oauth::codex_limit_override;
     claurst_core::codex_oauth::CODEX_MODELS
         .iter()
@@ -477,6 +497,7 @@ fn codex_fallback_models() -> Vec<ModelEntry> {
                     format_context_window(ctx)
                 ),
                 is_current: false,
+                provider_id: provider_id.to_string(),
             }
         })
         .collect()
@@ -485,12 +506,13 @@ fn codex_fallback_models() -> Vec<ModelEntry> {
 /// Curated free-mode model list used by `models_for_provider_from_registry`.
 /// Always shows `free/auto` first; one pin entry per catalog upstream so the
 /// user can target a specific provider when they need to.
-fn free_provider_models() -> Vec<ModelEntry> {
+fn free_provider_models(provider_id: &str) -> Vec<ModelEntry> {
     let mut entries = vec![ModelEntry {
         id: "free/auto".to_string(),
         display_name: "Auto (round-robin across configured providers)".to_string(),
         description: "stacks every free-tier key you've added · $0.00 per M".to_string(),
         is_current: false,
+        provider_id: provider_id.to_string(),
     }];
 
     for upstream in claurst_api::FREE_CATALOG {
@@ -499,6 +521,7 @@ fn free_provider_models() -> Vec<ModelEntry> {
             display_name: format!("{} \u{2014} {}", upstream.title, upstream.default_model),
             description: format!("{} · $0.00 per M", upstream.note),
             is_current: false,
+            provider_id: provider_id.to_string(),
         });
     }
 
@@ -523,6 +546,25 @@ pub struct ModelPickerState {
     pub models_loaded: bool,
     /// `true` while the background fetch is in flight.
     pub loading_models: bool,
+    /// Favorited model keys ("provider/model" format), loaded from Settings.
+    pub favorites: Vec<String>,
+    /// Synthetic "Default" entry prepended to the model list.
+    default_entry: ModelEntry,
+    /// When true, the picker shows models from all connected providers
+    /// grouped by provider name.
+    pub all_providers_mode: bool,
+    /// Provider ID → display name map, populated from the model registry
+    /// when the all-providers picker opens. Used for group headers so
+    /// built-in providers (nvidia, deepinfra, etc.) show their real name
+    /// instead of "Other".
+    pub provider_names: std::collections::HashMap<String, String>,
+    /// When true, show ALL providers (including unconfigured) in the picker.
+    /// Default false — only connected providers shown.
+    pub show_all_providers: bool,
+    /// Set of connected provider IDs. When `show_all_providers` is false,
+    /// only models whose provider_id is in this set are shown (plus the
+    /// default entry). Populated by `open_model_picker_all_providers`.
+    pub connected_provider_ids: std::collections::HashSet<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -551,6 +593,18 @@ impl ModelPickerState {
             fast_mode_model: None,
             models_loaded: false,
             loading_models: false,
+            favorites: Vec::new(),
+            default_entry: ModelEntry {
+                id: DEFAULT_MODEL_SENTINEL.to_string(),
+                display_name: "Default".to_string(),
+                description: "Provider's recommended model (auto-selects best)".to_string(),
+                is_current: false,
+                provider_id: String::new(),
+            },
+            all_providers_mode: false,
+            provider_names: std::collections::HashMap::new(),
+            show_all_providers: false,
+            connected_provider_ids: std::collections::HashSet::new(),
         }
     }
 
@@ -568,6 +622,45 @@ impl ModelPickerState {
         self.open_with_title("Select model", current_model, effort, fast_mode);
     }
 
+    /// Open in all-providers mode — shows models from all connected
+    /// providers grouped by provider name.
+    pub fn open_all_providers(&mut self, current_model: &str, effort: EffortLevel, fast_mode: bool) {
+        self.all_providers_mode = true;
+        self.open_with_title("Select model (all providers)", current_model, effort, fast_mode);
+    }
+
+    /// Get the display name for a provider ID (for all-providers mode).
+    /// Reads the custom-provider display name from the cached
+    /// `provider_names` map (populated once when the picker opens), never
+    /// from the settings file, so rendering stays allocation-light.
+    pub fn provider_group_name(provider_id: &str) -> String {
+        match provider_id {
+            "anthropic" => "Anthropic".to_string(),
+            "openai" => "OpenAI".to_string(),
+            "google" => "Google".to_string(),
+            "groq" => "Groq".to_string(),
+            "openrouter" => "OpenRouter".to_string(),
+            "deepseek" => "DeepSeek".to_string(),
+            "ollama" => "Ollama".to_string(),
+            "lmstudio" => "LM Studio".to_string(),
+            "llamacpp" | "llama-cpp" | "llama-server" => "llama.cpp".to_string(),
+            "github-copilot" => "GitHub Copilot".to_string(),
+            "codex" | "openai-codex" => "OpenAI Codex".to_string(),
+            "cohere" => "Cohere".to_string(),
+            "xai" => "xAI".to_string(),
+            "free" => "Free Mode".to_string(),
+            "cerebras" => "Cerebras".to_string(),
+            "sambanova" => "SambaNova".to_string(),
+            "together-ai" | "togetherai" => "Together AI".to_string(),
+            "mistral" => "Mistral".to_string(),
+            "perplexity" => "Perplexity".to_string(),
+            "azure" => "Azure OpenAI".to_string(),
+            "amazon-bedrock" => "AWS Bedrock".to_string(),
+            "custom-openai" => "Custom OpenAI".to_string(),
+            _ => "Other".to_string(),
+        }
+    }
+
     pub fn open_with_title(
         &mut self,
         title: impl Into<String>,
@@ -576,15 +669,24 @@ impl ModelPickerState {
         fast_mode: bool,
     ) {
         for m in &mut self.models {
-            m.is_current = m.id == current_model;
+            m.is_current = m.id == current_model
+                || current_model == format!("{}/{}", m.provider_id, m.id);
         }
-        self.selected_idx = self
-            .models
-            .iter()
-            .position(|m| m.is_current)
-            .unwrap_or(0);
+        // Mark default entry as current when no explicit model is set.
+        self.default_entry.is_current = current_model.is_empty()
+            || current_model == DEFAULT_MODEL_SENTINEL;
         self.title = title.into();
+        // Clear the filter BEFORE computing selected_idx so a stale filter
+        // can't hide the current model and leave the cursor on row 0.
         self.filter.clear();
+        // Compute selected_idx from the grouped list (default entry at 0,
+        // favorites first, then non-favorites) — not the raw models vec —
+        // so the cursor highlights the correct row.
+        self.selected_idx = self
+            .filtered_models_grouped()
+            .iter()
+            .position(|(m, _)| m.is_current)
+            .unwrap_or(0);
         self.effort_level = effort;
         self.fast_mode = fast_mode;
         self.fast_mode_model = fast_mode.then_some(current_model.to_string());
@@ -595,6 +697,10 @@ impl ModelPickerState {
     pub fn close(&mut self) {
         self.visible = false;
         self.filter.clear();
+        self.all_providers_mode = false;
+        self.provider_names.clear();
+        self.show_all_providers = false;
+        self.connected_provider_ids.clear();
     }
 
     pub fn is_selected_fast_mode_model(&self, model_id: &str) -> bool {
@@ -603,7 +709,7 @@ impl ModelPickerState {
 
     /// Move selection up one row (wraps to last if at top).
     pub fn select_prev(&mut self) {
-        let count = self.filtered_models().len();
+        let count = self.filtered_models_grouped().len();
         if count == 0 { return; }
         if self.selected_idx == 0 {
             self.selected_idx = count - 1;
@@ -614,9 +720,90 @@ impl ModelPickerState {
 
     /// Move selection down one row (wraps to first if at bottom).
     pub fn select_next(&mut self) {
-        let count = self.filtered_models().len();
+        let count = self.filtered_models_grouped().len();
         if count == 0 { return; }
         self.selected_idx = (self.selected_idx + 1) % count;
+    }
+
+    /// Jump to the first model of the next provider group (all-providers mode).
+    /// Wraps around to the default entry (index 0) after the last provider.
+    pub fn select_next_provider(&mut self) {
+        let grouped = self.filtered_models_grouped();
+        if grouped.is_empty() {
+            return;
+        }
+        let current_provider = grouped
+            .get(self.selected_idx)
+            .map(|(m, _)| m.provider_id.as_str())
+            .unwrap_or("");
+        // Find the first entry after the current position with a different
+        // non-empty provider_id. Skip the default entry (empty provider_id).
+        for (i, (entry, _)) in grouped.iter().enumerate().skip(self.selected_idx + 1) {
+            let pid = entry.provider_id.as_str();
+            if !pid.is_empty() && pid != current_provider {
+                self.selected_idx = i;
+                return;
+            }
+        }
+        // Wrap around: find the first entry with a non-empty provider_id
+        // from the beginning (skips default entry at index 0).
+        for (i, (entry, _)) in grouped.iter().enumerate().take(self.selected_idx) {
+            let pid = entry.provider_id.as_str();
+            if !pid.is_empty() && pid != current_provider {
+                self.selected_idx = i;
+                return;
+            }
+        }
+        // No other provider found — stay put.
+    }
+
+    /// Jump to the first model of the previous provider group (all-providers mode).
+    /// Wraps around to the last provider's first model after index 0.
+    pub fn select_prev_provider(&mut self) {
+        let grouped = self.filtered_models_grouped();
+        if grouped.is_empty() {
+            return;
+        }
+        let current_provider = grouped
+            .get(self.selected_idx)
+            .map(|(m, _)| m.provider_id.as_str())
+            .unwrap_or("");
+        // Walk backwards to find the first entry of the previous provider.
+        // We need to find the boundary: the first entry whose provider_id
+        // differs from current AND is non-empty, then from that point find
+        // the FIRST entry of that provider group.
+        let mut prev_provider = None;
+        if self.selected_idx > 0 {
+            for i in (0..self.selected_idx).rev() {
+                let pid = grouped[i].0.provider_id.as_str();
+                if !pid.is_empty() && pid != current_provider {
+                    prev_provider = Some(pid);
+                    // Now find the first entry of this provider group.
+                    for (j, (entry2, _)) in grouped.iter().enumerate().take(i + 1) {
+                        if entry2.provider_id == pid {
+                            self.selected_idx = j;
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+        // Wrap around: find the last provider group's first entry.
+        if prev_provider.is_none() {
+            // Find the last distinct provider group.
+            let mut last_provider = "";
+            let mut last_provider_first_idx = 0;
+            for (i, (m, _)) in grouped.iter().enumerate() {
+                let pid = m.provider_id.as_str();
+                if !pid.is_empty() && pid != last_provider {
+                    last_provider = pid;
+                    last_provider_first_idx = i;
+                }
+            }
+            if !last_provider.is_empty() && last_provider != current_provider {
+                self.selected_idx = last_provider_first_idx;
+            }
+        }
     }
 
     pub fn select_first(&mut self) {
@@ -624,17 +811,27 @@ impl ModelPickerState {
     }
 
     pub fn select_last(&mut self) {
-        let count = self.filtered_models().len();
+        let count = self.filtered_models_grouped().len();
         self.selected_idx = count.saturating_sub(1);
+    }
+
+    /// Toggle showing all providers vs only connected ones.
+    pub fn toggle_show_all_providers(&mut self) {
+        self.show_all_providers = !self.show_all_providers;
+        // Reset selection to stay in bounds.
+        let count = self.filtered_models_grouped().len();
+        if count > 0 && self.selected_idx >= count {
+            self.selected_idx = count - 1;
+        }
     }
 
     /// The reasoning-effort ladder of the currently highlighted model (ascending,
     /// no ultracode). Empty when nothing is highlighted or the model is
     /// non-reasoning.
     fn selected_ladder(&self) -> Vec<EffortLevel> {
-        let filtered = self.filtered_models();
+        let filtered = self.filtered_models_grouped();
         match filtered.get(self.selected_idx) {
-            Some(m) => picker_variant_ladder(&m.id),
+            Some((m, _)) => picker_variant_ladder(&m.id),
             None => Vec::new(),
         }
     }
@@ -671,7 +868,7 @@ impl ModelPickerState {
     /// Returns the selected model; the caller is responsible for persisting it
     /// in the correct provider-aware format.
     pub fn confirm(&mut self) -> Option<(String, Option<EffortLevel>)> {
-        let filtered = self.filtered_models();
+        let filtered = self.filtered_models_grouped();
         let custom = self.filter.trim();
         if filtered.is_empty() {
             if custom.is_empty() {
@@ -681,8 +878,12 @@ impl ModelPickerState {
             self.close();
             return Some((id, None));
         }
-        let entry = filtered.get(self.selected_idx)?;
+        let (entry, _is_fav) = filtered.get(self.selected_idx)?;
         let id = entry.id.clone();
+        if id == DEFAULT_MODEL_SENTINEL {
+            self.close();
+            return Some((id, None));
+        }
         let ladder = picker_variant_ladder(&id);
         let effort = if ladder.len() > 1 {
             Some(clamp_to_ladder(&ladder, self.effort_level))
@@ -723,6 +924,152 @@ impl ModelPickerState {
             .collect()
     }
 
+    /// Load favorites from the app's effective Config into the picker
+    /// state. Called once when the picker opens, not per frame.
+    pub fn load_favorites(&mut self, favorites: Vec<String>) {
+        self.favorites = favorites;
+    }
+
+    /// Toggle favorite status on a model key. Saves to Settings immediately.
+    pub fn toggle_favorite(&mut self, model_key: &str) {
+        if self.favorites.contains(&model_key.to_string()) {
+            self.favorites.retain(|f| f != model_key);
+        } else {
+            self.favorites.push(model_key.to_string());
+        }
+        // Persist to settings.
+        if let Ok(mut settings) = claurst_core::Settings::load_sync() {
+            settings.favorite_models = self.favorites.clone();
+            let _ = settings.save_sync();
+        }
+    }
+
+    /// Check if a model key is favorited.
+    pub fn is_favorite(&self, model_key: &str) -> bool {
+        self.favorites.contains(&model_key.to_string())
+    }
+
+    /// Get the list of valid favorites — those present in the picker's
+    /// current model list. Stale favorites (model removed from catalog)
+    /// are silently excluded from display but NOT removed from settings.
+    ///
+    /// Matching uses each entry's `provider_id`, so `free/auto` and other
+    /// slash-carrying ids match exactly instead of splitting on the first
+    /// `/` and matching the wrong provider's model.
+    pub fn valid_favorites(&self) -> Vec<String> {
+        // Canonical keys for the current model list: routing-prefixed ids
+        // ("free/auto") stay as-is; bare ids are keyed as "provider/model"
+        // when the entry carries a provider, else bare. Bare ids are also
+        // accepted directly for single-provider mode, where favorites may
+        // have been stored unprefixed.
+        let mut keys: std::collections::HashSet<String> = self
+            .models
+            .iter()
+            .map(|m| {
+                if m.id.contains('/') || m.provider_id.is_empty() {
+                    m.id.clone()
+                } else {
+                    format!("{}/{}", m.provider_id, m.id)
+                }
+            })
+            .collect();
+        for m in &self.models {
+            keys.insert(m.id.clone());
+        }
+        self.favorites
+            .iter()
+            .filter(|f| keys.contains(f.as_str()))
+            .cloned()
+            .collect()
+    }
+
+    /// Returns model entries for display: favorites first (marked with ★),
+    /// then all other models. Applies the current filter to both sections.
+    pub fn filtered_models_grouped(&self) -> Vec<(&ModelEntry, bool)> {
+        // Canonical favorite keys, recomputed the same way valid_favorites
+        // builds its match set, so `free/auto` and other prefixed ids are
+        // not mangled by splitting on the first '/'.
+        let valid_favs = self.valid_favorites();
+        let fav_keys: std::collections::HashSet<&str> =
+            valid_favs.iter().map(|f| f.as_str()).collect();
+        let is_fav = |m: &ModelEntry| -> bool {
+            if m.id.contains('/') || m.provider_id.is_empty() {
+                fav_keys.contains(m.id.as_str())
+            } else {
+                fav_keys.contains(format!("{}/{}", m.provider_id, m.id).as_str())
+                    || fav_keys.contains(m.id.as_str())
+            }
+        };
+
+        // Connected-providers filter: when show_all_providers is false AND
+        // we're in all-providers mode, only show models whose provider_id is
+        // in the connected set. The default entry (empty provider_id) always
+        // passes.
+        let connected_filter = |m: &&ModelEntry| -> bool {
+            if m.provider_id.is_empty() {
+                return true;
+            }
+            if self.show_all_providers || !self.all_providers_mode {
+                return true;
+            }
+            self.connected_provider_ids.contains(&m.provider_id)
+        };
+
+        if self.filter.is_empty() {
+            // No filter: favorites section, then all models
+            let mut result = Vec::new();
+            // Default entry always at top.
+            result.push((&self.default_entry, false));
+            // Favorites first
+            for m in &self.models {
+                if is_fav(m) && connected_filter(&m) {
+                    result.push((m, true));
+                }
+            }
+            // Then non-favorites
+            for m in &self.models {
+                if !is_fav(m) && connected_filter(&m) {
+                    result.push((m, false));
+                }
+            }
+            result
+        } else {
+            let needle = self.filter.to_lowercase();
+            let mut result = Vec::new();
+            // Default entry — always show if filter matches or is empty.
+            if self.filter.is_empty()
+                || "default".contains(&needle)
+                || self.default_entry.display_name.to_lowercase().contains(&needle)
+                || self.default_entry.description.to_lowercase().contains(&needle)
+            {
+                result.push((&self.default_entry, false));
+            }
+            // Favorites matching filter
+            for m in &self.models {
+                if is_fav(m)
+                    && (m.id.to_lowercase().contains(&needle)
+                        || m.display_name.to_lowercase().contains(&needle)
+                        || m.description.to_lowercase().contains(&needle))
+                    && connected_filter(&m)
+                {
+                    result.push((m, true));
+                }
+            }
+            // Non-favorites matching filter
+            for m in &self.models {
+                if !is_fav(m)
+                    && (m.id.to_lowercase().contains(&needle)
+                        || m.display_name.to_lowercase().contains(&needle)
+                        || m.description.to_lowercase().contains(&needle))
+                    && connected_filter(&m)
+                {
+                    result.push((m, false));
+                }
+            }
+            result
+        }
+    }
+
     /// Replace the model list with dynamically loaded entries.
     ///
     /// Called by the app event loop when the background fetch completes.
@@ -731,8 +1078,8 @@ impl ModelPickerState {
         self.models = entries;
         self.loading_models = false;
         self.models_loaded = true;
-        // Keep selected_idx in bounds.
-        let count = self.filtered_models().len();
+        // Keep selected_idx in bounds (grouped view includes default entry).
+        let count = self.filtered_models_grouped().len();
         if count > 0 && self.selected_idx >= count {
             self.selected_idx = count - 1;
         }
@@ -769,8 +1116,8 @@ impl ModelPickerState {
         }
         self.loading_models = false;
         self.models_loaded = true;
-        // Keep selected_idx in bounds.
-        let count = self.filtered_models().len();
+        // Keep selected_idx in bounds (grouped view includes default entry).
+        let count = self.filtered_models_grouped().len();
         if count > 0 && self.selected_idx >= count {
             self.selected_idx = count - 1;
         }
@@ -820,8 +1167,8 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
     // ── Dialog size ──
     let width = 65u16.min(area.width.saturating_sub(6));
     let max_height = (area.height as f32 * 0.75) as u16;
-    let filtered = state.filtered_models();
-    let content_h = (filtered.len() as u16 + 6).min(max_height).max(8);
+    let grouped = state.filtered_models_grouped();
+    let content_h = (grouped.len() as u16 + 6).min(max_height).max(8);
     let dialog_area = centered_rect(width, content_h, area);
 
     // ── Fill dialog bg (no border) ──
@@ -909,7 +1256,7 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
         lines.push(Line::from(""));
     }
 
-    if filtered.is_empty() {
+    if grouped.is_empty() {
         lines.push(Line::from(vec![Span::styled(" No results found", Style::default().fg(dim))]));
         if !state.filter.trim().is_empty() {
             lines.push(Line::from(vec![Span::styled(
@@ -918,7 +1265,24 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
             )]));
         }
     } else {
-        for (i, model) in filtered.iter().enumerate() {
+        let mut last_provider: Option<&str> = None;
+        for (i, (model, is_fav)) in grouped.iter().enumerate() {
+            // Provider group header in all-providers mode — skip for the
+            // synthetic default entry (empty provider_id).
+            if state.all_providers_mode
+                && model.id != DEFAULT_MODEL_SENTINEL
+                && last_provider != Some(&model.provider_id) {
+                last_provider = Some(&model.provider_id);
+                let group_name = state
+                    .provider_names
+                    .get(&model.provider_id)
+                    .cloned()
+                    .unwrap_or_else(|| ModelPickerState::provider_group_name(&model.provider_id));
+                lines.push(Line::from(vec![Span::styled(
+                    format!(" {} ", group_name),
+                    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                )]));
+            }
             let is_selected = i == state.selected_idx;
             let supports_effort = model_supports_effort(&model.id);
 
@@ -934,12 +1298,18 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
 
             let mut spans: Vec<Span<'static>> = Vec::new();
 
-            // Current model indicator
-            if model.is_current {
+            // Default entry gets a star (★); active model gets a green dot (●).
+            if model.id == DEFAULT_MODEL_SENTINEL {
+                spans.push(Span::styled(" \u{2605} ", Style::default().fg(Color::Cyan).bg(bg)));
+            } else if model.is_current {
                 spans.push(Span::styled(" \u{25cf} ", Style::default().fg(Color::Green).bg(bg)));
             } else {
                 spans.push(Span::styled("   ", Style::default().bg(bg)));
             }
+
+            // Favorite indicator — heart (♥) when favorited.
+            let heart = if *is_fav { "\u{2665} " } else { "  " };
+            spans.push(Span::styled(heart.to_string(), Style::default().fg(Color::Yellow).bg(bg)));
 
             spans.push(Span::styled(model.display_name.clone(), Style::default().fg(fg).bg(bg)));
 
@@ -990,11 +1360,37 @@ pub fn render_model_picker(state: &ModelPickerState, area: Rect, buf: &mut Buffe
 
     para.render(body_area, buf);
 
-    let mut footer_spans = vec![
-        Span::styled(" enter", Style::default().fg(dim)),
-        Span::styled(" select", Style::default().fg(dim)),
-    ];
-    if let Some(model) = filtered.get(state.selected_idx) {
+    let mut footer_spans = vec![];
+    // Show "enter set default" when the default sentinel is selected,
+    // otherwise "enter select".
+    let is_on_default = grouped
+        .get(state.selected_idx)
+        .map(|(m, _)| m.id == DEFAULT_MODEL_SENTINEL)
+        .unwrap_or(false);
+    if is_on_default {
+        footer_spans.push(Span::styled(" enter", Style::default().fg(dim)));
+        footer_spans.push(Span::styled(" set default", Style::default().fg(dim)));
+    } else {
+        footer_spans.push(Span::styled(" enter", Style::default().fg(dim)));
+        footer_spans.push(Span::styled(" select", Style::default().fg(dim)));
+    }
+    // Favorite toggle shortcut.
+    footer_spans.push(Span::raw("  "));
+    footer_spans.push(Span::styled("f", Style::default().fg(dim)));
+    footer_spans.push(Span::styled(" favorite", Style::default().fg(dim)));
+    // Tab to jump between provider groups.
+    footer_spans.push(Span::raw("  "));
+    footer_spans.push(Span::styled("Tab", Style::default().fg(dim)));
+    footer_spans.push(Span::styled(" providers", Style::default().fg(dim)));
+    // Show-all toggle shortcut.
+    footer_spans.push(Span::raw("  "));
+    footer_spans.push(Span::styled("a", Style::default().fg(dim)));
+    if state.show_all_providers {
+        footer_spans.push(Span::styled(" connected", Style::default().fg(dim)));
+    } else {
+        footer_spans.push(Span::styled(" all", Style::default().fg(dim)));
+    }
+    if let Some((model, _)) = grouped.get(state.selected_idx) {
         if model_supports_effort(&model.id) {
             footer_spans.push(Span::raw("  "));
             footer_spans.push(Span::styled("\u{2190}/\u{2192}", Style::default().fg(dim)));
@@ -1026,18 +1422,21 @@ mod tests {
                 display_name: "Claude Opus 4.6".to_string(),
                 description: "200K context".to_string(),
                 is_current: false,
+                provider_id: "anthropic".to_string(),
             },
             ModelEntry {
                 id: "claude-sonnet-4-6".to_string(),
                 display_name: "Claude Sonnet 4.6".to_string(),
                 description: "200K context".to_string(),
                 is_current: false,
+                provider_id: "anthropic".to_string(),
             },
             ModelEntry {
                 id: "claude-haiku-4-5".to_string(),
                 display_name: "Claude Haiku 4.5".to_string(),
                 description: "200K context".to_string(),
                 is_current: false,
+                provider_id: "anthropic".to_string(),
             },
         ]
     }
@@ -1137,7 +1536,7 @@ mod tests {
     #[test]
     fn select_next_wraps() {
         let mut p = make_picker_with_current("claude-opus-4-6");
-        let total = p.filtered_models().len();
+        let total = p.filtered_models_grouped().len();
         p.selected_idx = total - 1;
         p.select_next();
         assert_eq!(p.selected_idx, 0);
@@ -1149,7 +1548,7 @@ mod tests {
         let mut p = make_picker_with_current("claude-opus-4-6");
         p.selected_idx = 0;
         p.select_prev();
-        let total = p.filtered_models().len();
+        let total = p.filtered_models_grouped().len();
         assert_eq!(p.selected_idx, total - 1);
     }
 
@@ -1182,10 +1581,10 @@ mod tests {
     #[test]
     fn confirm_returns_id_and_closes() {
         let mut p = make_picker_with_current("claude-opus-4-6");
-        p.selected_idx = 0;
-        let first_id = p.filtered_models()[0].id.clone();
+        p.selected_idx = 1; // skip Default sentinel at index 0
+        let first_model_id = p.filtered_models()[0].id.clone();
         let result = p.confirm();
-        assert_eq!(result.map(|(id, _)| id), Some(first_id));
+        assert_eq!(result.map(|(id, _)| id), Some(first_model_id));
         assert!(!p.visible, "picker should be closed after confirm");
     }
 
@@ -1478,6 +1877,7 @@ mod tests {
                 display_name: "LIVE OVERWRITE".to_string(),
                 description: "live desc".to_string(),
                 is_current: false,
+                provider_id: "anthropic".to_string(),
             },
             // A brand-new live id absent from the catalog — must be appended.
             ModelEntry {
@@ -1485,6 +1885,7 @@ mod tests {
                 display_name: "GPT-5.5 (live)".to_string(),
                 description: "live only".to_string(),
                 is_current: false,
+                provider_id: "anthropic".to_string(),
             },
         ];
         p.merge_models(live);
@@ -1530,12 +1931,14 @@ mod tests {
             "default",
             "Default model",
             "no catalog entry for this provider",
+            "anthropic",
         )]);
         p.merge_models(vec![ModelEntry {
             id: "llama3.3".to_string(),
             display_name: "Llama 3.3".to_string(),
             description: "local".to_string(),
             is_current: false,
+            provider_id: "anthropic".to_string(),
         }]);
         assert!(
             !p.models.iter().any(|m| m.id == "default"),
@@ -1581,5 +1984,534 @@ mod tests {
         }
         assert!(!provider_has_authoritative_live_models("github-copilot"));
         assert!(!provider_has_authoritative_live_models("openrouter"));
+    }
+
+    #[test]
+    fn valid_favorites_filters_stale_entries() {
+        let mut state = ModelPickerState::new();
+        state.models = vec![
+            ModelEntry { id: "model-a".to_string(), display_name: "A".to_string(), description: "".to_string(), is_current: false, provider_id: "prov".to_string() },
+            ModelEntry { id: "model-b".to_string(), display_name: "B".to_string(), description: "".to_string(), is_current: false, provider_id: "prov".to_string() },
+            // Routing-prefixed id (free/auto) must match exactly, not split.
+            ModelEntry { id: "free/auto".to_string(), display_name: "Auto".to_string(), description: "".to_string(), is_current: false, provider_id: "free".to_string() },
+        ];
+        state.favorites = vec![
+            "prov/model-a".to_string(),  // valid canonical key
+            "prov/model-c".to_string(),  // stale (not in models list)
+            "model-b".to_string(),       // valid bare fallback
+            "free/auto".to_string(),     // valid routing-prefixed key
+        ];
+        let valid = state.valid_favorites();
+        assert_eq!(valid.len(), 3, "valid favorites: {:?}", valid);
+        assert!(valid.contains(&"prov/model-a".to_string()));
+        assert!(valid.contains(&"model-b".to_string()));
+        assert!(valid.contains(&"free/auto".to_string()));
+        assert!(!valid.contains(&"prov/model-c".to_string()));
+    }
+
+    #[test]
+    fn filtered_models_grouped_puts_favorites_first() {
+        let mut state = ModelPickerState::new();
+        state.models = vec![
+            ModelEntry { id: "regular".to_string(), display_name: "Regular".to_string(), description: "".to_string(), is_current: false, provider_id: "prov".to_string() },
+            ModelEntry { id: "pinned".to_string(), display_name: "Pinned".to_string(), description: "".to_string(), is_current: false, provider_id: "prov".to_string() },
+            ModelEntry { id: "other".to_string(), display_name: "Other".to_string(), description: "".to_string(), is_current: false, provider_id: "prov".to_string() },
+        ];
+        state.favorites = vec!["prov/pinned".to_string()];
+        let grouped = state.filtered_models_grouped();
+        assert_eq!(grouped.len(), 4);
+        // Default sentinel at top.
+        assert_eq!(grouped[0].0.id, DEFAULT_MODEL_SENTINEL);
+        // Favorite must come next.
+        assert_eq!(grouped[1].0.id, "pinned");
+        assert!(grouped[1].1);
+        // Rest are non-favorites, preserve source order.
+        assert_eq!(grouped[2].0.id, "regular");
+        assert!(!grouped[2].1);
+        assert_eq!(grouped[3].0.id, "other");
+        assert!(!grouped[3].1);
+    }
+
+    #[test]
+    fn filtered_models_grouped_respects_filter() {
+        let mut state = ModelPickerState::new();
+        state.models = vec![
+            ModelEntry { id: "pinned-a".to_string(), display_name: "Pinned A".to_string(), description: "".to_string(), is_current: false, provider_id: "prov".to_string() },
+            ModelEntry { id: "pinned-b".to_string(), display_name: "Other B".to_string(), description: "".to_string(), is_current: false, provider_id: "prov".to_string() },
+        ];
+        state.favorites = vec![
+            "prov/pinned-a".to_string(),
+            "prov/pinned-b".to_string(),
+        ];
+        for c in "pinned a".chars() {
+            state.push_filter_char(c);
+        }
+        let grouped = state.filtered_models_grouped();
+        // Only the favorite matching the filter appears, on top.
+        assert_eq!(grouped.len(), 1);
+        assert_eq!(grouped[0].0.id, "pinned-a");
+        assert!(grouped[0].1);
+    }
+
+    #[test]
+    fn is_favorite_roundtrips_without_persist() {
+        let mut state = ModelPickerState::new();
+        state.favorites = vec!["anthropic/claude-sonnet-4-6".to_string()];
+        assert!(state.is_favorite("anthropic/claude-sonnet-4-6"));
+        assert!(!state.is_favorite("openai/gpt-4o"));
+    }
+
+    #[test]
+    fn default_entry_appears_at_top() {
+        let mut picker = ModelPickerState::new();
+        picker.set_models(vec![
+            ModelEntry {
+                id: "model-a".to_string(),
+                display_name: "Model A".to_string(),
+                description: "desc".to_string(),
+                is_current: false,
+                provider_id: String::new(),
+            },
+            ModelEntry {
+                id: "model-b".to_string(),
+                display_name: "Model B".to_string(),
+                description: "desc".to_string(),
+                is_current: false,
+                provider_id: String::new(),
+            },
+        ]);
+        picker.open("model-a");
+        let grouped = picker.filtered_models_grouped();
+        assert_eq!(grouped.len(), 3);
+        assert_eq!(grouped[0].0.id, DEFAULT_MODEL_SENTINEL);
+        assert_eq!(grouped[1].0.id, "model-a");
+    }
+
+    #[test]
+    fn default_entry_is_current_when_no_model() {
+        let mut picker = ModelPickerState::new();
+        picker.set_models(vec![
+            ModelEntry {
+                id: "model-a".to_string(),
+                display_name: "Model A".to_string(),
+                description: "desc".to_string(),
+                is_current: false,
+                provider_id: String::new(),
+            },
+        ]);
+        picker.open_with_title("Test", "", EffortLevel::Medium, false);
+        assert!(picker.default_entry.is_current);
+    }
+
+    #[test]
+    fn confirm_returns_default_sentinel() {
+        let mut picker = ModelPickerState::new();
+        picker.set_models(vec![
+            ModelEntry {
+                id: "model-a".to_string(),
+                display_name: "Model A".to_string(),
+                description: "desc".to_string(),
+                is_current: false,
+                provider_id: String::new(),
+            },
+        ]);
+        picker.open("model-a");
+        picker.selected_idx = 0; // Default entry
+        let result = picker.confirm();
+        assert_eq!(result.unwrap().0, DEFAULT_MODEL_SENTINEL);
+    }
+
+    // --- selected_idx preselection from grouped order (Bug 1 + Bug 2) ---
+
+    #[test]
+    fn open_with_title_preselects_current_in_grouped_order() {
+        let mut p = make_picker();
+        // Set the model at raw index 1 (claude-sonnet-4-6) as current.
+        // Grouped order: [default, opus, sonnet, haiku] (no favorites).
+        // The grouped index of sonnet should be 2 (default=0, opus=1, sonnet=2).
+        p.open_with_title("Test", "claude-sonnet-4-6", EffortLevel::Medium, false);
+        let grouped = p.filtered_models_grouped();
+        let expected_idx = grouped
+            .iter()
+            .position(|(m, _)| m.id == "claude-sonnet-4-6")
+            .unwrap();
+        assert_eq!(
+            p.selected_idx, expected_idx,
+            "selected_idx must match grouped position, not raw models position"
+        );
+        // Sanity: grouped includes default entry at 0.
+        assert_eq!(grouped[0].0.id, DEFAULT_MODEL_SENTINEL);
+        assert!(p.models.iter().find(|m| m.id == "claude-sonnet-4-6").unwrap().is_current);
+    }
+
+    #[test]
+    fn open_with_title_preselects_default_entry_when_no_model() {
+        let mut p = make_picker();
+        p.open_with_title("Test", "", EffortLevel::Medium, false);
+        assert!(p.default_entry.is_current);
+        assert_eq!(p.selected_idx, 0);
+    }
+
+    #[test]
+    fn open_with_title_preselects_with_provider_prefixed_current() {
+        let models = vec![
+            ModelEntry {
+                id: "revolut-ca/glm-5-2".to_string(),
+                display_name: "GLM 5.2".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "together-ai-coding".to_string(),
+            },
+            ModelEntry {
+                id: "some-other-model".to_string(),
+                display_name: "Other".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "together-ai-coding".to_string(),
+            },
+        ];
+        let mut p = ModelPickerState::new();
+        p.set_models(models);
+        p.open_with_title(
+            "Test",
+            "together-ai-coding/revolut-ca/glm-5-2",
+            EffortLevel::Medium,
+            false,
+        );
+        let glm = p
+            .models
+            .iter()
+            .find(|m| m.id == "revolut-ca/glm-5-2")
+            .unwrap();
+        assert!(glm.is_current, "provider-prefixed current must set is_current");
+        // Other model must NOT be current.
+        assert!(!p
+            .models
+            .iter()
+            .find(|m| m.id == "some-other-model")
+            .unwrap()
+            .is_current);
+        let grouped = p.filtered_models_grouped();
+        let expected_idx = grouped
+            .iter()
+            .position(|(m, _)| m.id == "revolut-ca/glm-5-2")
+            .unwrap();
+        assert_eq!(p.selected_idx, expected_idx);
+    }
+
+    #[test]
+    fn open_with_title_preselects_correct_row_with_favorites() {
+        // Build a picker where a NON-current model is a favorite.
+        // sample_models: [opus, sonnet, haiku] (all anthropic).
+        // Favorite: anthropic/claude-sonnet-4-6
+        // Current:  claude-opus-4-6
+        // Grouped order: [default, sonnet(fav), opus, haiku]
+        // So opus is at grouped index 2, not raw index 0.
+        let mut p = make_picker();
+        p.favorites = vec!["anthropic/claude-sonnet-4-6".to_string()];
+        p.open_with_title("Test", "claude-opus-4-6", EffortLevel::Medium, false);
+        let grouped = p.filtered_models_grouped();
+        // Verify grouped order: default, sonnet (favorite), opus, haiku.
+        assert_eq!(grouped.len(), 4);
+        assert_eq!(grouped[0].0.id, DEFAULT_MODEL_SENTINEL);
+        assert_eq!(grouped[1].0.id, "claude-sonnet-4-6");
+        assert!(grouped[1].1, "sonnet should be favorite");
+        assert_eq!(grouped[2].0.id, "claude-opus-4-6");
+        assert!(!grouped[2].1, "opus should not be favorite");
+        assert_eq!(grouped[3].0.id, "claude-haiku-4-5");
+        // selected_idx must point to opus in grouped order (index 2).
+        assert_eq!(
+            p.selected_idx, 2,
+            "selected_idx must be the grouped position of the current model, not the raw index"
+        );
+    }
+
+    #[test]
+    fn open_all_providers_preselects_provider_prefixed_model() {
+        let models = vec![
+            ModelEntry {
+                id: "revolut-ca/glm-5-2".to_string(),
+                display_name: "GLM 5.2".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "together-ai-coding".to_string(),
+            },
+            ModelEntry {
+                id: "another-model".to_string(),
+                display_name: "Another".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "together-ai-coding".to_string(),
+            },
+        ];
+        let mut p = ModelPickerState::new();
+        p.set_models(models);
+        p.connected_provider_ids =
+            ["together-ai-coding".to_string()].into_iter().collect();
+        p.open_all_providers(
+            "together-ai-coding/revolut-ca/glm-5-2",
+            EffortLevel::Medium,
+            false,
+        );
+        assert!(p.all_providers_mode);
+        let glm = p
+            .models
+            .iter()
+            .find(|m| m.id == "revolut-ca/glm-5-2")
+            .unwrap();
+        assert!(glm.is_current, "all-providers mode must match provider-prefixed current");
+        let grouped = p.filtered_models_grouped();
+        let expected_idx = grouped
+            .iter()
+            .position(|(m, _)| m.id == "revolut-ca/glm-5-2")
+            .unwrap();
+        assert_eq!(p.selected_idx, expected_idx);
+    }
+
+    #[test]
+    fn default_entry_does_not_get_group_header() {
+        let entry = ModelEntry {
+            id: DEFAULT_MODEL_SENTINEL.to_string(),
+            display_name: "Default".to_string(),
+            description: "".to_string(),
+            is_current: false,
+            provider_id: String::new(),
+        };
+        // The render condition checks model.id != DEFAULT_MODEL_SENTINEL
+        // before pushing a group header. The default entry must NOT pass.
+        assert!(entry.id == DEFAULT_MODEL_SENTINEL);
+    }
+
+    #[test]
+    fn selected_provider_id_captured_before_close() {
+        // When a filter is active and the user navigates + confirms,
+        // the provider_id must be captured BEFORE close() clears the filter.
+        let mut picker = ModelPickerState::new();
+        picker.all_providers_mode = true;
+        picker.connected_provider_ids =
+            ["together-ai-coding".to_string(), "cohere".to_string()]
+                .into_iter()
+                .collect();
+        picker.set_models(vec![
+            ModelEntry {
+                id: "glm-5-2".to_string(),
+                display_name: "GLM 5.2".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "together-ai-coding".to_string(),
+            },
+            ModelEntry {
+                id: "opus-4-8".to_string(),
+                display_name: "Opus 4.8".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "cohere".to_string(),
+            },
+        ]);
+        // Type filter "glm" so only the glm model shows (default entry is
+        // filtered out because "glm" does not match "default").
+        for c in "glm".chars() {
+            picker.push_filter_char(c);
+        }
+        // glm is the only filtered result → grouped index 0.
+        picker.selected_idx = 0;
+        // Capture provider BEFORE confirm (as the fixed Enter handler does).
+        let captured_provider = picker
+            .filtered_models_grouped()
+            .get(picker.selected_idx)
+            .map(|(m, _)| m.provider_id.clone());
+        // Now confirm — this closes and clears the filter.
+        let confirmed_id = picker.confirm();
+        // After close, the filter is cleared — unfiltered list is different.
+        // But we captured the provider BEFORE close.
+        assert_eq!(confirmed_id, Some(("glm-5-2".to_string(), None)));
+        assert_eq!(captured_provider, Some("together-ai-coding".to_string()));
+        // If we had re-read AFTER close, selected_idx=0 would point to the
+        // default entry (provider_id="") in the unfiltered list — the bug.
+        assert_ne!(
+            picker
+                .filtered_models_grouped().first()
+                .map(|(m, _)| m.provider_id.clone()),
+            Some("together-ai-coding".to_string())
+        );
+    }
+
+    // --- Tab / BackTab provider-group navigation (all-providers mode) ---
+
+    /// Two providers with two models each — the basic multi-provider fixture.
+    fn two_provider_models() -> Vec<ModelEntry> {
+        vec![
+            ModelEntry {
+                id: "model-a1".to_string(),
+                display_name: "Model A1".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "provider-a".to_string(),
+            },
+            ModelEntry {
+                id: "model-a2".to_string(),
+                display_name: "Model A2".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "provider-a".to_string(),
+            },
+            ModelEntry {
+                id: "model-b1".to_string(),
+                display_name: "Model B1".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "provider-b".to_string(),
+            },
+            ModelEntry {
+                id: "model-b2".to_string(),
+                display_name: "Model B2".to_string(),
+                description: "".to_string(),
+                is_current: false,
+                provider_id: "provider-b".to_string(),
+            },
+        ]
+    }
+
+    #[test]
+    fn select_next_provider_jumps_to_next_group() {
+        let mut p = ModelPickerState::new();
+        p.set_models(two_provider_models());
+        p.connected_provider_ids =
+            ["provider-a".to_string(), "provider-b".to_string()]
+                .into_iter()
+                .collect();
+        p.open_all_providers("model-a1", EffortLevel::Medium, false);
+        // Default entry at index 0, then provider-a models, then provider-b.
+        let grouped = p.filtered_models_grouped();
+        let a1_idx = grouped.iter().position(|(m, _)| m.id == "model-a1").unwrap();
+        let b1_idx = grouped.iter().position(|(m, _)| m.id == "model-b1").unwrap();
+        p.selected_idx = a1_idx;
+        p.select_next_provider();
+        assert_eq!(
+            p.selected_idx, b1_idx,
+            "Tab from provider A should jump to provider B's first model"
+        );
+    }
+
+    #[test]
+    fn select_prev_provider_jumps_to_previous_group() {
+        let mut p = ModelPickerState::new();
+        p.set_models(two_provider_models());
+        p.connected_provider_ids =
+            ["provider-a".to_string(), "provider-b".to_string()]
+                .into_iter()
+                .collect();
+        p.open_all_providers("model-b1", EffortLevel::Medium, false);
+        let grouped = p.filtered_models_grouped();
+        let a1_idx = grouped.iter().position(|(m, _)| m.id == "model-a1").unwrap();
+        let b1_idx = grouped.iter().position(|(m, _)| m.id == "model-b1").unwrap();
+        p.selected_idx = b1_idx;
+        p.select_prev_provider();
+        assert_eq!(
+            p.selected_idx, a1_idx,
+            "BackTab from provider B should jump to provider A's first model"
+        );
+    }
+
+    #[test]
+    fn select_next_provider_wraps_around() {
+        let mut p = ModelPickerState::new();
+        p.set_models(two_provider_models());
+        p.connected_provider_ids =
+            ["provider-a".to_string(), "provider-b".to_string()]
+                .into_iter()
+                .collect();
+        p.open_all_providers("model-b2", EffortLevel::Medium, false);
+        let grouped = p.filtered_models_grouped();
+        let b2_idx = grouped.iter().position(|(m, _)| m.id == "model-b2").unwrap();
+        let a1_idx = grouped.iter().position(|(m, _)| m.id == "model-a1").unwrap();
+        p.selected_idx = b2_idx;
+        p.select_next_provider();
+        assert_eq!(
+            p.selected_idx, a1_idx,
+            "Tab from last provider should wrap to first provider's first model"
+        );
+    }
+
+    #[test]
+    fn select_next_provider_skips_default_entry() {
+        let mut p = ModelPickerState::new();
+        p.set_models(two_provider_models());
+        p.connected_provider_ids =
+            ["provider-a".to_string(), "provider-b".to_string()]
+                .into_iter()
+                .collect();
+        p.open_all_providers("", EffortLevel::Medium, false);
+        // No current model → default entry (index 0) is selected.
+        {
+            let grouped = p.filtered_models_grouped();
+            assert_eq!(p.selected_idx, 0, "default entry should be at index 0");
+            assert_eq!(grouped[0].0.id, DEFAULT_MODEL_SENTINEL);
+            assert_eq!(grouped[0].0.provider_id, "");
+        }
+        p.select_next_provider();
+        // Tab must skip the default entry and land on the first real
+        // provider's first model — never back on the default entry.
+        assert_ne!(
+            p.selected_idx, 0,
+            "Tab must never select the default entry"
+        );
+        let selected_pid = p.filtered_models_grouped()[p.selected_idx].0.provider_id.clone();
+        assert!(
+            !selected_pid.is_empty(),
+            "Tab must land on a real provider, not the default entry"
+        );
+    }
+
+    #[test]
+    fn connected_filter_hides_unconnected_providers() {
+        let mut state = ModelPickerState::new();
+        state.all_providers_mode = true;
+        state.connected_provider_ids =
+            ["provider-a".to_string()].into_iter().collect();
+        state.set_models(vec![
+            ModelEntry { id: "model-a1".to_string(), display_name: "A1".to_string(), description: "".to_string(), is_current: false, provider_id: "provider-a".to_string() },
+            ModelEntry { id: "model-a2".to_string(), display_name: "A2".to_string(), description: "".to_string(), is_current: false, provider_id: "provider-a".to_string() },
+            ModelEntry { id: "model-b1".to_string(), display_name: "B1".to_string(), description: "".to_string(), is_current: false, provider_id: "provider-b".to_string() },
+            ModelEntry { id: "model-b2".to_string(), display_name: "B2".to_string(), description: "".to_string(), is_current: false, provider_id: "provider-b".to_string() },
+        ]);
+        let grouped = state.filtered_models_grouped();
+        // Default entry + 2 provider-a models. Provider-b filtered out.
+        assert_eq!(grouped.len(), 3);
+        assert_eq!(grouped[0].0.id, DEFAULT_MODEL_SENTINEL);
+        let provider_ids: std::collections::HashSet<&str> =
+            grouped.iter().map(|(m, _)| m.provider_id.as_str()).collect();
+        assert!(!provider_ids.contains("provider-b"));
+        assert!(provider_ids.contains("provider-a"));
+    }
+
+    #[test]
+    fn show_all_providers_shows_everyone() {
+        let mut state = ModelPickerState::new();
+        state.all_providers_mode = true;
+        state.show_all_providers = true;
+        state.connected_provider_ids =
+            ["provider-a".to_string()].into_iter().collect();
+        state.set_models(vec![
+            ModelEntry { id: "model-a1".to_string(), display_name: "A1".to_string(), description: "".to_string(), is_current: false, provider_id: "provider-a".to_string() },
+            ModelEntry { id: "model-b1".to_string(), display_name: "B1".to_string(), description: "".to_string(), is_current: false, provider_id: "provider-b".to_string() },
+        ]);
+        let grouped = state.filtered_models_grouped();
+        // Default entry + 1 from provider-a + 1 from provider-b.
+        assert_eq!(grouped.len(), 3);
+        let provider_ids: std::collections::HashSet<&str> =
+            grouped.iter().map(|(m, _)| m.provider_id.as_str()).collect();
+        assert!(provider_ids.contains("provider-a"));
+        assert!(provider_ids.contains("provider-b"));
+    }
+
+    #[test]
+    fn toggle_show_all_providers_flips_state() {
+        let mut state = ModelPickerState::new();
+        assert!(!state.show_all_providers);
+        state.toggle_show_all_providers();
+        assert!(state.show_all_providers);
+        state.toggle_show_all_providers();
+        assert!(!state.show_all_providers);
     }
 }


### PR DESCRIPTION
## Summary

Rebased version of #386 — custom providers and model picker overhaul. Carries the full review-response rework addressing all points from the #386 review threads.

### Changes

- **Custom OpenAI-compatible providers** via `settings.json` `customProviders`; resolved once into `Config.custom_providers` at load time (no per-request/per-frame `Settings::load_sync()`).
- **Model picker overhaul**: grouped by provider, connected filter, Tab nav, favorites (matched via `ModelEntry.provider_id`, so `free/auto` works), default selection.
- **All picker keys routed through `keybindings.rs`**: new `KeyContext::ModelPicker` with 13 default bindings (`prevModel`...`toggleFavorite`, `toggleShowAllProviders`). Typing "claude"/"haiku"/"flash" in the filter works.
- **Id-collision check**: custom provider ids colliding with any of the 47 builtin ids are skipped with a `tracing::warn!`.
- **`requestTimeoutSecs` applied** via `OpenAiCompatProvider::with_request_timeout()`.
- **`resolve_api_key` uses `substitute_env_vars`** so `{env:FOO}` and embedded `Bearer` patterns work; empty-after-substitution yields `None` (picker no longer marks unset providers connected).
- **`contextWindow` defaults to 128k with a warning** when unset.
- **In-memory tests only**: no reads of real `~/.claurst/settings.json`, no internal gateway ids in fixtures.

### Rebase notes

- Mapped `app.rs` changes to new `app/` modules (`keys.rs`, `providers.rs`, `mod.rs`).
- Cursor ACP excluded (separate PR, per review point 7).
- Bang/poke/selection payload excluded (lives in #404/#406/#407/#408).
- CRLF preserved in `keybindings.rs` and `registry.rs`.

### Validation

- `cargo check --workspace` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 678 passed, 1 pre-existing failure (`settings_screen`, fails on main too)

Supersedes #386.
